### PR TITLE
fix(security): separate WEB_SESSION_SECRET + constant-time password compare (C2 + H4)

### DIFF
--- a/bot/config.py
+++ b/bot/config.py
@@ -21,6 +21,7 @@ class Settings(BaseSettings):
     NUDGE_TIMEOUT_HOURS: int = 48
     INTRO_REFRESH_DAYS: int = 90
     WEB_PASSWORD: str | None = None
+    WEB_SESSION_SECRET: str | None = None
     DEV_MODE: bool = False  # Use SQLite + MemoryStorage for local testing
 
     model_config = {"env_file": ".env", "env_file_encoding": "utf-8", "extra": "ignore"}
@@ -36,6 +37,18 @@ class Settings(BaseSettings):
             return self
 
         raise ValueError("WEB_PASSWORD is required when DEV_MODE=false")
+
+    @model_validator(mode="after")
+    def validate_web_session_secret(self) -> Settings:
+        if self.WEB_SESSION_SECRET is not None:
+            return self
+
+        if self.DEV_MODE:
+            logging.warning("WEB_SESSION_SECRET is not set; generated an ephemeral dev session secret")
+            self.WEB_SESSION_SECRET = secrets.token_urlsafe(32)
+            return self
+
+        raise ValueError("WEB_SESSION_SECRET is required when DEV_MODE=false")
 
 
 settings = Settings()  # type: ignore[call-arg]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,7 @@ def app_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
     monkeypatch.setenv("WEB_BOT_USERNAME", "vibeshkoder_dev_bot")
     monkeypatch.setenv("DB_PASSWORD", "changeme")
     monkeypatch.setenv("WEB_PASSWORD", "test-pass")
+    monkeypatch.setenv("WEB_SESSION_SECRET", "test-session-secret")
     monkeypatch.setenv("DEV_MODE", "true")
     _clear_modules()
     yield

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -23,6 +23,7 @@ def test_settings_accept_explicit_values(app_env) -> None:
         WEB_BOT_USERNAME="vibeshkoder_dev_bot",
         DB_PASSWORD="changeme",
         WEB_PASSWORD="test-pass",
+        WEB_SESSION_SECRET="test-session-secret",
         DEV_MODE=True,
     )
 
@@ -30,6 +31,7 @@ def test_settings_accept_explicit_values(app_env) -> None:
     assert settings.ADMIN_IDS == [149820031]
     assert settings.DEV_MODE is True
     assert settings.WEB_PASSWORD == "test-pass"
