### PR TITLE
docs: stale-runtime cleanup + GHCR PAT rotation policy (B2 + B3)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,5 +21,6 @@ Vibe Gatekeeper is a Telegram + web gatekeeping system for managing community ap
 
 ## Current Migration Rule
 
-- The legacy production runtime at `/home/claw/vibe-gatekeeper` remains the live path until the new GitHub/GHCR/Coolify path is verified.
-- Do not cut over the production bot token during bootstrap work.
+- Coolify is the production runtime for bot and web deploys.
+- Legacy `/home/claw/vibe-gatekeeper` is retained only as rollback fallback until
+  `scripts/cleanup-legacy.sh` passes its A3, soak window, and disk preflights.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,8 +28,9 @@ Vibe Gatekeeper is a Telegram + web gatekeeping system for managing community ap
 
 ## Current Migration Rule
 
-- The legacy production runtime at `/home/claw/vibe-gatekeeper` remains the live path until the new GitHub/GHCR/Coolify path is verified.
-- Do not cut over the production bot token during bootstrap work.
+- Coolify is the production runtime for bot and web deploys.
+- Legacy `/home/claw/vibe-gatekeeper` is retained only as rollback fallback until
+  `scripts/cleanup-legacy.sh` passes its A3, soak window, and disk preflights.
 
 ## Memory System Cycle (active 2026-04-26+)
 

--- a/docs/ops/ghcr-pat-rotation.md
+++ b/docs/ops/ghcr-pat-rotation.md
@@ -1,0 +1,94 @@
+# GHCR PAT Rotation Policy
+
+Last verified: 2026-04-26.
+
+This policy covers the GitHub PAT used by the VPS Docker daemon to pull private
+GHCR images for Coolify-managed `vibe-gatekeeper` services.
+
+## Scope
+
+Use a GitHub PAT with `read:packages` for runtime pulls.
+
+Do not grant `write:packages` to the runtime pull PAT. The release workflow pushes
+images with `secrets.GITHUB_TOKEN` and workflow permission `packages: write`, so a
+separate write-capable PAT is not required by the current repo.
+
+## Expiry
+
+Chosen expiry: 90 days.
+
+Set reminders before expiry:
+
+- 14 days before expiry.
+- 7 days before expiry.
+- 1 day before expiry.
+
+## Storage Locations
+
+Current active locations:
+
+- VPS root Docker auth: `/root/.docker/config.json`.
+- Local operator backup: `~/.env.tokens`, entry `GHCR_PAT=<your-PAT>`.
+
+Current non-locations:
+
+- Coolify Registry Credentials are not used for this project as of 2026-04-26.
+- GitHub Actions secret `GHCR_PAT` is not referenced by `.github/workflows/*.yml`.
+
+If either non-location becomes active later, update this policy in the same PR
+that introduces it.
+
+## Rotation Procedure
+
+1. Generate a new GitHub PAT in GitHub Settings -> Developer settings ->
+   Personal access tokens with `read:packages` scope and 90-day expiry.
+2. Update the local recovery copy in `~/.env.tokens`:
+   `GHCR_PAT=<your-PAT>`.
+3. Update the VPS host-level Docker login:
+
+   ```bash
+   source ~/.env.tokens
+   test -n "${GHCR_PAT:?GHCR_PAT missing}"
+   printf '%s\n' "$GHCR_PAT" \
+     | ssh claw@187.77.98.73 'sudo -n docker login ghcr.io -u Jekudy --password-stdin'
+   ```
+
+   Do not paste the PAT value into shell history.
+4. Coolify Registry Credentials are not active for this project. If a registry
+   credential is added later, update the GHCR credential in the Coolify UI or API
+   before redeploying.
+5. If a future workflow references `secrets.GHCR_PAT`, update the GitHub Actions
+   repository secret before triggering a release.
+6. Trigger one Coolify deploy for bot and web, or manually verify both pulls:
+
+   ```bash
+   docker pull ghcr.io/jekudy/vibe-gatekeeper-bot:main
+   docker pull ghcr.io/jekudy/vibe-gatekeeper-web:main
+   ```
+
+7. Confirm the new deploy starts cleanly and logs do not show `denied` or
+   `unauthorized` on GHCR pull.
+8. Revoke the old PAT in GitHub Settings.
+9. Append an audit entry to `memory/worklog.md` with date, operator, token name,
+   expiry date, verification command, and result. Do not record the token value.
+
+## Calendar Reminder
+
+Create a recurring reminder at day 75 of each 90-day token window. Example:
+`todoist quick add "Rotate vibe-gatekeeper GHCR PAT" due "every 75 days"`.
+
+## Audit Trail Template
+
+Append this to `memory/worklog.md` after each rotation:
+
+```markdown
+## YYYY-MM-DD - GHCR PAT rotation
+
+- Operator: <name>
+- Token name: <token-name>
+- Scope: `read:packages`
+- New expiry: YYYY-MM-DD
+- Updated locations: `/root/.docker/config.json`, `~/.env.tokens`
+- Verification: bot and web `docker pull` checks succeeded
+- Old token revoked: yes
+```

