### PR TITLE
fix(security): require non-empty + min-length for WEB_SESSION_SECRET (CRIT-04)

### DIFF
--- a/bot/config.py
+++ b/bot/config.py
@@ -6,6 +6,9 @@ import secrets
 from pydantic import model_validator
 from pydantic_settings import BaseSettings
 
+_MIN_WEB_PASSWORD_LENGTH = 12
+_MIN_WEB_SESSION_SECRET_LENGTH = 32
+
 
 class Settings(BaseSettings):
     BOT_TOKEN: str
@@ -29,27 +32,47 @@ class Settings(BaseSettings):
 
     @model_validator(mode="after")
     def validate_web_password(self) -> Settings:
-        if self.WEB_PASSWORD is not None:
+        if self.WEB_PASSWORD is None:
+            if self.DEV_MODE:
+                logging.warning("WEB_PASSWORD is not set; generated an ephemeral dev password")
+                self.WEB_PASSWORD = secrets.token_urlsafe(16)
+                return self
+
+            raise ValueError("WEB_PASSWORD must be at least 12 characters in production")
+
+        if len(self.WEB_PASSWORD) >= _MIN_WEB_PASSWORD_LENGTH:
             return self
 
         if self.DEV_MODE:
-            logging.warning("WEB_PASSWORD is not set; generated an ephemeral dev password")
-            self.WEB_PASSWORD = secrets.token_urlsafe(16)
+            logging.warning("WEB_PASSWORD is shorter than 12 characters; accepted in DEV_MODE only")
             return self
 
-        raise ValueError("WEB_PASSWORD is required when DEV_MODE=false")
+        raise ValueError("WEB_PASSWORD must be at least 12 characters in production")
 
     @model_validator(mode="after")
     def validate_web_session_secret(self) -> Settings:
-        if self.WEB_SESSION_SECRET is not None:
+        if self.WEB_SESSION_SECRET is None:
+            if self.DEV_MODE:
+                logging.warning(
+                    "WEB_SESSION_SECRET is not set; generated an ephemeral dev session secret"
+                )
+                self.WEB_SESSION_SECRET = secrets.token_urlsafe(32)
+                return self
+
+            raise ValueError(
+                "WEB_SESSION_SECRET must be at least 32 characters in production"
+            )
+
+        if len(self.WEB_SESSION_SECRET) >= _MIN_WEB_SESSION_SECRET_LENGTH:
             return self
 
         if self.DEV_MODE:
-            logging.warning("WEB_SESSION_SECRET is not set; generated an ephemeral dev session secret")
-            self.WEB_SESSION_SECRET = secrets.token_urlsafe(32)
+            logging.warning(
+                "WEB_SESSION_SECRET is shorter than 32 characters; accepted in DEV_MODE only"
+            )
             return self
 
-        raise ValueError("WEB_SESSION_SECRET is required when DEV_MODE=false")
+        raise ValueError("WEB_SESSION_SECRET must be at least 32 characters in production")
 
 
 settings = Settings()  # type: ignore[call-arg]

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -7,6 +7,9 @@ from pydantic import ValidationError
 
 from tests.conftest import import_module
 
+VALID_WEB_PASSWORD = "valid-test-pass"
+VALID_WEB_SESSION_SECRET = "s" * 32
+
 
 def test_settings_accept_explicit_values(app_env) -> None:
     config = import_module("bot.config")
