### PR TITLE
docs(memory): bootstrap canonical memory system docs + dev env scaffold

### DIFF
--- a/.env.dev.example
+++ b/.env.dev.example
@@ -1,0 +1,36 @@
+# Dev bot environment template.
+# Copy to .env.dev (gitignored) and fill in secrets.
+# Used for local live-ingestion testing of memory pipeline against dev postgres.
+
+# Telegram dev bot — fill in actual token in .env.dev (DO NOT commit)
+TELEGRAM_BOT_TOKEN=PLACEHOLDER_FILL_IN_DEV_BOT_TOKEN
+
+# Dev mode — enables permissive checks and verbose logging
+DEV_MODE=true
+LOG_LEVEL=DEBUG
+
+# Dev postgres (docker-compose.dev.yml exposes port 5433 to avoid prod clash)
+DATABASE_URL=postgresql+asyncpg://shkoder_dev:shkoder_dev@localhost:5433/shkoder_dev
+
+# Web admin — separate password and port from prod/staging
+WEB_PASSWORD=PLACEHOLDER_DEV_WEB_PASSWORD
+WEB_HOST=127.0.0.1
+WEB_PORT=8001
+
+# Google Sheets — disable or use a dedicated dev sheet, never the prod sheet
+GOOGLE_SHEETS_ENABLED=false
+GOOGLE_SHEETS_CREDENTIALS_PATH=
+GOOGLE_SHEETS_ID=
+
+# Community chat — fill with the dev chat id where the dev bot lives
+COMMUNITY_CHAT_ID=PLACEHOLDER_DEV_CHAT_ID
+
+# Admin Telegram user IDs (comma-separated) for dev — typically just your own id
+ADMIN_IDS=
+
+# Memory feature flags (default OFF — only enable explicitly during testing)
+# These are the runtime flags; the canonical defaults live in feature_flags table once T1-01 lands.
+MEMORY_INGESTION_RAW_UPDATES_ENABLED=false
+MEMORY_QA_ENABLED=false
+MEMORY_IMPORT_APPLY_ENABLED=false
+MEMORY_EXTRACTION_ENABLED=false

--- a/.env.dev.example
+++ b/.env.dev.example
@@ -22,15 +22,26 @@ GOOGLE_SHEETS_ENABLED=false
 GOOGLE_SHEETS_CREDENTIALS_PATH=
 GOOGLE_SHEETS_ID=
 
-# Community chat — fill with the dev chat id where the dev bot lives
-COMMUNITY_CHAT_ID=PLACEHOLDER_DEV_CHAT_ID
+# Community chat — fill with the SANDBOX dev chat id (NOT the real community chat).
+# Real-community testing requires a separate .env.dev.real (also gitignored) AND team-lead
+# approval in the PR. See docs/memory-system/DEV_SETUP.md §'Privacy guardrails for dev DB'.
+COMMUNITY_CHAT_ID=PLACEHOLDER_SANDBOX_DEV_CHAT_ID
 
 # Admin Telegram user IDs (comma-separated) for dev — typically just your own id
 ADMIN_IDS=
 
-# Memory feature flags (default OFF — only enable explicitly during testing)
+# Memory feature flags (default OFF — only enable explicitly during testing).
 # These are the runtime flags; the canonical defaults live in feature_flags table once T1-01 lands.
+# IMPORTANT: MEMORY_INGESTION_RAW_UPDATES_ENABLED MUST stay false until BOTH:
+#   (a) T1-12 + T1-13 land (deterministic #nomem / #offrecord detector + offrecord_marks), AND
+#   (b) T1-04 wires the detector inside the same DB transaction as the raw insert
+#       (per AUTHORIZED_SCOPE.md §'#offrecord ordering rule').
+# Setting this to true earlier will commit raw_json content for #offrecord messages → privacy violation.
 MEMORY_INGESTION_RAW_UPDATES_ENABLED=false
 MEMORY_QA_ENABLED=false
 MEMORY_IMPORT_APPLY_ENABLED=false
 MEMORY_EXTRACTION_ENABLED=false
+MEMORY_CARDS_ENABLED=false
+MEMORY_DIGEST_ENABLED=false
+MEMORY_WIKI_ENABLED=false
+MEMORY_GRAPH_ENABLED=false

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .env.dev
 .env.dev.real
 .superflow-state.json
+.par-evidence.json
 .worktrees/
 .claude/agent-memory/
 .claude/worktrees/

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 .env.production
 .env.staging
 .env.local
+.env.dev
+.superflow-state.json
 .worktrees/
 .claude/agent-memory/
 .claude/worktrees/

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .env.staging
 .env.local
 .env.dev
+.env.dev.real
 .superflow-state.json
 .worktrees/
 .claude/agent-memory/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,3 +30,22 @@ Vibe Gatekeeper is a Telegram + web gatekeeping system for managing community ap
 
 - The legacy production runtime at `/home/claw/vibe-gatekeeper` remains the live path until the new GitHub/GHCR/Coolify path is verified.
 - Do not cut over the production bot token during bootstrap work.
+
+## Memory System Cycle (active 2026-04-26+)
+
+A multi-phase migration from gatekeeper → governed community memory is in progress on a
+separate worktree (`feat/memory-foundation`). Read these BEFORE touching anything under
+`bot/db/`, `bot/services/`, `bot/handlers/chat_messages.py`, or adding `alembic/versions/`:
+
+1. `docs/memory-system/AUTHORIZED_SCOPE.md` — what is allowed in the immediate cycle
+   (Phase 0 + Phase 1). What is **not** authorized. Critical safety rule for `#offrecord`.
+2. `docs/memory-system/HANDOFF.md` — canonical 12-phase architecture, ticket backlog
+   (T0-* through T11-*), governance / ingestion / search / qa specs, future butler boundary.
+3. `docs/memory-system/IMPLEMENTATION_STATUS.md` — current status of every ticket. Updated
+   after every PR merge.
+4. `docs/memory-system/ROADMAP.md` — at-a-glance phase table with gates.
+5. `docs/memory-system/DEV_SETUP.md` — isolated dev postgres + dev bot live ingestion testing
+   protocol (sandbox-first; real chat requires team-lead approval).
+
+Issue tracker for memory cycle: **GitHub Issues** (label `phase:0`, `phase:1`, etc.). The
+`nt` (Notion) plugin remains the tracker for non-memory work in this repo if any.

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,33 @@
+# Dev compose — isolated postgres for memory pipeline testing.
+# Port 5433 deliberately avoids clash with prod/staging (5432).
+# Volume name suffixed -dev to avoid clash with existing volumes.
+#
+# Usage:
+#   cp .env.dev.example .env.dev
+#   # fill secrets in .env.dev
+#   docker compose -f docker-compose.dev.yml --env-file .env.dev up -d postgres-dev
+#   alembic upgrade head
+#   python -m bot
+#
+# Bot itself is run on the host so we can hot-iterate code; only the DB lives in compose.
+
+services:
+  postgres-dev:
+    image: postgres:16
+    container_name: shkoder-postgres-dev
+    environment:
+      POSTGRES_USER: shkoder_dev
+      POSTGRES_PASSWORD: shkoder_dev
+      POSTGRES_DB: shkoder_dev
+    ports:
+      - "127.0.0.1:5433:5432"
+    volumes:
+      - shkoder-postgres-dev:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "shkoder_dev", "-d", "shkoder_dev"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+volumes:
+  shkoder-postgres-dev:

--- a/docs/memory-system/AUTHORIZED_SCOPE.md
+++ b/docs/memory-system/AUTHORIZED_SCOPE.md
@@ -95,6 +95,40 @@ Committed storage for `#offrecord` keeps only minimal metadata:
 **No** search, q&a, extraction, summary, catalog, vector, graph, or wiki may use `#offrecord`
 content. Forbidden content never reaches `llm_gateway`.
 
+### `#offrecord` ordering rule (T1-04 ↔ T1-12 cross-cutting requirement)
+
+The ticket order in this cycle puts T1-04 (raw update persistence) BEFORE T1-12 (deterministic
+policy detector). Without an explicit rule, a compliant T1-04 implementation would commit
+content-bearing `raw_json` for several days before T1-12 lands the detector. That is a silent
+violation of the `#offrecord` rule.
+
+**Cross-cutting requirement (binding for both tickets):**
+
+1. **T1-04 must not merge until either (a) the detector stub is in place, or (b) the raw
+   archive feature flag `memory.ingestion.raw_updates.enabled` defaults to `false` AND there
+   is no production environment in which it is set to `true` until T1-12 lands.**
+
+2. T1-04's PR MUST include `bot/services/governance.py::detect_policy(text, caption) ->
+   ('normal'|'nomem'|'offrecord', mark_payload_or_None)` as a stub returning `('normal', None)`
+   for any input. The stub MUST be called inside the same DB transaction as the
+   `telegram_updates` insert. This guarantees that when T1-12 replaces the stub with the real
+   detector, the redaction path is already wired and atomic.
+
+3. T1-04's PR MUST persist content-bearing `raw_json` ONLY in the same DB transaction that
+   runs `detect_policy()`. If a future implementation moves the raw write to its own
+   transaction, the move requires explicit team-lead approval and a follow-up safety review.
+
+4. T1-12's PR replaces the stub with the real detector AND adds `offrecord_marks` insertion
+   (T1-13 is in the same PR or merged immediately after). Between T1-12 merge and T1-13 merge,
+   the detector still works — `offrecord_marks` adds the audit row, not the redaction itself.
+
+5. The redaction itself happens inside the same transaction: when `detect_policy()` returns
+   `'offrecord'`, the raw_json `text` / `caption` / `entities` fields are nulled or replaced
+   with a sentinel before commit. The hash, ids, timestamps, and policy marker are kept.
+
+If you are picking up T1-04 in isolation: implement the stub. Do not skip it. Do not merge a
+T1-04 that writes raw_json without going through the (stub) detector path.
+
 ---
 
 ## Telegram import rule (relevant if T2-01 is picked up)

--- a/docs/memory-system/AUTHORIZED_SCOPE.md
+++ b/docs/memory-system/AUTHORIZED_SCOPE.md
@@ -1,0 +1,164 @@
+# Authorized Execution Scope — Memory System Bootstrap
+
+**Date:** 2026-04-26
+**Cycle:** memory-foundation (first execution cycle on `feat/memory-foundation`)
+**Authority:** team lead cover note from architect handoff
+
+---
+
+## TL;DR
+
+Build only the **safety + source-of-truth foundation**. No LLM. No extraction. No catalog. No
+wiki. No graph. No butler. No public surfaces.
+
+If a ticket is not in the **authorized list** below, it is **out of scope** for this cycle and
+must wait for its phase gate.
+
+---
+
+## Authorized: Phase 0 — Gatekeeper stabilization
+
+| ID    | Title                                                              | Status                          |
+|-------|--------------------------------------------------------------------|---------------------------------|
+| T0-01 | Fix forward_lookup membership/admin check                          | DONE (PR#11, commit 7f95b53) — verifying coverage |
+| T0-02 | Fix/contain sqlite vs postgres upsert in UserRepo                  | TODO                            |
+| T0-03 | Make MessageRepo.save idempotent                                   | TODO                            |
+| T0-04 | Implementation status doc                                          | DONE in this commit (this dir) |
+| T0-05 | Add /healthz and startup checks                                    | TODO                            |
+| T0-06 | Add gatekeeper regression tests for T0-01..T0-03                   | TODO                            |
+
+## Authorized: Phase 1 — Source of truth + raw archive
+
+| ID    | Title                                                              | Notes                           |
+|-------|--------------------------------------------------------------------|---------------------------------|
+| T1-01 | feature_flags table/repo                                           | All memory flags default OFF    |
+| T1-02 | ingestion_runs table                                               | Run-id tagging                  |
+| T1-03 | telegram_updates table (raw archive)                               | Idempotent on update_id         |
+| T1-04 | raw update persistence service (`bot/services/ingestion.py`)       | Persists BEFORE normalization   |
+| T1-05 | Extend `chat_messages` (reply_to / thread / caption / kind / policy / visibility / content_hash) | Additive, all nullable |
+| T1-06 | message_versions table                                             | Provenance for citations later  |
+| T1-07 | Backfill v1 message_versions from existing chat_messages           | Chunked if needed               |
+| T1-08 | content_hash strategy                                              | Hash normalized text+caption+entities+kind |
+| T1-09 | Persist reply_to_message_id                                        | Nullable, unresolved OK         |
+| T1-10 | Persist message_thread_id                                          | Nullable                        |
+| T1-11 | Persist caption + classify message_kind                            | First-class content             |
+| T1-12 | Minimal `#nomem` / `#offrecord` policy detector                    | Deterministic only, no LLM      |
+| T1-13 | Minimal `offrecord_marks` table                                    | Pair with redaction in Phase 3  |
+| T1-14 | edited_message handler — only AFTER versions exist                 | Append v2 on hash change        |
+
+## Stretch (only if Phase 0+1 complete with time left)
+
+| ID    | Title                                                              | Notes                           |
+|-------|--------------------------------------------------------------------|---------------------------------|
+| T3-01 | forget_events tombstone skeleton                                   | Required before import apply    |
+| T2-01 | Telegram Desktop import dry-run parser                             | Dry-run only, no apply          |
+
+---
+
+## NOT authorized (future phases — gates not passed)
+
+Do not start, design, or write speculative code for:
+
+- Import **apply** (Phase 2b) — needs T3-01 + policy detection minimum.
+- Q&A bot (Phase 4) — needs message_versions + governance filters.
+- LLM calls of any kind — needs `llm_gateway` + ledger (Phase 5).
+- LLM extraction — Phase 5.
+- Vector search / pgvector — Phase 4+ at earliest.
+- Catalog / knowledge cards — Phase 6.
+- Daily summaries — Phase 7.
+- Weekly digest — Phase 8.
+- Wiki (member or public) — Phase 9.
+- Graph projection (Neo4j / Graphiti) — Phase 10.
+- Butler / action execution — Phase 12 (postponed; design only).
+- Person expertise pages — Phase 6+.
+- Public surfaces of any kind — Phase 9 with explicit approval.
+
+---
+
+## Critical safety rule for `#offrecord`
+
+> `#offrecord` content **must not** be durably stored as raw visible content.
+
+Implementation default for the policy detector + raw persistence:
+
+- **Detect `#offrecord` BEFORE committing content-bearing `raw_json`**, OR
+- Write raw update + redaction in the same transaction before commit.
+
+Committed storage for `#offrecord` keeps only minimal metadata:
+- chat id
+- message id
+- timestamp
+- hash / tombstone key
+- policy marker
+- audit metadata
+
+**No** search, q&a, extraction, summary, catalog, vector, graph, or wiki may use `#offrecord`
+content. Forbidden content never reaches `llm_gateway`.
+
+---
+
+## Telegram import rule (relevant if T2-01 is picked up)
+
+Telegram Desktop import has two modes:
+
+- **Dry-run** — allowed before full governance (Phase 2a). Parses the export, reports stats, **no
+  content writes**.
+- **Apply** — blocked until `#nomem` / `#offrecord` detection AND `forget_events` tombstone
+  skeleton both exist. Apply must use the same normalization + governance path as live Telegram
+  updates.
+
+---
+
+## `allowed_updates` rollout rule
+
+Do not add Telegram update types before storage + handler exist.
+
+| Update type                         | Required prerequisites                                  |
+|-------------------------------------|---------------------------------------------------------|
+| `edited_message`                    | message_versions table + edit handler (T1-06 + T1-14)   |
+| `message_reaction`                  | reactions table + handler (Phase 5)                     |
+| `message_reaction_count`            | reactions table + handler (Phase 5)                     |
+
+Adding an update type without a handler causes silent data loss. Always test the allowed_updates
+list against the registered routers.
+
+---
+
+## Agent execution rules
+
+Coding agents (any subagent that writes code in this cycle) MUST:
+
+1. Inspect current code before editing.
+2. Work ticket-by-ticket. One ticket per PR.
+3. Keep PRs small. If diff > ~400 lines, split.
+4. Preserve existing gatekeeper behaviour (onboarding / questionnaire / vouching / intro refresh).
+5. Add tests with every change.
+6. Never assume docs/specs are implemented — verify against the code.
+7. Never introduce LLM calls outside `llm_gateway` (which does not exist yet — so no LLM calls
+   at all in this cycle).
+8. Never implement future phases early.
+9. Never log secrets / env values.
+10. List changed files, tests run, and risks in the PR body.
+
+---
+
+## First-sprint definition of done
+
+By the end of the first sprint (this cycle):
+
+- Current gatekeeper still working (regression tests green).
+- `forward_lookup` privacy fix verified.
+- Sqlite/postgres upsert issue contained.
+- Duplicate message save safe (idempotent `MessageRepo.save`).
+- `feature_flags` table.
+- `ingestion_runs` table.
+- `telegram_updates` table.
+- Raw update persistence for current message updates.
+- Extended `chat_messages` fields.
+- `message_versions` with v1 backfill.
+- `reply_to_message_id` / `message_thread_id` / `caption` / `message_kind` persistence.
+- Minimal `#nomem` / `#offrecord` policy detection.
+- Minimal `offrecord_marks` table with detector wiring.
+- Tests covering all of the above.
+
+Everything else is out of scope until phase gates pass.

