### PR TITLE
fix(security): bind invite to user, strict vouched admission (CRIT-01)

### DIFF
--- a/alembic/versions/009_bind_application_invites.py
+++ b/alembic/versions/009_bind_application_invites.py
@@ -1,0 +1,54 @@
+"""bind_application_invites
+
+CRIT-01: record the Telegram user an invite was issued to, so chat admission can reject
+forwarded bearer invite links. The column is additive and nullable for safe deploys.
+Existing vouched/added applications are backfilled to their applicant id so in-flight
+legitimate invites keep working after the migration.
+
+Revision ID: 009
+Revises: 008
+Create Date: 2026-04-27
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "009"
+down_revision: Union[str, Sequence[str], None] = "008"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "applications",
+        sa.Column("invite_user_id", sa.BigInteger(), nullable=True),
+    )
+    op.create_foreign_key(
+        "fk_applications_invite_user_id",
+        "applications",
+        "users",
+        ["invite_user_id"],
+        ["id"],
+    )
+    op.execute(
+        """
+        UPDATE applications
+        SET invite_user_id = user_id
+        WHERE status IN ('vouched', 'added')
+          AND invite_user_id IS NULL
+        """
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "fk_applications_invite_user_id",
+        "applications",
+        type_="foreignkey",
+    )
+    op.drop_column("applications", "invite_user_id")

--- a/alembic/versions/009_bind_application_invites.py
+++ b/alembic/versions/009_bind_application_invites.py
@@ -34,6 +34,7 @@ def upgrade() -> None:
         "users",
         ["invite_user_id"],
         ["id"],
+        ondelete="SET NULL",
     )
     op.execute(
         """

--- a/bot/db/models.py
+++ b/bot/db/models.py
@@ -56,7 +56,7 @@ class Application(Base):
     questionnaire_message_id: Mapped[int | None] = mapped_column(BigInteger)
     vouched_by: Mapped[int | None] = mapped_column(BigInteger, ForeignKey("users.id"))
     vouched_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
-    invite_user_id: Mapped[int | None] = mapped_column(BigInteger, ForeignKey("users.id"))
+    invite_user_id: Mapped[int | None] = mapped_column(BigInteger, ForeignKey("users.id", ondelete="SET NULL"))
     notified_admin_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
     nudged_newcomer_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
     rejected_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))

--- a/bot/db/models.py
+++ b/bot/db/models.py
@@ -56,6 +56,7 @@ class Application(Base):
     questionnaire_message_id: Mapped[int | None] = mapped_column(BigInteger)
     vouched_by: Mapped[int | None] = mapped_column(BigInteger, ForeignKey("users.id"))
     vouched_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    invite_user_id: Mapped[int | None] = mapped_column(BigInteger, ForeignKey("users.id"))
     notified_admin_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
     nudged_newcomer_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
     rejected_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))

--- a/bot/handlers/chat_events.py
+++ b/bot/handlers/chat_events.py
@@ -40,6 +40,19 @@ def _is_leave(update: ChatMemberUpdated) -> bool:
     )
 
 