@@ -36,9 +39,12 @@ def test_settings_accept_explicit_values(app_env) -> None:
 
 def test_config_no_password_prod_raises(app_env, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("WEB_PASSWORD")
+    monkeypatch.setenv("WEB_SESSION_SECRET", VALID_WEB_SESSION_SECRET)
     monkeypatch.setenv("DEV_MODE", "false")
 
-    with pytest.raises(ValidationError, match="WEB_PASSWORD is required when DEV_MODE=false"):
+    with pytest.raises(
+        ValidationError, match="WEB_PASSWORD must be at least 12 characters in production"
+    ):
         import_module("bot.config")
 
 
@@ -48,9 +54,12 @@ def test_settings_no_password_prod_raises_direct_call(
     config = import_module("bot.config")
     Settings = config.Settings
     monkeypatch.delenv("WEB_PASSWORD")
+    monkeypatch.setenv("WEB_SESSION_SECRET", VALID_WEB_SESSION_SECRET)
     monkeypatch.setenv("DEV_MODE", "false")
 
-    with pytest.raises(ValidationError, match="WEB_PASSWORD is required when DEV_MODE=false"):
+    with pytest.raises(
+        ValidationError, match="WEB_PASSWORD must be at least 12 characters in production"
+    ):
         Settings()
 
 
@@ -75,11 +84,13 @@ def test_config_no_session_secret_prod_raises(
 ) -> None:
     config = import_module("bot.config")
     Settings = config.Settings
+    monkeypatch.setenv("WEB_PASSWORD", VALID_WEB_PASSWORD)
     monkeypatch.delenv("WEB_SESSION_SECRET")
     monkeypatch.setenv("DEV_MODE", "false")
 
     with pytest.raises(
-        ValidationError, match="WEB_SESSION_SECRET is required when DEV_MODE=false"
+        ValidationError,
+        match="WEB_SESSION_SECRET must be at least 32 characters in production",
     ):
         Settings()
 
@@ -104,8 +115,69 @@ def test_config_explicit_password_used(app_env, monkeypatch: pytest.MonkeyPatch)
     config = import_module("bot.config")
     Settings = config.Settings
     monkeypatch.setenv("WEB_PASSWORD", "explicit-pass")
+    monkeypatch.setenv("WEB_SESSION_SECRET", VALID_WEB_SESSION_SECRET)
     monkeypatch.setenv("DEV_MODE", "false")
 
     settings = Settings()
 
     assert settings.WEB_PASSWORD == "explicit-pass"
+
+
+def test_empty_web_session_secret_prod_raises(
+    app_env, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config = import_module("bot.config")
+    Settings = config.Settings
+    monkeypatch.setenv("WEB_PASSWORD", VALID_WEB_PASSWORD)
+    monkeypatch.setenv("WEB_SESSION_SECRET", "")
+    monkeypatch.setenv("DEV_MODE", "false")
+
+    with pytest.raises(
+        ValidationError,
+        match="WEB_SESSION_SECRET must be at least 32 characters in production",
+    ):
+        Settings()
+
+
+def test_short_web_session_secret_prod_raises(
+    app_env, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config = import_module("bot.config")
+    Settings = config.Settings
+    monkeypatch.setenv("WEB_PASSWORD", VALID_WEB_PASSWORD)
+    monkeypatch.setenv("WEB_SESSION_SECRET", "s" * 16)
+    monkeypatch.setenv("DEV_MODE", "false")
+
+    with pytest.raises(
+        ValidationError,
+        match="WEB_SESSION_SECRET must be at least 32 characters in production",
+    ):
+        Settings()
+
+
+def test_short_web_session_secret_dev_warns(
+    app_env, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    config = import_module("bot.config")
+    Settings = config.Settings
+    monkeypatch.setenv("WEB_SESSION_SECRET", "s" * 16)
+    monkeypatch.setenv("DEV_MODE", "true")
+
+    with caplog.at_level(logging.WARNING):
+        settings = Settings()
+
+    assert settings.WEB_SESSION_SECRET == "s" * 16
+    assert "WEB_SESSION_SECRET is shorter than 32 characters" in caplog.text
+
+
+def test_empty_web_password_prod_raises(app_env, monkeypatch: pytest.MonkeyPatch) -> None:
+    config = import_module("bot.config")
+    Settings = config.Settings
+    monkeypatch.setenv("WEB_PASSWORD", "")
+    monkeypatch.setenv("WEB_SESSION_SECRET", VALID_WEB_SESSION_SECRET)
+    monkeypatch.setenv("DEV_MODE", "false")
+
+    with pytest.raises(
+        ValidationError, match="WEB_PASSWORD must be at least 12 characters in production"
+    ):
+        Settings()


### PR DESCRIPTION
## Summary

CRIT-04 from Hard Review 2026-04-27. W1 sprint validator (commit ade13b3) checked only `is None`. Empty string `""` passed through, becoming the cookie signing key — trivially forgeable signatures.

## Fix

`bot/config.py`:
- `validate_web_session_secret`: prod requires `len >= 32`. None / "" / short → ValueError.
- `validate_web_password`: same pattern with min len 12 for prod.
- DEV_MODE: short value accepted with warning, missing → ephemeral.

## Tests

`tests/test_settings.py` — 4 new:
- `test_empty_web_session_secret_prod_raises`
- `test_short_web_session_secret_prod_raises` (16 chars)
- `test_short_web_session_secret_dev_warns`
- `test_empty_web_password_prod_raises`

11/11 settings tests pass, ruff clean.

## Notion

CRIT-04: https://www.notion.so/34ff1cc3549b8127baeac667a3a75ce7

🤖 Generated with [Claude Code](https://claude.com/claude-code)