### PR TITLE
[T0-02] fix(db): contain sqlite/postgres upsert via postgres-only dev

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,11 +12,26 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: vibe
+          POSTGRES_PASSWORD: changeme
+          POSTGRES_DB: vibe_gatekeeper
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U vibe -d vibe_gatekeeper"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 10
     env:
       BOT_TOKEN: 123456:test-token
       COMMUNITY_CHAT_ID: -1001234567890
       ADMIN_IDS: '[149820031]'
-      DATABASE_URL: postgresql+asyncpg://vibe:changeme@db:5432/vibe_gatekeeper
+      # Postgres service is reachable on localhost:5432 from the runner.
+      DATABASE_URL: postgresql+asyncpg://vibe:changeme@localhost:5432/vibe_gatekeeper
       REDIS_URL: redis://redis:6379/0
       GOOGLE_SHEETS_CREDS_FILE: ""
       GOOGLE_SHEET_ID: ""
@@ -24,6 +39,7 @@ jobs:
       WEB_BOT_USERNAME: vibeshkoder_dev_bot
       DB_PASSWORD: changeme
       WEB_PASSWORD: test-pass
+      WEB_SESSION_SECRET: test-session-secret
       DEV_MODE: "true"
     steps:
       - uses: actions/checkout@v4
@@ -34,6 +50,9 @@ jobs:
 
       - name: Install dependencies
         run: pip install -e ".[dev]"
+
+      - name: Run alembic migrations against the test postgres
+        run: alembic upgrade head
 
       - name: Run tests
         run: pytest -q

--- a/README.md
+++ b/README.md
@@ -18,14 +18,28 @@ Copy `.env.example` to `.env` and fill the required values.
 
 Recommended local settings:
 
-- `DEV_MODE=true`
+- `DEV_MODE=true` — enables permissive checks (e.g. ephemeral web password)
 - a separate development bot token
 - local-only `WEB_PASSWORD`
+- a `DATABASE_URL` pointing at a local postgres (see step 1.5)
 
-With `DEV_MODE=true`, the app uses:
+`DEV_MODE=true` makes the web app generate ephemeral credentials and uses in-memory FSM
+storage instead of Redis. **It does NOT change the database driver** — postgres is required
+in all environments (T0-02; see `bot/db/engine.py`). Sqlite is no longer supported as a
+runtime DB.
 
-- SQLite (`vibe_gatekeeper.db`)
-- in-memory FSM storage instead of Redis
+### 1.5. Start a local postgres
+
+If you are working on the memory system cycle, use the dev postgres in the memory worktree:
+
+```bash
+cd .worktrees/memory
+cp .env.dev.example .env.dev
+docker compose -f docker-compose.dev.yml --env-file .env.dev up -d postgres-dev
+alembic upgrade head
+```
+
+For other workflows, any reachable postgres 16 instance works — set `DATABASE_URL` to its URL.
 
 ### 2. Install dependencies
 
@@ -38,7 +52,7 @@ pip install -e ".[dev]"
 ### 3. Run local checks
 
 ```bash
-pytest -q
+pytest -q              # DB-backed tests skip cleanly if postgres is unreachable
 ruff check .
 ```
 

--- a/bot/__main__.py
+++ b/bot/__main__.py
@@ -20,7 +20,12 @@ logger = logging.getLogger(__name__)
 
 
 async def _init_db() -> None:
-    """Create tables in dev mode (SQLite)."""
+    """Ensure tables exist when running in dev mode without alembic.
+
+    Production uses ``alembic upgrade head`` against postgres. Dev mode against an empty
+    postgres can rely on this helper to bootstrap the schema directly from SQLAlchemy
+    metadata, mirroring what ``alembic upgrade head`` would have produced.
+    """
     from bot.db.engine import engine
     from bot.db.models import Base
 
@@ -30,7 +35,8 @@ async def _init_db() -> None:
 
 
 async def main() -> None:
-    # Storage: Redis in prod, Memory in dev
+    # Storage: Redis in prod, in-memory FSM in dev. The DB driver is postgres in both modes
+    # (T0-02; see bot/db/engine.py).
     if settings.DEV_MODE:
         from aiogram.fsm.storage.memory import MemoryStorage
 

--- a/bot/config.py
+++ b/bot/config.py
@@ -22,7 +22,8 @@ class Settings(BaseSettings):
     INTRO_REFRESH_DAYS: int = 90
     WEB_PASSWORD: str | None = None
     WEB_SESSION_SECRET: str | None = None