--- a/docs/memory-system/DEV_SETUP.md
+++ b/docs/memory-system/DEV_SETUP.md
@@ -1,0 +1,87 @@
+# Dev Setup — Memory System Live Testing
+
+Goal: run a dev instance of the bot against a separate dev postgres so we can verify the full
+ingestion + normalization + policy detection pipeline on real Telegram messages, without
+touching staging or prod data.
+
+## Components
+
+- **Dev bot** (token `8732572884:...` — kept in `.env.dev`, gitignored). Already added to the
+  target community chat with sufficient rights.
+- **Dev postgres** — isolated container on port 5433 (`docker-compose.dev.yml`).
+- **Local bot process** — runs on the host (`python -m bot`) reading `.env.dev` so we can
+  hot-iterate.
+
+## First-time setup
+
+```bash
+cd .worktrees/memory
+cp .env.dev.example .env.dev
+# fill in TELEGRAM_BOT_TOKEN, COMMUNITY_CHAT_ID, ADMIN_IDS, WEB_PASSWORD
+docker compose -f docker-compose.dev.yml --env-file .env.dev up -d postgres-dev
+docker compose -f docker-compose.dev.yml ps   # confirm postgres-dev is healthy
+alembic upgrade head
+```
+
+## Run the dev bot
+
+```bash
+# in worktree root
+set -a; source .env.dev; set +a
+python -m bot
+```
+
+Logs go to stdout. Keep this in one terminal; in another terminal do `psql` or `docker exec` to
+inspect tables.
+
+## Inspect dev DB
+
+```bash
+docker exec -it shkoder-postgres-dev psql -U shkoder_dev -d shkoder_dev -c "\dt"
+docker exec -it shkoder-postgres-dev psql -U shkoder_dev -d shkoder_dev -c "select count(*) from chat_messages;"
+```
+
+## Reset dev DB
+
+```bash
+docker compose -f docker-compose.dev.yml down -v   # WARNING: drops the dev volume
+docker compose -f docker-compose.dev.yml up -d postgres-dev
+alembic upgrade head
+```
+
+## Live testing flow per ticket
+
+For each Phase 1 ticket that touches ingestion (T1-03, T1-04, T1-05, T1-06, T1-12, T1-14):
+
+1. Apply migration locally: `alembic upgrade head`.
+2. Restart dev bot.
+3. Send a test message in the dev community chat (or use `/forward` for forward_lookup tests).
+4. Verify the row appears in the expected table:
+   - `select * from telegram_updates order by id desc limit 5;`
+   - `select * from chat_messages order by id desc limit 5;`
+   - `select * from message_versions order by id desc limit 5;`
+   - `select * from offrecord_marks order by id desc limit 5;`
+5. For edited_message: edit the test message in Telegram, verify a new `message_versions` row
+   appears with `version_seq = 2`.
+6. For policy detection: send a message containing `#nomem` or `#offrecord` token, verify
+   `memory_policy` and `offrecord_marks`.
+
+## Privacy guardrails for dev DB
+
+The dev bot is **in the real community chat**. As soon as `memory.ingestion.raw_updates.enabled`
+becomes true, the dev DB will start collecting real member messages. To minimize blast radius:
+
+- Keep the dev DB **local only** (no remote port binding — `127.0.0.1:5433` only).
+- `.env.dev` is gitignored. Never commit it.
+- Do NOT enable extraction / LLM / catalog / wiki flags in the dev environment until those
+  phases are gated.
+- When you are done testing for the day: `docker compose -f docker-compose.dev.yml down -v` to
+  drop the dev volume, OR keep it but understand the data sensitivity.
+- Once T1-12 + T1-13 land, `#nomem` / `#offrecord` detection will at least mark sensitive
+  messages — but minimal exposure remains the operative principle.
+
+## Out of scope for dev setup
+
+- staging / prod credentials — never used here
+- pulling prod data into dev — explicitly forbidden until a PII scrub pipeline exists
+- Google Sheets sync — disabled by default in `.env.dev.example`

