### PR TITLE
fix(security): don't auto-grant membership from chat messages (H2)

### DIFF
--- a/bot/handlers/chat_messages.py
+++ b/bot/handlers/chat_messages.py
@@ -28,7 +28,7 @@ async def save_chat_message(
     if message.from_user is None:
         return
 
-    # Upsert user and mark as member (if they're writing in the chat, they're a member)
+    # Keep sender profile fresh for message attribution and admin lookups.
     await UserRepo.upsert(
         session,
         telegram_id=message.from_user.id,
@@ -36,8 +36,6 @@ async def save_chat_message(
         first_name=message.from_user.first_name,
         last_name=message.from_user.last_name,
     )
-    await UserRepo.set_member(session, message.from_user.id, is_member=True)
-    logger.info("Marked user %s as member from chat message", message.from_user.id)
 
     try:
         await MessageRepo.save(

--- a/tests/test_chat_messages_no_auto_member.py
+++ b/tests/test_chat_messages_no_auto_member.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+from tests.conftest import import_module
+
+
+def test_save_chat_message_does_not_auto_mark_member(app_env, monkeypatch) -> None:
+    handler = import_module("bot.handlers.chat_messages")
+    session = AsyncMock()
+    raw_json = {"message_id": 101, "text": "hello from chat"}
+    message_date = datetime.now(timezone.utc)
+    message = SimpleNamespace(
+        message_id=101,
+        chat=SimpleNamespace(id=-1001234567890),
+        from_user=SimpleNamespace(
+            id=222,
+            username="not_member_yet",
+            first_name="Alice",
+            last_name="Example",
+        ),
+        text="hello from chat",
+        date=message_date,
+        model_dump=Mock(return_value=raw_json),
+    )
+
+    user_upsert = AsyncMock()
+    user_set_member = AsyncMock()
+    message_save = AsyncMock()
+
+    monkeypatch.setattr(handler.UserRepo, "upsert", user_upsert)
+    monkeypatch.setattr(handler.UserRepo, "set_member", user_set_member)
+    monkeypatch.setattr(handler.MessageRepo, "save", message_save)
+
+    asyncio.run(handler.save_chat_message(message, session))
+
+    user_upsert.assert_awaited_once_with(
+        session,
+        telegram_id=222,
+        username="not_member_yet",
+        first_name="Alice",
+        last_name="Example",
+    )
+    user_set_member.assert_not_called()
+    message_save.assert_awaited_once_with(
+        session,
+        message_id=101,
+        chat_id=-1001234567890,
+        user_id=222,
+        text="hello from chat",
+        date=message_date,
+        raw_json=raw_json,
+    )


### PR DESCRIPTION
## Summary

Sprint H2. Closes a security loophole where ANY user who sent a message in the community chat was marked `is_member=True`, bypassing the vouching/admin-add flow.

**Bug:** `bot/handlers/chat_messages.py:save_chat_message` called `UserRepo.set_member(..., is_member=True)` on every chat message. Non-member who got into the chat (link leak, admin mistake, bot in wrong chat) → instant "member" via one message.

**Fix:** remove the `set_member` call. Membership is now set only from `chat_member` events in `bot/handlers/chat_events.py` (Telegram-confirmed join/leave). User upsert + message save preserved for attribution.

## Reviews

- 2× Claude reviewers (per user rule: Codex impl → Claude review).

## Test plan

- [ ] `pytest -v` → 25 passed (4 db-postgres skipped without DB)
- [ ] `ruff check bot/ tests/` → clean
- [ ] New test: `test_chat_messages_no_auto_member` — verifies set_member NOT called

## Out of scope

- `bot/handlers/chat_events.py` (canonical membership signal — preserved)
- UserRepo, MessageRepo internals
- New application status values

## Memory team scope note

`bot/handlers/chat_messages.py` is in their T1-04 / T1-05 authorized scope. Surface area = 1 line removed. Their PR will rebase cleanly on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)