-    DEV_MODE: bool = False  # Use SQLite + MemoryStorage for local testing
+    DEV_MODE: bool = False  # Permissive checks (e.g. ephemeral web password / session secret).
+    # Note: postgres is required regardless of DEV_MODE (T0-02). See docs/memory-system/DEV_SETUP.md.
 
     model_config = {"env_file": ".env", "env_file_encoding": "utf-8", "extra": "ignore"}
 

--- a/bot/db/engine.py
+++ b/bot/db/engine.py
@@ -1,12 +1,38 @@
-from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine, AsyncSession
+"""Async SQLAlchemy engine, postgres-only.
+
+Sqlite was previously used as a dev fallback, but the codebase relies on postgres-specific
+SQL (e.g. ``ON CONFLICT DO UPDATE`` in ``UserRepo.upsert``) that compiles only against the
+postgres dialect. Running against sqlite caused silent runtime failures.
+
+Per ``docs/memory-system/HANDOFF.md`` §0 and ticket T0-02 acceptance, dev/test now requires
+postgres. The dev compose stack provides one on ``127.0.0.1:5433`` (see
+``docker-compose.dev.yml`` and ``docs/memory-system/DEV_SETUP.md``).
+"""
+
+from __future__ import annotations
+
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from bot.config import settings
 
-if settings.DEV_MODE:
-    _url = "sqlite+aiosqlite:///vibe_gatekeeper.db"
-    engine = create_async_engine(_url, echo=False)
-else:
-    _url = settings.DATABASE_URL
-    engine = create_async_engine(_url, echo=False)
+
+def _validate_postgres_url(url: str) -> str:
+    if not url:
+        raise RuntimeError(
+            "DATABASE_URL is empty. Set it to a postgres URL such as "
+            "'postgresql+asyncpg://user:pass@host:port/dbname'. See "
+            "docs/memory-system/DEV_SETUP.md for the dev setup."
+        )
+    if url.startswith("sqlite") or "+aiosqlite" in url:
+        raise RuntimeError(
+            "DATABASE_URL points at sqlite, which is no longer supported. The codebase "
+            "relies on postgres-specific SQL (see ticket T0-02). Use the dev postgres "
+            "from docker-compose.dev.yml — see docs/memory-system/DEV_SETUP.md."
+        )
+    return url
+
+
+_url = _validate_postgres_url(settings.DATABASE_URL)
+engine = create_async_engine(_url, echo=False)
 
 async_session = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)

--- a/bot/db/engine.py
+++ b/bot/db/engine.py
@@ -23,11 +23,11 @@ def _validate_postgres_url(url: str) -> str:
             "'postgresql+asyncpg://user:pass@host:port/dbname'. See "
             "docs/memory-system/DEV_SETUP.md for the dev setup."
         )
-    if url.startswith("sqlite") or "+aiosqlite" in url:
+    if not (url.startswith("postgresql://") or url.startswith("postgresql+")):
         raise RuntimeError(
-            "DATABASE_URL points at sqlite, which is no longer supported. The codebase "
-            "relies on postgres-specific SQL (see ticket T0-02). Use the dev postgres "
-            "from docker-compose.dev.yml — see docs/memory-system/DEV_SETUP.md."
+            f"DATABASE_URL must point at postgres (got scheme: {url.split('://', 1)[0]!r}). "
+            "The codebase relies on postgres-specific SQL (see ticket T0-02). Use the dev "
+            "postgres from docker-compose.dev.yml — see docs/memory-system/DEV_SETUP.md."
         )
     return url
 

--- a/docs/memory-system/IMPLEMENTATION_STATUS.md
+++ b/docs/memory-system/IMPLEMENTATION_STATUS.md
@@ -27,7 +27,7 @@
 | T0-01-r1 | Test: admin authorized via `settings.ADMIN_IDS` (env-only) | not started    | nice-to-have. Does NOT block T0-06 regression suite. Standalone GitHub issue #18. |
 | T0-01-r2 | Test: unknown user (UserRepo.get returns None) silent return | not started   | nice-to-have. Does NOT block T0-06. GitHub issue #19. |
 | T0-01-r3 | Distinguish denial log lines: "user not in DB" vs "not a member" | not started | quality. Does NOT block T0-06. GitHub issue #20. |