--- a/docs/memory-system/DEV_SETUP.md
+++ b/docs/memory-system/DEV_SETUP.md
@@ -68,17 +68,42 @@ For each Phase 1 ticket that touches ingestion (T1-03, T1-04, T1-05, T1-06, T1-1
 
 ## Privacy guardrails for dev DB
 
-The dev bot is **in the real community chat**. As soon as `memory.ingestion.raw_updates.enabled`
-becomes true, the dev DB will start collecting real member messages. To minimize blast radius:
+**Default rule: dev testing happens in a dedicated sandbox Telegram chat, NOT the real
+community chat.** The dev bot ALSO has access to the real community chat for cases where
+real-traffic verification is required, but that path requires explicit team-lead approval AND
+a verified pre-commit `#offrecord` redaction (T1-12 + T1-13 + the `#offrecord` ordering rule
+in AUTHORIZED_SCOPE.md).
 
-- Keep the dev DB **local only** (no remote port binding — `127.0.0.1:5433` only).
-- `.env.dev` is gitignored. Never commit it.
-- Do NOT enable extraction / LLM / catalog / wiki flags in the dev environment until those
-  phases are gated.
-- When you are done testing for the day: `docker compose -f docker-compose.dev.yml down -v` to
-  drop the dev volume, OR keep it but understand the data sensitivity.
-- Once T1-12 + T1-13 land, `#nomem` / `#offrecord` detection will at least mark sensitive
-  messages — but minimal exposure remains the operative principle.
+### Hard guardrails (verifiable)
+
+1. **Sandbox-first.** Default `COMMUNITY_CHAT_ID` in `.env.dev` points at a dedicated test
+   chat. Tests in the real community chat require a separate `.env.dev.real` (which still
+   stays gitignored) AND team-lead sign-off in the PR description.
+2. **Raw archive disabled by default.** `.env.dev.example` sets
+   `MEMORY_INGESTION_RAW_UPDATES_ENABLED=false`. The T1-01 feature flag migration MUST default
+   the DB flag to `false`. Verify with:
+   ```bash
+   docker exec shkoder-postgres-dev psql -U shkoder_dev -d shkoder_dev -c \
+     "select flag_key, enabled from feature_flags where flag_key like 'memory.%';"
+   ```
+   Expected: every memory.* flag → `f`. If any is `t` without explicit team-lead approval,
+   stop and investigate.
+3. **No remote port binding.** `docker-compose.dev.yml` binds postgres to `127.0.0.1:5433`
+   only — never `0.0.0.0`. Verify with `docker ps --format '{{.Ports}}' | grep 5433`.
+4. **`.env.dev` and `.env.dev.real` are gitignored.** Never commit. `git check-ignore -q
+   .env.dev` must succeed.
+5. **No LLM / extraction / catalog / wiki flags** in dev until those phases are gated.
+6. **Volume cleanup after risky tests:** `docker compose -f docker-compose.dev.yml down -v`
+   drops the dev volume. Run after any session that touched the real chat.
+7. **No prod data pulls.** Never copy staging or prod DB content into dev. There is no PII
+   scrub pipeline yet — until one exists, this is forbidden.
+
+### Pre-commit `#offrecord` requirement (cross-ref)
+
+Until T1-12 + T1-13 land AND verifiable redaction is wired in T1-04 (per AUTHORIZED_SCOPE.md
+§`#offrecord` ordering rule), the dev environment MUST run with
+`MEMORY_INGESTION_RAW_UPDATES_ENABLED=false` even in sandbox mode. This prevents accidental
+durable storage of `#offrecord` content during early development.
 
 ## Out of scope for dev setup
 

--- a/docs/memory-system/HANDOFF.md
+++ b/docs/memory-system/HANDOFF.md
@@ -1,0 +1,1172 @@
+# Memory System — Architect Handoff (Canonical)
+
+**Captured:** 2026-04-26
+**Status:** canonical specification. All planning, ticketing, and execution derive from this
+document. Supersedes the v0.5 design spec (archived).
+
+---
+
+## Execution cover note for team lead
+
+This is the final architecture / backlog handoff for shkoder.
+
+**Important:** the document below describes the entire roadmap, but immediate execution scope is
+**limited**.
+
+### Authorized immediate scope
+
+On the first cycle of development, allowed to implement only:
+
+**Phase 0:**
+- fix `forward_lookup` privacy issue
+- fix / contain sqlite vs postgres upsert issue
+- make `MessageRepo.save` idempotent
+- add implementation status doc
+- add health / startup checks
+- add regression tests
+
+**Phase 1:**
+- add `feature_flags`
+- add `ingestion_runs`
+- add `telegram_updates`
+- add raw update persistence service
+- extend `chat_messages`
+- add `message_versions` + v1 backfill
+- persist `reply_to_message_id`
+- persist `message_thread_id`
+- persist `caption` / `message_kind`
+- add minimal `#nomem` / `#offrecord` detection
+- add `offrecord_marks` minimal table
+- add `edited_message` handler **only after** `message_versions` exists
+
+**Stretch:**
+- add `forget_events` tombstone skeleton
+- import dry-run parser
+
+### Not authorized yet
+
+Do not implement yet:
+
+- import apply
+- q&a bot
+- LLM calls
+- LLM extraction
+- vector search
+- catalog / cards
+- daily summaries
+- weekly digest
+- wiki
+- graph / Neo4j / Graphiti
+- butler / action execution
+- person expertise pages
+- public surfaces
+
+### Critical safety rule for `#offrecord`
+
+`#offrecord` must **not** be durably stored as raw visible content.
+
+Implementation default:
+
+- detect `#offrecord` BEFORE committing content-bearing `raw_json`, OR
+- write raw update + redaction in the same transaction before commit
+
+Committed storage for `#offrecord` should keep only minimal metadata:
+- chat id
+- message id
+- timestamp
+- hash / tombstone key
+- policy marker
+- audit metadata
+
+No search, q&a, extraction, summary, catalog, vector, graph, or wiki may use `#offrecord`
+content.
+
+### Import rule
+
+Telegram Desktop import has two modes:
+
+- **dry-run** — allowed before full governance
+- **apply** — blocked until `#nomem` / `#offrecord` detection AND `forget_events` /
+  tombstone skeleton both exist
+
+Import apply must use the same normalization / governance path as live Telegram updates.
+
+### `allowed_updates` rollout rule
+
+Do not add Telegram update types before storage / handler exists.
+
+- `edited_message` can be added only after `message_versions` and edited handler exist.
+- `message_reaction` / `message_reaction_count` can be added only after reactions table and
+  handlers exist.
+
+### Agent execution rules
+
+Coding agents must:
+
+- inspect current code before editing
+- work ticket-by-ticket
+- keep PRs small
+- preserve existing gatekeeper behaviour
+- add tests with every change
+- never assume docs / specs are implemented
+- never introduce LLM calls outside `llm_gateway`
+- never implement future phases early
+- never log secrets / env values
+- list changed files, tests run, and risks
+
+### First sprint target
+
+By the end of the first sprint:
+
+- current gatekeeper still working
+- `forward_lookup` privacy fixed
+- DB upsert issue contained
+- duplicate message save safe
+- `feature_flags` table
+- `ingestion_runs` table
+- `telegram_updates` table
+- raw update persistence for current message updates
+- extended `chat_messages` fields
+- `message_versions` with v1 backfill
+- reply / thread / caption / message_kind persistence
+- minimal `#nomem` / `#offrecord` policy detection
+- tests covering all of the above
+
+Everything else is out of scope until phase gates pass.
+
+---
+
+## §0. Team lead summary
+
+### What exists today
+
+The current repo is a vibe-gatekeeper foundation, **not a memory system**.
+
+Confirmed by audit of current git:
+
+- bot runs on aiogram long polling
+- `allowed_updates` currently includes only `message`, `callback_query`, `chat_member`,
+  `my_chat_member`
+- **no** `edited_message`, `message_reaction`, `message_reaction_count`
+- **no** handlers for edits / reactions
+- `chat_messages` stores only minimal fields: `id`, `message_id`, `chat_id`, `user_id`, `text`,
+  `date`, `raw_json`, `created_at`
+- **no** raw `telegram_updates`
+- **no** `message_versions`
+- **no** `reply_to_message_id`, `message_thread_id`, captions / entities / links / attachments
+  normalization
+- **no** import telegram desktop export
+- **no** `#nomem`, `#offrecord`, `/forget`, `/forget_me`, tombstones
+- admin web is the gatekeeper dashboard, not a memory review UI
+- **no** q&a with citations / confidence / abstention
+- **no** `llm_usage_ledger`, `feature_flags`
+- immediate risks present:
+  - `forward_lookup` could leak member intro without membership / admin check
+  - dev sqlite could conflict with postgres-specific upsert
+  - `chat_messages.save` is not a clean idempotent path
+
+### What we are building
+
+The next goal is a librarian / governed community memory system on top of the current
+gatekeeper:
+
+```
+gatekeeper
+  → source-of-truth archive
+    → governance
+      → import
+        → search / q&a with citations
+          → events / observations / candidates
+            → reviewed catalog / cards
+              → daily / weekly digest
+                → internal / member wiki
+```
+
+Future butler / action assistant is **not** built now. Only preserve extension points:
+permissions, audit, action boundary, future `action_requests` / `action_runs`.
+
+### What must happen first
+
+1. Close current safety / runtime risks.
+2. Add `feature_flags`.
+3. Add raw `telegram_updates`.
+4. Extend `chat_messages` without breaking existing gatekeeper.
+5. Add `message_versions`.
+6. Add minimal `#nomem` / `#offrecord` detector and `offrecord_marks`.
+7. Add `forget_events` tombstone skeleton.
+8. Only then — import apply, search / q&a, LLM, extraction.
+
+### What cannot be built yet
+
+Do not build until phase gates:
+
+- public wiki
+- graph DB
+- LLM extraction
+- vector-only q&a
+- auto digest
+- catalog without admin review
+- person expertise pages
+- butler action execution
+
+### Key risks
+
+| Risk                              | Why it matters                                                      |
+|-----------------------------------|---------------------------------------------------------------------|
+| Gatekeeper breakage               | Current functionality must survive.                                 |
+| Privacy leak                      | `forward_lookup` risk already exists; memory amplifies consequences |
+| Forgotten content resurrection    | Import / extraction / catalog without tombstones revives deleted    |
+| Bad citations                     | Without `message_versions`, q&a cites unstable text                 |
+| Docs / spec confusion             | Old docs ≠ implementation                                           |
+| AI agents jumping ahead           | LLM / catalog / wiki before governance — forbidden                  |
+
+### Recommended execution mode
+
+- One lead holds the phase gates.
+- AI dev agents take small tickets.
+- Every PR:
+  - small
+  - with tests
+  - with listed changed files
+  - without future-phase scope creep
+  - without secrets / logging values
+  - without LLM calls outside `llm_gateway`
+  - without search / extraction access to forbidden content
+
+---
+
+## §1. Final implementation strategy
+
+### Strategy
+
+1. **Preserve gatekeeper.** Existing onboarding / questionnaire / vouching / intro refresh /
+   Google Sheets / admin dashboard must keep working. Early migrations are additive.
+   `chat_messages` is extended, not replaced.
+
+2. **Build source-of-truth archive.** Before q&a / import / extraction:
+   - `feature_flags`
+   - `ingestion_runs`
+   - `telegram_updates`
+   - extended `chat_messages`
+   - `message_versions`
+   - `chat_threads`
+   - metadata tables: `entities`, `links`, `attachments`
+
+3. **Add governance before memory.** `#nomem`, `#offrecord`, `/forget`, `/forget_me`,
+   tombstones, audit must appear before extraction / catalog / digest / wiki.
+
+4. **Add search / q&a before extraction.** First lexical / full-text retrieval + evidence bundle
+   + citations + abstention. Provides value without premature "smart" memory extraction.
+
+5. **Add extraction before catalog.** Only after governance / search / source trace:
+   - deterministic prefilter
+   - event extraction
+   - observations
+   - candidates
+   - LLM ledger
+   - admin review
+
+6. **Add catalog before digest / wiki.** Digest / wiki must reference approved cards / sources,
+   not loose extractions.
+
+7. **Postpone graph and butler.** Graph is a derived projection after cards / events stable.
+   Butler is design-only, no implementation.
+
+### Critical path
+
+```
+phase 0 safety
+  → feature_flags
+    → ingestion_runs + telegram_updates
+      → extend chat_messages
+        → message_versions
+          → #nomem/#offrecord + offrecord_marks
+            → forget_events / tombstones
+              → import apply
+                → fts / evidence
+                  → q&a with citations
+                    → llm_gateway / ledger
+                      → extraction / events / observations / candidates
+                        → cards / admin review
+                          → summaries / digests / wiki
+```
+
+### Parallelizable tracks
+
+After phase 0:
+
+- DB migration drafting
+- tests / fixtures
+- admin health / read-only screens
+- import dry-run parser
+- docs implementation status
+- q&a eval case design
+
+Cannot parallelize without gate:
+
+- import apply before tombstones
+- `edited_message` before `message_versions`
+- reactions before reactions table / handler
+- LLM extraction before `llm_gateway` + governance
+- wiki before review / source trace
+
+### Phase gates
+
+| Gate                  | Must be true                                                                            |
+|-----------------------|-----------------------------------------------------------------------------------------|
+| Gatekeeper safety     | privacy fix, idempotent save, upsert contained, tests green                             |
+| Source of truth       | raw updates + message versions + basic normalization exist                              |
+| Governance            | `#nomem` / `#offrecord`, tombstones, forget skeleton, filters exist                     |
+| Q&A                   | FTS, evidence bundle, citations, refusal, policy filters                                |
+| Extraction            | LLM gateway, ledger, source validation, budget guard                                    |
+| Catalog               | cards require sources and admin review                                                  |
+| Wiki                  | visibility + review + source trace + forget purge                                       |
+
+### Non-negotiable invariants
+
+1. Existing gatekeeper must not break.
+2. No LLM calls outside `llm_gateway`.
+3. No extraction / search / q&a over `#nomem` / `#offrecord` / forgotten.
+4. Citations point to `message_version_id` or approved card sources.
+5. Summary is never canonical truth.
+6. Graph is never source of truth.
+7. Future butler cannot read raw DB directly; must use governance-filtered evidence context.
+8. Import apply must go through the same normalization / governance path as live updates.
+9. Tombstones are durable and not casually rolled back.
+10. Public wiki remains disabled until review / source trace / governance are proven.
+
+---
+
+## §2. Phase roadmap
+
+### Phase 0 — gatekeeper stabilization
+
+- **Objective:** close immediate safety / runtime risks.
+- **Starting point:** working gatekeeper, simple admin web, minimal message capture.
+- **Scope:** `forward_lookup` privacy, upsert containment, idempotent message save, docs
+  implementation status, health checks, regression tests.
+- **Out of scope:** memory schema, import, q&a, LLM.
+- **Dependencies:** none.
+- **Entry criteria:** current repo baseline audited.
+- **Exit criteria:** current gatekeeper tests pass; privacy risk fixed; duplicate message safe.
+- **Acceptance:** non-member cannot use `forward_lookup` to reveal intro; `MessageRepo.save`
+  duplicate-safe; dev / test upsert safe; `/healthz` exists.
+- **Risks:** small fixes accidentally change onboarding / vouch behaviour.
+- **Rollback:** code-only rollback; no destructive data changes.
+
+### Phase 1 — source of truth + raw archive
+
+- **Objective:** create governed source-of-truth archive.
+- **Starting point:** no raw `telegram_updates`, no versions.
+- **Scope:** `feature_flags`, `ingestion_runs`, `telegram_updates`, extend `chat_messages`,
+  `message_versions`, `chat_threads`, metadata tables.
+- **Out of scope:** import apply, q&a, LLM, catalog.
+- **Dependencies:** phase 0.
+- **Entry criteria:** duplicate-safe message save; tests green.
+- **Exit criteria:** live message produces raw update + normalized message + v1 version.
+- **Acceptance:** reply / thread / caption / `message_kind` persisted; raw update idempotent;
+  existing messages backfilled to v1 versions.
+- **Risks:** raw payload privacy; transaction boundaries.
+- **Rollback:** additive migrations; feature flags default off.
+
+### Phase 2a — Telegram Desktop import dry-run
+
+- **Objective:** parse export and produce safe stats without content writes.
+- **Starting point:** no importer.
+- **Scope:** JSON parser, dry-run report, fixture tests.
+- **Out of scope:** apply mode, LLM, catalog.
+- **Dependencies:** phase 1 preferred; can start parser earlier with fixtures.
+- **Entry criteria:** import file format understood enough for fixture parser.
+- **Exit criteria:** dry-run reports counts / date / users / replies / duplicates / policy
+  markers.
+- **Acceptance:** dry-run does not write message content.
+- **Risks:** export format ambiguity.
+- **Rollback:** no content mutation.
+
+### Phase 2b — Telegram Desktop import apply (only after governance skeleton)
+
+- **Objective:** import history through same governed normalization path.
+- **Scope:** synthetic `telegram_updates`, idempotent apply, duplicate prevention, reply
+  resolver, tombstone / policy checks.
+- **Dependencies:** phase 1 + phase 3 skeleton.
+- **Entry criteria:** `forget_events`, `offrecord_marks`, `#nomem` / `#offrecord` detector
+  exist.
+- **Exit criteria:** same export can be applied twice without duplicates.
+- **Acceptance:** imported rows tagged by `ingestion_run_id`; tombstone conflicts skipped.
+- **Risks:** resurrection, duplicate imports, sensitive historical content.
+- **Rollback:** imported run can be logically rolled back before derived layers.
+
+### Phase 3 — governance
+
+- **Objective:** implement memory privacy / governance primitives.
+- **Scope:** `#nomem`, `#offrecord`, `/forget`, `/forget_me`, `offrecord_marks`,
+  `forget_events`, `admin_actions`, cascade skeleton.
+- **Dependencies:** phase 1.
+- **Entry criteria:** messages and versions exist.
+- **Exit criteria:** forbidden content is excluded from future search / extraction / import.
+- **Acceptance:** `/forget` creates tombstone; offrecord content redacted; nomem excluded;
+  reimport tombstone check exists.
+- **Risks:** incomplete cascade, historical `raw_json` content.
+- **Rollback:** completed forget is not casually rolled back.
+
+### Phase 4 — hybrid search + q&a with citations
+
+- **Objective:** answer questions from evidence only.
+- **Scope:** FTS-first retrieval, evidence bundle, citations, confidence / abstention, q&a
+  traces.
+- **Dependencies:** phases 1 and 3.
+- **Entry criteria:** `message_versions` and governance filters exist.
+- **Exit criteria:** bot can answer simple history questions with citations or refuse.
+- **Acceptance:** cites `message_version_id`; excludes forbidden content; refuses no evidence.
+- **Risks:** hallucination if LLM used too early.
+- **Rollback:** q&a feature flag off.
+
+### Phase 5 — events + observations + extraction candidates
+
+- **Objective:** create structured pre-catalog memory.
+- **Scope:** `llm_usage_ledger`, `extraction_runs`, `memory_events`, `observations`,
+  `reflection_runs`, `memory_candidates`.
+- **Dependencies:** phase 4 + `llm_gateway`.
+- **Entry criteria:** governance filters, evidence bundle, ledger, budget guard.
+- **Exit criteria:** high-signal windows produce sourced candidates.
+- **Acceptance:** no forbidden source sent to LLM; every output has source refs.
+- **Risks:** hallucinated extraction, budget runaway.
+- **Rollback:** derived rows rebuildable / deletable.
+
+### Phase 6 — knowledge cards + admin review
+
+- **Objective:** curated catalog with review and source trace.
+- **Scope:** `memory_items`, `knowledge_cards`, `card_sources`, `card_relations`, review UI.
+- **Dependencies:** phase 5.
+- **Entry criteria:** candidates with source refs and admin actions.
+- **Exit criteria:** admin can approve cards with citations.
+- **Acceptance:** card cannot become active without source; visibility enforced.
+- **Risks:** extractions becoming "truth" without review.
+- **Rollback:** hide cards via status / flag.
+
+### Phase 7 — daily summaries
+
+- **Objective:** daily sourced recap.
+- **Scope:** `summaries`, `summary_sources`, daily draft, review / publish.
+- **Dependencies:** phase 4 minimum; phase 5 / 6 recommended.
+- **Acceptance:** every bullet has source; forgotten source redacts bullet.
+
+### Phase 8 — weekly digest
+
+- **Objective:** weekly editorial digest.
+- **Scope:** `digests`, `digest_sections`, weekly ranking / review / publish.
+- **Dependencies:** phase 7 and cards / events preferred.
+- **Acceptance:** required sections have sources and review state.
+
+### Phase 9 — wiki / community catalog
+
+- **Objective:** internal / member browsable catalog.
+- **Scope:** member / internal pages, digest archive, source citations, visibility filters.
+- **Dependencies:** phases 3, 6, 8.
+- **Acceptance:** member catalog shows only approved visible cards. **Public wiki disabled by
+  default.**
+
+### Phase 10 — Graphiti / Neo4j projection
+
+- **Objective:** derived graph traversal.
+- **Scope:** `graph_sync_runs`, incremental / full rebuild, graph sidecar.
+- **Dependencies:** stable cards / events / relations.
+- **Acceptance:** graph can be rebuilt from postgres; forget purges graph.
+
+### Phase 11 — shkoderbench / evals hardening
+
+- **Objective:** regression safety for q&a / catalog / digest / governance.
+- **Scope:** `eval_cases`, `eval_runs`, `eval_results`, runner, admin eval view.
+- **Acceptance:** no-evidence, citation, leakage, stale tests exist.
+
+### Phase 12 — future butler action layer (design only / postponed)
+
+- **Objective:** preserve extension points only.
+- **Scope:** design notes, **no code execution**.
+- **Acceptance:** team has documented boundary for future butler.
+- **No-go:** no butler code shipped.
+
+---
+
+## §3. Dependency graph
+
+```
+phase 0 safety
+├── forward_lookup privacy
+├── upsert containment
+├── idempotent message save
+└── tests / health / docs
+
+phase 1 source-of-truth
+├── feature_flags
+├── ingestion_runs
+├── telegram_updates
+├── extend chat_messages
+│   ├── reply_to_message_id
+│   ├── message_thread_id
+│   ├── caption / message_kind
+│   └── memory_policy / visibility fields
+├── message_versions
+│   └── edited_message handler
+└── metadata tables
+    ├── message_entities
+    ├── message_links
+    └── attachments
+
+phase 3 governance
+├── offrecord_marks
+├── forget_events
+├── admin_actions
+├── /forget
+├── /forget_me
+└── cascade skeleton
+
+phase 2 import
+├── 2a dry-run can start after parser fixtures
+└── 2b apply blocked by phase 3 skeleton
+
+phase 4 q&a
+├── blocked by message_versions
+├── blocked by governance filters
+├── full-text search
+├── evidence bundle
+└── q&a handler
+
+phase 5 extraction
+├── blocked by q&a / source trace
+├── blocked by governance
+├── blocked by llm_gateway / ledger
+└── events / observations / candidates
+
+phase 6 cards
+└── blocked by candidates + admin review
+
+phase 7/8 digest
+└── blocked by source trace + events / cards
+
+phase 9 wiki
+└── blocked by governance + review + source trace
+
+phase 10 graph
+└── blocked by cards / events / relations stable
+
+phase 12 butler
+└── blocked / postponed; design only
+```
+
+### Sequential blockers
+
+| Blocked item                | Blocker                                                  |
+|-----------------------------|----------------------------------------------------------|
+| `edited_message` allowed    | `message_versions` table + handler                       |
+| `message_reaction` updates  | reactions table + handler                                |
+| import apply                | tombstone + policy skeleton                              |
+| q&a                         | `message_versions` + governance filters                  |
+| LLM answer generation       | `llm_gateway` + ledger                                   |
+| extraction                  | governance + evidence / source trace + LLM gateway       |
+| cards                       | candidates + admin review                                |
+| wiki                        | cards + review + visibility + governance                 |
+| graph                       | postgres events / cards / relations stable               |
+| butler                      | future permissions / action audit, not now               |
+
+---
+
+## §4. Implementation epics
+
+| Epic | Title                                       | Phase | Pri | Description                                              |
+|------|---------------------------------------------|-------|-----|----------------------------------------------------------|
+| E0   | Gatekeeper safety fixes                     | 0     | p0  | Fix current privacy / runtime risks from audit.          |
+| E1   | Feature flags                               | 1     | p0  | Persistent rollout flags for memory surfaces.            |
+| E2   | Raw Telegram update log                     | 1     | p0  | Store raw updates before normalization.                  |
+| E3   | Normalized message archive                  | 1     | p0  | Extend `chat_messages` for normalized fields.            |
+| E4   | Message versions and edit handling          | 1     | p0  | Create `message_versions`; add edit handler.             |
+| E5   | Reply / thread / caption / entities / links / attachments metadata | 1 | p1 | Normalize Telegram metadata. |
+| E6   | `#nomem` / `#offrecord` policy detection    | 3     | p0  | Deterministic policy detection before memory / search.   |
+| E7   | `forget_events` / tombstones / cascade      | 3     | p0  | Right-to-forget primitives.                              |
+| E8   | Telegram Desktop import dry-run             | 2a    | p1  | Parse export and report stats.                           |
+| E9   | Telegram Desktop import apply               | 2b    | p1  | Import via synthetic updates.                            |
+| E10  | Full-text search and evidence bundle        | 4     | p0  | FTS + evidence / citations.                              |
+| E11  | Q&A with citations / confidence / abstention| 4     | p0  | Member q&a from evidence only.                           |
+| E12  | LLM gateway and usage ledger                | 5     | p0  | Single audited LLM path.                                 |
+| E13  | Reactions ingestion and scoring             | 5     | p1  | Add reactions as importance signal.                      |
+| E14  | Event calendar                              | 5     | p1  | Structured `memory_events`.                              |
+| E15  | Observations / reflection / candidates      | 5     | p1  | Analytical layer and review candidates.                  |
+| E16  | Knowledge cards / sources / relations       | 6     | p1  | Curated catalog data model.                              |
+| E17  | Admin review UI                             | 6     | p1  | Review candidates / cards / digests / governance.        |
+| E18  | Daily summary                               | 7     | p2  | Sourced daily recap.                                     |
+| E19  | Weekly digest                               | 8     | p2  | Weekly editorial digest.                                 |
+| E20  | Wiki / community catalog                    | 9     | p2  | Internal / member catalog / wiki.                        |
+| E21  | Graph projection                            | 10    | p2  | Graphiti / Neo4j projection.                             |
+| E22  | Shkoderbench / evals                        | 4–11  | p1  | Eval cases / runs / results.                             |
+| E23  | Future butler extension design — postponed  | 12    | p2  | Document action boundary only.                           |
+
+---
+
+## §5. Ticket backlog (full)
+
+> Authorized for the immediate cycle: **all of T0-* and T1-* below**, plus stretch T3-01 and
+> T2-01. Everything else is for later phases. See `AUTHORIZED_SCOPE.md`.
+
+### Phase 0 tickets
+
+| ID    | Title                                          | Pri | Cmplx | Deps     | Acceptance                                                              |
+|-------|------------------------------------------------|-----|-------|----------|-------------------------------------------------------------------------|
+| T0-01 | Fix `forward_lookup` membership/admin check    | p0  | s     | none     | non-member denied; member allowed; admin allowed; no intro in denial    |
+| T0-02 | Fix / contain sqlite vs postgres upsert        | p0  | m     | none     | upsert works in configured dev / test                                   |
+| T0-03 | Make `MessageRepo.save` idempotent             | p0  | m     | T0-02    | duplicate same chat / message no error                                  |
+| T0-04 | Implementation status doc                      | p1  | s     | none     | doc names memory as not implemented                                     |
+| T0-05 | `/healthz` + startup checks                    | p1  | m     | none     | `/healthz` exists; web health test                                      |
+| T0-06 | Regression tests for T0-01..T0-03              | p0  | m     | T0-01..03| privacy / upsert / duplicate tests green                                |
+
+### Phase 1 tickets
+
+| ID    | Title                                          | Pri | Cmplx | Deps     | Acceptance                                                              |
+|-------|------------------------------------------------|-----|-------|----------|-------------------------------------------------------------------------|
+| T1-01 | `feature_flags` table / repo                   | p0  | s     | T0       | default memory flags off                                                |
+| T1-02 | `ingestion_runs`                               | p0  | s     | T1-01    | run row tracks live / import                                            |
+| T1-03 | `telegram_updates`                             | p0  | m     | T1-02    | unique `update_id`; idempotent insert                                   |
+| T1-04 | Raw update persistence service                 | p0  | m     | T1-03    | message update writes raw row before normalization                      |
+| T1-05 | Extend `chat_messages` fields                  | p0  | l     | T1-04    | old rows survive; new fields nullable                                   |
+| T1-06 | `message_versions`                             | p0  | l     | T1-05    | new message has v1                                                      |
+| T1-07 | Backfill v1 `message_versions`                 | p0  | m     | T1-06    | all existing messages get v1                                            |
+| T1-08 | `content_hash` strategy                        | p0  | s     | T1-06    | same content same hash; uses normalized text+caption+entities+kind      |
+| T1-09 | Persist `reply_to_message_id`                  | p0  | s     | T1-05    | reply id stored                                                         |
+| T1-10 | Persist `message_thread_id`                    | p0  | s     | T1-05    | thread id stored if present                                             |
+| T1-11 | Persist caption / `message_kind`               | p0  | m     | T1-05    | caption not lost; media classified                                      |
+| T1-12 | Minimal `#nomem` / `#offrecord` detector       | p0  | m     | T1-05    | policy persists                                                         |
+| T1-13 | `offrecord_marks` minimal table                | p0  | m     | T1-12    | mark exists for policy token                                            |
+| T1-14 | `edited_message` handler (after versions)      | p1  | m     | T1-06    | edit creates v2                                                         |
+
+### Phase 2/3 tickets (stretch only T2-01 and T3-01 in this cycle)
+
+| ID    | Title                                          | Pri | Cmplx | Deps             | Acceptance                                              |
+|-------|------------------------------------------------|-----|-------|------------------|---------------------------------------------------------|
+| T2-01 | Import dry-run parser                          | p1  | m     | T1-02            | no content writes; fixture dry-run                      |
+| T2-02 | Import dry-run duplicate / policy stats        | p1  | m     | T2-01, T1-12     | stats include conflicts                                 |
+| T3-01 | `forget_events` table                          | p0  | m     | T1-13            | tombstone key unique                                    |
+| T3-02 | `/forget` reply command                        | p0  | m     | T3-01, T1-06     | own / admin allowed, others denied                      |
+| T3-03 | `/forget_me` skeleton                          | p1  | l     | T3-01            | event created and queued                                |
+| T3-04 | Cascade worker skeleton                        | p0  | l     | T3-01            | event status progresses                                 |
+| T3-05 | Reimport tombstone prevention                  | p0  | m     | T3-01, T2-01     | skipped content recorded                                |
+| T2-03 | Import apply with synthetic updates            | p1  | xl    | T3-05, T1-04     | no duplicates                                           |
+
+### Phase 4+ tickets (later cycles)
+
+T4-01 FTS, T4-02 evidence bundle, T4-03 q&a handler, T4-04 citations / confidence / abstention,
+T4-05 q&a traces, T5-01 LLM gateway + ledger, T5-02 extraction runs, T5-03 memory events,
+T5-04 observations / reflection / candidates, T6-01 cards + sources, T6-02 card relations + admin
+review UI, T7-01 daily summary, T8-01 weekly digest, T9-01 member / internal wiki, T10-01 graph
+projection, T11-01 eval tables / runner.
+
+---
+
+## §6. Database migration specification (essentials)
+
+### Global migration rules
+
+- Early migrations are **additive**.
+- Do not add NOT NULL columns to populated tables without default / backfill.
+- Preserve existing gatekeeper tables and behaviour.
+- `chat_messages` stays the canonical normalized message table early on.
+- Imported data must be tagged by `ingestion_run_id`.
+- Tombstones are durable.
+- Derived layers are rebuildable.
+
+### Authorized migrations (this cycle)
+
+| # | Migration name                          | Notes                                                          |
+|---|-----------------------------------------|----------------------------------------------------------------|
+| 1 | `add_feature_flags`                     | Unique `(flag_key, scope_type, scope_id)`. Memory flags off.   |
+| 2 | `add_ingestion_runs`                    | `run_type` check: live / import / dry_run / cancelled.         |
+| 3 | `add_telegram_updates`                  | Unique `update_id` (partial where not null). Raw archive.      |
+| 4 | `extend_chat_messages`                  | All new columns nullable / default. Backfill memory_policy='normal'. |
+| 5 | `add_message_versions`                  | Unique `(chat_message_id, version_seq)`. v1 backfill.          |
+| 6 | `add_chat_threads`                      | Optional this cycle; useful for explicit topics.               |
+| 7 | `add_message_entities` (if scope allows)| Derived; can defer if T1-11 enough.                            |
+| 8 | `add_message_links`                     | Deterministic parse from text / caption only. No external fetch. |
+| 9 | `add_attachments`                       | Metadata only. No downloads.                                   |
+|11 | `add_offrecord_marks`                   | Deterministic detector writes here.                            |
+
+> Tables 10 (user consent fields), 12 (`forget_events`), 13 (`admin_actions`), 14 (FTS + qa
+> traces), 15+ (reactions, ledger, extraction, events, cards, etc.) — later phases.
+
+Full column-by-column spec lives further down in the architect's original handoff (see archived
+copy if needed). For each migration in this cycle, the implementation ticket holds the column
+list it implements.
+
+---
+
+## §7. Module and service contracts (this cycle)
+
+### `bot/services/ingestion.py` (Phase 1)
+
+- **Public methods:** `record_update(update, source_kind='live', ingestion_run_id=None) ->
+  TelegramUpdateRecord`; `get_or_create_live_run()`; `mark_update_processed(update_id, status)`.
+- **Idempotency:** `update_id` for live; raw hash / export id for import.
+- **Must not:** call LLM; do extraction; do catalog; do policy redaction beyond delegating to
+  governance redactor when it exists.
+- **Tests:** duplicate update; raw hash; import synthetic update.
+
+### `bot/services/normalization.py` (Phase 1)
+
+- **Public methods:** `normalize_message(raw_update_id, message_obj)`,
+  `normalize_edited_message(raw_update_id, edited_message_obj)`,
+  `extract_entities_links_attachments(message_version_id, message_obj)`.
+- **Outputs:** `chat_message`, `message_version`, metadata rows.
+- **Idempotency:** `(chat_id, message_id)` and `(message_id, content_hash)` for versions.
+- **Must not:** summarize / extract; fetch external; generate answers.
+- **Tests:** text / caption / reply / thread / edit / media.
+
+### `bot/services/governance.py` (Phase 1 detector skeleton; Phase 3 full)
+
+- **Public methods (this cycle):** `detect_policy(text, caption)`,
+  `apply_policy(message_id, policy)`. Tombstone / cascade / forget come in Phase 3.
+- **Fail closed:** if policy unknown, exclude from memory until resolved.
+- **Must not:** silently hard-delete without tombstone / admin action.
+- **Tests:** `#nomem` / `#offrecord` token detection in text and caption.
+
+### `bot/services/health.py` (Phase 0)
+
+- **Public methods:** `check_db()`, `check_bot_identity()`, `check_settings()`, `report()`.
+- Used by `/healthz` and startup.
+
+---
+
+## §8. Bot runtime changes
+
+### `allowed_updates` rollout
+
+| Stage                    | `allowed_updates`                                        | Reason                              |
+|--------------------------|----------------------------------------------------------|-------------------------------------|
+| Current                  | `message`, `callback_query`, `chat_member`, `my_chat_member` | current gatekeeper              |
+| After Phase 1 versions   | add `edited_message`                                     | only when `message_versions` and handler exist |
+| After reactions table    | add `message_reaction`, `message_reaction_count`         | only when persisted / processed     |
+
+Never silently — adding an update type without a handler = invisible data loss.
+
+### Feature flag gating (Phase 1+)
+
+- `memory.ingestion.raw_updates.enabled`
+- `memory.qa.enabled`
+- `memory.import.apply.enabled`
+- `memory.extraction.enabled`
+- `memory.cards.enabled`
+- `memory.digest.enabled`
+- `memory.wiki.enabled`
+- `memory.graph.enabled`
+
+Default: all risky flags off except raw archive after deployment.
+
+### Startup checks (Phase 0)
+
+- bot identity check
+- DB connection
+- configured community chat id present
+- `allowed_updates` logged
+- feature flags snapshot logged without secrets
+
+### Health (`/healthz`)
+
+- app alive + DB reachable
+- no env values in response
+
+---
+
+## §9. Ingestion + normalization spec
+
+### Live message update flow
+
+1. Persist raw `telegram_updates` (idempotent on `update_id`).
+2. Normalize user / chat (upsert users; create chat row if phase includes chats; do not infer
+   consent).
+3. Detect `#nomem` / `#offrecord` deterministically; write `memory_policy`; write
+   `offrecord_marks` when table exists.
+4. Upsert `chat_messages` keyed by `(chat_id, message_id)` with new normalized fields.
+5. Create `message_versions` v1 if new message; if duplicate same hash → no new version.
+6. Persist `reply_to_message_id` (nullable; unresolved OK).
+7. Persist `message_thread_id` (nullable; create `chat_threads` row if explicit topic).
+8. Persist caption / `message_kind`. Captions are first-class content. Media-only messages still
+   get metadata.
+9. Persist entities / links / attachments metadata as the phase allows. No external fetch. No
+   attachment download by default.
+10. Do not extract / summarize / search forbidden content. `#nomem`: exclude from memory /
+    search / q&a / extraction. `#offrecord`: redact content per policy.
+
+### Edited message flow
+
+1. Persist raw update.
+2. Find `chat_messages` by `(chat_id, message_id)`.
+3. Compute new content hash.
+4. If hash changed:
+   - insert `message_versions` with `version_seq = max + 1`
+   - update `current_version_id`
+   - update current text / caption compatibility fields if needed
+5. Re-run policy detection.
+6. Mark derived objects stale later.
+7. If original message missing: create placeholder `chat_messages` with
+   `message_kind='unknown_prior_version'`, then version from edit; log unresolved prior version.
+
+### Transaction boundaries
+
+- Raw update insert in its own safe transaction OR at the beginning of the update transaction.
+- Normalization in same transaction after raw insert.
+- Derived jobs queued only after commit.
+- Duplicate conflicts handled in repos, not broad handler rollback.
+
+### Idempotency keys
+
+| Object                        | Key                                                            |
+|-------------------------------|----------------------------------------------------------------|
+| Raw live update               | `update_id`                                                    |
+| Synthetic import update       | `ingestion_run_id` + `export_message_id` or raw hash           |
+| Chat message                  | `(chat_id, message_id)`                                        |
+| Message version               | `(chat_message_id, content_hash)` or `(chat_message_id, version_seq)` |
+| Link                          | `(message_version_id, canonical_url)`                          |
+| Attachment                    | `file_unique_id` + message ref                                 |
+
+### `content_hash` strategy
+
+Hash normalized tuple:
+```
+text || caption || entities_json_normalized || message_kind
+```
+Do not hash volatile `raw_json` fields.
+
+### `raw_json` redaction strategy
+
+For `#offrecord`:
+- keep ids / timestamps / hash / policy marker
+- redact text / caption / entities / media captions
+- keep tombstone key
+
+For `#nomem`:
+- content may remain internal / raw but excluded from derived layers
+
+---
+
+## §10. Governance spec (skeleton)
+
+### Policy table
+
+| Policy   | Stored content                  | Search / q&a | Extraction | Summaries / digest | Catalog / wiki / graph | LLM         |
+|----------|---------------------------------|--------------|------------|--------------------|-------------------------|-------------|
+| normal   | yes                             | yes if visibility allows | yes if eligible | yes              | yes if reviewed         | via gateway |
+| nomem    | internal / raw allowed          | no           | no         | no                 | no                      | no          |
+| offrecord| redacted / minimal metadata     | no           | no         | no                 | no                      | no          |
+| forgotten| tombstone / minimal metadata    | no           | no         | no                 | no                      | no          |
+
+### `#nomem`
+
+- Detect in text / caption.
+- Set `memory_policy='nomem'`.
+- Write `offrecord_marks(mark_type='nomem')`.
+- Exclude before FTS / vector / extraction / q&a / summary / catalog.
+
+### `#offrecord`
+
+- Detect in text / caption.
+- Set `memory_policy='offrecord'`.
+- Write `offrecord_marks(mark_type='offrecord')`.
+- Redact durable content. Keep ids / timestamps / hash / policy marker.
+
+### `forget_events` (Phase 3)
+
+Required fields: target type / id; actor; `authorized_by`; `tombstone_key`; reason; policy;
+status; cascade status.
+
+Tombstone keys (multiple matching where possible):
+- `message:<chat_id>:<message_id>`
+- `message_hash:<sha256 normalized content>`
+- `user:<telegram_user_id>`
+- `export:<source>:<export_message_id>` for import
+
+### `/forget` authorization (Phase 3)
+
+| Actor          | Target              | Allowed                        |
+|----------------|---------------------|--------------------------------|
+| author         | own message         | yes                            |
+| admin          | any message         | yes                            |
+| other member   | another user message| no, or admin-review request    |
+| unknown        | any                 | no                             |
+
+### Cascade layers (Phase 3 skeleton)
+
+`chat_messages` → `message_versions` → `message_entities` → `message_links` → `attachments` →
+FTS / search materialized rows if present. Later: vectors, events, observations, candidates,
+cards, summaries, digests, graph, wiki rendered pages, eval cases.
+
+---
+
+## §11. Test strategy and quality gates
+
+| Category               | Phase | What to test                                              |
+|------------------------|-------|-----------------------------------------------------------|
+| Unit                   | 0     | Pure services / repos. Policy detector, content hash.     |
+| DB                     | 0–1   | Migrations / repos / constraints. Upsert, duplicate, v1.  |
+| Handler                | 0–4   | Bot handlers offline. forward lookup, q&a trigger, forget.|
+| Import                 | 2     | Dry-run / apply fixtures. Duplicate, replies, media.      |
+| Governance             | 3     | Policy / forget / cascade. nomem exclusion, offrecord.    |
+| Search / q&a           | 4     | FTS / evidence / answer. No-evidence refusal, citations.  |
+| Extraction             | 5     | Schemas / ledger / source validation.                     |
+| Catalog                | 6     | Card lifecycle. Active card needs source / review.        |
+| Digest                 | 7–8   | Summary / digest sources. Every bullet has source.        |
+| Wiki visibility        | 9     | member / public / internal filters.                       |
+| Graph rebuild          | 10    | Derived graph. Full rebuild, forget purge.                |
+| Eval / shkoderbench    | 4–11  | Regression suite.                                         |
+
+### Must-have tests (this cycle)
+
+- non-member `forward_lookup` denied — DONE in T0-01
+- `UserRepo.upsert` works in dev / test — T0-02
+- duplicate message safe — T0-03
+- raw update idempotency — T1-03
+- `message_versions` v1 backfill — T1-07
+- edited message creates v2 — T1-14 (after T1-06)
+- `reply_to_message_id` persists — T1-09
+- `message_thread_id` persists — T1-10
+- caption persists — T1-11
+- `#nomem` excluded from memory derived layers — T1-12 / T1-13
+
+---
+
+## §12. Rollout and deployment plan
+
+### Phase 0 rollout
+
+- Deploy code-only fixes.
+- Verify `forward_lookup` denial.
+- Verify `/healthz` endpoint.
+- Verify gatekeeper flows.
+
+### Phase 1 rollout
+
+- Apply additive migrations.
+- Deploy raw update persistence disabled or shadow mode.
+- Enable raw update logging.
+- Verify no handler latency spike.
+- Backfill v1 versions after reviewing script / migration.
+
+### Rollback
+
+| Layer                 | Rollback                                                |
+|-----------------------|---------------------------------------------------------|
+| Feature               | turn flag off                                           |
+| Raw update logging    | disable new writes; keep existing rows                  |
+| Import                | rollback import run before derived layers               |
+| Q&A                   | disable q&a handler flag                                |
+| Extraction            | disable extraction; derived rows hidden / deleted       |
+| Forget                | do not rollback tombstones casually                     |
+
+### Monitoring (this cycle)
+
+- `/healthz` uptime
+- ingestion error counts
+- duplicate update count (after T1-03)
+- policy detection count (after T1-12)
+
+---
+
+## §13. Agentic development instructions
+
+Coding agents:
+
+1. Always inspect current code before editing.
+2. Never assume docs / specs are implemented.
+3. Keep PRs small and ticket-scoped.
+4. Preserve gatekeeper behaviour.
+5. Add tests with every change.
+6. Do not bypass repositories / services.
+7. Do not log secrets / env values.
+8. Do not introduce LLM calls outside `llm_gateway`.
+9. Do not access forbidden content in search / extraction.
+10. Do not implement future phases early.
+11. Do not add update types without handler / storage.
+12. Every ticket must include self-review.
+
+### Pre-PR checklist
+
+- ticket id included
+- changed files listed
+- tests added / updated
+- tests run locally or verification method stated
+- no secrets logged
+- no future-phase scope creep
+- gatekeeper compatibility checked
+- migration additive or explicitly justified
+- forbidden content filters considered
+- rollback / disable path stated
+- risks stated
+
+---
+
+## §14. First sprint execution plan
+
+### Sprint goal
+
+Within 7–10 working days: stabilize gatekeeper and lay source-of-truth foundation without
+launching memory product.
+
+### Exact task order
+
+1. T0-01 — DONE (verified).
+2. T0-02 fix / contain sqlite / postgres upsert.
+3. T0-03 make `MessageRepo.save` idempotent.
+4. T0-06 add regression tests for above.
+5. T1-01 add `feature_flags`.
+6. T1-02 add `ingestion_runs`.
+7. T1-03 add `telegram_updates`.
+8. T1-04 add raw update persistence service.
+9. T1-05 extend `chat_messages`.
+10. T1-06 / T1-07 add / backfill `message_versions`.
+11. T1-09 / T1-10 / T1-11 persist reply / thread / caption / kind.
+12. T1-12 / T1-13 minimal policy detector + `offrecord_marks`.
+13. T1-14 `edited_message` handler only after versions.
+14. Stretch: T3-01 `forget_events` skeleton.
+15. Stretch: T2-01 import dry-run parser.
+
+### Recommended parallelization (subagents)
+
+| Agent | Work                                          |
+|-------|-----------------------------------------------|
+| A     | T0-01 verify (done) + T0-06 regression tests  |
+| B     | T0-02, T0-03 repo / DB idempotency            |
+| C     | T1-01 / T1-02 migrations                      |
+| D     | T1-03 / T1-04 ingestion service               |
+| E     | T1-05 / T1-06 / T1-07 schema + versions       |
+| F     | T2-01 import dry-run fixture (no apply)       |
+
+### Files / modules touched
+
+- `bot/handlers/forward_lookup.py` (verified — no further changes this ticket)
+- `bot/db/repos/user.py`
+- `bot/db/repos/message.py`
+- `bot/db/models.py`
+- `bot/handlers/chat_messages.py`
+- `bot/__main__.py`
+- `bot/services/ingestion.py` (new)
+- `bot/services/normalization.py` (new)
+- `bot/services/governance.py` (new)
+- `bot/services/health.py` (new)
+- `alembic/versions/*` (new)
+- `tests/*`
+
+---
+
+## §15. Team lead operating guide
+
+### Sequential review required
+
+- migrations touching existing tables
+- governance / tombstones
+- raw update persistence
+- visibility / public surfaces
+
+### Code review checklist
+
+- no secrets logged
+- no future-phase scope
+- no direct LLM provider call
+- no raw DB access from future action layer
+- service / repo boundaries respected
+- migrations additive
+- tests cover failure cases
+
+### Privacy checklist
+
+- requester authorization checked
+- visibility filters applied
+- forbidden content excluded
+- public / member separation respected
+- audit actions logged
+
+### Escalate to product owner only for
+
+- exact retention / legal policy if stronger than defaults
+- whether `/forget_me` redacts all authored content or anonymizes only
+- whether public wiki is ever allowed
+- whether member identity can appear in expertise pages
+- whether historical already-saved content should be retrospectively scanned / redacted
+
+---
+
+## §16. Risk register
+
+| Risk                                         | Phase  | Impact     | Mitigation                                              |
+|----------------------------------------------|--------|------------|---------------------------------------------------------|
+| Gatekeeper breakage                          | 0–1    | high       | Additive changes, feature flags                         |
+| `forward_lookup` privacy leak                | 0      | high       | membership / admin check (DONE)                         |
+| Dev / prod DB mismatch                       | 0      | medium-high| Dialect-safe repos or postgres dev                      |
+| Raw update privacy                           | 1      | high       | offrecord redaction, no public raw views                |
+| `#offrecord` stored too durably              | 3      | critical   | Redact content fields, keep minimal metadata            |
+| Forget resurrection                          | 3 / 2b+| critical   | Tombstones checked everywhere                           |
+| Import duplicates                            | 2      | high       | Idempotency keys                                        |
+| Bad citations                                | 4      | high       | `message_versions` / evidence validation                |
+| Q&A hallucination                            | 4      | high       | Evidence-only prompt / refusal                          |
+| LLM cost runaway                             | 5      | medium-high| Gateway caps                                            |
+| Public wiki leak                             | 9      | critical   | Public disabled by default                              |
+| Person expertise creepiness                  | 6 / 9  | high       | Member / internal, evidence-based, opt-out              |
+| Graph divergence                             | 10     | medium-high| Graph derived / rebuildable                             |
+| Butler bypassing governance                  | 12 (future) | critical | Postponed; action boundary docs                       |
+| Docs / spec confusion                        | 0+     | medium     | Implementation status doc maintained                    |
+| Agents implement future phases too early     | all    | high       | Ticket scope, phase gates, checklist enforcement        |
+
+---
+
+## §17. Definition of done
+
+### Ticket DoD
+- ticket acceptance criteria met
+- tests added / updated
+- changed files listed
+- no secrets
+- no scope creep
+- rollback / disable path stated
+- privacy impact considered
+
+### Phase DoD
+- phase exit criteria met
+- phase gate checklist passed
+- deployment / rollback reviewed
+- docs / status updated
+- next phase blockers known
+
+### Migration DoD
+- additive or explicitly reviewed
+- no unsafe non-null on populated table
+- indexes / constraints reviewed
+- downgrade / rollback note present
+- backfill tested
+- existing gatekeeper data preserved
+
+### Governance feature DoD
+- policy behaviour tested
+- audit / tombstone created
+- search / extraction exclusion tested
+- import resurrection tested if applicable
+
+---
+
+## §18. Final recommendation
+
+**Go for Phase 0 and Phase 1.**
+**No-go for q&a / extraction / catalog / digest / wiki / graph / butler** until their phase gates
+are satisfied.
+
+### Exact first move
+
+T0-01 was already merged by the security audit cycle (PR#11, commit `7f95b53`) and is verified
+PASS by the architect's hard acceptance criteria. Three minor follow-up gaps captured as
+T0-01-r1/r2/r3 (test coverage only).
+
+**Next first move: T0-02 fix / contain sqlite vs postgres upsert.** Direct gatekeeper safety
+fix and unblocks T0-03 (idempotent message save).
+
+### Recommendation to team lead
+
+Run this as a controlled migration from gatekeeper to librarian: first close current safety
+gaps, then build raw / source / version / governance foundation, and only then add search /
+q&a, extraction, cards, digest and wiki. Do not let AI agents accelerate into LLM, graph or
+butler: without tombstones, source trace and review this becomes not a memory system but a very
+confident archiver of private problems. The first sprint must be boring and ironclad — privacy,
+idempotency, raw archive, versions, policy skeleton. That is what gives shkoder the right to
+remember later.

--- a/docs/memory-system/HANDOFF.md
+++ b/docs/memory-system/HANDOFF.md
@@ -625,7 +625,7 @@ phase 12 butler
 | T1-01 | `feature_flags` table / repo                   | p0  | s     | T0       | default memory flags off                                                |
 | T1-02 | `ingestion_runs`                               | p0  | s     | T1-01    | run row tracks live / import                                            |
 | T1-03 | `telegram_updates`                             | p0  | m     | T1-02    | unique `update_id`; idempotent insert                                   |
-| T1-04 | Raw update persistence service                 | p0  | m     | T1-03    | message update writes raw row before normalization                      |
+| T1-04 | Raw update persistence service                 | p0  | m     | T1-03    | message update writes raw row before normalization; **MUST include stub `governance.detect_policy()` returning `('normal', None)` called in same DB transaction as raw insert** (cross-ref AUTHORIZED_SCOPE `#offrecord` ordering rule); raw archive flag defaults OFF |
 | T1-05 | Extend `chat_messages` fields                  | p0  | l     | T1-04    | old rows survive; new fields nullable                                   |
 | T1-06 | `message_versions`                             | p0  | l     | T1-05    | new message has v1                                                      |
 | T1-07 | Backfill v1 `message_versions`                 | p0  | m     | T1-06    | all existing messages get v1                                            |
@@ -633,7 +633,7 @@ phase 12 butler
 | T1-09 | Persist `reply_to_message_id`                  | p0  | s     | T1-05    | reply id stored                                                         |
 | T1-10 | Persist `message_thread_id`                    | p0  | s     | T1-05    | thread id stored if present                                             |
 | T1-11 | Persist caption / `message_kind`               | p0  | m     | T1-05    | caption not lost; media classified                                      |
-| T1-12 | Minimal `#nomem` / `#offrecord` detector       | p0  | m     | T1-05    | policy persists                                                         |
+| T1-12 | Minimal `#nomem` / `#offrecord` detector       | p0  | m     | T1-05    | `#nomem` and `#offrecord` detected in BOTH text AND caption fields; `chat_messages.memory_policy` persists; `offrecord_marks` row created (with T1-13); `#offrecord` raw_json text/caption fields redacted in same transaction as raw insert (cross-ref AUTHORIZED_SCOPE §`#offrecord` ordering rule) |
 | T1-13 | `offrecord_marks` minimal table                | p0  | m     | T1-12    | mark exists for policy token                                            |
 | T1-14 | `edited_message` handler (after versions)      | p1  | m     | T1-06    | edit creates v2                                                         |
 
@@ -672,23 +672,47 @@ projection, T11-01 eval tables / runner.
 - Tombstones are durable.
 - Derived layers are rebuildable.
 
-### Authorized migrations (this cycle)
+### Authorized migrations (this cycle — strict)
 
-| # | Migration name                          | Notes                                                          |
-|---|-----------------------------------------|----------------------------------------------------------------|
-| 1 | `add_feature_flags`                     | Unique `(flag_key, scope_type, scope_id)`. Memory flags off.   |
-| 2 | `add_ingestion_runs`                    | `run_type` check: live / import / dry_run / cancelled.         |
-| 3 | `add_telegram_updates`                  | Unique `update_id` (partial where not null). Raw archive.      |
-| 4 | `extend_chat_messages`                  | All new columns nullable / default. Backfill memory_policy='normal'. |
-| 5 | `add_message_versions`                  | Unique `(chat_message_id, version_seq)`. v1 backfill.          |
-| 6 | `add_chat_threads`                      | Optional this cycle; useful for explicit topics.               |
-| 7 | `add_message_entities` (if scope allows)| Derived; can defer if T1-11 enough.                            |
-| 8 | `add_message_links`                     | Deterministic parse from text / caption only. No external fetch. |
-| 9 | `add_attachments`                       | Metadata only. No downloads.                                   |
-|11 | `add_offrecord_marks`                   | Deterministic detector writes here.                            |
+Only migrations that have a corresponding ticket in `AUTHORIZED_SCOPE.md` are authorized in
+this cycle. Implementing additional migrations without a ticket is out-of-scope creep.
 
-> Tables 10 (user consent fields), 12 (`forget_events`), 13 (`admin_actions`), 14 (FTS + qa
-> traces), 15+ (reactions, ledger, extraction, events, cards, etc.) — later phases.
+| # | Migration name                          | Ticket  | Notes                                                          |
+|---|-----------------------------------------|---------|----------------------------------------------------------------|
+| 1 | `add_feature_flags`                     | T1-01   | Unique `(flag_key, scope_type, scope_id)`. Memory flags off.   |
+| 2 | `add_ingestion_runs`                    | T1-02   | `run_type` check: live / import / dry_run / cancelled.         |
+| 3 | `add_telegram_updates`                  | T1-03   | Unique `update_id` (partial where not null). Raw archive.      |
+| 4 | `extend_chat_messages`                  | T1-05   | All new columns nullable / default. Backfill memory_policy='normal'. |
+| 5 | `add_message_versions`                  | T1-06 + T1-07 | Unique `(chat_message_id, version_seq)`. v1 backfill.    |
+| 6 | `add_offrecord_marks`                   | T1-13   | Deterministic detector writes here.                            |
+| 7 | (stretch) `add_forget_events`           | T3-01   | Tombstone skeleton. Stretch.                                   |
+
+### NOT authorized this cycle (later phases — DO NOT IMPLEMENT)
+
+| Migration name                          | Phase   | Why not now                                                    |
+|-----------------------------------------|---------|----------------------------------------------------------------|
+| `add_chat_threads`                      | 1+      | No ticket in this cycle. Adding a `message_thread_id` int on `chat_messages` is enough for T1-10. |
+| `add_message_entities`                  | 1+      | Derived metadata. Defer until search / qa needs it.            |
+| `add_message_links`                     | 1+ / 4  | Defer until search / qa needs link normalization.              |
+| `add_attachments`                       | 1+ / 5  | Defer until reactions / extraction needs media metadata.       |
+| `add_user_consent_anonymization_fields` | 3       | Phase 3 governance.                                            |
+| `add_admin_actions`                     | 3       | Phase 3 governance audit.                                      |
+| `add_search_indexes_and_qa_traces`      | 4       | Phase 4 q&a.                                                   |
+| `add_reactions`                         | 5       | Phase 5; requires reactions handler first.                     |
+| `add_llm_usage_ledger`                  | 5       | Phase 5; requires `llm_gateway`.                               |
+| `add_extraction_runs` and downstream    | 5+      | Phase 5+ extraction.                                           |
+| `add_memory_events`                     | 5       | Phase 5.                                                       |
+| `add_observations`                      | 5       | Phase 5.                                                       |
+| `add_reflection_runs`                   | 5       | Phase 5.                                                       |
+| `add_memory_candidates`                 | 5       | Phase 5.                                                       |
+| `add_memory_items`                      | 6       | Phase 6 catalog.                                               |
+| `add_knowledge_cards`                   | 6       | Phase 6 catalog.                                               |
+| `add_card_sources`                      | 6       | Phase 6.                                                       |
+| `add_card_relations`                    | 6       | Phase 6.                                                       |
+| `add_summaries` / `add_summary_sources` | 7       | Phase 7.                                                       |
+| `add_digests` / `add_digest_sections`   | 8       | Phase 8.                                                       |
+| `add_graph_sync_runs`                   | 10      | Phase 10.                                                      |
+| `add_eval_tables`                       | 11      | Phase 11.                                                      |
 
 Full column-by-column spec lives further down in the architect's original handoff (see archived
 copy if needed). For each migration in this cycle, the implementation ticket holds the column