--- a/docs/ops/ghcr-registry-access.md
+++ b/docs/ops/ghcr-registry-access.md
@@ -1,23 +1,64 @@
-# GHCR Registry Access — vibe-gatekeeper
+# GHCR Registry Access
 
-Document records the exact GHCR pull mechanism used for this project plus rotation history.
+Last verified: 2026-04-26.
 
-## Chosen mechanism
+This project deploys pre-built private GHCR images into Coolify. The active pull
+mechanism is host-level Docker registry authentication on the VPS, not a Coolify
+Registry Credential resource.
 
-<filled by Spec B on <date>> — one of:
-- host-level `docker login` (see playbook#p1 mechanism 1)
-- Coolify Registry Credentials (see playbook#p1 mechanism 2)
+## Images and Tags
 
-## PAT details
+Release workflow: `.github/workflows/release.yml`.
 
-- Token name: <filled by Spec B on <date>>
-- Scope: `read:packages`
-- Creation date: <filled by Spec B on <date>>
-- Expiry date: <filled by Spec B on <date>>
-- Calendar alerts set: 14 / 7 / 1 days before expiry — <filled by Spec B on <date>>
+Published images:
 
-## Rotation log
+- `ghcr.io/jekudy/vibe-gatekeeper-bot`
+- `ghcr.io/jekudy/vibe-gatekeeper-web`
 
-| Date | Action | New token ID | Notes |
-|------|--------|--------------|-------|
-| <filled by Spec B on <date>> | initial | <filled by Spec B on <date>> | <filled by Spec B on <date>> |
+Each successful release from `main` pushes two tags per image:
+
+- `:sha-<git-commit-sha>` - immutable build tag from the CI head SHA.
+- `:main` - mutable production tracking tag used by current Coolify resources.
+
+Current Coolify prod resources in `docs/runbook.md` reference `:main`. Rollback
+should prefer a previous deployment digest or a known-good `:sha-<git-commit-sha>`
+tag instead of guessing from `:main`.
+
+## Pull Mechanism
+
+Current runtime path:
+
+1. The VPS root user is logged in to GHCR with a GitHub PAT:
+   `docker login ghcr.io -u Jekudy`.
+2. Docker stores the credential material in `/root/.docker/config.json`.
+3. Coolify reuses the host Docker daemon, so Coolify can pull the private GHCR
+   images without a separate Coolify Registry Credential resource.
+
+Do not add a second Coolify Registry Credential unless the project intentionally
+moves away from host-level auth. If that migration happens, update this document
+and `docs/ops/ghcr-pat-rotation.md` in the same change.
+
+## PAT Storage
+
+Active deployment pull auth:
+
+- VPS: `/root/.docker/config.json` after root-level `docker login`.
+- Coolify Registry Credentials: not used for this project as of 2026-04-26.
+
+Operator-side recovery copy:
+
+- Local: `~/.env.tokens`, entry `GHCR_PAT=<your-PAT>`.
+- Current cleanup note: no local `GHCR_PAT` entry was found on 2026-04-26; add
+  it during the next rotation so the deployment pull credential is recoverable.
+
+GitHub Actions:
+
+- `.github/workflows/release.yml` pushes with `secrets.GITHUB_TOKEN` and
+  workflow permission `packages: write`.
+- No repository secret named `GHCR_PAT` is referenced by the current workflows.
+- Runtime pull PAT only needs `read:packages`; it must not be used for release
+  pushes unless a future workflow explicitly documents that requirement.
+
+## Rotation
+
+Rotation policy and steps live in `docs/ops/ghcr-pat-rotation.md`.


### PR DESCRIPTION
## Summary

Sprint B2+B3. Combined docs cleanup.

**B2:** AGENTS.md/CLAUDE.md said legacy `/home/claw/vibe-gatekeeper` is the live path "until new GitHub/GHCR/Coolify is verified". After Round 1+3 + memory team's T0/T1 work, Coolify IS the production runtime. Updated to reflect reality with rollback path noted.

`docs/ops/ghcr-registry-access.md` was a placeholder scaffold (`<filled by Spec B>`). Replaced with the actual mechanism: image tagging, host-level docker login, PAT storage locations.

**B3:** New `docs/ops/ghcr-pat-rotation.md` covering scope, expiry policy, storage, rotation procedure, calendar reminder, audit trail.

## Changes

- `AGENTS.md` — 1 line update
- `CLAUDE.md` — sync with AGENTS.md
- `docs/ops/ghcr-registry-access.md` — full rewrite (placeholder → real)
- `docs/ops/ghcr-pat-rotation.md` — new file

## Test plan

- [ ] gitleaks pass (no PAT values in committed docs)
- [ ] markdownlint clean
- [ ] Manual review: rotation procedure reads cleanly for someone in a 3am rotation

## Out of scope

- Don't rotate the actual PAT (just policy)
- GitHub OIDC migration deferred

🤖 Generated with [Claude Code](https://claude.com/claude-code)