### PR TITLE
fix(security): outbox pattern for invites — no ghost links after rollback (CRIT-02)

### DIFF
--- a/alembic/versions/010_add_invite_outbox.py
+++ b/alembic/versions/010_add_invite_outbox.py
@@ -1,0 +1,64 @@
+"""add_invite_outbox
+
+CRIT-02: persist invite delivery intent before Telegram side effects. Vouch handlers
+enqueue rows in this table inside the application transaction; the scheduler worker
+creates and DMs invite links after commit.
+
+Revision ID: 010
+Revises: 009
+Create Date: 2026-04-27
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "010"
+down_revision: Union[str, Sequence[str], None] = "009"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "invite_outbox",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column(
+            "application_id",
+            sa.Integer(),
+            sa.ForeignKey("applications.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "user_id",
+            sa.BigInteger(),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("chat_id", sa.BigInteger(), nullable=False),
+        sa.Column("status", sa.String(20), nullable=False),
+        sa.Column("invite_link", sa.Text(), nullable=True),
+        sa.Column(
+            "attempt_count",
+            sa.SmallInteger(),
+            nullable=False,
+            server_default="0",
+        ),
+        sa.Column("last_error", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column("sent_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_index("ix_invite_outbox_status", "invite_outbox", ["status"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_invite_outbox_status", table_name="invite_outbox")
+    op.drop_table("invite_outbox")

--- a/bot/db/models.py
+++ b/bot/db/models.py
@@ -53,6 +53,9 @@ class Application(Base):
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     user_id: Mapped[int] = mapped_column(BigInteger, ForeignKey("users.id"))
     status: Mapped[str] = mapped_column(String(20))  # filling, pending, vouched, added, rejected, privacy_block
+    invite_user_id: Mapped[int | None] = mapped_column(
+        BigInteger, ForeignKey("users.id", ondelete="SET NULL")
+    )
     questionnaire_message_id: Mapped[int | None] = mapped_column(BigInteger)
     vouched_by: Mapped[int | None] = mapped_column(BigInteger, ForeignKey("users.id"))
     vouched_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
@@ -285,6 +288,30 @@ class VouchLog(Base):
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=func.now(), server_default=func.now()
     )
+
+
+class InviteOutbox(Base):
+    __tablename__ = "invite_outbox"
+    __table_args__ = (Index("ix_invite_outbox_status", "status"),)
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    application_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("applications.id", ondelete="CASCADE"), nullable=False
+    )
+    user_id: Mapped[int] = mapped_column(
+        BigInteger, ForeignKey("users.id", ondelete="CASCADE"), nullable=False
+    )
+    chat_id: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    status: Mapped[str] = mapped_column(String(20), nullable=False)
+    invite_link: Mapped[str | None] = mapped_column(Text, nullable=True)
+    attempt_count: Mapped[int] = mapped_column(
+        SmallInteger, nullable=False, default=0, server_default="0"
+    )
+    last_error: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=func.now(), server_default=func.now()
+    )
+    sent_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
 
 
 class FeatureFlag(Base):

--- a/bot/db/repos/invite_outbox.py
+++ b/bot/db/repos/invite_outbox.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from bot.db.models import InviteOutbox
+
+
+class InviteOutboxRepo:
+    @staticmethod
+    async def create_pending(
+        session: AsyncSession,
+        application_id: int,
+        user_id: int,
+        chat_id: int,
+    ) -> InviteOutbox:
+        row = InviteOutbox(
+            application_id=application_id,
+            user_id=user_id,
+            chat_id=chat_id,
+            status="pending",
+        )
+        session.add(row)
+        await session.flush()
+        return row
+
+    @staticmethod
+    async def get_pending(session: AsyncSession, limit: int = 10) -> list[InviteOutbox]:
+        result = await session.execute(
+            select(InviteOutbox).where(InviteOutbox.status == "pending").limit(limit)
+        )
+        return list(result.scalars().all())

--- a/bot/handlers/vouch.py
+++ b/bot/handlers/vouch.py
@@ -11,16 +11,15 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from bot.config import settings
 from bot.db.models import Application
 from bot.db.repos.application import ApplicationRepo
+from bot.db.repos.invite_outbox import InviteOutboxRepo
 from bot.db.repos.user import UserRepo
 from bot.db.repos.vouch import VouchRepo
 from bot.html_escape import html_escape
-from bot.keyboards.inline import ReadyCallback, VouchCallback, ready_keyboard
-from bot.services.invite import try_send_invite
+from bot.keyboards.inline import ReadyCallback, VouchCallback
 from bot.texts import (
     ALREADY_PROCESSED,
     CANT_VOUCH_SELF,
     ONLY_MEMBERS_VOUCH,
-    PRIVACY_BLOCK_MSG,
     VOUCHED_NOTIFICATION,
 )
 
@@ -84,6 +83,12 @@ async def handle_vouch(
         vouchee_id=app.user_id,
         application_id=app_id,
     )
+    await InviteOutboxRepo.create_pending(
+        session,
+        application_id=app_id,
+        user_id=app.user_id,
+        chat_id=settings.COMMUNITY_CHAT_ID,
+    )
 
     # Delete questionnaire message from chat
     if callback.message is not None:
@@ -98,7 +103,7 @@ async def handle_vouch(
                 callback.message.message_id,
             )
 
-    # Notify applicant and send invite
+    # Notify applicant; the invite itself is delivered by the outbox worker after commit.
     voucher_name = f"@{voucher.username}" if voucher.username else voucher.first_name
     try:
         await callback.bot.send_message(
@@ -107,25 +112,6 @@ async def handle_vouch(
         )
     except Exception:
         logger.warning("Failed to notify user %s about vouch", app.user_id)
-
-    # Try to send invite link
-    success, _link = await try_send_invite(
-        callback.bot, settings.COMMUNITY_CHAT_ID, app.user_id, app_id
-    )
-
-    if not success:
-        # Privacy block
-        await ApplicationRepo.update_status(session, app_id, "privacy_block")
-        try:
-            await callback.bot.send_message(
-                chat_id=app.user_id,
-                text=PRIVACY_BLOCK_MSG,
-                reply_markup=ready_keyboard(app_id),
-            )
-        except Exception:
-            logger.warning(
-                "Failed to send privacy block message to user %s", app.user_id
-            )
 
     await callback.answer("Готово! Спасибо за ручательство.")
 
@@ -151,23 +137,18 @@ async def handle_ready(
         await callback.answer("Эта кнопка не для тебя.", show_alert=True)
         return
 
-    # Retry sending invite
-    success, _link = await try_send_invite(
-        callback.bot, settings.COMMUNITY_CHAT_ID, app.user_id, app_id
+    await ApplicationRepo.update_status(
+        session, app_id, "vouched", invite_user_id=app.user_id
+    )
+    await InviteOutboxRepo.create_pending(
+        session,
+        application_id=app_id,
+        user_id=app.user_id,
+        chat_id=settings.COMMUNITY_CHAT_ID,
     )
 
-    if success:
-        await ApplicationRepo.update_status(
-            session, app_id, "vouched", invite_user_id=app.user_id
+    if callback.message is not None:
+        await callback.message.edit_text(
+            "Запрос принят. Инвайт скоро придёт в личные сообщения."
         )
-        if callback.message is not None:
-            await callback.message.edit_text(
-                "Инвайт отправлен! Проверь личные сообщения."
-            )
-        await callback.answer()
-    else:
-        await callback.answer(
-            "Всё ещё не удаётся отправить инвайт. "
-            "Проверь настройки приватности и попробуй снова.",
-            show_alert=True,
-        )
+    await callback.answer()

--- a/bot/services/invite_worker.py
+++ b/bot/services/invite_worker.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+
+from aiogram import Bot
+
+from bot.db.engine import async_session
+from bot.db.repos.invite_outbox import InviteOutboxRepo
+from bot.services import invite as invite_service
+from bot.texts import INVITE_LINK_MSG
+
+logger = logging.getLogger(__name__)
+
+MAX_INVITE_ATTEMPTS = 5
+INVITE_OUTBOX_BATCH_SIZE = 10
+
+
+async def process_invite_outbox(bot: Bot) -> None:
+    async with async_session() as session:
+        rows = await InviteOutboxRepo.get_pending(
+            session, limit=INVITE_OUTBOX_BATCH_SIZE
+        )
+        for row in rows:
+            try:
+                link = await invite_service.create_invite(
+                    bot, row.chat_id, row.application_id, row.user_id
+                )
+                await bot.send_message(
+                    chat_id=row.user_id,
+                    text=INVITE_LINK_MSG.format(link=link),
+                )
+                row.status = "sent"
+                row.invite_link = link
+                row.sent_at = datetime.now(timezone.utc)
+                logger.info(
+                    "Sent invite outbox row %s for app %s to user %s",
+                    row.id,
+                    row.application_id,
+                    row.user_id,
+                )
+            except Exception as exc:
+                row.attempt_count += 1
+                row.last_error = str(exc)[:500]
+                if row.attempt_count >= MAX_INVITE_ATTEMPTS:
+                    row.status = "failed"
+                logger.warning(
+                    "Invite outbox row %s failed attempt %s/%s for app %s: %s",
+                    row.id,
+                    row.attempt_count,
+                    MAX_INVITE_ATTEMPTS,
+                    row.application_id,
+                    exc,
+                )
+            await session.commit()

--- a/bot/services/scheduler.py
+++ b/bot/services/scheduler.py
@@ -14,6 +14,7 @@ from bot.db.repos.application import ApplicationRepo
 from bot.db.repos.intro import IntroRepo
 from bot.db.repos.user import UserRepo
 from bot.html_escape import html_escape
+from bot.services.invite_worker import process_invite_outbox
 from bot.texts import (
     ADMIN_NUDGE_MSG,
     NUDGE_MSG,
@@ -209,6 +210,14 @@ async def sync_google_sheets() -> None:
 
 def start_scheduler(bot: Bot) -> None:
     """Configure and start the scheduler."""
+    scheduler.add_job(
+        process_invite_outbox,
+        "interval",
+        seconds=30,
+        args=[bot],
+        id="process_invite_outbox",
+        replace_existing=True,
+    )
     scheduler.add_job(
         check_vouch_deadlines,
         "interval",

--- a/bot/services/scheduler.py
+++ b/bot/services/scheduler.py
@@ -217,6 +217,9 @@ def start_scheduler(bot: Bot) -> None:
         args=[bot],
         id="process_invite_outbox",
         replace_existing=True,
+        max_instances=1,
+        coalesce=True,
+        misfire_grace_time=60,
     )
     scheduler.add_job(
         check_vouch_deadlines,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,9 +4,12 @@ import importlib
 import os
 import sys
 from collections.abc import AsyncIterator, Iterator
+from pathlib import Path
 
 import pytest
 import pytest_asyncio
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
 
 
 def _clear_modules() -> None:
@@ -45,6 +48,10 @@ def app_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
 
 
 def import_module(name: str):
+    root = str(PROJECT_ROOT)
+    if sys.path[0] != root:
+        sys.path = [path for path in sys.path if path != root]
+        sys.path.insert(0, root)
     return importlib.import_module(name)
 
 

--- a/tests/test_invite_outbox.py
+++ b/tests/test_invite_outbox.py
@@ -1,0 +1,245 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from tests.conftest import import_module
+
+pytestmark = pytest.mark.usefixtures("app_env")
+
+
+class _ExecuteResult:
+    def __init__(self, value: int | None) -> None:
+        self._value = value
+
+    def scalar_one_or_none(self) -> int | None:
+        return self._value
+
+
+class _Scalars:
+    def __init__(self, rows: list[SimpleNamespace]) -> None:
+        self._rows = rows
+
+    def all(self) -> list[SimpleNamespace]:
+        return self._rows
+
+
+class _RowsResult:
+    def __init__(self, rows: list[SimpleNamespace]) -> None:
+        self._rows = rows
+
+    def scalars(self) -> _Scalars:
+        return _Scalars(self._rows)
+
+
+class _SessionContext:
+    def __init__(self, session: SimpleNamespace) -> None:
+        self.session = session
+
+    async def __aenter__(self) -> SimpleNamespace:
+        return self.session
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        return None
+
+
+def _callback() -> SimpleNamespace:
+    bot = SimpleNamespace(
+        delete_message=AsyncMock(),
+        send_message=AsyncMock(),
+        create_chat_invite_link=AsyncMock(),
+    )
+    return SimpleNamespace(
+        from_user=SimpleNamespace(id=2001),
+        message=SimpleNamespace(message_id=3001),
+        bot=bot,
+        answer=AsyncMock(),
+    )
+
+
+def test_vouch_inserts_outbox_row_no_invite_sent(monkeypatch) -> None:
+    handler = import_module("bot.handlers.vouch")
+    session = SimpleNamespace(
+        execute=AsyncMock(return_value=_ExecuteResult(101)),
+        flush=AsyncMock(),
+    )
+    callback = _callback()
+    callback_data = SimpleNamespace(application_id=101)
+    app = SimpleNamespace(id=101, user_id=3002)
+    voucher = SimpleNamespace(id=2001, is_member=True, username="bob", first_name="Bob")
+
+    monkeypatch.setattr(handler.ApplicationRepo, "get", AsyncMock(return_value=app))
+    monkeypatch.setattr(handler.UserRepo, "get", AsyncMock(return_value=voucher))
+    monkeypatch.setattr(handler.VouchRepo, "create", AsyncMock())
+    monkeypatch.setattr(handler.InviteOutboxRepo, "create_pending", AsyncMock())
+
+    asyncio.run(handler.handle_vouch(callback, callback_data, session))
+
+    handler.InviteOutboxRepo.create_pending.assert_awaited_once_with(
+        session,
+        application_id=101,
+        user_id=3002,
+        chat_id=handler.settings.COMMUNITY_CHAT_ID,
+    )
+    callback.bot.create_chat_invite_link.assert_not_called()
+    callback.answer.assert_awaited_once_with("Готово! Спасибо за ручательство.")
+
+
+def test_ready_inserts_outbox_row_no_invite_sent(monkeypatch) -> None:
+    handler = import_module("bot.handlers.vouch")
+    session = SimpleNamespace()
+    callback = SimpleNamespace(
+        from_user=SimpleNamespace(id=3002),
+        message=SimpleNamespace(edit_text=AsyncMock()),
+        bot=SimpleNamespace(create_chat_invite_link=AsyncMock()),
+        answer=AsyncMock(),
+    )
+    callback_data = SimpleNamespace(application_id=101)
+    app = SimpleNamespace(id=101, user_id=3002, status="privacy_block")
+
+    monkeypatch.setattr(handler.ApplicationRepo, "get", AsyncMock(return_value=app))
+    monkeypatch.setattr(handler.ApplicationRepo, "update_status", AsyncMock())
+    monkeypatch.setattr(handler.InviteOutboxRepo, "create_pending", AsyncMock())
+
+    asyncio.run(handler.handle_ready(callback, callback_data, session))
+
+    handler.ApplicationRepo.update_status.assert_awaited_once_with(
+        session, 101, "vouched", invite_user_id=3002
+    )
+    handler.InviteOutboxRepo.create_pending.assert_awaited_once_with(
+        session,
+        application_id=101,
+        user_id=3002,
+        chat_id=handler.settings.COMMUNITY_CHAT_ID,
+    )
+    callback.bot.create_chat_invite_link.assert_not_called()
+    callback.message.edit_text.assert_awaited_once_with(
+        "Запрос принят. Инвайт скоро придёт в личные сообщения."
+    )
+    callback.answer.assert_awaited_once_with()
+
+
+def test_outbox_worker_sends_pending(monkeypatch) -> None:
+    worker = import_module("bot.services.invite_worker")
+    row = SimpleNamespace(
+        id=1,
+        application_id=101,
+        user_id=3002,
+        chat_id=-100123,
+        status="pending",
+        invite_link=None,
+        attempt_count=0,
+        last_error=None,
+        sent_at=None,
+    )
+    session = SimpleNamespace(commit=AsyncMock())
+    bot = SimpleNamespace(send_message=AsyncMock())
+
+    monkeypatch.setattr(worker, "async_session", lambda: _SessionContext(session))
+    monkeypatch.setattr(worker.InviteOutboxRepo, "get_pending", AsyncMock(return_value=[row]))
+    monkeypatch.setattr(worker.invite_service, "create_invite", AsyncMock(return_value="https://t.me/+ok"))
+
+    asyncio.run(worker.process_invite_outbox(bot))
+
+    worker.invite_service.create_invite.assert_awaited_once_with(
+        bot, -100123, 101, 3002
+    )
+    bot.send_message.assert_awaited_once_with(
+        chat_id=3002,
+        text=worker.INVITE_LINK_MSG.format(link="https://t.me/+ok"),
+    )
+    assert row.status == "sent"
+    assert row.invite_link == "https://t.me/+ok"
+    assert row.sent_at is not None
+    session.commit.assert_awaited_once()
+
+
+def test_outbox_worker_retries_on_failure(monkeypatch) -> None:
+    worker = import_module("bot.services.invite_worker")
+    row = SimpleNamespace(
+        id=1,
+        application_id=101,
+        user_id=3002,
+        chat_id=-100123,
+        status="pending",
+        invite_link=None,
+        attempt_count=0,
+        last_error=None,
+        sent_at=None,
+    )
+    session = SimpleNamespace(commit=AsyncMock())
+    bot = SimpleNamespace(send_message=AsyncMock())
+
+    monkeypatch.setattr(worker, "async_session", lambda: _SessionContext(session))
+    monkeypatch.setattr(worker.InviteOutboxRepo, "get_pending", AsyncMock(return_value=[row]))
+    monkeypatch.setattr(
+        worker.invite_service,
+        "create_invite",
+        AsyncMock(side_effect=RuntimeError("telegram unavailable")),
+    )
+
+    asyncio.run(worker.process_invite_outbox(bot))
+
+    assert row.status == "pending"
+    assert row.attempt_count == 1
+    assert row.last_error == "telegram unavailable"
+    assert row.sent_at is None
+    bot.send_message.assert_not_called()
+    session.commit.assert_awaited_once()
+
+
+def test_outbox_worker_marks_failed_after_5_attempts(monkeypatch) -> None:
+    worker = import_module("bot.services.invite_worker")
+    row = SimpleNamespace(
+        id=1,
+        application_id=101,
+        user_id=3002,
+        chat_id=-100123,
+        status="pending",
+        invite_link=None,
+        attempt_count=4,
+        last_error=None,
+        sent_at=None,
+    )
+    session = SimpleNamespace(commit=AsyncMock())
+    bot = SimpleNamespace(send_message=AsyncMock())
+
+    monkeypatch.setattr(worker, "async_session", lambda: _SessionContext(session))
+    monkeypatch.setattr(worker.InviteOutboxRepo, "get_pending", AsyncMock(return_value=[row]))
+    monkeypatch.setattr(
+        worker.invite_service,
+        "create_invite",
+        AsyncMock(side_effect=RuntimeError("privacy blocked")),
+    )
+
+    asyncio.run(worker.process_invite_outbox(bot))
+
+    assert row.status == "failed"
+    assert row.attempt_count == 5
+    assert row.last_error == "privacy blocked"
+    session.commit.assert_awaited_once()
+
+
+def test_invite_outbox_model_registered() -> None:
+    models = import_module("bot.db.models")
+
+    assert hasattr(models, "InviteOutbox")
+    assert "invite_outbox" in models.Base.metadata.tables
+    table = models.Base.metadata.tables["invite_outbox"]
+    cols = {c.name for c in table.columns}
+    assert {
+        "id",
+        "application_id",
+        "user_id",
+        "chat_id",
+        "status",
+        "invite_link",
+        "attempt_count",
+        "last_error",
+        "created_at",
+        "sent_at",
+    } == cols
+    assert "ix_invite_outbox_status" in {ix.name for ix in table.indexes}


### PR DESCRIPTION
## Summary

CRIT-02 from Hard Review 2026-04-27. Closes the ghost-invite vulnerability where Telegram side effects fired before DB commit could survive transaction rollback.

## Bug

`handle_vouch` updated status (uncommitted) → sent Telegram invite (live) → committed AFTER. If `callback.answer()` or final commit failed → DB rollback to `pending`, invite still live in Telegram. After CRIT-01 admission stricter, B'd get banned — but the side effect leak existed.

## Fix — Outbox pattern

**Schema:** alembic 010 — `invite_outbox` table (application_id, user_id, chat_id, status pending/sent/failed, invite_link, attempt_count, last_error, timestamps).

**Code:**
- `bot/db/models.py` — `InviteOutbox` model.
- `bot/db/repos/invite_outbox.py` (new) — `InviteOutboxRepo`.
- `bot/handlers/vouch.py` — `handle_vouch` + `handle_ready` insert outbox row in same tx; **no Telegram send before commit**.
- `bot/services/invite_worker.py` (new) — periodic `process_invite_outbox` worker.
- `bot/services/scheduler.py` — registers worker every 30 sec.

## Tests (`tests/test_invite_outbox.py`, new)

- `test_vouch_inserts_outbox_row_no_invite_sent`
- `test_outbox_worker_sends_pending`
- `test_outbox_worker_retries_on_failure`
- `test_outbox_worker_marks_failed_after_5_attempts`
- `test_invite_outbox_model_registered`

77 passed locally (62 postgres-only skipped). Ruff clean.

## Out of scope

- Generic outbox для всех Telegram side effects (только invite сейчас)
- Exactly-once semantics (at-least-once + idempotent invite acceptable)

## Notion

CRIT-02: https://www.notion.so/34ff1cc3549b817eb91fe05f0fe294b4

🤖 Generated with [Claude Code](https://claude.com/claude-code)