@@ -746,16 +770,24 @@ Never silently — adding an update type without a handler = invisible data loss
 
 ### Feature flag gating (Phase 1+)
 
-- `memory.ingestion.raw_updates.enabled`
-- `memory.qa.enabled`
-- `memory.import.apply.enabled`
-- `memory.extraction.enabled`
-- `memory.cards.enabled`
-- `memory.digest.enabled`
-- `memory.wiki.enabled`
-- `memory.graph.enabled`
+> **Naming convention:** feature flag keys use **dot notation** (`memory.ingestion.raw_updates.enabled`).
+> Database column names use **underscore** (`memory_policy`, `is_redacted`). These are
+> deliberately different — a flag-key lookup is `feature_flags.get('memory.ingestion.raw_updates.enabled')`,
+> a column read is `chat_messages.memory_policy`. Do not confuse them.
 
-Default: all risky flags off except raw archive after deployment.
+Flag keys (canonical defaults: ALL OFF until their phase gate):
+
+- `memory.ingestion.raw_updates.enabled` — raw `telegram_updates` write enabled (T1-03 / T1-04). MUST stay OFF until T1-12 + T1-13 land per the `#offrecord` ordering rule.
+- `memory.qa.enabled` — q&a handler enabled (Phase 4)
+- `memory.import.apply.enabled` — Telegram Desktop import apply (Phase 2b)
+- `memory.extraction.enabled` — LLM extraction runs (Phase 5)
+- `memory.cards.enabled` — knowledge cards lifecycle (Phase 6)
+- `memory.digest.enabled` — daily / weekly digests (Phase 7-8)
+- `memory.wiki.enabled` — internal / member wiki (Phase 9)
+- `memory.graph.enabled` — graph projection sync (Phase 10)
+
+Default: all flags OFF in this cycle. Operators may toggle `memory.ingestion.raw_updates.enabled`
+ON ONLY after T1-12 / T1-13 land AND the `#offrecord` ordering rule is verifiable.
 
 ### Startup checks (Phase 0)
 
