### PR TITLE
[T1-01] feat(db): add feature_flags table + FeatureFlagRepo

### DIFF
--- a/alembic/versions/003_add_feature_flags.py
+++ b/alembic/versions/003_add_feature_flags.py
@@ -4,6 +4,14 @@ T1-01: persistent rollout flags for memory surfaces. All memory.* flags default 
 the migration does NOT seed any flag rows. Operators enable flags explicitly via the
 admin UI (later phase) or via SQL.
 
+Note on NULL semantics: postgres treats NULLs as DISTINCT in unique constraints by default,
+so a constraint over ``(flag_key, scope_type, scope_id)`` would let multiple global-scope
+rows (both scope columns NULL) coexist for the same flag_key. We need the opposite
+behavior — global scope must be unique per flag_key. Postgres 15+ supports
+``NULLS NOT DISTINCT`` on unique constraints, which is what we use here. CI runs against
+postgres:16 (see ``.github/workflows/ci.yml``); dev compose pins postgres:16
+(``docker-compose.dev.yml``).
+
 Revision ID: 003
 Revises: 002
 Create Date: 2026-04-26
@@ -50,16 +58,23 @@ def upgrade() -> None:
             nullable=False,
         ),
         sa.PrimaryKeyConstraint("id"),
-        # Logical uniqueness: (flag_key, scope_type, scope_id). Postgres unique constraints
-        # treat NULLs as distinct, which is exactly what we want — global scope (both NULL)
-        # is one unique row, and per-scope rows can coexist alongside.
-        sa.UniqueConstraint(
-            "flag_key", "scope_type", "scope_id", name="uq_feature_flags_key_scope"
-        ),
+    )
+    # Unique key with NULLS NOT DISTINCT so a single global-scope row per flag_key is
+    # actually unique. Without NULLS NOT DISTINCT, two rows with (scope_type=NULL,
+    # scope_id=NULL) would coexist and ON CONFLICT in FeatureFlagRepo.set_enabled would
+    # never fire. SQLAlchemy 2.0.20+ exposes ``postgresql_nulls_not_distinct`` on
+    # UniqueConstraint / unique Index. Postgres 15+ required (we run 16 everywhere).
+    op.create_index(
+        "uq_feature_flags_key_scope",
+        "feature_flags",
+        ["flag_key", "scope_type", "scope_id"],
+        unique=True,
+        postgresql_nulls_not_distinct=True,
     )
     op.create_index("ix_feature_flags_enabled", "feature_flags", ["enabled"])
 
 
 def downgrade() -> None:
     op.drop_index("ix_feature_flags_enabled", table_name="feature_flags")
+    op.drop_index("uq_feature_flags_key_scope", table_name="feature_flags")
     op.drop_table("feature_flags")