-| T0-02  | Fix/contain sqlite vs postgres upsert in UserRepo           | not started    | First implementation ticket of this cycle. |
+| T0-02  | Fix/contain sqlite vs postgres upsert in UserRepo           | done           | Sprint 2 / PR #42. Option A chosen (postgres-only dev). `bot/db/engine.py` drops sqlite branch, validates DATABASE_URL, raises clear error on sqlite/empty. CI gets postgres service container. New test module `tests/db/test_user_repo.py` (4 DB-backed tests + 2 engine-validation tests). Existing 24 tests still pass. `pytest-asyncio` added to dev deps with `asyncio_mode = "auto"`. `aiosqlite` moved from runtime to dev deps (used only by `tests/test_scheduler_deadlines.py`). |
 | T0-03  | Make MessageRepo.save idempotent                            | not started    |
 | T0-04  | Implementation status doc                                   | done           | This file + ROADMAP.md + AUTHORIZED_SCOPE.md + HANDOFF.md. |
 | T0-05  | /healthz + startup checks                                   | not started    |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,12 +20,15 @@ dependencies = [
     "itsdangerous>=2.0",
     "httpx>=0.28",
     "python-multipart>=0.0.9",
-    "aiosqlite>=0.20",
 ]
 
 [project.optional-dependencies]
 dev = [
     "pytest>=8.3",
+    "pytest-asyncio>=0.24",
+    # aiosqlite is dev-only — used by tests/test_scheduler_deadlines.py for in-memory sqlite
+    # isolation. Production runtime requires postgres (T0-02; see bot/db/engine.py).
+    "aiosqlite>=0.20",
     "ruff>=0.11",
 ]
 ops = [
@@ -42,6 +45,7 @@ include = ["bot*", "web*"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 pythonpath = ["."]
+asyncio_mode = "auto"
 
 [tool.ruff]
 line-length = 100

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import importlib
+import os
 import sys
-from collections.abc import Iterator
+from collections.abc import AsyncIterator, Iterator
 
 import pytest
+import pytest_asyncio
 
 
 def _clear_modules() -> None:
@@ -18,7 +20,12 @@ def app_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
     monkeypatch.setenv("BOT_TOKEN", "123456:test-token")
     monkeypatch.setenv("COMMUNITY_CHAT_ID", "-1001234567890")
     monkeypatch.setenv("ADMIN_IDS", "[149820031]")
-    monkeypatch.setenv("DATABASE_URL", "postgresql+asyncpg://vibe:changeme@db:5432/vibe_gatekeeper")
+    monkeypatch.setenv(
+        "DATABASE_URL",
+        # Default for unit tests that mock the DB and never connect.
+        # DB-backed tests override this via the postgres_url fixture.
+        "postgresql+asyncpg://vibe:changeme@db:5432/vibe_gatekeeper",
+    )
     monkeypatch.setenv("REDIS_URL", "redis://redis:6379/0")
     monkeypatch.setenv("GOOGLE_SHEETS_CREDS_FILE", "")
     monkeypatch.setenv("GOOGLE_SHEET_ID", "")
@@ -35,3 +42,61 @@ def app_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
 
 def import_module(name: str):
     return importlib.import_module(name)
+
+
+# ─── DB-backed test fixtures ─────────────────────────────────────────────────────────────────
+#
+# Tests that exercise real SQL (e.g. UserRepo.upsert) require a reachable postgres.
+#
+# Resolution order for the URL:
+#   1. TEST_DATABASE_URL env var (preferred — explicit override)
+#   2. DATABASE_URL env var (CI sets this to the postgres service)
+#   3. Local default postgres on 127.0.0.1:5433 (matches docker-compose.dev.yml dev postgres)
+#
+# If postgres is unreachable, DB-backed tests are SKIPPED (not failed) so that contributors
+# without local postgres can still run the unit suite. CI runs against a real postgres
+# service container, so missed coverage is caught before merge.
+
+DEFAULT_LOCAL_POSTGRES_URL = "postgresql+asyncpg://shkoder_dev:shkoder_dev@127.0.0.1:5433/shkoder_dev"
+
+
+def _resolve_test_postgres_url() -> str:
+    return (
+        os.environ.get("TEST_DATABASE_URL")
+        or os.environ.get("DATABASE_URL")
+        or DEFAULT_LOCAL_POSTGRES_URL
+    )
+
+
+@pytest_asyncio.fixture()
+async def postgres_engine():
+    """Yield an async SQLAlchemy engine bound to the test postgres, or skip the test if
+    postgres is unreachable. Each test gets a fresh engine so connection pools do not leak."""
+    from sqlalchemy.ext.asyncio import create_async_engine
+
+    url = _resolve_test_postgres_url()
+    engine = create_async_engine(url, echo=False)
+    try:
+        async with engine.connect() as conn:
+            await conn.execute(__import__("sqlalchemy").text("SELECT 1"))
+    except Exception as exc:  # pragma: no cover — environment guard, not behaviour
+        await engine.dispose()
+        pytest.skip(f"postgres unreachable at {url}: {exc!s}")
+    try:
+        yield engine
+    finally:
+        await engine.dispose()
+
+
+@pytest_asyncio.fixture()
+async def db_session(postgres_engine) -> AsyncIterator:
+    """Yield an AsyncSession bound to the test postgres. The session is rolled back at the
+    end of the test so tests do not pollute each other's data."""
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+    Session = async_sessionmaker(postgres_engine, class_=AsyncSession, expire_on_commit=False)
+    async with Session() as session:
+        try:
+            yield session
+        finally:
+            await session.rollback()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,17 +15,21 @@ def _clear_modules() -> None:
             sys.modules.pop(name, None)
 
 
+DEFAULT_LOCAL_POSTGRES_URL = "postgresql+asyncpg://shkoder_dev:shkoder_dev@127.0.0.1:5433/shkoder_dev"
+
+
 @pytest.fixture()
 def app_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
     monkeypatch.setenv("BOT_TOKEN", "123456:test-token")
     monkeypatch.setenv("COMMUNITY_CHAT_ID", "-1001234567890")
     monkeypatch.setenv("ADMIN_IDS", "[149820031]")
-    monkeypatch.setenv(
-        "DATABASE_URL",
-        # Default for unit tests that mock the DB and never connect.
-        # DB-backed tests override this via the postgres_url fixture.
-        "postgresql+asyncpg://vibe:changeme@db:5432/vibe_gatekeeper",
-    )
+    # Set DATABASE_URL ONLY if it is not already set externally. CI provides the postgres-
+    # service URL via env (`localhost:5432`); overriding it here would route DB-backed tests
+    # at a non-existent host and cause silent skips. Locally, fall back to the dev postgres
+    # exposed by ``docker-compose.dev.yml`` on 127.0.0.1:5433. Tests that mock the DB never
+    # connect and accept any valid postgres URL.
+    if not os.environ.get("DATABASE_URL"):
+        monkeypatch.setenv("DATABASE_URL", DEFAULT_LOCAL_POSTGRES_URL)
     monkeypatch.setenv("REDIS_URL", "redis://redis:6379/0")
     monkeypatch.setenv("GOOGLE_SHEETS_CREDS_FILE", "")
     monkeypatch.setenv("GOOGLE_SHEET_ID", "")
@@ -57,9 +61,6 @@ def import_module(name: str):
 # without local postgres can still run the unit suite. CI runs against a real postgres
 # service container, so missed coverage is caught before merge.
 
-DEFAULT_LOCAL_POSTGRES_URL = "postgresql+asyncpg://shkoder_dev:shkoder_dev@127.0.0.1:5433/shkoder_dev"
-
-
 def _resolve_test_postgres_url() -> str:
     return (
         os.environ.get("TEST_DATABASE_URL")
@@ -68,20 +69,31 @@ def _resolve_test_postgres_url() -> str:
     )
 
 
+def _safe_url_repr(url_str: str) -> str:
+    """Render a SQLAlchemy URL string with the password redacted, for safe logging."""
+    from sqlalchemy.engine.url import make_url
+
+    try:
+        return make_url(url_str).render_as_string(hide_password=True)
+    except Exception:
+        return "<unparseable URL>"
+
+
 @pytest_asyncio.fixture()
 async def postgres_engine():
     """Yield an async SQLAlchemy engine bound to the test postgres, or skip the test if
     postgres is unreachable. Each test gets a fresh engine so connection pools do not leak."""
+    from sqlalchemy import text
     from sqlalchemy.ext.asyncio import create_async_engine
 
     url = _resolve_test_postgres_url()
     engine = create_async_engine(url, echo=False)
     try:
         async with engine.connect() as conn:
-            await conn.execute(__import__("sqlalchemy").text("SELECT 1"))
+            await conn.execute(text("SELECT 1"))
     except Exception as exc:  # pragma: no cover — environment guard, not behaviour
         await engine.dispose()
-        pytest.skip(f"postgres unreachable at {url}: {exc!s}")
+        pytest.skip(f"postgres unreachable at {_safe_url_repr(url)}: {exc!s}")
     try:
         yield engine
     finally:
@@ -90,13 +102,23 @@ async def postgres_engine():
 
 @pytest_asyncio.fixture()
 async def db_session(postgres_engine) -> AsyncIterator:
-    """Yield an AsyncSession bound to the test postgres. The session is rolled back at the
-    end of the test so tests do not pollute each other's data."""
+    """Yield an AsyncSession bound to the test postgres.
+
+    Isolation: the session uses a single connection wrapped in an outer transaction. The
+    outer transaction is rolled back at fixture teardown, discarding all changes the test
+    made. Tests MUST NOT call ``session.commit()`` — doing so would commit data to the DB
+    permanently and break isolation. Use ``session.flush()`` instead (UserRepo methods
+    already flush internally).
+    """
     from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
-    Session = async_sessionmaker(postgres_engine, class_=AsyncSession, expire_on_commit=False)
-    async with Session() as session:
-        try:
-            yield session
-        finally:
-            await session.rollback()
+    async with postgres_engine.connect() as conn:
+        outer = await conn.begin()
+        Session = async_sessionmaker(bind=conn, class_=AsyncSession, expire_on_commit=False)
+        async with Session() as session:
+            try:
+                yield session
+            finally:
+                # Always roll back the outer transaction; this discards all test data.
+                if outer.is_active:
+                    await outer.rollback()

--- a/tests/db/test_user_repo.py
+++ b/tests/db/test_user_repo.py
@@ -1,0 +1,182 @@
+"""T0-02 acceptance tests — UserRepo.upsert against real postgres.
+
+These tests exercise the real ON CONFLICT DO UPDATE path and confirm:
+- new row is inserted with the supplied fields
+- repeat upsert with same telegram id updates fields without raising or duplicating
+- the returned object is the persisted row (single row in the table)
+- conflict on the primary key is resolved transparently
+
+Tests are SKIPPED if no postgres is reachable (see conftest.postgres_engine). CI runs against
+a postgres service container so this coverage runs on every PR.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import delete, select
+
+# `app_env` from conftest sets DATABASE_URL via env var (CI sets the postgres service URL,
+# local dev gets the docker-compose dev postgres URL). The `postgres_engine` fixture in
+# conftest is the single resolver; no per-test override is needed.
+pytestmark = pytest.mark.usefixtures("app_env")
+
+
+async def _delete_user(session, telegram_id: int) -> None:
+    from bot.db.models import User
+
+    await session.execute(delete(User).where(User.id == telegram_id))
+    await session.flush()
+
+
+async def _count_users_with_id(session, telegram_id: int) -> int:
+    from bot.db.models import User
+
+    result = await session.execute(select(User).where(User.id == telegram_id))
+    return len(result.scalars().all())
+
+
+async def test_upsert_new_user_inserts_row(db_session) -> None:
+    from bot.db.repos.user import UserRepo
+
+    telegram_id = 1000_001
+    await _delete_user(db_session, telegram_id)
+    await db_session.commit()
+
+    user = await UserRepo.upsert(
+        db_session,
+        telegram_id=telegram_id,
+        username="newcomer",
+        first_name="New",
+        last_name="Comer",
+    )
+    await db_session.commit()
+
+    assert user.id == telegram_id
+    assert user.username == "newcomer"
+    assert user.first_name == "New"
+    assert user.last_name == "Comer"
+    assert await _count_users_with_id(db_session, telegram_id) == 1
+
+    await _delete_user(db_session, telegram_id)
+    await db_session.commit()
+
+
+async def test_upsert_existing_user_updates_fields_no_duplicate(db_session) -> None:
+    from bot.db.repos.user import UserRepo
+
+    telegram_id = 1000_002
+    await _delete_user(db_session, telegram_id)
+    await db_session.commit()
+
+    await UserRepo.upsert(
+        db_session,
+        telegram_id=telegram_id,
+        username="old_name",
+        first_name="Old",
+        last_name=None,
+    )
+    await db_session.commit()
+
+    updated = await UserRepo.upsert(
+        db_session,
+        telegram_id=telegram_id,
+        username="new_name",
+        first_name="New",
+        last_name="Surname",
+    )
+    await db_session.commit()
+
+    assert updated.id == telegram_id
+    assert updated.username == "new_name"
+    assert updated.first_name == "New"
+    assert updated.last_name == "Surname"
+    assert await _count_users_with_id(db_session, telegram_id) == 1
+
+    await _delete_user(db_session, telegram_id)
+    await db_session.commit()
+
+
+async def test_upsert_returns_row_after_insert(db_session) -> None:
+    """Smoke test: the return value of upsert is the persisted row, not a transient copy."""
+    from bot.db.models import User
+    from bot.db.repos.user import UserRepo
+
+    telegram_id = 1000_003
+    await _delete_user(db_session, telegram_id)
+    await db_session.commit()
+
+    returned = await UserRepo.upsert(
+        db_session,
+        telegram_id=telegram_id,
+        username="probe",
+        first_name="Probe",
+        last_name=None,
+    )
+    await db_session.commit()
+
+    fetched = (await db_session.execute(select(User).where(User.id == telegram_id))).scalar_one()
+    assert returned.id == fetched.id
+    assert returned.username == fetched.username
+
+    await _delete_user(db_session, telegram_id)
+    await db_session.commit()
+
+
+async def test_upsert_returns_row_after_update(db_session) -> None:
+    """The return value after a conflict is the row reflecting the new values."""
+    from bot.db.repos.user import UserRepo
+
+    telegram_id = 1000_004
+    await _delete_user(db_session, telegram_id)
+    await db_session.commit()
+
+    await UserRepo.upsert(
+        db_session,
+        telegram_id=telegram_id,
+        username="first_iter",
+        first_name="First",
+        last_name=None,
+    )
+    await db_session.commit()
+
+    updated = await UserRepo.upsert(
+        db_session,
+        telegram_id=telegram_id,
+        username="second_iter",
+        first_name="Second",
+        last_name="Iteration",
+    )
+    await db_session.commit()
+
+    assert updated.username == "second_iter"
+    assert updated.first_name == "Second"
+    assert updated.last_name == "Iteration"
+
+    await _delete_user(db_session, telegram_id)
+    await db_session.commit()
+
+
+def test_engine_rejects_sqlite_url(monkeypatch) -> None:
+    """Engine module must refuse a sqlite URL with a clear error pointing at T0-02."""
+    monkeypatch.setenv("DATABASE_URL", "sqlite+aiosqlite:///vibe_gatekeeper.db")
+    # Force re-import so the module sees the new env var.
+    import sys
+
+    for name in list(sys.modules):
+        if name == "bot.db.engine" or name == "bot.config":
+            sys.modules.pop(name, None)
+
+    with pytest.raises(RuntimeError, match="sqlite"):
+        import bot.db.engine  # noqa: F401
+
+
+def test_engine_rejects_empty_url(monkeypatch) -> None:
+    monkeypatch.setenv("DATABASE_URL", "")
+    import sys
+
+    for name in list(sys.modules):
+        if name == "bot.db.engine" or name == "bot.config":
+            sys.modules.pop(name, None)
+
+    with pytest.raises(RuntimeError, match="DATABASE_URL is empty"):
+        import bot.db.engine  # noqa: F401

--- a/tests/db/test_user_repo.py
+++ b/tests/db/test_user_repo.py
@@ -1,31 +1,35 @@
 """T0-02 acceptance tests — UserRepo.upsert against real postgres.
 
-These tests exercise the real ON CONFLICT DO UPDATE path and confirm:
-- new row is inserted with the supplied fields
-- repeat upsert with same telegram id updates fields without raising or duplicating
-- the returned object is the persisted row (single row in the table)
-- conflict on the primary key is resolved transparently
+Test isolation strategy: each test runs inside the `db_session` fixture's outer transaction
+which is rolled back at fixture teardown. Tests do NOT call ``session.commit()`` — they call
+``UserRepo.upsert()`` (which flushes internally) and verify state with ``session.execute(select(...))``.
+``pg_insert.on_conflict_do_update`` works correctly within a single transaction: the second
+upsert sees the first via the in-progress flush.
 
-Tests are SKIPPED if no postgres is reachable (see conftest.postgres_engine). CI runs against
-a postgres service container so this coverage runs on every PR.
+Tests use random telegram ids (high range, randomized per test) so any leaked rows from a
+prior failed run cannot collide with a fresh run, and so concurrent test runs against the
+same DB do not interfere.
+
+Tests are SKIPPED if no postgres is reachable (see ``conftest.postgres_engine``). CI runs
+against a postgres service container so this coverage runs on every PR.
 """
 
 from __future__ import annotations
 
-import pytest
-from sqlalchemy import delete, select
+import random
 
-# `app_env` from conftest sets DATABASE_URL via env var (CI sets the postgres service URL,
-# local dev gets the docker-compose dev postgres URL). The `postgres_engine` fixture in
-# conftest is the single resolver; no per-test override is needed.
+import pytest
+from sqlalchemy import select
+
+# `app_env` from conftest sets BOT_TOKEN, ADMIN_IDS, etc. via env vars, but does NOT override
+# DATABASE_URL when one is set externally (CI provides the postgres service URL there).
+# The `postgres_engine` fixture in conftest is the single resolver for the test DB URL.
 pytestmark = pytest.mark.usefixtures("app_env")
 
 
-async def _delete_user(session, telegram_id: int) -> None:
-    from bot.db.models import User
-
-    await session.execute(delete(User).where(User.id == telegram_id))
-    await session.flush()
+def _random_test_id() -> int:
+    # 9-digit space, well above any real telegram id seen in test fixtures.
+    return random.randint(900_000_000, 999_999_999)
 
 
 async def _count_users_with_id(session, telegram_id: int) -> int:
@@ -38,9 +42,7 @@ async def _count_users_with_id(session, telegram_id: int) -> int:
 async def test_upsert_new_user_inserts_row(db_session) -> None:
     from bot.db.repos.user import UserRepo
 
-    telegram_id = 1000_001
-    await _delete_user(db_session, telegram_id)
-    await db_session.commit()
+    telegram_id = _random_test_id()
 
     user = await UserRepo.upsert(
         db_session,
@@ -49,7 +51,6 @@ async def test_upsert_new_user_inserts_row(db_session) -> None:
         first_name="New",
         last_name="Comer",
     )
-    await db_session.commit()
 
     assert user.id == telegram_id
     assert user.username == "newcomer"
@@ -57,16 +58,11 @@ async def test_upsert_new_user_inserts_row(db_session) -> None:
     assert user.last_name == "Comer"
     assert await _count_users_with_id(db_session, telegram_id) == 1
 
-    await _delete_user(db_session, telegram_id)
-    await db_session.commit()
-
 
 async def test_upsert_existing_user_updates_fields_no_duplicate(db_session) -> None:
     from bot.db.repos.user import UserRepo
 
-    telegram_id = 1000_002
-    await _delete_user(db_session, telegram_id)
-    await db_session.commit()
+    telegram_id = _random_test_id()
 
     await UserRepo.upsert(
         db_session,
@@ -75,7 +71,6 @@ async def test_upsert_existing_user_updates_fields_no_duplicate(db_session) -> N
         first_name="Old",
         last_name=None,
     )
-    await db_session.commit()
 
     updated = await UserRepo.upsert(
         db_session,
@@ -84,7 +79,6 @@ async def test_upsert_existing_user_updates_fields_no_duplicate(db_session) -> N
         first_name="New",
         last_name="Surname",
     )
-    await db_session.commit()
 
     assert updated.id == telegram_id
     assert updated.username == "new_name"
@@ -92,18 +86,13 @@ async def test_upsert_existing_user_updates_fields_no_duplicate(db_session) -> N
     assert updated.last_name == "Surname"
     assert await _count_users_with_id(db_session, telegram_id) == 1
 
-    await _delete_user(db_session, telegram_id)
-    await db_session.commit()
-
 
 async def test_upsert_returns_row_after_insert(db_session) -> None:
-    """Smoke test: the return value of upsert is the persisted row, not a transient copy."""
+    """The return value of upsert is the persisted row (matches a follow-up SELECT)."""
     from bot.db.models import User
     from bot.db.repos.user import UserRepo
 
-    telegram_id = 1000_003
-    await _delete_user(db_session, telegram_id)
-    await db_session.commit()
+    telegram_id = _random_test_id()
 
     returned = await UserRepo.upsert(
         db_session,
@@ -112,23 +101,18 @@ async def test_upsert_returns_row_after_insert(db_session) -> None:
         first_name="Probe",
         last_name=None,
     )
-    await db_session.commit()
 
     fetched = (await db_session.execute(select(User).where(User.id == telegram_id))).scalar_one()
     assert returned.id == fetched.id
     assert returned.username == fetched.username
-
-    await _delete_user(db_session, telegram_id)
-    await db_session.commit()
+    assert returned.first_name == fetched.first_name
 
 
 async def test_upsert_returns_row_after_update(db_session) -> None:
-    """The return value after a conflict is the row reflecting the new values."""
+    """After a conflict, the return value reflects the new (updated) values."""
     from bot.db.repos.user import UserRepo
 
-    telegram_id = 1000_004
-    await _delete_user(db_session, telegram_id)
-    await db_session.commit()
+    telegram_id = _random_test_id()
 
     await UserRepo.upsert(
         db_session,
@@ -137,7 +121,6 @@ async def test_upsert_returns_row_after_update(db_session) -> None:
         first_name="First",
         last_name=None,
     )
-    await db_session.commit()
 
     updated = await UserRepo.upsert(
         db_session,
@@ -146,14 +129,10 @@ async def test_upsert_returns_row_after_update(db_session) -> None:
         first_name="Second",
         last_name="Iteration",
     )
-    await db_session.commit()
 
     assert updated.username == "second_iter"
     assert updated.first_name == "Second"
     assert updated.last_name == "Iteration"
-
-    await _delete_user(db_session, telegram_id)
-    await db_session.commit()
 
 
 def test_engine_rejects_sqlite_url(monkeypatch) -> None:


### PR DESCRIPTION
Closes #21.

## Sprint 2 of memory-foundation cycle

Single-ticket PR per `sprint_pr_queue` policy.

## Bug
`bot/db/repos/user.py` uses postgres-specific `pg_insert.on_conflict_do_update`, but
`bot/db/engine.py` substituted a sqlite URL when `DEV_MODE=true`. The postgres-specific
INSERT failed to compile against sqlite at runtime. This blocked T0-03 and every Phase 1
schema ticket relying on postgres-only features (JSON, partial unique indexes, FTS).

## Decision: Option A — postgres-only dev

Per HANDOFF.md §0 ("Recommended default: postgres for integration") and the architect's T0-02
acceptance, dropped the sqlite fallback. Aligns runtime with prod and eliminates a class of
dialect bugs forever. Option B (dialect-aware UserRepo.upsert) was rejected because Phase 1
adds JSON columns, partial unique on `update_id`, etc — all postgres-only regardless.

## Files changed (8)
- `bot/db/engine.py` — drops sqlite branch; `_validate_postgres_url` raises a clear
  RuntimeError on empty / sqlite URL with a pointer to `DEV_SETUP.md`.
- `bot/config.py` — `DEV_MODE` docstring updated (no longer mentions sqlite).
- `pyproject.toml` — adds `pytest-asyncio>=0.24` to dev deps; sets `asyncio_mode = "auto"`.
- `tests/conftest.py` — adds `postgres_engine` and `db_session` fixtures with skip-if-
  unreachable behaviour. Resolution: `TEST_DATABASE_URL` → `DATABASE_URL` → local default
  `127.0.0.1:5433`.
- `tests/db/__init__.py` — new package.
- `tests/db/test_user_repo.py` (new) — 4 DB-backed acceptance tests + 2 engine-validation
  tests (sqlite URL rejected; empty URL rejected).
- `.github/workflows/ci.yml` — postgres:16 service container; `DATABASE_URL` →
  `localhost:5432`; runs `alembic upgrade head` before pytest.
- `docs/memory-system/IMPLEMENTATION_STATUS.md` — T0-02 row → `done`.

## Tests
- 24 existing tests pass — no regressions.
- 2 engine-validation tests pass locally.
- 4 DB-backed tests skip locally (no postgres on dev machine in this run); will run in CI.

## Risks
- Anyone running `python -m bot` locally must have postgres reachable via `DATABASE_URL`.
  `DEV_SETUP.md` already covers this (Sprint 1).
- CI runtime: +~2s for postgres service startup.

## Rollback
If sqlite is ever needed back, restore the DEV_MODE branch in `engine.py` and make every
postgres-only repo dialect-aware. Both are tracked by the validation errors today.

## Reviewers
- Claude product reviewer — scope, decision rationale, contract adherence.
- Codex technical reviewer (`codex:codex-rescue`) — DB safety, CI service config, test design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)