@@ -776,11 +808,19 @@ Default: all risky flags off except raw archive after deployment.
 
 ### Live message update flow
 
-1. Persist raw `telegram_updates` (idempotent on `update_id`).
+> **Critical ordering rule:** steps 1 and 3 happen in the SAME DB transaction. The raw insert
+> calls `governance.detect_policy()` (stub or real) BEFORE commit. If `detect_policy` returns
+> `'offrecord'`, the raw_json text/caption/entities are redacted (nulled or sentinel-replaced)
+> in the same transaction. Hash / ids / timestamps / policy marker are kept. See
+> AUTHORIZED_SCOPE.md §`#offrecord` ordering rule.
+
+1. Persist raw `telegram_updates` row in transaction T (idempotent on `update_id`); do NOT
+   commit yet.
 2. Normalize user / chat (upsert users; create chat row if phase includes chats; do not infer
-   consent).
-3. Detect `#nomem` / `#offrecord` deterministically; write `memory_policy`; write
-   `offrecord_marks` when table exists.
+   consent). Same transaction T.
+3. Detect `#nomem` / `#offrecord` deterministically (T1-12 detector or T1-04 stub); write
+   `memory_policy`; write `offrecord_marks` when table exists. If `'offrecord'`: redact
+   raw_json content fields in transaction T BEFORE commit.
 4. Upsert `chat_messages` keyed by `(chat_id, message_id)` with new normalized fields.
 5. Create `message_versions` v1 if new message; if duplicate same hash → no new version.
 6. Persist `reply_to_message_id` (nullable; unresolved OK).

