### PR TITLE
fix(tests): isolate scheduler_deadlines from module-clearing pollution

### DIFF
--- a/tests/test_scheduler_deadlines.py
+++ b/tests/test_scheduler_deadlines.py
@@ -2,25 +2,39 @@ from __future__ import annotations
 
 import asyncio
 from datetime import datetime, timedelta, timezone
+from importlib import import_module
 
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
-from bot.db.models import Application, Base
-from bot.db.repos.application import ApplicationRepo
 
-
-async def _get_pending_ids(app: Application, hours: int = 72) -> list[int]:
+async def _get_pending_ids(
+    *,
+    user_id: int,
+    created_at: datetime,
+    submitted_at: datetime | None,
+    hours: int = 72,
+) -> list[int]:
+    models = import_module("bot.db.models")
+    application_repo = import_module("bot.db.repos.application")
+    app = models.Application(
+        user_id=user_id,
+        status="pending",
+        created_at=created_at,
+        submitted_at=submitted_at,
+    )
     engine = create_async_engine("sqlite+aiosqlite:///:memory:")
     sessionmaker = async_sessionmaker(engine, expire_on_commit=False)
     try:
         async with engine.begin() as conn:
-            await conn.run_sync(Base.metadata.create_all)
+            await conn.run_sync(models.Base.metadata.create_all)
 
         async with sessionmaker() as session:
             session.add(app)
             await session.commit()
 
-            result = await ApplicationRepo.get_pending_older_than(session, hours)
+            result = await application_repo.ApplicationRepo.get_pending_older_than(
+                session, hours
+            )
             return [pending_app.id for pending_app in result]
     finally:
         await engine.dispose()
@@ -28,41 +42,38 @@ async def _get_pending_ids(app: Application, hours: int = 72) -> list[int]:
 
 def test_pending_older_than_uses_submitted_at() -> None:
     now = datetime.now(timezone.utc)
-    app = Application(
-        user_id=1001,
-        status="pending",
-        created_at=now - timedelta(hours=80),
-        submitted_at=now - timedelta(hours=10),
+    pending_ids = asyncio.run(
+        _get_pending_ids(
+            user_id=1001,
+            created_at=now - timedelta(hours=80),
+            submitted_at=now - timedelta(hours=10),
+        )
     )
-
-    pending_ids = asyncio.run(_get_pending_ids(app))
 
     assert pending_ids == []
 
 
 def test_pending_older_than_legacy_null_falls_back_to_created_at() -> None:
     now = datetime.now(timezone.utc)
-    app = Application(
-        user_id=1002,
-        status="pending",
-        created_at=now - timedelta(hours=80),
-        submitted_at=None,
+    pending_ids = asyncio.run(
+        _get_pending_ids(
+            user_id=1002,
+            created_at=now - timedelta(hours=80),
+            submitted_at=None,
+        )
     )
-
-    pending_ids = asyncio.run(_get_pending_ids(app))
 
     assert pending_ids == [1]
 
 
 def test_pending_within_threshold_not_returned() -> None:
     now = datetime.now(timezone.utc)
-    app = Application(
-        user_id=1003,
-        status="pending",
-        created_at=now - timedelta(hours=80),
-        submitted_at=now - timedelta(hours=50),
+    pending_ids = asyncio.run(
+        _get_pending_ids(
+            user_id=1003,
+            created_at=now - timedelta(hours=80),
+            submitted_at=now - timedelta(hours=50),
+        )
     )
-
-    pending_ids = asyncio.run(_get_pending_ids(app))
 
     assert pending_ids == []


### PR DESCRIPTION
## Summary

Hotfix for a test-suite regression introduced when Round 1 security sprints (N1, C3, N3) all landed on main. Running `pytest -v` from project root failed with 3 SQLAlchemy mapper errors in `test_scheduler_deadlines`. Root cause was test pollution from `conftest.py::_clear_modules()` — N3's tests imported models at module level instead of inside the test helper, so when forward_lookup tests (alphabetically first) cleared `bot.*` modules, the next module-level import in scheduler_deadlines got mapper-class drift.

## Fix

Move `bot.db.models` + `bot.db.repos.application` imports INSIDE the test helper via `importlib.import_module`. Each test now re-resolves mappers in a clean state.

## Why this slipped past per-PR review

CI for each PR ran the suite with only that PR's NEW test files added. The C3 + N3 test interaction never appeared in any single-PR CI run.

## Verification

- `pytest -v` from project root → **14 passed** (was 3 failures + 11 passed)
- `pytest tests/test_forward_lookup.py tests/test_scheduler_deadlines.py -v` → **6 passed** (worst-case ordering)
- `pytest tests/test_scheduler_deadlines.py -v` in isolation → **3 passed**
- `ruff check bot/ tests/` clean

## Out of scope

- `tests/conftest.py::_clear_modules()` is intentionally aggressive and serves the env-toggling tests correctly.
- No production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)