### PR TITLE
fix(reliability): TTL cache for Sheets client (B1)

### DIFF
--- a/bot/services/sheets.py
+++ b/bot/services/sheets.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import logging
+import threading
+import time
 from datetime import datetime, timezone
-from functools import lru_cache
 
 import gspread
 from google.oauth2.service_account import Credentials
@@ -18,6 +19,7 @@ from bot.html_escape import html_escape
 logger = logging.getLogger(__name__)
 
 SCOPES = ["https://www.googleapis.com/auth/spreadsheets"]
+_CLIENT_TTL_SECONDS = 300
 
 HEADERS = [
     "Telegram ID",
@@ -50,20 +52,46 @@ def _is_configured() -> bool:
     return bool(settings.GOOGLE_SHEETS_CREDS_FILE and settings.GOOGLE_SHEET_ID)
 
 
-@lru_cache(maxsize=1)
+_client: gspread.Client | None = None
+_client_ts = 0.0
+_client_checked = False
+_client_configured = False
+_client_lock = threading.Lock()
+
+
 def _get_client() -> gspread.Client | None:
-    """Return a cached gspread client, or None if credentials are not configured."""
-    if not _is_configured():
-        logger.debug("Google Sheets credentials not configured — skipping.")
-        return None
-    try:
-        creds = Credentials.from_service_account_file(
-            settings.GOOGLE_SHEETS_CREDS_FILE, scopes=SCOPES
-        )
-        return gspread.authorize(creds)
-    except Exception:
-        logger.exception("Failed to create Google Sheets client")
-        return None
+    """Return a TTL-cached gspread client, or None if credentials are not configured."""
+    global _client, _client_checked, _client_configured, _client_ts
+
+    now = time.monotonic()
+    with _client_lock:
+        configured = _is_configured()
+        if not configured:
+            _client = None
+            _client_ts = now
+            _client_checked = True
+            _client_configured = False
+            logger.debug("Google Sheets credentials not configured — skipping.")
+            return None
+
+        cache_expired = now - _client_ts > _CLIENT_TTL_SECONDS
+        should_refresh = not _client_checked or not _client_configured or cache_expired
+        if not should_refresh:
+            return _client
+
+        try:
+            creds = Credentials.from_service_account_file(
+                settings.GOOGLE_SHEETS_CREDS_FILE, scopes=SCOPES
+            )
+            _client = gspread.authorize(creds)
+        except Exception:
+            logger.exception("Failed to create Google Sheets client")
+            _client = None
+
+        _client_ts = now
+        _client_checked = True
+        _client_configured = True
+        return _client
 
 
 def _get_sheet() -> gspread.Worksheet | None:

--- a/tests/test_sheets_ttl.py
+++ b/tests/test_sheets_ttl.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from tests.conftest import import_module
+
+
+class _Clock:
+    def __init__(self, now: float = 0.0) -> None:
+        self.now = now
+
+    def monotonic(self) -> float:
+        return self.now
+
+
+def test_get_client_retries_after_ttl_on_none(app_env, monkeypatch) -> None:
+    sheets = import_module("bot.services.sheets")
+    clock = _Clock()
+    configured = False
+    credential_loads = []
+    client = object()
+
+    def is_configured() -> bool:
+        return configured
+
+    def load_credentials(creds_file: str, scopes: list[str]) -> object:
+        credential_loads.append((creds_file, scopes))
+        return object()
+
+    monkeypatch.setattr(sheets.time, "monotonic", clock.monotonic)
+    monkeypatch.setattr(sheets, "_is_configured", is_configured)
+    monkeypatch.setattr(sheets.Credentials, "from_service_account_file", load_credentials)
+    monkeypatch.setattr(sheets.gspread, "authorize", lambda creds: client)
+
+    assert sheets._get_client() is None
+    assert credential_loads == []
+
+    configured = True
+    clock.now += sheets._CLIENT_TTL_SECONDS + 1
+
+    assert sheets._get_client() is client
+    assert len(credential_loads) == 1
+
+
+def test_get_client_caches_within_ttl(app_env, monkeypatch) -> None:
+    sheets = import_module("bot.services.sheets")
+    clock = _Clock(now=100.0)
+    credential_loads = []
+    clients = [object(), object()]
+    authorize_calls = 0
+
+    def load_credentials(creds_file: str, scopes: list[str]) -> object:
+        credential_loads.append((creds_file, scopes))
+        return object()
+
+    def authorize(creds: object) -> object:
+        nonlocal authorize_calls
+        client = clients[authorize_calls]
+        authorize_calls += 1
+        return client
+
+    monkeypatch.setattr(sheets.time, "monotonic", clock.monotonic)
+    monkeypatch.setattr(sheets, "_is_configured", lambda: True)
+    monkeypatch.setattr(sheets.Credentials, "from_service_account_file", load_credentials)
+    monkeypatch.setattr(sheets.gspread, "authorize", authorize)
+
+    assert sheets._get_client() is clients[0]
+    clock.now += sheets._CLIENT_TTL_SECONDS - 1
+    assert sheets._get_client() is clients[0]
+    assert len(credential_loads) == 1
+    assert authorize_calls == 1
+
+    clock.now += 2
+    assert sheets._get_client() is clients[1]
+    assert len(credential_loads) == 2
+    assert authorize_calls == 2


### PR DESCRIPTION
## Summary

Sprint B1. Replace `@lru_cache(maxsize=1)` on `bot/services/sheets.py:_get_client` with TTL cache.

**Bug:** if credential load failed (file missing, expired, network blip), the `None` got cached forever. Every subsequent sync silently skipped until process restart. Symmetric problem for runtime-added creds: "not configured" sentinel never re-evaluated.

**Fix:** TTL cache (5 min) + thread lock. Re-attempts on cache miss OR TTL expiry. apscheduler runs in threads, hence the lock.

## Tests (`tests/test_sheets_ttl.py`)

- `test_get_client_retries_after_ttl_on_none` — None state recovers after TTL + creds available
- `test_get_client_caches_within_ttl` — 2 calls within TTL → 1 credential load

Uses controllable clock via monkeypatch on `sheets.time.monotonic`.

## Test plan

- [ ] CI gates pass
- [ ] Pytest 2/2 new tests pass

## Out of scope

- gspread token refresh (library handles)
- async sheets client
- credentials format / loading

## Note

Codex implementer's CLI stream disconnected mid-write due to DNS, but diff is complete (verified by pytest + ruff in worktree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)