--- a/docs/memory-system/IMPLEMENTATION_STATUS.md
+++ b/docs/memory-system/IMPLEMENTATION_STATUS.md
@@ -1,0 +1,117 @@
+# Memory System — Implementation Status
+
+**Last updated:** 2026-04-26 (cycle start)
+**Branch:** `feat/memory-foundation` (worktree `.worktrees/memory`)
+**Source of truth:** this file is updated after every PR merge into `main`.
+
+---
+
+## Reading this file
+
+- **Status legend:**
+  - `not started` — no code exists
+  - `in progress` — branch open, PR not merged
+  - `done` — merged into `main`, verified
+  - `verified` — `done` + independent reviewer confirmed acceptance criteria
+  - `done (legacy)` — code existed before this cycle; needs verification mapping
+
+- If a phase is missing from the table — it has not begun.
+
+---
+
+## Phase 0 — Gatekeeper stabilization
+
+| Ticket | Title                                                       | Status         | Notes |
+|--------|-------------------------------------------------------------|----------------|-------|
+| T0-01  | Fix forward_lookup membership/admin check                   | verified       | Merged in PR#11 / commit `7f95b53` (security audit C3). Verified 2026-04-26: PASS by architect's hard criteria (auth guard before DB lookup; silent denial; no info leakage; admin allowed; member allowed; tests cover (a)(b)(c)(d)). Three minor follow-up gaps captured as T0-01-r1/r2/r3 below. |
+| T0-01-r1 | Test: admin authorized via `settings.ADMIN_IDS` (env-only) | not started    | nice-to-have. Patch ADMIN_IDS=[user_id] with is_admin=False in DB; verify lookup proceeds. |
+| T0-01-r2 | Test: unknown user (UserRepo.get returns None) silent return | not started   | nice-to-have. Cover the ghost-user code path. |
+| T0-01-r3 | Distinguish denial log lines: "user not in DB" vs "not a member" | not started | quality. Audit log clarity. |
+| T0-02  | Fix/contain sqlite vs postgres upsert in UserRepo           | not started    | First implementation ticket of this cycle. |
+| T0-03  | Make MessageRepo.save idempotent                            | not started    |
+| T0-04  | Implementation status doc                                   | done           | This file + ROADMAP.md + AUTHORIZED_SCOPE.md + HANDOFF.md. |
+| T0-05  | /healthz + startup checks                                   | not started    |
+| T0-06  | Regression tests for T0-01..T0-03                           | not started    |
+
+## Phase 1 — Source of truth + raw archive
+
+| Ticket | Title                                                       | Status         | Notes |
+|--------|-------------------------------------------------------------|----------------|-------|
+| T1-01  | feature_flags table/repo                                    | not started    |
+| T1-02  | ingestion_runs table                                        | not started    |
+| T1-03  | telegram_updates table                                      | not started    |
+| T1-04  | raw update persistence service                              | not started    |
+| T1-05  | Extend chat_messages columns                                | not started    | All new columns nullable / default. |
+| T1-06  | message_versions table                                      | not started    |
+| T1-07  | v1 backfill                                                 | not started    | Chunked if needed. |
+| T1-08  | content_hash strategy                                       | not started    | Normalized text+caption+entities+kind. |
+| T1-09  | Persist reply_to_message_id                                 | not started    |
+| T1-10  | Persist message_thread_id                                   | not started    |
+| T1-11  | Persist caption + message_kind                              | not started    |
+| T1-12  | Minimal #nomem / #offrecord detector                        | not started    | Deterministic only. No LLM. |
+| T1-13  | offrecord_marks minimal table                               | not started    |
+| T1-14  | edited_message handler                                      | not started    | Blocked by T1-06. |
+
+## Phase 2a — Import dry-run (stretch)
+
+| Ticket | Title                                                       | Status         | Notes |
+|--------|-------------------------------------------------------------|----------------|-------|
+| T2-01  | Telegram Desktop import dry-run parser                      | not started    | Stretch only. No apply. |
+
+## Phase 3 — Governance (stretch skeleton)
+
+| Ticket | Title                                                       | Status         | Notes |
+|--------|-------------------------------------------------------------|----------------|-------|
+| T3-01  | forget_events tombstone skeleton                            | not started    | Stretch. Required before T2-02 import apply. |
+
+## Phases 2b, 4–12
+
+Not started. Not authorized. See `AUTHORIZED_SCOPE.md` for gating rules.
+
+---
+
+## What exists in the current codebase (baseline 2026-04-26)
+
+Confirmed by inspecting `bot/`, `web/`, `alembic/`, `tests/` on `main`:
+
+- aiogram bot (long polling), `bot/__main__.py`. `allowed_updates` currently includes only:
+  `message`, `callback_query`, `chat_member`, `my_chat_member`. **No** `edited_message`,
+  `message_reaction`, `message_reaction_count`. No edit / reaction handlers.
+- `bot/db/models.py` — `users`, `applications`, `questionnaire_answers`, `intros`,
+  `chat_messages`, `intro_refresh_tracking`, `vouch_log`. `chat_messages` has only:
+  `id`, `message_id`, `chat_id`, `user_id`, `text`, `date`, `raw_json`, `created_at`. No
+  `reply_to_message_id`, no `message_thread_id`, no `caption`, no `message_kind`, no
+  `memory_policy`, no `visibility`, no `content_hash`, no `current_version_id`.
+- No `telegram_updates` table.
+- No `message_versions` table.
+- No `feature_flags` / `ingestion_runs` / `offrecord_marks` / `forget_events` / `chat_threads`.
+- No import path (Telegram Desktop or otherwise).
+- No `#nomem` / `#offrecord` detection.
+- No `/forget` / `/forget_me` commands.
+- No q&a, no LLM gateway, no extraction, no catalog, no wiki, no graph.
+- Admin web is the gatekeeper dashboard, not a memory review UI.
+- Tests: `test_all.py`, `test_flow.py`, plus `tests/` with security audit additions and
+  `scheduler_deadlines` isolation fix from commit `c70cc4e`.
+
+## Active risks (carried from architect handoff)
+
+| Risk                                                | Status                                |
+|-----------------------------------------------------|---------------------------------------|
+| `forward_lookup` privacy leak                       | fixed in PR#11; verifier confirming   |
+| Dev sqlite vs postgres-specific upsert              | open — T0-02                          |
+| `MessageRepo.save` not cleanly idempotent           | open — T0-03                          |
+| Old `SPEC.md` and v0.5 design spec out of date      | mitigated — v0.5 archived; SPEC.md    |
+|                                                     | will get a status banner in T0-04 PR  |
+
+---
+
+## Update protocol
+
+After each PR merge into `main`:
+
+1. Move ticket(s) from `not started` / `in progress` → `done`.
+2. After verifier subagent confirms acceptance criteria, mark `verified`.
+3. Add the merge commit SHA in the Notes column.
+4. If a ticket is split or new follow-ups appear, add rows. Never silently delete a row — if
+   superseded, write `superseded by T#-##` in Notes.
+5. Update `Last updated` at the top.