--- a/alembic/versions/003_add_feature_flags.py
+++ b/alembic/versions/003_add_feature_flags.py
@@ -1,0 +1,65 @@
+"""add_feature_flags
+
+T1-01: persistent rollout flags for memory surfaces. All memory.* flags default OFF;
+the migration does NOT seed any flag rows. Operators enable flags explicitly via the
+admin UI (later phase) or via SQL.
+
+Revision ID: 003
+Revises: 002
+Create Date: 2026-04-26
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "003"
+down_revision: Union[str, Sequence[str], None] = "002"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "feature_flags",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("flag_key", sa.String(length=255), nullable=False),
+        sa.Column("scope_type", sa.String(length=64), nullable=True),
+        sa.Column("scope_id", sa.String(length=255), nullable=True),
+        sa.Column(
+            "enabled",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+        sa.Column("config_json", sa.JSON(), nullable=True),
+        sa.Column("updated_by", sa.BigInteger(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        # Logical uniqueness: (flag_key, scope_type, scope_id). Postgres unique constraints
+        # treat NULLs as distinct, which is exactly what we want — global scope (both NULL)
+        # is one unique row, and per-scope rows can coexist alongside.
+        sa.UniqueConstraint(
+            "flag_key", "scope_type", "scope_id", name="uq_feature_flags_key_scope"
+        ),
+    )
+    op.create_index("ix_feature_flags_enabled", "feature_flags", ["enabled"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_feature_flags_enabled", table_name="feature_flags")
+    op.drop_table("feature_flags")

--- a/bot/db/models.py
+++ b/bot/db/models.py
@@ -155,6 +155,12 @@ class FeatureFlag(Base):
     Logical key: ``(flag_key, scope_type, scope_id)``. Global flags use ``scope_type=None``
     and ``scope_id=None``. Per-chat / per-user flags pin a non-null scope.
 
+    The DB-level unique index ``uq_feature_flags_key_scope`` uses ``NULLS NOT DISTINCT``
+    so global-scope rows are actually unique per flag_key (postgres 15+ feature; postgres
+    16 is the runtime). The model's ``__table_args__`` declares the unique index with the
+    same flag so ``Base.metadata.create_all`` (used by ``bot/__main__.py::_init_db`` in
+    dev) produces the same shape as the alembic migration.
+
     All ``memory.*`` flag keys default to OFF — the migration does not seed any rows, and
     ``FeatureFlagRepo.get`` returns ``False`` for missing flags. Operators enable flags
     explicitly via SQL until an admin UI lands in a later phase.
@@ -163,9 +169,14 @@ class FeatureFlag(Base):
     __tablename__ = "feature_flags"
     __table_args__ = (
         Index("ix_feature_flags_enabled", "enabled"),
-        # Unique on the logical key. Postgres treats NULLs as distinct, so global rows
-        # (both scope columns NULL) coexist with per-scope rows.
-        # Constraint name matches the migration.
+        Index(
+            "uq_feature_flags_key_scope",
+            "flag_key",
+            "scope_type",
+            "scope_id",
+            unique=True,
+            postgresql_nulls_not_distinct=True,
+        ),
     )
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)

--- a/bot/db/models.py
+++ b/bot/db/models.py
@@ -147,3 +147,39 @@ class VouchLog(Base):
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=func.now(), server_default=func.now()
     )
+
+
+class FeatureFlag(Base):
+    """Persistent rollout flag for memory surfaces (T1-01).
+
+    Logical key: ``(flag_key, scope_type, scope_id)``. Global flags use ``scope_type=None``
+    and ``scope_id=None``. Per-chat / per-user flags pin a non-null scope.
+
+    All ``memory.*`` flag keys default to OFF — the migration does not seed any rows, and
+    ``FeatureFlagRepo.get`` returns ``False`` for missing flags. Operators enable flags
+    explicitly via SQL until an admin UI lands in a later phase.
+    """
+
+    __tablename__ = "feature_flags"
+    __table_args__ = (
+        Index("ix_feature_flags_enabled", "enabled"),
+        # Unique on the logical key. Postgres treats NULLs as distinct, so global rows
+        # (both scope columns NULL) coexist with per-scope rows.
+        # Constraint name matches the migration.
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    flag_key: Mapped[str] = mapped_column(String(255), nullable=False)
+    scope_type: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    scope_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    enabled: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default="false"
+    )
+    config_json: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+    updated_by: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=func.now(), server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=func.now(), server_default=func.now(), onupdate=func.now()
+    )

--- a/bot/db/repos/feature_flag.py
+++ b/bot/db/repos/feature_flag.py
@@ -1,0 +1,81 @@
+"""Repository for ``feature_flags`` (T1-01).
+
+The contract is intentionally minimal: ``get()`` returns a bool, defaulting to False for
+missing flags. ``set_enabled()`` is provided as a small helper for tests, future admin UI,
+and one-off SQL-equivalent operations from a Python REPL.
+
+All ``memory.*`` flags default OFF until an explicit row toggles them on. The migration
+does NOT seed any rows — see ``alembic/versions/003_add_feature_flags.py``.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from bot.db.models import FeatureFlag
+
+
+class FeatureFlagRepo:
+    @staticmethod
+    async def get(
+        session: AsyncSession,
+        flag_key: str,
+        scope_type: str | None = None,
+        scope_id: str | None = None,
+    ) -> bool:
+        """Return the boolean state of a flag. Missing flag → False.
+
+        Resolution does NOT walk the scope hierarchy — callers ask for the scope they care
+        about and get a direct yes/no. A future ``get_with_fallback()`` could implement
+        scope-walk semantics if needed.
+        """
+        stmt = select(FeatureFlag.enabled).where(
+            FeatureFlag.flag_key == flag_key,
+            FeatureFlag.scope_type.is_(scope_type) if scope_type is None else FeatureFlag.scope_type == scope_type,
+            FeatureFlag.scope_id.is_(scope_id) if scope_id is None else FeatureFlag.scope_id == scope_id,
+        )
+        result = await session.execute(stmt)
+        row = result.scalar_one_or_none()
+        return bool(row) if row is not None else False
+
+    @staticmethod
+    async def set_enabled(
+        session: AsyncSession,
+        flag_key: str,
+        enabled: bool,
+        scope_type: str | None = None,
+        scope_id: str | None = None,
+        config_json: dict | None = None,
+        updated_by: int | None = None,
+    ) -> FeatureFlag:
+        """Upsert a flag row by ``(flag_key, scope_type, scope_id)`` and set its state.
+
+        Flushes; does not commit. Caller controls the transaction lifecycle. Postgres-only
+        (uses ON CONFLICT). Conflict target is the unique constraint
+        ``uq_feature_flags_key_scope``.
+        """
+        stmt = (
+            pg_insert(FeatureFlag)
+            .values(
+                flag_key=flag_key,
+                scope_type=scope_type,
+                scope_id=scope_id,
+                enabled=enabled,
+                config_json=config_json,
+                updated_by=updated_by,
+            )
+            .on_conflict_do_update(
+                constraint="uq_feature_flags_key_scope",
+                set_={
+                    "enabled": enabled,
+                    "config_json": config_json,
+                    "updated_by": updated_by,
+                },
+            )
+            .returning(FeatureFlag)
+        )
+        result = await session.execute(stmt)
+        await session.flush()
+        return result.scalar_one()