+    assert settings.WEB_SESSION_SECRET == "test-session-secret"
 
 
 def test_config_no_password_prod_raises(app_env, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -66,6 +68,36 @@ def test_config_no_password_dev_warns(
     assert settings.WEB_PASSWORD
     assert settings.WEB_PASSWORD != "admin"
     assert "WEB_PASSWORD is not set" in caplog.text
+
+
+def test_config_no_session_secret_prod_raises(
+    app_env, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config = import_module("bot.config")
+    Settings = config.Settings
+    monkeypatch.delenv("WEB_SESSION_SECRET")
+    monkeypatch.setenv("DEV_MODE", "false")
+
+    with pytest.raises(
+        ValidationError, match="WEB_SESSION_SECRET is required when DEV_MODE=false"
+    ):
+        Settings()
+
+
+def test_config_no_session_secret_dev_warns(
+    app_env, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    config = import_module("bot.config")
+    Settings = config.Settings
+    monkeypatch.delenv("WEB_SESSION_SECRET")
+    monkeypatch.setenv("DEV_MODE", "true")
+
+    with caplog.at_level(logging.WARNING):
+        settings = Settings()
+
+    assert settings.WEB_SESSION_SECRET
+    assert len(settings.WEB_SESSION_SECRET) >= 32
+    assert "WEB_SESSION_SECRET is not set" in caplog.text
 
 
 def test_config_explicit_password_used(app_env, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_web_auth.py
+++ b/tests/test_web_auth.py
@@ -14,6 +14,18 @@ def test_password_and_session_cookie_roundtrip(app_env) -> None:
     assert payload == {"authenticated": True}
 
 
+def test_verify_password_constant_time_correct(app_env) -> None:
+    auth = import_module("web.auth")
+
+    assert auth.verify_password("test-pass") is True
+
+
+def test_verify_password_constant_time_incorrect(app_env) -> None:
+    auth = import_module("web.auth")
+
+    assert auth.verify_password("wrong-pass") is False
+
+
 def test_invalid_cookie_returns_none(app_env) -> None:
     auth = import_module("web.auth")
 

--- a/web/auth.py
+++ b/web/auth.py
@@ -1,20 +1,23 @@
 from __future__ import annotations
 
-import hashlib
+import hmac
 
 from itsdangerous import URLSafeTimedSerializer, BadSignature, SignatureExpired
 
 from web.config import settings
 
-_SECRET_KEY = hashlib.sha256(settings.BOT_TOKEN.encode()).hexdigest()
+_SECRET_KEY = settings.WEB_SESSION_SECRET
 _serializer = URLSafeTimedSerializer(_SECRET_KEY)
 
 _COOKIE_MAX_AGE = 7 * 24 * 60 * 60  # 7 days
 
 
-def verify_password(password: str) -> bool:
+def verify_password(password: str | None) -> bool:
     """Check password against the configured WEB_PASSWORD."""
-    return password == settings.WEB_PASSWORD
+    if not password or settings.WEB_PASSWORD is None:
+        return False
+
+    return hmac.compare_digest(password.encode(), settings.WEB_PASSWORD.encode())
 
 
 def create_session_cookie() -> str:


### PR DESCRIPTION
## Summary

Sprint W1 from the security audit (Round 3, batched two findings on the same file).

**C2 (critical):** cookie signing key was derived from `BOT_TOKEN` via `hashlib.sha256(...)`. If `BOT_TOKEN` ever leaked, session forgery would be trivially possible — the bot identity AND web admin auth shared a single compromise vector. Fix introduces a separate `WEB_SESSION_SECRET` env var (independently rotatable).

**H4 (high):** `verify_password` used `password == settings.WEB_PASSWORD` (non-constant-time). Replaced with `hmac.compare_digest` over byte-encoded operands, with defensive guards for None/empty.

## Reviews

- **Product (Claude Code Reviewer)** — APPROVE. Spec done criteria 100% met. 3 nits (test naming, edge-case coverage, release notes one-liner) deferred.
- **Technical (Claude superpowers:code-reviewer)** — APPROVE. hmac semantics, defensive guard, validator ordering, test fidelity all sound.
- **Pattern**: Codex implementer → 2× Claude reviewers (different-model review per user rule).

## Files

- `bot/config.py` — added `WEB_SESSION_SECRET` field + validator (mirrors N1 WEB_PASSWORD pattern)
- `web/auth.py` — `_SECRET_KEY = settings.WEB_SESSION_SECRET` (BOT_TOKEN no longer in import chain), `verify_password` uses `hmac.compare_digest`
- `tests/conftest.py` — `app_env` fixture sets `WEB_SESSION_SECRET` (otherwise every test using app_env breaks the new prod validator)
- `tests/test_settings.py` + `tests/test_web_auth.py` — 4 new tests

## Test plan

- [ ] `.venv/bin/python -m pytest -v` → 18 passed
- [ ] `.venv/bin/python -m ruff check bot/ web/ tests/` → clean
- [ ] Manual smoke: prod env without WEB_SESSION_SECRET → app refuses to start
- [ ] Manual smoke: existing user sessions (signed with old BOT_TOKEN-derived key) get forced re-login on first deploy — expected, document in release notes

## Deployment notes

⚠️ **Coolify env must set `WEB_SESSION_SECRET` BEFORE deploy** or the bot will refuse to start. Generate via:
```
python -c "import secrets; print(secrets.token_urlsafe(32))"
```

⚠️ **Forced re-login**: all sessions signed with the previous (BOT_TOKEN-derived) key are invalidated on first deploy. Users must log in again. This is expected and consistent with proper secret rotation.

## Out of scope

- Cookie `secure=True` flag (deferred — requires TLS sprint C1 first)
- Session rotation, expiry changes
- Cookie payload format
- `web/routes/auth.py` changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)