--- a/docs/memory-system/IMPLEMENTATION_STATUS.md
+++ b/docs/memory-system/IMPLEMENTATION_STATUS.md
@@ -23,10 +23,10 @@
 
 | Ticket | Title                                                       | Status         | Notes |
 |--------|-------------------------------------------------------------|----------------|-------|
-| T0-01  | Fix forward_lookup membership/admin check                   | verified       | Merged in PR#11 / commit `7f95b53` (security audit C3). Verified 2026-04-26: PASS by architect's hard criteria (auth guard before DB lookup; silent denial; no info leakage; admin allowed; member allowed; tests cover (a)(b)(c)(d)). Three minor follow-up gaps captured as T0-01-r1/r2/r3 below. |
-| T0-01-r1 | Test: admin authorized via `settings.ADMIN_IDS` (env-only) | not started    | nice-to-have. Patch ADMIN_IDS=[user_id] with is_admin=False in DB; verify lookup proceeds. |
-| T0-01-r2 | Test: unknown user (UserRepo.get returns None) silent return | not started   | nice-to-have. Cover the ghost-user code path. |
-| T0-01-r3 | Distinguish denial log lines: "user not in DB" vs "not a member" | not started | quality. Audit log clarity. |
+| T0-01  | Fix forward_lookup membership/admin check                   | verified       | Merged in PR#11 / commit `7f95b53` (security audit C3). Verified 2026-04-26 by independent code-reviewer subagent (output preserved in PR #16 description and commit message). Acceptance verbatim: "non-member denied; member allowed; admin allowed; no intro in denial response; auth guard runs BEFORE any DB lookup of message author or intro." Tests cover (a) non-member denied, (b) member allowed, (c) admin allowed via DB flag, (d) no intro leaked in denial. Independent reviewer also confirmed no bypass code path (`F.forward_origin` registered only in `forward_lookup.py`). |
+| T0-01-r1 | Test: admin authorized via `settings.ADMIN_IDS` (env-only) | not started    | nice-to-have. Does NOT block T0-06 regression suite. Standalone GitHub issue #18. |
+| T0-01-r2 | Test: unknown user (UserRepo.get returns None) silent return | not started   | nice-to-have. Does NOT block T0-06. GitHub issue #19. |
+| T0-01-r3 | Distinguish denial log lines: "user not in DB" vs "not a member" | not started | quality. Does NOT block T0-06. GitHub issue #20. |
 | T0-02  | Fix/contain sqlite vs postgres upsert in UserRepo           | not started    | First implementation ticket of this cycle. |
 | T0-03  | Make MessageRepo.save idempotent                            | not started    |
 | T0-04  | Implementation status doc                                   | done           | This file + ROADMAP.md + AUTHORIZED_SCOPE.md + HANDOFF.md. |
@@ -62,7 +62,7 @@
 
 | Ticket | Title                                                       | Status         | Notes |
 |--------|-------------------------------------------------------------|----------------|-------|
-| T3-01  | forget_events tombstone skeleton                            | not started    | Stretch. Required before T2-02 import apply. |
+| T3-01  | forget_events tombstone skeleton                            | not started    | Stretch. Required before T2-03 import apply (which is itself out of scope this cycle). |
 
 ## Phases 2b, 4–12
 