+def _admission_rejection_reason(active_app, user_id: int) -> str | None:
+    if active_app is None:
+        return "no active application"
+    if active_app.status != "vouched":
+        return f"application {active_app.id} status={active_app.status!r}"
+    if active_app.invite_user_id != user_id:
+        return (
+            f"application {active_app.id} invite_user_id="
+            f"{active_app.invite_user_id!r}"
+        )
+    return None
+
+
 @router.chat_member()
 async def handle_chat_member(
     event: ChatMemberUpdated,
@@ -51,7 +64,13 @@ async def handle_chat_member(
     tg_user = event.new_chat_member.user
     old_status = event.old_chat_member.status
     new_status = event.new_chat_member.status
-    logger.info("ChatMemberUpdated: user %s (%s) %s -> %s", tg_user.id, tg_user.first_name, old_status, new_status)
+    logger.info(
+        "ChatMemberUpdated: user %s (%s) %s -> %s",
+        tg_user.id,
+        tg_user.first_name,
+        old_status,
+        new_status,
+    )
 
     if _is_join(event):
         logger.info("Detected JOIN for user %s", tg_user.id)
@@ -59,6 +78,63 @@ async def handle_chat_member(
     elif _is_leave(event):
         logger.info("Detected LEAVE for user %s", tg_user.id)
         await _handle_leave(session, tg_user)
+
+
+async def _reject_join(
+    event: ChatMemberUpdated,
+    session: AsyncSession,
+    tg_user,
+    now: datetime,
+    reason: str,
+) -> None:
+    logger.warning(
+        "Rejecting join for user %s (%s): %s",
+        tg_user.id,
+        tg_user.username or tg_user.first_name,
+        reason,
+    )
+    chat_id = event.chat.id
+
+    # Check if this is the first kick (user not previously kicked)
+    user = await UserRepo.get(session, tg_user.id)
+    first_kick = user is None or user.left_at is None
+
+    try:
+        await event.bot.ban_chat_member(chat_id, tg_user.id)
+        await event.bot.unban_chat_member(chat_id, tg_user.id)
+    except Exception:
+        logger.exception("Failed to kick user %s", tg_user.id)
+
+    # Post message in chat only on first kick
+    if first_kick:
+        mention = f"@{tg_user.username}" if tg_user.username else tg_user.first_name
+        mention = html_escape(mention)
+        try:
+            await event.bot.send_message(
+                chat_id=chat_id,
+                text=(
+                    f"Мимо меня хотел(-а) пройти {mention}. "
+                    f"Если хотите помочь человеку попасть сюда, "
+                    f"скиньте ему мой юзернейм @vibeshkoder_bot"
+                ),
+            )
+        except Exception:
+            logger.exception("Failed to post kick message for user %s", tg_user.id)
+
+    # Try to DM the user
+    try:
+        await event.bot.send_message(
+            chat_id=tg_user.id,
+            text=(
+                "Привет! Чтобы попасть в чат вайб-шкодеров, нужно заполнить анкету. "
+                "Напиши мне /start"
+            ),
+        )
+    except Exception:
+        logger.debug("Cannot DM kicked user %s (hasn't started bot)", tg_user.id)
+
+    # Mark user as not member with left_at (so next kick is not "first")
+    await UserRepo.set_member(session, tg_user.id, is_member=False, left_at=now)
 
 
 async def _handle_join(
@@ -69,7 +145,7 @@ async def _handle_join(
     now = datetime.now(timezone.utc)
 
     # Upsert user and mark as member
-    user = await UserRepo.upsert(
+    await UserRepo.upsert(
         session,
         telegram_id=tg_user.id,
         username=tg_user.username,
@@ -83,102 +159,66 @@ async def _handle_join(
     # Check if user already has an intro (don't overwrite)
     existing_intro = await IntroRepo.get(session, tg_user.id)
     if existing_intro is not None:
-        logger.info("User %s already has intro, skipping intro creation on join", tg_user.id)
+        logger.info(
+            "User %s already has intro, skipping intro creation on join", tg_user.id
+        )
         return
 
-    # Check for active vouched application
+    if tg_user.id in settings.ADMIN_IDS:
+        logger.info("Admin user %s joined without gatekeeper admission", tg_user.id)
+        return
+
+    # Check for active vouched application with a user-bound invite.
     active_app = await ApplicationRepo.get_active(session, tg_user.id)
+    rejection_reason = _admission_rejection_reason(active_app, tg_user.id)
 
-    # If no intro and no vouched application — user joined without the questionnaire
-    if active_app is None and tg_user.id not in settings.ADMIN_IDS:
-        logger.warning(
-            "User %s (%s) joined without questionnaire, kicking",
-            tg_user.id,
-            tg_user.username or tg_user.first_name,
-        )
-        chat_id = event.chat.id
+    if rejection_reason is not None:
+        await _reject_join(event, session, tg_user, now, rejection_reason)
+        return
 
-        # Check if this is the first kick (user not previously kicked)
-        user = await UserRepo.get(session, tg_user.id)
-        first_kick = user is None or user.left_at is None
+    await ApplicationRepo.update_status(
+        session, active_app.id, "added", added_at=now
+    )
 
-        try:
-            await event.bot.ban_chat_member(chat_id, tg_user.id)
-            await event.bot.unban_chat_member(chat_id, tg_user.id)
-        except Exception:
-            logger.exception("Failed to kick user %s", tg_user.id)
+    # Build and save intro
+    answers = await QuestionnaireRepo.get_answers(
+        session, tg_user.id, application_id=active_app.id
+    )
+    if answers:
+        intro_text = build_intro_preview(answers)
 
-        # Post message in chat only on first kick
-        if first_kick:
-            mention = f"@{tg_user.username}" if tg_user.username else tg_user.first_name
-            mention = html_escape(mention)
-            try:
-                await event.bot.send_message(
-                    chat_id=chat_id,
-                    text=(
-                        f"Мимо меня хотел(-а) пройти {mention}. "
-                        f"Если хотите помочь человеку попасть сюда, "
-                        f"скиньте ему мой юзернейм @vibeshkoder_bot"
-                    ),
+        # Get voucher @username
+        vouched_by_name = "—"
+        if active_app.vouched_by:
+            voucher = await UserRepo.get(session, active_app.vouched_by)
+            if voucher:
+                vouched_by_name = (
+                    f"@{voucher.username}" if voucher.username else voucher.first_name
                 )
-            except Exception:
-                logger.exception("Failed to post kick message for user %s", tg_user.id)
+        vouched_by_display = html_escape(vouched_by_name)
 
-        # Try to DM the user
+        await IntroRepo.upsert(
+            session,
+            user_id=tg_user.id,
+            intro_text=intro_text,
+            vouched_by_name=vouched_by_name,
+        )
+
+        # Post intro in community chat
+        header = f"🎉 Новый участник: {html_escape(tg_user.first_name)}"
+        if tg_user.username:
+            header += f" (@{html_escape(tg_user.username)})"
+        header += f"\nПоручился: {vouched_by_display}\n\n"
+
         try:
             await event.bot.send_message(
-                chat_id=tg_user.id,
-                text="Привет! Чтобы попасть в чат вайб-шкодеров, нужно заполнить анкету. Напиши мне /start",
+                chat_id=settings.COMMUNITY_CHAT_ID,
+                text=header + intro_text,
             )
         except Exception:
-            logger.debug("Cannot DM kicked user %s (hasn't started bot)", tg_user.id)
-
-        # Mark user as not member with left_at (so next kick is not "first")
-        await UserRepo.set_member(session, tg_user.id, is_member=False, left_at=now)
-        return
-
-    if active_app is not None:
-        await ApplicationRepo.update_status(
-            session, active_app.id, "added", added_at=now
-        )
-
-        # Build and save intro
-        answers = await QuestionnaireRepo.get_answers(
-            session, tg_user.id, application_id=active_app.id
-        )
-        if answers:
-            intro_text = build_intro_preview(answers)
-
-            # Get voucher @username
-            vouched_by_name = "—"
-            if active_app.vouched_by:
-                voucher = await UserRepo.get(session, active_app.vouched_by)
-                if voucher:
-                    vouched_by_name = f"@{voucher.username}" if voucher.username else voucher.first_name
-            vouched_by_display = html_escape(vouched_by_name)
-
-            await IntroRepo.upsert(
-                session,
-                user_id=tg_user.id,
-                intro_text=intro_text,
-                vouched_by_name=vouched_by_name,
+            logger.exception(
+                "Failed to post intro for user %s", tg_user.id
             )
-
-            # Post intro in community chat
-            header = f"🎉 Новый участник: {html_escape(tg_user.first_name)}"
-            if tg_user.username:
-                header += f" (@{html_escape(tg_user.username)})"
-            header += f"\nПоручился: {vouched_by_display}\n\n"
-
-            try:
-                await event.bot.send_message(
-                    chat_id=settings.COMMUNITY_CHAT_ID,
-                    text=header + intro_text,
-                )
-            except Exception:
-                logger.exception(
-                    "Failed to post intro for user %s", tg_user.id
-                )
 
 
 @router.message(F.new_chat_members)

--- a/bot/handlers/vouch.py
+++ b/bot/handlers/vouch.py
@@ -66,6 +66,7 @@ async def handle_vouch(
             status="vouched",
             vouched_by=voucher_id,
             vouched_at=datetime.now(timezone.utc),
+            invite_user_id=app.user_id,
         )
         .returning(Application.id)
     )
@@ -156,7 +157,9 @@ async def handle_ready(
     )
 
     if success:
-        await ApplicationRepo.update_status(session, app_id, "vouched")
+        await ApplicationRepo.update_status(
+            session, app_id, "vouched", invite_user_id=app.user_id
+        )
         if callback.message is not None:
             await callback.message.edit_text(
                 "Инвайт отправлен! Проверь личные сообщения."

--- a/bot/services/invite.py
+++ b/bot/services/invite.py
@@ -8,13 +8,15 @@ from aiogram.exceptions import TelegramForbiddenError, TelegramBadRequest
 logger = logging.getLogger(__name__)
 
 
-async def create_invite(bot: Bot, chat_id: int, app_id: int) -> str:
+async def create_invite(bot: Bot, chat_id: int, app_id: int, user_id: int) -> str:
     """Create a one-time invite link for the community chat."""
     link = await bot.create_chat_invite_link(
         chat_id=chat_id,
         member_limit=1,
+        creates_join_request=False,
         name=f"app-{app_id}",
     )
+    logger.info("Created invite for app %s bound to user %s", app_id, user_id)
     return link.invite_link
 
 
@@ -27,7 +29,7 @@ async def try_send_invite(
     If sending the DM fails due to privacy, returns (False, None).
     """
     try:
-        invite_link = await create_invite(bot, chat_id, app_id)
+        invite_link = await create_invite(bot, chat_id, app_id, user_id)
     except Exception:
         logger.exception("Failed to create invite link for app %s", app_id)
         return False, None

--- a/tests/test_invite_admission.py
+++ b/tests/test_invite_admission.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from types import SimpleNamespace
+from unittest.mock import ANY, AsyncMock, call
+
+from tests.conftest import import_module
+
+
+COMMUNITY_CHAT_ID = -1001234567890
+
+
+def _user(user_id: int = 111) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=user_id,
+        username=f"user{user_id}",
+        first_name=f"User {user_id}",
+        last_name=None,
+    )
+
+
+def _db_user(*, left_at=None) -> SimpleNamespace:
+    return SimpleNamespace(left_at=left_at)
+
+
+def _application(
+    *,
+    app_id: int = 555,
+    status: str,
+    invite_user_id: int | None,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=app_id,
+        status=status,
+        invite_user_id=invite_user_id,
+        vouched_by=999,
+    )
+
+
+def _join_event() -> SimpleNamespace:
+    return SimpleNamespace(
+        chat=SimpleNamespace(id=COMMUNITY_CHAT_ID),
+        bot=SimpleNamespace(
+            ban_chat_member=AsyncMock(),
+            unban_chat_member=AsyncMock(),
+            send_message=AsyncMock(),
+        ),
+    )
+
+
+def _patch_join_dependencies(
+    handler,
+    monkeypatch,
+    *,
+    active_app: SimpleNamespace | None,
+) -> tuple[AsyncMock, AsyncMock]:
+    user_upsert = AsyncMock(return_value=_db_user())
+    user_set_member = AsyncMock()
+    user_get = AsyncMock(return_value=_db_user())
+
+    monkeypatch.setattr(handler.UserRepo, "upsert", user_upsert)
+    monkeypatch.setattr(handler.UserRepo, "set_member", user_set_member)
+    monkeypatch.setattr(handler.UserRepo, "get", user_get)
+    monkeypatch.setattr(handler.IntroRepo, "get", AsyncMock(return_value=None))
+    monkeypatch.setattr(
+        handler.ApplicationRepo,
+        "get_active",
+        AsyncMock(return_value=active_app),
+    )
+    monkeypatch.setattr(handler.ApplicationRepo, "update_status", AsyncMock())
+    monkeypatch.setattr(handler.QuestionnaireRepo, "get_answers", AsyncMock(return_value=[]))
+    monkeypatch.setattr(handler.IntroRepo, "upsert", AsyncMock())
+
+    return user_set_member, handler.ApplicationRepo.update_status
+
+
+def test_filling_user_using_forwarded_invite_rejected(
+    app_env, monkeypatch, caplog
+) -> None:
+    handler = import_module("bot.handlers.chat_events")
+    session = AsyncMock()
+    event = _join_event()
+    tg_user = _user(222)
+    user_set_member, update_status = _patch_join_dependencies(
+        handler,
+        monkeypatch,
+        active_app=_application(status="filling", invite_user_id=None),
+    )
+
+    with caplog.at_level(logging.WARNING):
+        asyncio.run(handler._handle_join(event, session, tg_user))
+
+    event.bot.ban_chat_member.assert_awaited_once_with(COMMUNITY_CHAT_ID, 222)
+    event.bot.unban_chat_member.assert_awaited_once_with(COMMUNITY_CHAT_ID, 222)
+    update_status.assert_not_called()
+    user_set_member.assert_has_awaits(
+        [
+            call(session, 222, is_member=True, joined_at=ANY),
+            call(session, 222, is_member=False, left_at=ANY),
+        ]
+    )
+    assert "status='filling'" in caplog.text
+
+
+def test_pending_user_join_rejected(app_env, monkeypatch) -> None:
+    handler = import_module("bot.handlers.chat_events")
+    session = AsyncMock()
+    event = _join_event()
+    tg_user = _user(222)
+    _user_set_member, update_status = _patch_join_dependencies(
+        handler,
+        monkeypatch,
+        active_app=_application(status="pending", invite_user_id=None),
+    )
+
+    asyncio.run(handler._handle_join(event, session, tg_user))
+
+    event.bot.ban_chat_member.assert_awaited_once_with(COMMUNITY_CHAT_ID, 222)
+    event.bot.unban_chat_member.assert_awaited_once_with(COMMUNITY_CHAT_ID, 222)
+    update_status.assert_not_called()
+
+
+def test_vouched_user_join_accepted(app_env, monkeypatch) -> None:
+    handler = import_module("bot.handlers.chat_events")
+    session = AsyncMock()
+    event = _join_event()
+    tg_user = _user(111)
+    _user_set_member, update_status = _patch_join_dependencies(
+        handler,
+        monkeypatch,
+        active_app=_application(status="vouched", invite_user_id=111),
+    )
+
+    asyncio.run(handler._handle_join(event, session, tg_user))
+
+    event.bot.ban_chat_member.assert_not_called()
+    event.bot.unban_chat_member.assert_not_called()
+    update_status.assert_awaited_once()
+    args = update_status.await_args.args
+    kwargs = update_status.await_args.kwargs
+    assert args == (session, 555, "added")
+    assert "added_at" in kwargs
+
+
+def test_invite_bound_to_user_id(app_env, monkeypatch, caplog) -> None:
+    handler = import_module("bot.handlers.chat_events")
+    invite_service = import_module("bot.services.invite")
+    session = AsyncMock()
+    event = _join_event()
+    tg_user = _user(222)
+    _user_set_member, update_status = _patch_join_dependencies(
+        handler,
+        monkeypatch,
+        active_app=_application(status="vouched", invite_user_id=111),
+    )
+
+    with caplog.at_level(logging.WARNING):
+        asyncio.run(handler._handle_join(event, session, tg_user))
+
+    event.bot.ban_chat_member.assert_awaited_once_with(COMMUNITY_CHAT_ID, 222)
+    update_status.assert_not_called()
+    assert "invite_user_id=111" in caplog.text
+
+    bot = AsyncMock()
+    bot.create_chat_invite_link.return_value = SimpleNamespace(
+        invite_link="https://t.me/+bound"
+    )
+
+    invite_link = asyncio.run(
+        invite_service.create_invite(
+            bot,
+            chat_id=COMMUNITY_CHAT_ID,
+            app_id=555,
+            user_id=111,
+        )
+    )
+
+    assert invite_link == "https://t.me/+bound"
+    bot.create_chat_invite_link.assert_awaited_once_with(
+        chat_id=COMMUNITY_CHAT_ID,
+        member_limit=1,
+        creates_join_request=False,
+        name="app-555",
+    )


### PR DESCRIPTION
## Summary

CRIT-01 from Hard Review 2026-04-27. Closes the bypass-vouching attack chain identified by codex pass-2.

## Bug

Invite created with `member_limit=1` but NOT user-bound. `ApplicationRepo.get_active` accepted ANY of `(filling, pending, privacy_block, vouched)` for admission. Vouched user A forwarded invite to friend B → B `/start`'d → got `filling` app → used invite → admitted without voucher.

## Fix

**Schema (alembic 009):** add `applications.invite_user_id` BIGINT FK to users, nullable. Backfill: vouched/added rows get `invite_user_id = applications.user_id` (legacy semantic preserved).

**Code:**
- `bot/services/invite.py` — `create_invite()` accepts `user_id`, sets `creates_join_request=False` explicitly.
- `bot/handlers/vouch.py` — sets `application.invite_user_id = applicant_user_id` after successful vouch.
- `bot/handlers/chat_events.py` — admission filter: status MUST `== "vouched"` AND `invite_user_id == joining_user_id`, else `ban_chat_member` + warning log.

## Tests

`tests/test_invite_admission.py` — 4 new:
- filling user using forwarded invite → rejected
- pending user join → rejected
- vouched user join → accepted (happy path)
- invite forwarded to wrong user_id → ban + warning

55 tests pass locally (62 postgres-dependent skipped in sandbox). Ruff clean.

## Notion

CRIT-01: https://www.notion.so/34ff1cc3549b81d79a9afb016cf70019

🤖 Generated with [Claude Code](https://claude.com/claude-code)