--- a/bot/db/repos/feature_flag.py
+++ b/bot/db/repos/feature_flag.py
@@ -10,7 +10,7 @@ does NOT seed any rows — see ``alembic/versions/003_add_feature_flags.py``.
 
 from __future__ import annotations
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -31,14 +31,22 @@ class FeatureFlagRepo:
         about and get a direct yes/no. A future ``get_with_fallback()`` could implement
         scope-walk semantics if needed.
         """
-        stmt = select(FeatureFlag.enabled).where(
-            FeatureFlag.flag_key == flag_key,
-            FeatureFlag.scope_type.is_(scope_type) if scope_type is None else FeatureFlag.scope_type == scope_type,
-            FeatureFlag.scope_id.is_(scope_id) if scope_id is None else FeatureFlag.scope_id == scope_id,
+        stmt = (
+            select(FeatureFlag.enabled)
+            .where(
+                FeatureFlag.flag_key == flag_key,
+                FeatureFlag.scope_type.is_(scope_type)
+                if scope_type is None
+                else FeatureFlag.scope_type == scope_type,
+                FeatureFlag.scope_id.is_(scope_id)
+                if scope_id is None
+                else FeatureFlag.scope_id == scope_id,
+            )
+            .limit(1)  # defence in depth: even if the unique constraint regresses, return one row
         )
         result = await session.execute(stmt)
         row = result.scalar_one_or_none()
-        return bool(row) if row is not None else False
+        return bool(row)  # None → False; False → False; True → True
 
     @staticmethod
     async def set_enabled(
@@ -53,8 +61,12 @@ class FeatureFlagRepo:
         """Upsert a flag row by ``(flag_key, scope_type, scope_id)`` and set its state.
 
         Flushes; does not commit. Caller controls the transaction lifecycle. Postgres-only