--- a/docs/memory-system/README.md
+++ b/docs/memory-system/README.md
@@ -1,0 +1,51 @@
+<!-- Root: ~/Vibe/CLAUDE.md — ALWAYS read it first for vault-wide rules and structure -->
+
+# Shkoderbot Memory System — Documentation
+
+This directory holds the canonical specification and roadmap for the Shkoderbot memory system —
+the migration from a pure community gatekeeper into a governed community memory.
+
+## Read order
+
+1. `HANDOFF.md` — full architect handoff (canonical, verbatim). Covers vision, 12-phase roadmap,
+   governance invariants, ticket backlog, migration spec, ingestion/normalization spec, governance
+   spec, search/qa spec, future butler boundary, risk register.
+2. `AUTHORIZED_SCOPE.md` — what is allowed in the immediate execution cycle (Phase 0 + Phase 1
+   only). What is NOT authorized yet. Critical safety rules for `#offrecord` and import.
+3. `ROADMAP.md` — condensed phase table with gates, dependencies, parallelization guide.
+4. `IMPLEMENTATION_STATUS.md` — what is implemented vs planned. Authoritative status of each
+   ticket. Updated after every PR merge.
+5. `DEV_SETUP.md` — how to run the dev bot locally with isolated dev postgres for live ingestion
+   testing.
+
+## Source of truth
+
+If a previous spec disagrees with `HANDOFF.md`, `HANDOFF.md` wins. The legacy v0.5 design spec
+(`docs/superpowers/archive/2026-04-22-shkoderbot-memory-editor-design.SUPERSEDED.md`) is
+superseded — do not implement from it.
+
+## Workflow
+
+- Branch: `feat/memory-foundation` in worktree `.worktrees/memory/`.
+- Framework: superflow (per-worktree state file, does not collide with the main `security-audit`
+  cycle running on `main`).
+- Issue tracker: GitHub Issues. Labels: `phase:0`, `phase:1`, `area:memory`,
+  `area:gatekeeper-safety`, `area:db`, `area:governance`, `area:ingestion`.
+- PR target: `main`. Sprint-PR-queue mode (one PR per ticket, sequential rebase, CI green before
+  merge).
+- Reviewers per PR: Claude product reviewer + Codex technical reviewer (dual review). Codex used
+  for migrations and security-sensitive code.
+- Documentation: every merged PR updates `IMPLEMENTATION_STATUS.md`.
+
+## Non-negotiable invariants (from HANDOFF.md §1)
+
+1. Existing gatekeeper must not break.
+2. No LLM calls outside `llm_gateway`.
+3. No extraction/search/qa over `#nomem` / `#offrecord` / forgotten content.
+4. Citations point to `message_version_id` or approved card sources.
+5. Summary is never canonical truth.
+6. Graph is never source of truth.
+7. Future butler cannot read raw DB directly; must use governance-filtered evidence context.
+8. Import apply must go through the same normalization/governance path as live updates.
+9. Tombstones are durable; not casually rolled back.
+10. Public wiki disabled until review/source-trace/governance proven.

--- a/docs/memory-system/ROADMAP.md
+++ b/docs/memory-system/ROADMAP.md
@@ -1,0 +1,79 @@
+# Memory System — 12-Phase Roadmap (condensed)
+
+Full architect text in `HANDOFF.md`. This file is the at-a-glance map.
+
+## Strategy
+
+```
+phase 0 safety
+  → feature_flags
+    → ingestion_runs + telegram_updates
+      → extend chat_messages
+        → message_versions
+          → #nomem/#offrecord + offrecord_marks
+            → forget_events / tombstones
+              → import apply
+                → fts / evidence
+                  → q&a with citations
+                    → llm_gateway / ledger
+                      → extraction / events / observations / candidates
+                        → cards / admin review
+                          → summaries / digests / wiki
+```
+
+## Phases
+
+| # | Name                                       | Authorized? | Exit gate                                                                 |
+|---|--------------------------------------------|-------------|---------------------------------------------------------------------------|
+| 0 | Gatekeeper stabilization                   | YES (now)   | privacy fix, idempotent save, upsert contained, /healthz, regression tests green |
+| 1 | Source of truth + raw archive              | YES (now)   | live message produces raw update + normalized message + v1 version, edits create v2 |
+| 2a| Telegram Desktop import — dry-run          | STRETCH     | dry-run reports stats; **no content writes**                              |
+| 2b| Telegram Desktop import — apply            | NO          | requires Phase 3 skeleton (tombstones + policy detection)                 |
+| 3 | Governance (`#nomem` / `#offrecord` / `/forget` / tombstones) | NO  | forbidden content excluded from future search/extraction/import           |
+| 4 | Hybrid search + Q&A with citations         | NO          | bot answers from evidence only or refuses; no LLM general knowledge       |
+| 5 | LLM gateway + extraction (events / observations / candidates) | NO  | every LLM call logged in ledger; no forbidden source sent to LLM          |
+| 6 | Knowledge cards + admin review             | NO          | active card requires source + admin approval                              |
+| 7 | Daily summaries                            | NO          | every bullet has source; forgotten source redacts bullet                  |
+| 8 | Weekly digest                              | NO          | reviewed sourced sections; no auto-publish                                |
+| 9 | Wiki (member / internal)                   | NO          | visibility filter + governance + source trace; public stays disabled      |
+| 10| Graph projection (Neo4j / Graphiti)        | NO          | derived only; rebuildable from postgres; forget purges graph              |
+| 11| Shkoderbench / evals                       | NO          | leakage / citation / no-answer tests in CI nightly                        |
+| 12| Future butler — design-only                | NO          | docs only; no execution code                                              |
+
+## Phase gates (must be true to advance)
+
+| Gate                  | Conditions                                                                              |
+|-----------------------|-----------------------------------------------------------------------------------------|
+| Gatekeeper safety     | privacy fix, idempotent save, dialect-safe repos, regression tests green                |
+| Source of truth       | raw_updates + message_versions + basic normalization persist                            |
+| Governance            | `#nomem` / `#offrecord` detection, `forget_events`, cascade skeleton, filters           |
+| Q&A                   | FTS, evidence bundle, citations, refusal, policy filters                                |
+| Extraction            | `llm_gateway`, ledger, source validation, budget guard                                  |
+| Catalog               | cards require sources + admin review                                                    |
+| Wiki                  | visibility + review + source trace + forget purge proven                                |
+
+## Non-negotiable invariants (verbatim from HANDOFF.md §1)
+
+1. Existing gatekeeper must not break.
+2. No LLM calls outside `llm_gateway`.
+3. No extraction/search/qa over `#nomem` / `#offrecord` / forgotten.
+4. Citations point to `message_version_id` or approved card sources.
+5. Summary is never canonical truth.
+6. Graph is never source of truth.
+7. Future butler cannot read raw DB directly; uses governance-filtered evidence.
+8. Import apply must go through same normalization/governance path as live updates.
+9. Tombstones are durable; not casually rolled back.
+10. Public wiki remains disabled until review/source trace/governance proven.
+
+## Parallelization
+
+After Phase 0:
+- DB migration drafting | tests/fixtures | admin health/read-only screens | import dry-run
+  parser | docs implementation status | q&a eval case design — can run in parallel.
+
+Cannot parallelize without gate:
+- import **apply** before tombstones
+- `edited_message` before `message_versions` + handler
+- reactions before reactions table + handler
+- LLM extraction before `llm_gateway` + governance
+- wiki before review + source trace

--- a/docs/memory-system/ROADMAP.md
+++ b/docs/memory-system/ROADMAP.md
@@ -29,7 +29,7 @@ phase 0 safety
 | 1 | Source of truth + raw archive              | YES (now)   | live message produces raw update + normalized message + v1 version, edits create v2 |
 | 2a| Telegram Desktop import — dry-run          | STRETCH     | dry-run reports stats; **no content writes**                              |
 | 2b| Telegram Desktop import — apply            | NO          | requires Phase 3 skeleton (tombstones + policy detection)                 |
-| 3 | Governance (`#nomem` / `#offrecord` / `/forget` / tombstones) | NO  | forbidden content excluded from future search/extraction/import           |
+| 3 | Governance (`#nomem` / `#offrecord` / `/forget` / tombstones) | STRETCH (T3-01 skeleton only)  | forbidden content excluded from future search/extraction/import           |
 | 4 | Hybrid search + Q&A with citations         | NO          | bot answers from evidence only or refuses; no LLM general knowledge       |
 | 5 | LLM gateway + extraction (events / observations / candidates) | NO  | every LLM call logged in ledger; no forbidden source sent to LLM          |
 | 6 | Knowledge cards + admin review             | NO          | active card requires source + admin approval                              |

--- a/docs/superpowers/archive/2026-04-22-shkoderbot-memory-editor-design.SUPERSEDED.md
+++ b/docs/superpowers/archive/2026-04-22-shkoderbot-memory-editor-design.SUPERSEDED.md
@@ -1,6 +1,24 @@
-# Shkoderbot Memory Editor — Design Spec
+# [SUPERSEDED] Shkoderbot Memory Editor — Design Spec v0.5
 
-## Status
+> **STATUS: SUPERSEDED on 2026-04-26.**
+>
+> This v0.5 design spec (LiteLLM/Instructor/sqladmin/pgvector/RRF, single-instance asyncio.Semaphore,
+> direct extraction → findings, no governance phases) is **archived**.
+>
+> Canonical memory architecture is now: **`docs/memory-system/HANDOFF.md`** (governance-first phased
+> roadmap with telegram_updates + message_versions + offrecord_marks + forget_events).
+>
+> Why superseded: the new architecture prioritizes governance (#nomem/#offrecord/forget tombstones),
+> source-of-truth versioning, and phase gates BEFORE any LLM extraction. v0.5 jumped to extraction
+> without the safety primitives. Lessons from v0.5 (LLM provider abstraction, asyncio.Semaphore for
+> single-instance, sqladmin for admin UI, hybrid retrieval with RRF) are noted but not load-bearing
+> until governance phases are complete.
+>
+> Do not implement from this document. Do not cite it as the spec.
+
+---
+
+## Original Status (preserved for history)
 
 - **Version:** draft v0.5 (add §9 Public Wiki + §10 Member UX + §11 Content Safety + §12 Ops Pragmatics)
 - **Date:** 2026-04-22


### PR DESCRIPTION
## Sprint 1 of memory-foundation cycle

Lays the canonical specification, scope boundaries, and dev environment for the multi-phase
migration from gatekeeper → governed community memory system.

**No code changes. No migrations. No runtime behaviour change.**

## Why now

We need a single source-of-truth document that all subsequent code PRs (Phase 0 + Phase 1) can
cite. Without this, AI dev agents will re-invent decisions per ticket and drift across the
12-phase roadmap. The previous v0.5 design spec (LiteLLM/sqladmin/pgvector/RRF, direct
extraction → findings) jumped past the governance primitives — it has been archived with a
SUPERSEDED banner.

## What's in the PR

- `docs/memory-system/HANDOFF.md` — full architect handoff, verbatim. 12 phases with explicit
  gates, ticket backlog (T0-* through T11-*), governance / ingestion / search / qa specs,
  future butler boundary, risk register.
- `docs/memory-system/AUTHORIZED_SCOPE.md` — what is allowed in the immediate cycle (Phase 0 +
  Phase 1). What is explicitly **not** authorized. Critical safety rules for `#offrecord`,
  Telegram import gating, `allowed_updates` rollout rule, agent execution rules.
- `docs/memory-system/ROADMAP.md` — at-a-glance 12-phase table with gates, dependencies,
  parallelization guide.
- `docs/memory-system/IMPLEMENTATION_STATUS.md` — authoritative status of every ticket. T0-01
  marked **verified** (PR#11 / commit \`7f95b53\`) with three minor follow-up gaps captured as
  T0-01-r1/r2/r3 (test coverage only, not security holes).
- `docs/memory-system/README.md` — entry point + read order.
- `docs/memory-system/DEV_SETUP.md` — isolated dev postgres + dev bot live ingestion testing
  protocol.
- `.env.dev.example` + `docker-compose.dev.yml` — dev env scaffolding (bot stays on host,
  isolated postgres on 127.0.0.1:5433).
- `.gitignore` — adds \`.env.dev\` and \`.superflow-state.json\` (per-worktree state).
- v0.5 design spec → archived with SUPERSEDED banner.

## Authorized scope captured

**Phase 0** (gatekeeper stabilization): T0-01 done; T0-02 upsert containment, T0-03
`MessageRepo.save` idempotency, T0-04 status doc (this PR), T0-05 `/healthz`, T0-06 regression
tests.

**Phase 1** (source of truth + raw archive): T1-01 through T1-14 — feature_flags,
ingestion_runs, telegram_updates, raw update persistence, extended chat_messages,
message_versions + v1 backfill, content_hash, reply / thread / caption / kind persistence,
minimal `#nomem` / `#offrecord` detector + `offrecord_marks`, `edited_message` handler.

**Stretch**: T3-01 `forget_events` skeleton, T2-01 import dry-run parser.

**Out of scope until phase gates pass**: q&a bot, LLM calls, LLM extraction, vector search,
catalog / cards, daily summaries, weekly digest, wiki, graph / Neo4j / Graphiti, butler /
action execution, person expertise pages, public surfaces, import apply.

## T0-01 verification result

Independent code reviewer subagent verified the security-audit fix in commit \`7f95b53\`
(PR#11). Verdict: **PASS** by architect's hard acceptance criteria.

- Auth guard runs BEFORE any DB lookup of message author or intro.
- Non-member denied; member allowed; admin allowed (both env-IDS and DB flag).
- Denial is silent (no `message.answer` call); no info leakage.
- Logs only `user_id` (no secrets).
- Tests cover: (a) non-member denied, (b) member allowed, (c) admin allowed via DB flag, (d)
  no intro leaked in denial responses.
- No bypass code path exists (`F.forward_origin` registered only in `forward_lookup.py`).

Three minor follow-up gaps (not security holes, not blocking):
- T0-01-r1: add test for admin authorized via `settings.ADMIN_IDS` (env-only path).
- T0-01-r2: add test for unknown user (`UserRepo.get` → None) silent return.
- T0-01-r3: distinguish denial log lines ("user not in DB" vs "not a member").

## Test plan

- [ ] Verify `docs/memory-system/` files render correctly in GitHub markdown.
- [ ] Confirm no broken cross-references between AUTHORIZED_SCOPE.md / ROADMAP.md /
      IMPLEMENTATION_STATUS.md / HANDOFF.md.
- [ ] Confirm SUPERSEDED banner on archived v0.5 spec is visible.
- [ ] No code changes → no test runs needed in CI for this PR.

## Reviewers

- Claude product reviewer — consistency of scope/roadmap/status docs.
- Codex deep-product reviewer — technical correctness, governance invariants, contradictions.

## Next sprint

Sprint 2: T0-02 (sqlite/postgres upsert containment in `bot/db/repos/user.py`) + paired T0-06
regression test. Then Sprint 3 T0-03, Sprint 4 T0-05, Sprint 5 T0-06, then Phase 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)