### PR TITLE
fix(security): require membership for forward_lookup (C3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ dist/
 build/
 *.egg-info/
 docs/ops/private/
+.handoffs/

--- a/bot/handlers/forward_lookup.py
+++ b/bot/handlers/forward_lookup.py
@@ -6,6 +6,7 @@ from aiogram import F, Router
 from aiogram.types import Message
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from bot.config import settings
 from bot.db.repos.intro import IntroRepo
 from bot.db.repos.message import MessageRepo
 from bot.db.repos.user import UserRepo
@@ -28,6 +29,25 @@ async def handle_forwarded_message(
     session: AsyncSession,
 ) -> None:
     """Handle forwarded messages in private chat — look up author's intro."""
+
+    if message.from_user is None:
+        return
+
+    requester = await UserRepo.get(session, message.from_user.id)
+    if requester is None:
+        logger.info(
+            "forward_lookup denied for non-member user_id=%s",
+            message.from_user.id,
+        )
+        return
+
+    is_admin = requester.id in settings.ADMIN_IDS or requester.is_admin is True
+    if requester.is_member is not True and not is_admin:
+        logger.info(
+            "forward_lookup denied for non-member user_id=%s",
+            message.from_user.id,
+        )
+        return
 
     text = message.text
     if not text:

--- a/tests/test_forward_lookup.py
+++ b/tests/test_forward_lookup.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, call
+
+from tests.conftest import import_module
+
+
+def _message(requester_id: int, text: str = "stored community message") -> SimpleNamespace:
+    return SimpleNamespace(
+        from_user=SimpleNamespace(id=requester_id),
+        text=text,
+        answer=AsyncMock(),
+    )
+
+
+def _user(
+    user_id: int,
+    *,
+    is_member: bool,
+    is_admin: bool = False,
+    first_name: str = "Alice",
+    username: str | None = "alice",
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=user_id,
+        is_member=is_member,
+        is_admin=is_admin,
+        first_name=first_name,
+        username=username,
+    )
+
+
+def _chat_message(author_id: int = 222) -> SimpleNamespace:
+    return SimpleNamespace(user_id=author_id)
+
+
+def _intro(text: str = "private intro text") -> SimpleNamespace:
+    return SimpleNamespace(intro_text=text)
+
+
+def test_forward_lookup_member_can_lookup(app_env, monkeypatch) -> None:
+    handler = import_module("bot.handlers.forward_lookup")
+    session = AsyncMock()
+    message = _message(requester_id=111)
+
+    user_get = AsyncMock(side_effect=[_user(111, is_member=True), _user(222, is_member=True)])
+    message_lookup = AsyncMock(return_value=_chat_message())
+    intro_get = AsyncMock(return_value=_intro())
+
+    monkeypatch.setattr(handler.UserRepo, "get", user_get)
+    monkeypatch.setattr(handler.MessageRepo, "find_by_exact_text", message_lookup)
+    monkeypatch.setattr(handler.IntroRepo, "get", intro_get)
+
+    asyncio.run(handler.handle_forwarded_message(message, session))
+
+    user_get.assert_has_awaits([call(session, 111), call(session, 222)])
+    message_lookup.assert_awaited_once_with(session, "stored community message")
+    intro_get.assert_awaited_once_with(session, 222)
+    message.answer.assert_awaited_once()
+    answer_text = message.answer.await_args.args[0]
+    assert "Alice" in answer_text
+    assert "alice" in answer_text
+    assert "private intro text" in answer_text
+
+
+def test_forward_lookup_non_member_denied(app_env, monkeypatch) -> None:
+    handler = import_module("bot.handlers.forward_lookup")
+    session = AsyncMock()
+    message = _message(requester_id=111)
+
+    user_get = AsyncMock(return_value=_user(111, is_member=False))
+    message_lookup = AsyncMock(return_value=_chat_message())
+    intro_get = AsyncMock(return_value=_intro())
+
+    monkeypatch.setattr(handler.UserRepo, "get", user_get)
+    monkeypatch.setattr(handler.MessageRepo, "find_by_exact_text", message_lookup)
+    monkeypatch.setattr(handler.IntroRepo, "get", intro_get)
+
+    asyncio.run(handler.handle_forwarded_message(message, session))
+
+    user_get.assert_awaited_once_with(session, 111)
+    message_lookup.assert_not_called()
+    intro_get.assert_not_called()
+    message.answer.assert_not_called()
+    assert all("Alice" not in args.args for args in message.answer.await_args_list)
+    assert all("private intro text" not in args.args for args in message.answer.await_args_list)
+
+
+def test_forward_lookup_admin_can_lookup(app_env, monkeypatch) -> None:
+    handler = import_module("bot.handlers.forward_lookup")
+    session = AsyncMock()
+    message = _message(requester_id=333)
+
+    user_get = AsyncMock(
+        side_effect=[
+            _user(333, is_member=False, is_admin=True),
+            _user(222, is_member=True),
+        ]
+    )
+    message_lookup = AsyncMock(return_value=_chat_message())
+    intro_get = AsyncMock(return_value=_intro())
+
+    monkeypatch.setattr(handler.UserRepo, "get", user_get)
+    monkeypatch.setattr(handler.MessageRepo, "find_by_exact_text", message_lookup)
+    monkeypatch.setattr(handler.IntroRepo, "get", intro_get)
+
+    asyncio.run(handler.handle_forwarded_message(message, session))
+
+    user_get.assert_has_awaits([call(session, 333), call(session, 222)])
+    message_lookup.assert_awaited_once_with(session, "stored community message")
+    intro_get.assert_awaited_once_with(session, 222)
+    message.answer.assert_awaited_once()
+    answer_text = message.answer.await_args.args[0]
+    assert "Alice" in answer_text
+    assert "alice" in answer_text
+    assert "private intro text" in answer_text


### PR DESCRIPTION
## Summary

Sprint C3 from the security audit (Round 1, critical). Closes a PII-deanonymization leak in `forward_lookup`.

**Bug:** any user who DM'd the bot with a forwarded message got back the original author's first_name + username + intro_text. No membership check existed.

**Fix:** require requester to be a community member (`user.is_member`) or admin (`user.is_admin` or `id in settings.ADMIN_IDS`) before any author lookup. Non-authorized requesters get **silent return** — no answer, no log of author identity, no side channel.

## Reviews

- **Product (Claude Code Reviewer)** — APPROVE. Deny path verified silent (no answer, no author lookup, no PII in logs). 3 informational notes (none blocking).
- **Technical (Codex gpt-5.5 high)** — APPROVE. None-handling sound, authorization logic correct (is_admin nullable=False in migration), test isolation OK, no race conditions.

## Files

- `bot/handlers/forward_lookup.py` — requester gate before any author/intro queries
- `tests/test_forward_lookup.py` — 3 new tests (member, non-member, admin)

## Test plan

- [ ] `.venv/bin/python -m pytest -v` → 7 passed
- [ ] `.venv/bin/python -m ruff check bot/ web/ tests/` → clean
- [ ] Manual: as non-member, DM bot a forwarded message → no response (verify in logs that deny was logged)
- [ ] Manual: as member, same → get author + intro

## Out of scope

- Rate limiting (sprint H3)
- Other handler audits
- MessageRepo / IntroRepo internals

🤖 Generated with [Claude Code](https://claude.com/claude-code)