### PR TITLE
Add self-service Telegram aliases

### DIFF
--- a/alembic/versions/002_member_tag_cooldowns.py
+++ b/alembic/versions/002_member_tag_cooldowns.py
@@ -1,0 +1,39 @@
+"""member tag cooldowns
+
+Revision ID: 002
+Revises: 001
+Create Date: 2026-04-24
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "002"
+down_revision = "001"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "member_tag_cooldowns",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("chat_id", sa.BigInteger(), nullable=False),
+        sa.Column("user_id", sa.BigInteger(), nullable=False),
+        sa.Column("last_tag", sa.String(length=16), nullable=True),
+        sa.Column("changed_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_member_tag_cooldowns_chat_user",
+        "member_tag_cooldowns",
+        ["chat_id", "user_id"],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_member_tag_cooldowns_chat_user", table_name="member_tag_cooldowns")
+    op.drop_table("member_tag_cooldowns")

--- a/bot/__main__.py
+++ b/bot/__main__.py
@@ -8,7 +8,7 @@ from aiogram.client.default import DefaultBotProperties
 from aiogram.enums import ParseMode
 
 from bot.config import settings
-from bot.handlers import admin, chat_events, chat_messages, forward_lookup, questionnaire, start, vouch
+from bot.handlers import admin, alias, chat_events, chat_messages, forward_lookup, questionnaire, start, vouch
 from bot.middlewares.db_session import DbSessionMiddleware
 from bot.services.scheduler import start_scheduler, stop_scheduler
 
@@ -59,6 +59,7 @@ async def main() -> None:
         questionnaire.router,
         vouch.router,
         admin.router,
+        alias.router,
         chat_events.router,
         forward_lookup.router,
         chat_messages.router,  # lowest priority — catches all group messages

--- a/bot/db/models.py
+++ b/bot/db/models.py
@@ -146,3 +146,19 @@ class VouchLog(Base):
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=func.now(), server_default=func.now()
     )
+
+
+class MemberTagCooldown(Base):
+    __tablename__ = "member_tag_cooldowns"
+    __table_args__ = (
+        Index("ix_member_tag_cooldowns_chat_user", "chat_id", "user_id", unique=True),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    chat_id: Mapped[int] = mapped_column(BigInteger)
+    user_id: Mapped[int] = mapped_column(BigInteger, ForeignKey("users.id"))
+    last_tag: Mapped[str | None] = mapped_column(String(16))
+    changed_at: Mapped[datetime] = mapped_column(DateTime(timezone=True))
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=func.now(), server_default=func.now()
+    )

--- a/bot/db/repos/member_tag.py
+++ b/bot/db/repos/member_tag.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from bot.db.models import MemberTagCooldown
+
+
+class MemberTagRepo:
+    @staticmethod
+    async def get(session: AsyncSession, chat_id: int, user_id: int) -> MemberTagCooldown | None:
+        result = await session.execute(
+            select(MemberTagCooldown).where(
+                MemberTagCooldown.chat_id == chat_id,
+                MemberTagCooldown.user_id == user_id,
+            )
+        )
+        return result.scalar_one_or_none()
+
+    @staticmethod
+    async def set(
+        session: AsyncSession,
+        chat_id: int,
+        user_id: int,
+        tag: str | None,
+        changed_at: datetime,
+    ) -> MemberTagCooldown:
+        row = await MemberTagRepo.get(session, chat_id, user_id)
+        if row is None:
+            row = MemberTagCooldown(
+                chat_id=chat_id,
+                user_id=user_id,
+                last_tag=tag,
+                changed_at=changed_at,
+            )
+            session.add(row)
+        else:
+            row.last_tag = tag
+            row.changed_at = changed_at
+
+        await session.flush()
+        return row

--- a/bot/handlers/alias.py
+++ b/bot/handlers/alias.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import logging
+import unicodedata
+from datetime import datetime, timedelta, timezone
+
+from aiogram import Router
+from aiogram.exceptions import TelegramBadRequest
+from aiogram.filters import Command, CommandObject
+from aiogram.types import Message
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from bot.db.repos.member_tag import MemberTagRepo
+from bot.db.repos.user import UserRepo
+from bot.filters.chat_type import GroupChatFilter
+
+logger = logging.getLogger(__name__)
+
+router = Router(name="alias")
+
+ALIAS_COOLDOWN = timedelta(hours=1)
+MAX_TAG_LENGTH = 16
+MISSING_TAG_RIGHTS_TEXT = "Нужны права админа с управлением тегами."
+
+
+def normalize_member_tag(raw: str | None) -> str | None:
+    if raw is None:
+        return None
+
+    cleaned_chars: list[str] = []
+    for char in raw.strip():
+        if _is_disallowed_tag_char(char):
+            continue
+        cleaned_chars.append(char)
+
+    cleaned = "".join(cleaned_chars).strip()
+    if not cleaned or cleaned == "-":
+        return None
+
+    return cleaned[:MAX_TAG_LENGTH]
+
+
+def _is_disallowed_tag_char(char: str) -> bool:
+    codepoint = ord(char)
+    if codepoint in (0x200D, 0xFE0E, 0xFE0F, 0x20E3):
+        return True
+
+    if unicodedata.category(char) == "So" and codepoint >= 0x2600:
+        return True
+
+    emoji_ranges = (
+        (0x1F000, 0x1FAFF),
+        (0x2600, 0x27BF),
+    )
+    return any(start <= codepoint <= end for start, end in emoji_ranges)
+
+
+async def _bot_can_manage_tags(message: Message) -> bool:
+    bot_user = await message.bot.me()
+    bot_member = await message.bot.get_chat_member(message.chat.id, bot_user.id)
+    return bool(getattr(bot_member, "can_manage_tags", False))
+
+
+def _uses_admin_title(chat_type: str, member_status: str) -> bool:
+    return chat_type == "supergroup" and member_status in {"administrator", "creator"}
+
+
+@router.message(Command("alias"), GroupChatFilter())
+async def cmd_alias(
+    message: Message,
+    command: CommandObject,
+    session: AsyncSession,
+) -> None:
+    if message.from_user is None:
+        return
+
+    await UserRepo.upsert(
+        session,
+        telegram_id=message.from_user.id,
+        username=message.from_user.username,
+        first_name=message.from_user.first_name,
+        last_name=message.from_user.last_name,
+    )
+
+    if not await _bot_can_manage_tags(message):
+        await message.reply(MISSING_TAG_RIGHTS_TEXT)
+        return
+
+    now = datetime.now(timezone.utc)
+    cooldown = await MemberTagRepo.get(session, message.chat.id, message.from_user.id)
+    if cooldown is not None and now - cooldown.changed_at < ALIAS_COOLDOWN:
+        return
+
+    tag = normalize_member_tag(command.args)
+    sender_member = await message.bot.get_chat_member(message.chat.id, message.from_user.id)
+    use_admin_title = _uses_admin_title(message.chat.type, sender_member.status)
+
+    try:
+        if use_admin_title:
+            await message.bot.set_chat_administrator_custom_title(
+                chat_id=message.chat.id,
+                user_id=message.from_user.id,
+                custom_title=tag or "",
+            )
+        else:
+            await message.bot.set_chat_member_tag(
+                chat_id=message.chat.id,
+                user_id=message.from_user.id,
+                tag=tag,
+            )
+    except TelegramBadRequest:
+        logger.info(
+            "Failed to set alias in chat %s for user %s",
+            message.chat.id,
+            message.from_user.id,
+            exc_info=True,
+        )
+        return
+
+    await MemberTagRepo.set(
+        session,
+        chat_id=message.chat.id,
+        user_id=message.from_user.id,
+        tag=tag,
+        changed_at=now,
+    )

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -62,17 +62,16 @@ Never commit:
 
 ## Current Server State
 
-As of 2026-04-19:
+As of 2026-04-20 (prod cutover completed):
 
 - GitHub repo exists at `https://github.com/Jekudy/vibe-gatekeeper`.
 - CI is green on `main`.
 - Release workflow is gated on successful CI and pushes bot/web images to GHCR.
-- Coolify is installed on the VPS in parallel to the old runtime.
-- Coolify dashboard is intentionally bound to the Tailscale IP only:
-  - `http://100.101.196.21:8100`
-- The old production runtime is still alive:
-  - path: `/home/claw/vibe-gatekeeper`
-  - public web: `0.0.0.0:8080`
+- Coolify dashboard on Tailscale IP only: `http://100.101.196.21:8100`.
+- Public VPS IP: `187.77.98.73` (Hostinger srv1435593).
+- **Production bot `@vibeshkoder_bot` is now running under Coolify** (Docker-managed via Coolify).
+- Legacy runtime at `/home/claw/vibe-gatekeeper` was stopped and removed on 2026-04-20 via `docker compose down`.
+- Public web: `0.0.0.0:8080` is now owned by the Coolify-managed web container.
 
 ## Coolify Registry & SSH (resolved 2026-04-19)
 
@@ -84,15 +83,15 @@ As of 2026-04-19:
   - Coolify localhost public key re-added to `/root/.ssh/authorized_keys`
   - server validation now reports `is_reachable=true`, `is_usable=true`
 
-## Coolify Staging Resources
+## Coolify Prod Resources
 
-Created in Coolify on 2026-04-19, project `My first project` / environment `staging`:
+Initially created on 2026-04-19 as "staging" shells, repurposed as prod on 2026-04-20 after direct cutover (no staging phase; `DEV_MODE=false` on both apps). Names still carry `-staging` suffix — cosmetic, rename later. Coolify project: `My first project` / environment: `staging` (label, not runtime).
 
 | Kind | UUID | Notes |
 |---|---|---|
-| App `vibe-gatekeeper-web` | `cexv50jspo5gl3kq6ojypw43` | image `ghcr.io/jekudy/vibe-gatekeeper-web:main`, port `18080:8080` |
-| App `vibe-gatekeeper-bot-staging` | `maiwn569gziz935wv0w7kcch` | image `ghcr.io/jekudy/vibe-gatekeeper-bot:main` |
-| Postgres `vibe-gatekeeper-pg-staging` | `hdazvm5fz836xj9mdyn8c629` | `postgres:15-alpine`, db `vibe_gatekeeper`, user `vibe` |
+| App `vibe-gatekeeper-web` | `cexv50jspo5gl3kq6ojypw43` | image `ghcr.io/jekudy/vibe-gatekeeper-web:main`, port `8080:8080` (public), fqdn sslip `cexv50jspo5gl3kq6ojypw43.187.77.98.73.sslip.io` |
+| App `vibe-gatekeeper-bot-staging` | `maiwn569gziz935wv0w7kcch` | image `ghcr.io/jekudy/vibe-gatekeeper-bot:main`, polling mode |
+| Postgres `vibe-gatekeeper-pg-staging` | `hdazvm5fz836xj9mdyn8c629` | `postgres:15-alpine`, db `vibe_gatekeeper`, user `vibe`, data migrated from legacy on 2026-04-20 |
 | Redis `vibe-gatekeeper-redis-staging` | `gl28f0g5exzzo4k8w0auzygk` | `redis:7-alpine`, password set |
 
 Internal connection strings:
@@ -100,23 +99,37 @@ Internal connection strings:
 - `DATABASE_URL=postgresql+asyncpg://vibe:<DB_PW>@hdazvm5fz836xj9mdyn8c629:5432/vibe_gatekeeper`
 - `REDIS_URL=redis://default:<REDIS_PW>@gl28f0g5exzzo4k8w0auzygk:6379/0`
 
-DB / Redis / web passwords are stored in Coolify env vars only.
+DB / Redis / web passwords are stored in Coolify env vars only. API token in `~/.env.tokens:COOLIFY_API_TOKEN`.
 
-## Remaining Manual Steps Before First Successful Staging Boot
+Both apps use `custom_docker_run_options = -v /home/claw/vibe-gatekeeper/credentials.json:/app/credentials.json:ro` to mount Google service account credentials from the legacy directory (file preserved, not deleted).
 
-The web app currently fails at startup because pydantic settings reject the placeholder values. To finish staging, the following env vars on **both** apps must be replaced with real values:
+## Prod Cutover — 2026-04-20
 
-- `BOT_TOKEN` — staging bot token from `@BotFather` (or reuse the existing preview-env value if confirmed)
-- `COMMUNITY_CHAT_ID` — must be a valid integer
-- `GOOGLE_SHEET_ID` — staging Google Sheet ID
-- `WEB_BASE_URL` (web only) — public URL once Caddy / sslip mapping is decided
+Executed directly from legacy → Coolify prod (staging skipped, per user direction to work with prod only).
 
-Plus on the file system inside the web/bot containers:
+1. Cleaned Coolify env vars: deleted all `is_preview=true` duplicates; set runtime vars (`BOT_TOKEN`, `COMMUNITY_CHAT_ID=-1002716490518`, `ADMIN_IDS=[149820031]`, `GOOGLE_SHEET_ID`, `WEB_BASE_URL=http://187.77.98.73:8080`, `WEB_BOT_USERNAME=vibeshkoder_bot`, `WEB_PASSWORD=vibeshkoders2026`, `DEV_MODE=false`) sourced from legacy `/home/claw/vibe-gatekeeper/.env`.
+2. Mounted `credentials.json` into both apps via `custom_docker_run_options`.
+3. Dumped legacy DB (`vibe-gatekeeper-db-1` → `pg_dump --clean --if-exists`) and restored into Coolify postgres. Row counts post-restore: users=275, applications=58, intros=44, vouch_log=39, questionnaire_answers=340, chat_messages=3109, alembic_version=1.
+4. Stopped legacy bot first (Telegram session release), made a final incremental dump + restore to capture delta.
+5. `docker compose down` on legacy — port 8080 and BOT_TOKEN both free.
+6. PATCHed Coolify web `ports_mappings: 18080:8080 → 8080:8080` and redeployed.
+7. Deployed Coolify bot for the first time.
+8. Verified: `curl http://187.77.98.73:8080 → 302`, bot logs show `Run polling for bot @vibeshkoder_bot id=8271790115 - 'Shkoder'`, scheduler jobs registered (`check_vouch_deadlines`, `check_intro_refresh`, `sync_google_sheets`), real chat updates being handled within 500ms of start.
 
-- `/app/credentials.json` — Google service account JSON for `GOOGLE_SHEETS_CREDS_FILE`. Coolify volume mount or build-time secret needs to be wired.
+## Rollback Procedure
 
-After those values are set, redeploy web and bot from Coolify and run the smoke checks in `docs/ops/vibe-gatekeeper-staging-cutover.md`.
+If Coolify prod becomes unhealthy:
 
-## Current Bootstrap Limitation
+```bash
+ssh claw@187.77.98.73
+TOKEN=<coolify api token>
+API=http://100.101.196.21:8100/api/v1
+# 1. Stop Coolify bot FIRST to release BOT_TOKEN from Telegram session:
+curl -X POST -H "Authorization: Bearer $TOKEN" "$API/applications/maiwn569gziz935wv0w7kcch/stop"
+# 2. Stop Coolify web to free port 8080:
+curl -X POST -H "Authorization: Bearer $TOKEN" "$API/applications/cexv50jspo5gl3kq6ojypw43/stop"
+# 3. Restart legacy stack:
+cd /home/claw/vibe-gatekeeper && docker compose up -d
+```
 
-The old production runtime at `/home/claw/vibe-gatekeeper` remains the live user path until the new staging path is verified and a controlled bot cutover window is prepared.
+Legacy `docker-compose.yml`, `.env`, and `credentials.json` are preserved in `/home/claw/vibe-gatekeeper` — do not delete until prod has run stably for 7+ days.

--- a/tests/test_alias.py
+++ b/tests/test_alias.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from tests.conftest import import_module
+
+
+def test_normalize_member_tag_trims_emoji_and_limits_length(app_env) -> None:
+    alias = import_module("bot.handlers.alias")
+
+    assert alias.normalize_member_tag("  hello🙂world🚀team  ") == "helloworldteam"
+
+
+def test_normalize_member_tag_empty_after_cleanup_becomes_none(app_env) -> None:
+    alias = import_module("bot.handlers.alias")
+
+    assert alias.normalize_member_tag("🙂🚀") is None
+    assert alias.normalize_member_tag(" - ") is None
+
+
+def test_alias_cooldown_window_constant(app_env) -> None:
+    alias = import_module("bot.handlers.alias")
+
+    now = datetime.now(timezone.utc)
+    assert now + alias.ALIAS_COOLDOWN == now + timedelta(hours=1)
+
+
+def test_uses_admin_title_for_supergroup_admins(app_env) -> None:
+    alias = import_module("bot.handlers.alias")
+
+    assert alias._uses_admin_title("supergroup", "administrator") is True
+    assert alias._uses_admin_title("supergroup", "creator") is True
+    assert alias._uses_admin_title("group", "administrator") is False
+    assert alias._uses_admin_title("supergroup", "member") is False


### PR DESCRIPTION
- adds /alias for self-service aliases in group chats
- normalizes input to Telegram limits
- uses member tags for regular members
- uses custom titles for admins in supergroups
- adds 1-hour per-user per-chat cooldown
- adds DB migration for alias cooldown tracking