### PR TITLE
fix(security): CAS auto-reject — don't overwrite vouched (CRIT-03)

### DIFF
--- a/bot/db/repos/application.py
+++ b/bot/db/repos/application.py
@@ -64,6 +64,24 @@ class ApplicationRepo:
         await session.flush()
 
     @staticmethod
+    async def update_status_if(
+        session: AsyncSession,
+        app_id: int,
+        expected_from: str,
+        new_status: str,
+        **extra_fields,
+    ) -> bool:
+        """CAS update — returns True if matched and updated, False if no match."""
+        values: dict = {"status": new_status, **extra_fields}
+        result = await session.execute(
+            update(Application)
+            .where(Application.id == app_id, Application.status == expected_from)
+            .values(**values)
+        )
+        await session.flush()
+        return result.rowcount > 0
+
+    @staticmethod
     async def get_pending_older_than(
         session: AsyncSession, hours: int
     ) -> list[Application]:

--- a/bot/services/scheduler.py
+++ b/bot/services/scheduler.py
@@ -42,12 +42,20 @@ async def check_vouch_deadlines(bot: Bot) -> None:
             session, settings.VOUCH_TIMEOUT_HOURS
         )
         for app in apps_to_reject:
-            await ApplicationRepo.update_status(
+            rejected = await ApplicationRepo.update_status_if(
                 session,
                 app.id,
-                "rejected",
+                expected_from="pending",
+                new_status="rejected",
                 rejected_at=datetime.now(timezone.utc),
             )
+            if not rejected:
+                logger.info(
+                    "Skipping auto-reject for app %s — status changed since SELECT",
+                    app.id,
+                )
+                continue
+
             # Delete questionnaire message from chat
             if app.questionnaire_message_id:
                 try:

--- a/tests/test_scheduler_deadlines.py
+++ b/tests/test_scheduler_deadlines.py
@@ -3,8 +3,22 @@ from __future__ import annotations
 import asyncio
 from datetime import datetime, timedelta, timezone
 from importlib import import_module
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
+from sqlalchemy import update
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+
+class _AsyncSessionContext:
+    def __init__(self, session) -> None:
+        self._session = session
+
+    async def __aenter__(self):
+        return self._session
+
+    async def __aexit__(self, _exc_type, _exc, _traceback) -> None:
+        return None
 
 
 async def _get_pending_ids(
@@ -40,6 +54,89 @@ async def _get_pending_ids(
         await engine.dispose()
 
 
+async def _auto_reject_after_status_flip_to_vouched() -> tuple[bool, str]:
+    models = import_module("bot.db.models")
+    application_repo = import_module("bot.db.repos.application")
+    now = datetime.now(timezone.utc)
+    app = models.Application(
+        user_id=2001,
+        status="pending",
+        created_at=now - timedelta(hours=80),
+        submitted_at=now - timedelta(hours=80),
+    )
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    sessionmaker = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with engine.begin() as conn:
+            await conn.run_sync(models.Base.metadata.create_all)
+
+        async with sessionmaker() as session:
+            session.add(app)
+            await session.commit()
+
+            apps_to_reject = await application_repo.ApplicationRepo.get_pending_older_than(
+                session, 72
+            )
+            assert [pending_app.id for pending_app in apps_to_reject] == [app.id]
+
+            await session.execute(
+                update(models.Application)
+                .where(models.Application.id == app.id)
+                .values(status="vouched")
+            )
+            await session.flush()
+
+            rejected = await application_repo.ApplicationRepo.update_status_if(
+                session,
+                app.id,
+                expected_from="pending",
+                new_status="rejected",
+                rejected_at=datetime.now(timezone.utc),
+            )
+            await session.refresh(app)
+            return rejected, app.status
+    finally:
+        await engine.dispose()
+
+
+async def _auto_reject_when_status_still_pending() -> tuple[bool, str, bool]:
+    models = import_module("bot.db.models")
+    application_repo = import_module("bot.db.repos.application")
+    now = datetime.now(timezone.utc)
+    app = models.Application(
+        user_id=2002,
+        status="pending",
+        created_at=now - timedelta(hours=80),
+        submitted_at=now - timedelta(hours=80),
+    )
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    sessionmaker = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with engine.begin() as conn:
+            await conn.run_sync(models.Base.metadata.create_all)
+
+        async with sessionmaker() as session:
+            session.add(app)
+            await session.commit()
+
+            apps_to_reject = await application_repo.ApplicationRepo.get_pending_older_than(
+                session, 72
+            )
+            assert [pending_app.id for pending_app in apps_to_reject] == [app.id]
+
+            rejected = await application_repo.ApplicationRepo.update_status_if(
+                session,
+                app.id,
+                expected_from="pending",
+                new_status="rejected",
+                rejected_at=datetime.now(timezone.utc),
+            )
+            await session.refresh(app)
+            return rejected, app.status, app.rejected_at is not None
+    finally:
+        await engine.dispose()
+
+
 def test_pending_older_than_uses_submitted_at() -> None:
     now = datetime.now(timezone.utc)
     pending_ids = asyncio.run(
@@ -51,6 +148,70 @@ def test_pending_older_than_uses_submitted_at() -> None:
     )
 
     assert pending_ids == []
+
+
+def test_auto_reject_skips_when_status_changed_to_vouched() -> None:
+    rejected, status = asyncio.run(_auto_reject_after_status_flip_to_vouched())
+
+    assert rejected is False
+    assert status == "vouched"
+
+
+def test_auto_reject_succeeds_when_status_still_pending() -> None:
+    rejected, status, has_rejected_at = asyncio.run(_auto_reject_when_status_still_pending())
+
+    assert rejected is True
+    assert status == "rejected"
+    assert has_rejected_at is True
+
+
+def test_auto_reject_side_effects_are_skipped_when_cas_loses(app_env, monkeypatch) -> None:
+    async def run() -> None:
+        scheduler = import_module("bot.services.scheduler")
+        session = SimpleNamespace(commit=AsyncMock())
+        app = SimpleNamespace(
+            id=42,
+            user_id=2003,
+            status="pending",
+            questionnaire_message_id=9001,
+        )
+        get_pending_older_than = AsyncMock(return_value=[app])
+        update_status_if = AsyncMock(return_value=False)
+        get_pending_created_older_than = AsyncMock(return_value=[])
+        bot = SimpleNamespace(
+            delete_message=AsyncMock(),
+            send_message=AsyncMock(),
+        )
+
+        monkeypatch.setattr(
+            scheduler,
+            "async_session",
+            lambda: _AsyncSessionContext(session),
+        )
+        monkeypatch.setattr(
+            scheduler.ApplicationRepo,
+            "get_pending_older_than",
+            get_pending_older_than,
+        )
+        monkeypatch.setattr(
+            scheduler.ApplicationRepo,
+            "update_status_if",
+            update_status_if,
+        )
+        monkeypatch.setattr(
+            scheduler.ApplicationRepo,
+            "get_pending_created_older_than",
+            get_pending_created_older_than,
+        )
+
+        await scheduler.check_vouch_deadlines(bot)
+
+        update_status_if.assert_awaited_once()
+        bot.delete_message.assert_not_awaited()
+        bot.send_message.assert_not_awaited()
+        session.commit.assert_awaited_once()
+
+    asyncio.run(run())
 
 
 def test_pending_older_than_legacy_null_falls_back_to_created_at() -> None:


### PR DESCRIPTION
## Summary

CRIT-03 from Hard Review 2026-04-27. Race in `scheduler.check_vouch_deadlines`: SELECT pending → voucher concurrently sets vouched → scheduler UPDATE sets rejected without status guard.

## Fix

`ApplicationRepo.update_status_if(app_id, expected_from, new_status, **extra)` — CAS variant returning rowcount>0. Scheduler auto-reject uses CAS. Side effects (delete questionnaire msg, DM applicant) gated на successful CAS.

Existing `update_status` preserved для legitimate flows (vouch, admin add) — those already use optimistic UPDATE WHERE patterns at handler level.

## Tests

`tests/test_scheduler_deadlines.py` — 3 new:
- `test_auto_reject_skips_when_status_changed_to_vouched` — race scenario
- `test_auto_reject_succeeds_when_status_still_pending` — happy path control
- `test_auto_reject_side_effects_are_skipped_when_cas_loses` — bot.delete_message + send_message NOT called when CAS lost

6/6 scheduler tests pass. Ruff clean.

## Notion

CRIT-03: https://www.notion.so/34ff1cc3549b813e9df9cb388a315d7c

🤖 Generated with [Claude Code](https://claude.com/claude-code)