-        (uses ON CONFLICT). Conflict target is the unique constraint
-        ``uq_feature_flags_key_scope``.
+        (uses ON CONFLICT). The model's ``onupdate=func.now()`` does not fire through Core
+        ``pg_insert``, so ``updated_at`` is set explicitly for an accurate audit trail.
+
+        ``config_json`` is intentionally typed as a free-form dict but should NOT contain
+        secrets / tokens / passwords. The flags table is dumped in admin views and may be
+        copied for support. Treat it as policy metadata only (e.g., ``{"rolloutPct": 10}``).
         """
         stmt = (
             pg_insert(FeatureFlag)
@@ -67,11 +79,16 @@ class FeatureFlagRepo:
                 updated_by=updated_by,
             )
             .on_conflict_do_update(
-                constraint="uq_feature_flags_key_scope",
+                # Target the unique index by columns. The index is created with
+                # NULLS NOT DISTINCT so global-scope rows (NULL, NULL) actually conflict
+                # under ON CONFLICT — see migration 003.
+                index_elements=["flag_key", "scope_type", "scope_id"],
                 set_={
                     "enabled": enabled,
                     "config_json": config_json,
                     "updated_by": updated_by,
+                    # Manual updated_at on conflict; ORM-level onupdate does not fire here.
+                    "updated_at": func.now(),
                 },
             )
             .returning(FeatureFlag)

--- a/bot/db/repos/feature_flag.py
+++ b/bot/db/repos/feature_flag.py
@@ -88,7 +88,10 @@ class FeatureFlagRepo:
                     "config_json": config_json,
                     "updated_by": updated_by,
                     # Manual updated_at on conflict; ORM-level onupdate does not fire here.
-                    "updated_at": func.now(),
+                    # ``clock_timestamp()`` (statement time), not ``now()`` (transaction
+                    # start), so updates within a single transaction (e.g. tests, batched
+                    # toggles, or migrations) get distinguishable audit timestamps.
+                    "updated_at": func.clock_timestamp(),
                 },
             )
             .returning(FeatureFlag)

--- a/docs/memory-system/IMPLEMENTATION_STATUS.md
+++ b/docs/memory-system/IMPLEMENTATION_STATUS.md
@@ -37,7 +37,7 @@
 
 | Ticket | Title                                                       | Status         | Notes |
 |--------|-------------------------------------------------------------|----------------|-------|
-| T1-01  | feature_flags table/repo                                    | not started    |
+| T1-01  | feature_flags table/repo                                    | done           | Sprint 6 / PR #TBD. Alembic migration `003_add_feature_flags` (id pk, flag_key non-null, scope_type/scope_id nullable, enabled bool default false, config_json, updated_by, created_at/updated_at; unique `(flag_key, scope_type, scope_id)`; index on `enabled`). New `bot/db/models.py::FeatureFlag` + `bot/db/repos/feature_flag.py::FeatureFlagRepo` with `get(flag_key, scope_type, scope_id) -> bool` (missing → False) and `set_enabled(...)` upsert helper. Migration intentionally seeds NO rows — all `memory.*` flags default OFF. Tests under `tests/db/test_feature_flag_repo.py` (5 DB-backed + 1 metadata smoke) cover: missing-returns-false, set-creates-row, set-updates-no-duplicate, per-scope coexists with global, no-seed-rows invariant, model registered in metadata. |
 | T1-02  | ingestion_runs table                                        | not started    |
 | T1-03  | telegram_updates table                                      | not started    |
 | T1-04  | raw update persistence service                              | not started    |

--- a/tests/db/test_feature_flag_repo.py
+++ b/tests/db/test_feature_flag_repo.py
@@ -110,16 +110,47 @@ async def test_per_scope_flags_coexist_with_global(db_session) -> None:
     ) is True
 
 
-async def test_memory_flags_have_no_seed_rows(db_session) -> None:
-    """T1-01 invariant: the migration MUST NOT pre-enable any memory.* flag.
-    A regression that adds an INSERT into the migration would tripwire here."""
+async def test_memory_flags_have_no_enabled_seed_rows(db_session) -> None:
+    """T1-01 invariant: the migration MUST NOT seed any ENABLED memory.* flag.
+
+    Stricter than the bare "no seed rows" check — what we actually care about is that no
+    migration silently turns on a memory feature. A future ticket may legitimately seed a
+    documentation row with ``enabled=False`` (e.g., to expose a flag in an admin UI before
+    operators toggle it); that is fine. What is NEVER fine is a seed with ``enabled=True``.
+    """
     from bot.db.models import FeatureFlag
 
     rows = await db_session.execute(
-        select(FeatureFlag).where(FeatureFlag.flag_key.like("memory.%"))
+        select(FeatureFlag).where(
+            FeatureFlag.flag_key.like("memory.%"),
+            FeatureFlag.enabled.is_(True),
+        )
     )
     seeded = rows.scalars().all()
-    assert seeded == [], f"unexpected seeded memory.* flag rows: {[r.flag_key for r in seeded]}"
+    assert seeded == [], (
+        "memory.* flag was seeded with enabled=True by a migration: "
+        f"{[r.flag_key for r in seeded]}"
+    )
+
+
+async def test_set_enabled_updates_updated_at(db_session) -> None:
+    """Audit trail invariant: ``updated_at`` must change on conflict-update path.
+
+    The model declares ``onupdate=func.now()`` for ORM-managed updates, but
+    ``pg_insert(...).on_conflict_do_update(...)`` is a Core statement and does NOT trigger
+    the ORM hook. Repo sets ``updated_at`` explicitly in the conflict ``set_`` map.
+    """
+    from bot.db.repos.feature_flag import FeatureFlagRepo
+
+    key = _unique_flag_key()
+
+    inserted = await FeatureFlagRepo.set_enabled(db_session, flag_key=key, enabled=False)
+    original_updated_at = inserted.updated_at
+
+    updated = await FeatureFlagRepo.set_enabled(db_session, flag_key=key, enabled=True)
+    await db_session.refresh(updated)
+
+    assert updated.updated_at > original_updated_at
 
 
 def test_engine_module_imports_feature_flag_model(app_env) -> None:

--- a/tests/db/test_feature_flag_repo.py
+++ b/tests/db/test_feature_flag_repo.py
@@ -1,0 +1,145 @@
+"""T1-01 acceptance tests — feature_flags table + FeatureFlagRepo.
+
+Test isolation: outer-transaction rollback via the ``db_session`` fixture. Tests do NOT
+call ``session.commit()`` — they call repo methods (which flush internally on writes) and
+verify state with ``session.execute(select(...))``.
+
+Acceptance:
+- migration creates the table with the right columns + unique key + enabled index
+- ``FeatureFlagRepo.get`` returns ``False`` for missing flag
+- ``FeatureFlagRepo.set_enabled`` upserts; second call updates
+- All ``memory.*`` flag keys default OFF (no seed rows enabling them)
+- Per-scope flags coexist with global flags under the same flag_key
+"""
+
+from __future__ import annotations
+
+import random
+
+import pytest
+from sqlalchemy import select
+
+pytestmark = pytest.mark.usefixtures("app_env")
+
+
+def _unique_flag_key() -> str:
+    return f"memory.test.flag_{random.randint(900_000_000, 999_999_999)}"
+
+
+async def test_get_missing_flag_returns_false(db_session) -> None:
+    from bot.db.repos.feature_flag import FeatureFlagRepo
+
+    assert (
+        await FeatureFlagRepo.get(db_session, _unique_flag_key())
+    ) is False
+
+
+async def test_set_enabled_creates_row_and_get_returns_true(db_session) -> None:
+    from bot.db.models import FeatureFlag
+    from bot.db.repos.feature_flag import FeatureFlagRepo
+
+    key = _unique_flag_key()
+
+    flag = await FeatureFlagRepo.set_enabled(
+        db_session, flag_key=key, enabled=True, updated_by=42
+    )
+    assert flag.flag_key == key
+    assert flag.enabled is True
+    assert flag.scope_type is None
+    assert flag.scope_id is None
+    assert flag.updated_by == 42
+
+    assert (await FeatureFlagRepo.get(db_session, key)) is True
+
+    # Sanity: exactly one row by logical key.
+    rows = await db_session.execute(
+        select(FeatureFlag).where(
+            FeatureFlag.flag_key == key,
+            FeatureFlag.scope_type.is_(None),
+            FeatureFlag.scope_id.is_(None),
+        )
+    )
+    assert len(rows.scalars().all()) == 1
+
+
+async def test_set_enabled_updates_existing_row_no_duplicate(db_session) -> None:
+    from bot.db.models import FeatureFlag
+    from bot.db.repos.feature_flag import FeatureFlagRepo
+
+    key = _unique_flag_key()
+
+    await FeatureFlagRepo.set_enabled(db_session, flag_key=key, enabled=False)
+    await FeatureFlagRepo.set_enabled(db_session, flag_key=key, enabled=True, config_json={"v": 1})
+
+    assert (await FeatureFlagRepo.get(db_session, key)) is True
+
+    rows = await db_session.execute(
+        select(FeatureFlag).where(
+            FeatureFlag.flag_key == key,
+            FeatureFlag.scope_type.is_(None),
+            FeatureFlag.scope_id.is_(None),
+        )
+    )
+    persisted = rows.scalars().all()
+    assert len(persisted) == 1
+    await db_session.refresh(persisted[0])
+    assert persisted[0].enabled is True
+    assert persisted[0].config_json == {"v": 1}
+
+
+async def test_per_scope_flags_coexist_with_global(db_session) -> None:
+    from bot.db.repos.feature_flag import FeatureFlagRepo
+
+    key = _unique_flag_key()
+
+    # Global OFF; per-chat ON.
+    await FeatureFlagRepo.set_enabled(db_session, flag_key=key, enabled=False)
+    await FeatureFlagRepo.set_enabled(
+        db_session,
+        flag_key=key,
+        enabled=True,
+        scope_type="chat",
+        scope_id="-1001234567890",
+    )
+
+    assert (await FeatureFlagRepo.get(db_session, key)) is False
+    assert (
+        await FeatureFlagRepo.get(
+            db_session, key, scope_type="chat", scope_id="-1001234567890"
+        )
+    ) is True
+
+
+async def test_memory_flags_have_no_seed_rows(db_session) -> None:
+    """T1-01 invariant: the migration MUST NOT pre-enable any memory.* flag.
+    A regression that adds an INSERT into the migration would tripwire here."""
+    from bot.db.models import FeatureFlag
+
+    rows = await db_session.execute(
+        select(FeatureFlag).where(FeatureFlag.flag_key.like("memory.%"))
+    )
+    seeded = rows.scalars().all()
+    assert seeded == [], f"unexpected seeded memory.* flag rows: {[r.flag_key for r in seeded]}"
+
+
+def test_engine_module_imports_feature_flag_model(app_env) -> None:
+    """Smoke: the FeatureFlag model is importable and registers with SQLAlchemy metadata.
+    This is a non-DB sanity check that runs even without postgres."""
+    from tests.conftest import import_module
+
+    models = import_module("bot.db.models")
+    assert hasattr(models, "FeatureFlag")
+    assert "feature_flags" in models.Base.metadata.tables
+    table = models.Base.metadata.tables["feature_flags"]
+    cols = {c.name for c in table.columns}
+    assert {
+        "id",
+        "flag_key",
+        "scope_type",
+        "scope_id",
+        "enabled",
+        "config_json",
+        "updated_by",
+        "created_at",
+        "updated_at",
+    } == cols


### PR DESCRIPTION
Closes #25.

## Sprint 6 — first Phase 1 ticket

Persistent rollout flags for memory surfaces. All `memory.*` flag keys default OFF (migration seeds NO rows; `FeatureFlagRepo.get` returns False for missing). Operators enable flags via SQL until an admin UI lands later.

## Schema (alembic/versions/003_add_feature_flags.py)
- id pk, flag_key (not null), scope_type / scope_id (nullable), enabled bool default false, config_json, updated_by, created_at, updated_at
- unique `(flag_key, scope_type, scope_id)` — postgres NULL-distinct semantics let global rows coexist with per-scope rows under the same flag_key
- index on `enabled`

## Code
- `bot/db/models.py` — `FeatureFlag` model.
- `bot/db/repos/feature_flag.py` — `FeatureFlagRepo`:
  - `get(flag_key, scope_type=None, scope_id=None) -> bool` — missing → False, no scope-walking
  - `set_enabled(...)` — postgres ON CONFLICT upsert, no commit (caller owns tx)

## Tests (6)
- get of missing → False
- set_enabled creates row, get returns True
- set_enabled twice updates without duplicating
- per-scope coexists with global
- no memory.* seed rows (regression canary)
- model registered in metadata (offline smoke)

34 pass + 16 skip locally; ruff clean. CI runs DB-backed tests against postgres service.

## Out of scope
- Wiring flags into handlers (later Phase 1 tickets)
- Admin UI for toggling (Phase 6+)
- Scope-hierarchy walking in get() (deferred; current contract is direct lookup)

## Reviewers
- Claude product reviewer — acceptance fit, no-seed invariant, scope semantics
- Codex technical reviewer — postgres NULL-distinct correctness, ON CONFLICT target, isolation pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)