### PR TITLE
fix(security): remove default WEB_PASSWORD, fail-fast in prod (N1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ dist/
 build/
 *.egg-info/
 docs/ops/private/
+.handoffs/

--- a/bot/config.py
+++ b/bot/config.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import logging
+import secrets
+
+from pydantic import model_validator
 from pydantic_settings import BaseSettings
 
 
@@ -16,10 +20,22 @@ class Settings(BaseSettings):
     VOUCH_TIMEOUT_HOURS: int = 72
     NUDGE_TIMEOUT_HOURS: int = 48
     INTRO_REFRESH_DAYS: int = 90
-    WEB_PASSWORD: str = "admin"
+    WEB_PASSWORD: str | None = None
     DEV_MODE: bool = False  # Use SQLite + MemoryStorage for local testing
 
     model_config = {"env_file": ".env", "env_file_encoding": "utf-8", "extra": "ignore"}
+
+    @model_validator(mode="after")
+    def validate_web_password(self) -> Settings:
+        if self.WEB_PASSWORD is not None:
+            return self
+
+        if self.DEV_MODE:
+            logging.warning("WEB_PASSWORD is not set; generated an ephemeral dev password")
+            self.WEB_PASSWORD = secrets.token_urlsafe(16)
+            return self
+
+        raise ValueError("WEB_PASSWORD is required when DEV_MODE=false")
 
 
 settings = Settings()  # type: ignore[call-arg]

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -33,6 +33,16 @@ def test_settings_accept_explicit_values(app_env) -> None:
 
 
 def test_config_no_password_prod_raises(app_env, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("WEB_PASSWORD")
+    monkeypatch.setenv("DEV_MODE", "false")
+
+    with pytest.raises(ValidationError, match="WEB_PASSWORD is required when DEV_MODE=false"):
+        import_module("bot.config")
+
+
+def test_settings_no_password_prod_raises_direct_call(
+    app_env, monkeypatch: pytest.MonkeyPatch
+) -> None:
     config = import_module("bot.config")
     Settings = config.Settings
     monkeypatch.delenv("WEB_PASSWORD")

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
 
+import logging
+
+import pytest
+from pydantic import ValidationError
+
 from tests.conftest import import_module
 
 
@@ -25,3 +30,40 @@ def test_settings_accept_explicit_values(app_env) -> None:
     assert settings.ADMIN_IDS == [149820031]
     assert settings.DEV_MODE is True
     assert settings.WEB_PASSWORD == "test-pass"
+
+
+def test_config_no_password_prod_raises(app_env, monkeypatch: pytest.MonkeyPatch) -> None:
+    config = import_module("bot.config")
+    Settings = config.Settings
+    monkeypatch.delenv("WEB_PASSWORD")
+    monkeypatch.setenv("DEV_MODE", "false")
+
+    with pytest.raises(ValidationError, match="WEB_PASSWORD is required when DEV_MODE=false"):
+        Settings()
+
+
+def test_config_no_password_dev_warns(
+    app_env, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    config = import_module("bot.config")
+    Settings = config.Settings
+    monkeypatch.delenv("WEB_PASSWORD")
+    monkeypatch.setenv("DEV_MODE", "true")
+
+    with caplog.at_level(logging.WARNING):
+        settings = Settings()
+
+    assert settings.WEB_PASSWORD
+    assert settings.WEB_PASSWORD != "admin"
+    assert "WEB_PASSWORD is not set" in caplog.text
+
+
+def test_config_explicit_password_used(app_env, monkeypatch: pytest.MonkeyPatch) -> None:
+    config = import_module("bot.config")
+    Settings = config.Settings
+    monkeypatch.setenv("WEB_PASSWORD", "explicit-pass")
+    monkeypatch.setenv("DEV_MODE", "false")
+
+    settings = Settings()
+
+    assert settings.WEB_PASSWORD == "explicit-pass"

--- a/web/config.py
+++ b/web/config.py
@@ -1,3 +1,3 @@
-from bot.config import Settings
+from bot.config import settings
 
-settings = Settings()
+__all__ = ["settings"]


### PR DESCRIPTION
## Summary

Sprint N1 from the security audit (Round 1, critical). Removes the silent fallback to `WEB_PASSWORD = "admin"` that allowed unauthenticated access to the web admin panel whenever the env var was not set.

- **bot/config.py** — `WEB_PASSWORD` is now optional at the field level with a `model_validator` that:
  - uses an explicit value when provided (any DEV_MODE)
  - in `DEV_MODE=true` + missing → logs a warning and generates `secrets.token_urlsafe(16)` (ephemeral, dev convenience)
  - in `DEV_MODE=false` + missing → raises `ValueError("WEB_PASSWORD is required when DEV_MODE=false")` so the app fails to start
- **web/config.py** — re-exports the singleton from `bot.config` instead of constructing a second `Settings()` (round-2 fix to prevent dev-mode ephemeral password mismatch between bot and web)
- **tests/test_settings.py** — 4 new tests: import-time fail-fast, direct-call fail-fast, dev warning + ephemeral pwd, explicit override

## Reviews

- **Product (Claude Code Reviewer)** — APPROVE round 1: all done criteria met, scope honored, 3 low-severity ops/UX notes deferred.
- **Technical (Codex gpt-5.5 high)** — REQUEST_CHANGES round 1 → APPROVE round 2 after fixing import-time test coverage and `web/config.py` deduplication.
- **Evidence:** `.par-evidence.json` (gitignored, local only).

## Test plan

- [ ] `.venv/bin/python -m pytest -v` → 8 passed (5 settings, 2 web_auth, 1 web_app)
- [ ] `.venv/bin/python -m ruff check bot/ web/ tests/` → clean
- [ ] Manual smoke: prod env without WEB_PASSWORD → app refuses to start with clear error
- [ ] Manual smoke: DEV_MODE=true without WEB_PASSWORD → startup OK + warning in logs

## Out of scope

- TLS / cookie hardening (sprint C1)
- forward_lookup auth (sprint C3, parallel)
- vouch deadline timer (sprint N3, parallel)
- web/auth.py constant-time compare (sprint H4)
- `.env.example`, Coolify env (operational, separate)

## Deployment note

⚠️ After merge: `WEB_PASSWORD` becomes a **required** env var in production. Coolify/legacy `.env` must set it (the new value `kudr42` is in `~/.env.tokens` as `SHKODERBOT_WEB_PASSWORD`) before the next deploy, or the bot will refuse to start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)