### PR TITLE
[P1] fix(security): R5.3 CAS-guard outbox demote + unique pending index

### DIFF
--- a/alembic/versions/012_invite_outbox_pending_unique.py
+++ b/alembic/versions/012_invite_outbox_pending_unique.py
@@ -53,11 +53,11 @@ def upgrade() -> None:
         return
 
     bind = op.get_bind()
-    op.execute(DUPLICATE_PENDING_COUNT_SQL)
     duplicate_count = bind.execute(
         sa.text(DUPLICATE_PENDING_COUNT_SQL)
     ).scalar_one()
-    logger.warning(
+    log_fn = logger.warning if duplicate_count > 0 else logger.info
+    log_fn(
         "invite_outbox pending duplicate rows to delete before unique index: %s",
         duplicate_count,
     )

--- a/alembic/versions/012_invite_outbox_pending_unique.py
+++ b/alembic/versions/012_invite_outbox_pending_unique.py
@@ -1,0 +1,102 @@
+"""invite_outbox_pending_unique
+
+CRIT-02-r3: a stale duplicate pending outbox row must not be able to terminally
+retry and demote an already-vouched or already-added application. Keep only the
+oldest pending row per application, then enforce one pending invite intent per
+application at the database boundary.
+
+Revision ID: 012
+Revises: 011
+Create Date: 2026-04-27
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "012"
+down_revision: Union[str, Sequence[str], None] = "011"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+logger = logging.getLogger("alembic.runtime.migration")
+
+DUPLICATE_PENDING_COUNT_SQL = """
+SELECT COALESCE(SUM(duplicate_count - 1), 0) AS duplicate_pending_rows_to_delete
+FROM (
+    SELECT application_id, COUNT(*) AS duplicate_count
+    FROM invite_outbox
+    WHERE status = 'pending'
+    GROUP BY application_id
+    HAVING COUNT(*) > 1
+) duplicates
+"""
+
+
+def _is_postgresql() -> bool:
+    bind = op.get_bind()
+    if bind.dialect.name == "postgresql":
+        return True
+    logger.warning(
+        "Skipping invite_outbox pending unique index migration for %s dialect",
+        bind.dialect.name,
+    )
+    return False
+
+
+def upgrade() -> None:
+    if not _is_postgresql():
+        return
+
+    bind = op.get_bind()
+    op.execute(DUPLICATE_PENDING_COUNT_SQL)
+    duplicate_count = bind.execute(
+        sa.text(DUPLICATE_PENDING_COUNT_SQL)
+    ).scalar_one()
+    logger.warning(
+        "invite_outbox pending duplicate rows to delete before unique index: %s",
+        duplicate_count,
+    )
+
+    op.execute(
+        """
+        DELETE FROM invite_outbox AS target
+        USING (
+            SELECT id
+            FROM (
+                SELECT
+                    id,
+                    ROW_NUMBER() OVER (
+                        PARTITION BY application_id
+                        ORDER BY created_at ASC, id ASC
+                    ) AS row_num
+                FROM invite_outbox
+                WHERE status = 'pending'
+            ) ranked
+            WHERE row_num > 1
+        ) duplicates
+        WHERE target.id = duplicates.id
+        """
+    )
+    op.execute(
+        """
+        CREATE UNIQUE INDEX IF NOT EXISTS ix_invite_outbox_pending_unique
+        ON invite_outbox (application_id)
+        WHERE status = 'pending'
+        """
+    )
+
+
+def downgrade() -> None:
+    if not _is_postgresql():
+        return
+
+    op.drop_index(
+        "ix_invite_outbox_pending_unique",
+        table_name="invite_outbox",
+        if_exists=True,
+    )

--- a/bot/db/models.py
+++ b/bot/db/models.py
@@ -368,7 +368,16 @@ class VouchLog(Base):
 
 class InviteOutbox(Base):
     __tablename__ = "invite_outbox"
-    __table_args__ = (Index("ix_invite_outbox_status", "status"),)
+    __table_args__ = (
+        Index("ix_invite_outbox_status", "status"),
+        Index(
+            "ix_invite_outbox_pending_unique",
+            "application_id",
+            unique=True,
+            postgresql_where=text("status = 'pending'"),
+            sqlite_where=text("status = 'pending'"),
+        ),
+    )
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     application_id: Mapped[int] = mapped_column(

--- a/bot/services/invite_worker.py
+++ b/bot/services/invite_worker.py
@@ -46,25 +46,36 @@ async def process_invite_outbox(bot: Bot) -> None:
                 row.last_error = str(exc)[:500]
                 if row.attempt_count >= MAX_INVITE_ATTEMPTS:
                     row.status = "failed"
-                    # Hotfix CRIT-02-r3: outbox failed (DMs likely blocked).
-                    # Flip app back to privacy_block so /start + ready_keyboard
-                    # recovery flow works. Without this — applicant stuck
-                    # forever with status=vouched + no invite + dead "Я готов".
-                    await ApplicationRepo.update_status(
-                        session, row.application_id, "privacy_block"
+                    demoted = await ApplicationRepo.update_status_if(
+                        session,
+                        app_id=row.application_id,
+                        expected_from="pending",
+                        new_status="privacy_block",
                     )
-                    try:
-                        await bot.send_message(
-                            chat_id=row.user_id,
-                            text=PRIVACY_BLOCK_MSG,
-                            reply_markup=ready_keyboard(row.application_id),
-                        )
-                    except Exception:
-                        # Если DM всё ещё закрыт — applicant увидит сообщение
-                        # при следующем /start (handle status=privacy_block).
+                    if demoted:
+                        try:
+                            await bot.send_message(
+                                chat_id=row.user_id,
+                                text=PRIVACY_BLOCK_MSG,
+                                reply_markup=ready_keyboard(row.application_id),
+                            )
+                        except Exception:
+                            # Если DM всё ещё закрыт — applicant увидит сообщение
+                            # при следующем /start (handle status=privacy_block).
+                            logger.warning(
+                                "Could not DM privacy_block fallback for app %s",
+                                row.application_id,
+                            )
+                    else:
+                        app = await ApplicationRepo.get(session, row.application_id)
                         logger.warning(
-                            "Could not DM privacy_block fallback for app %s",
-                            row.application_id,
+                            "invite_worker.privacy_block_skipped",
+                            extra={
+                                "app_id": row.application_id,
+                                "observed_status": (
+                                    app.status if app is not None else None
+                                ),
+                            },
                         )
                 logger.warning(
                     "Invite outbox row %s failed attempt %s/%s for app %s: %s",

--- a/tests/test_invite_outbox.py
+++ b/tests/test_invite_outbox.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import itertools
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
@@ -9,6 +10,12 @@ import pytest
 from tests.conftest import import_module
 
 pytestmark = pytest.mark.usefixtures("app_env")
+
+_user_id_counter = itertools.count(start=9_100_000_000)
+
+
+def _next_user_id() -> int:
+    return next(_user_id_counter)
 
 
 class _ExecuteResult:
@@ -191,7 +198,7 @@ def test_outbox_worker_retries_on_failure(monkeypatch) -> None:
     session.commit.assert_awaited_once()
 
 
-def test_outbox_worker_marks_failed_after_5_attempts(monkeypatch) -> None:
+def test_invite_worker_exhausted_pending_app_demoted(monkeypatch, caplog) -> None:
     worker = import_module("bot.services.invite_worker")
     row = SimpleNamespace(
         id=1,
@@ -204,8 +211,19 @@ def test_outbox_worker_marks_failed_after_5_attempts(monkeypatch) -> None:
         last_error=None,
         sent_at=None,
     )
+    app = SimpleNamespace(id=101, status="pending")
     session = SimpleNamespace(commit=AsyncMock())
     bot = SimpleNamespace(send_message=AsyncMock())
+
+    async def cas_update(session_arg, app_id, expected_from, new_status, **extra_fields):
+        assert session_arg is session
+        assert app_id == app.id
+        assert expected_from == "pending"
+        assert extra_fields == {}
+        if app.status != expected_from:
+            return False
+        app.status = new_status
+        return True
 
     monkeypatch.setattr(worker, "async_session", lambda: _SessionContext(session))
     monkeypatch.setattr(worker.InviteOutboxRepo, "get_pending", AsyncMock(return_value=[row]))
@@ -214,17 +232,213 @@ def test_outbox_worker_marks_failed_after_5_attempts(monkeypatch) -> None:
         "create_invite",
         AsyncMock(side_effect=RuntimeError("privacy blocked")),
     )
-    update_status_mock = AsyncMock()
-    monkeypatch.setattr(worker.ApplicationRepo, "update_status", update_status_mock)
+    update_status_if_mock = AsyncMock(side_effect=cas_update)
+    get_mock = AsyncMock(return_value=app)
+    monkeypatch.setattr(worker.ApplicationRepo, "update_status_if", update_status_if_mock)
+    monkeypatch.setattr(worker.ApplicationRepo, "get", get_mock)
+    caplog.set_level("WARNING", logger=worker.logger.name)
 
     asyncio.run(worker.process_invite_outbox(bot))
 
     assert row.status == "failed"
     assert row.attempt_count == 5
     assert row.last_error == "privacy blocked"
-    update_status_mock.assert_awaited_once_with(session, 101, "privacy_block")
+    assert app.status == "privacy_block"
+    update_status_if_mock.assert_awaited_once_with(
+        session,
+        app_id=101,
+        expected_from="pending",
+        new_status="privacy_block",
+    )
+    get_mock.assert_not_awaited()
     bot.send_message.assert_awaited_once()
     session.commit.assert_awaited_once()
+    assert any("failed attempt 5/5" in record.message for record in caplog.records)
+
+
+def test_invite_worker_exhausted_vouched_app_preserved(monkeypatch, caplog) -> None:
+    worker = import_module("bot.services.invite_worker")
+    row = SimpleNamespace(
+        id=1,
+        application_id=101,
+        user_id=3002,
+        chat_id=-100123,
+        status="pending",
+        invite_link=None,
+        attempt_count=4,
+        last_error=None,
+        sent_at=None,
+    )
+    app = SimpleNamespace(id=101, status="vouched")
+    session = SimpleNamespace(commit=AsyncMock())
+    bot = SimpleNamespace(send_message=AsyncMock())
+
+    async def cas_update(session_arg, app_id, expected_from, new_status, **extra_fields):
+        assert session_arg is session
+        assert app_id == app.id
+        assert expected_from == "pending"
+        assert extra_fields == {}
+        if app.status != expected_from:
+            return False
+        app.status = new_status
+        return True
+
+    monkeypatch.setattr(worker, "async_session", lambda: _SessionContext(session))
+    monkeypatch.setattr(worker.InviteOutboxRepo, "get_pending", AsyncMock(return_value=[row]))
+    monkeypatch.setattr(
+        worker.invite_service,
+        "create_invite",
+        AsyncMock(side_effect=RuntimeError("privacy blocked")),
+    )
+    update_status_if_mock = AsyncMock(side_effect=cas_update)
+    get_mock = AsyncMock(return_value=app)
+    monkeypatch.setattr(worker.ApplicationRepo, "update_status_if", update_status_if_mock)
+    monkeypatch.setattr(worker.ApplicationRepo, "get", get_mock)
+    caplog.set_level("WARNING", logger=worker.logger.name)
+
+    asyncio.run(worker.process_invite_outbox(bot))
+
+    assert row.status == "failed"
+    assert row.attempt_count == 5
+    assert row.last_error == "privacy blocked"
+    assert app.status == "vouched"
+    update_status_if_mock.assert_awaited_once_with(
+        session,
+        app_id=101,
+        expected_from="pending",
+        new_status="privacy_block",
+    )
+    get_mock.assert_awaited_once_with(session, 101)
+    bot.send_message.assert_not_called()
+    session.commit.assert_awaited_once()
+    records = [
+        record
+        for record in caplog.records
+        if record.message == "invite_worker.privacy_block_skipped"
+    ]
+    assert len(records) == 1
+    assert records[0].app_id == 101
+    assert records[0].observed_status == "vouched"
+
+
+def test_invite_worker_exhausted_added_app_preserved(monkeypatch, caplog) -> None:
+    worker = import_module("bot.services.invite_worker")
+    row = SimpleNamespace(
+        id=1,
+        application_id=101,
+        user_id=3002,
+        chat_id=-100123,
+        status="pending",
+        invite_link=None,
+        attempt_count=4,
+        last_error=None,
+        sent_at=None,
+    )
+    app = SimpleNamespace(id=101, status="added")
+    session = SimpleNamespace(commit=AsyncMock())
+    bot = SimpleNamespace(send_message=AsyncMock())
+
+    async def cas_update(session_arg, app_id, expected_from, new_status, **extra_fields):
+        assert session_arg is session
+        assert app_id == app.id
+        assert expected_from == "pending"
+        assert extra_fields == {}
+        if app.status != expected_from:
+            return False
+        app.status = new_status
+        return True
+
+    monkeypatch.setattr(worker, "async_session", lambda: _SessionContext(session))
+    monkeypatch.setattr(worker.InviteOutboxRepo, "get_pending", AsyncMock(return_value=[row]))
+    monkeypatch.setattr(
+        worker.invite_service,
+        "create_invite",
+        AsyncMock(side_effect=RuntimeError("privacy blocked")),
+    )
+    update_status_if_mock = AsyncMock(side_effect=cas_update)
+    get_mock = AsyncMock(return_value=app)
+    monkeypatch.setattr(worker.ApplicationRepo, "update_status_if", update_status_if_mock)
+    monkeypatch.setattr(worker.ApplicationRepo, "get", get_mock)
+    caplog.set_level("WARNING", logger=worker.logger.name)
+
+    asyncio.run(worker.process_invite_outbox(bot))
+
+    assert row.status == "failed"
+    assert row.attempt_count == 5
+    assert row.last_error == "privacy blocked"
+    assert app.status == "added"
+    update_status_if_mock.assert_awaited_once_with(
+        session,
+        app_id=101,
+        expected_from="pending",
+        new_status="privacy_block",
+    )
+    get_mock.assert_awaited_once_with(session, 101)
+    bot.send_message.assert_not_called()
+    session.commit.assert_awaited_once()
+    records = [
+        record
+        for record in caplog.records
+        if record.message == "invite_worker.privacy_block_skipped"
+    ]
+    assert len(records) == 1
+    assert records[0].app_id == 101
+    assert records[0].observed_status == "added"
+
+
+async def test_invite_outbox_unique_pending_per_application(db_session) -> None:
+    from sqlalchemy import select
+    from sqlalchemy.exc import IntegrityError
+
+    from bot.db.models import InviteOutbox
+    from bot.db.repos.application import ApplicationRepo
+    from bot.db.repos.user import UserRepo
+
+    connection = await db_session.connection()
+    if connection.dialect.name != "postgresql":
+        pytest.skip("invite_outbox pending partial unique index is postgres-only")
+
+    user_id = _next_user_id()
+    await UserRepo.upsert(
+        db_session,
+        telegram_id=user_id,
+        username=f"u{user_id}",
+        first_name="T",
+        last_name=None,
+    )
+    app = await ApplicationRepo.create(db_session, user_id)
+    await ApplicationRepo.update_status(db_session, app.id, "pending")
+
+    first = InviteOutbox(
+        application_id=app.id,
+        user_id=user_id,
+        chat_id=-100123,
+        status="pending",
+    )
+    db_session.add(first)
+    await db_session.flush()
+
+    with pytest.raises(IntegrityError):
+        async with db_session.begin_nested():
+            db_session.add(
+                InviteOutbox(
+                    application_id=app.id,
+                    user_id=user_id,
+                    chat_id=-100123,
+                    status="pending",
+                )
+            )
+            await db_session.flush()
+
+    rows = (
+        await db_session.execute(
+            select(InviteOutbox).where(
+                InviteOutbox.application_id == app.id,
+                InviteOutbox.status == "pending",
+            )
+        )
+    ).scalars().all()
+    assert [row.id for row in rows] == [first.id]
 
 
 def test_invite_outbox_model_registered() -> None:
@@ -246,4 +460,11 @@ def test_invite_outbox_model_registered() -> None:
         "created_at",
         "sent_at",
     } == cols
-    assert "ix_invite_outbox_status" in {ix.name for ix in table.indexes}
+    indexes = {ix.name: ix for ix in table.indexes}
+    assert "ix_invite_outbox_status" in indexes
+    assert "ix_invite_outbox_pending_unique" in indexes
+    pending_unique = indexes["ix_invite_outbox_pending_unique"]
+    assert pending_unique.unique is True
+    assert str(pending_unique.dialect_options["postgresql"]["where"]) == (
+        "status = 'pending'"
+    )


### PR DESCRIPTION
Closes #72

## Problem

CRIT-02-r3 hotfix (commit `b1242a6`) introduced an unconditional `ApplicationRepo.update_status(app_id, "privacy_block")` on outbox terminal failure (5 attempts exhausted). No CAS — a stale or duplicate pending outbox row could demote any application, including `vouched` or `added` members, to `privacy_block`, silently erasing their membership.

## Changes

### `bot/services/invite_worker.py`
- Replaced unconditional `update_status(..., "privacy_block")` with `update_status_if(..., expected_from='pending', new_status='privacy_block')`
- CAS miss (application is no longer `pending`) → structured log `invite_worker.privacy_block_skipped` with `app_id` and `observed_status`
- Outbox row is always marked `status='failed'` regardless of CAS outcome — prevents infinite retry

### `alembic/versions/012_invite_outbox_pending_unique.py`
- Pre-step: audit + delete duplicate `pending` rows (keep oldest by `created_at`, log count before deletion)
- Creates unique partial index `ix_invite_outbox_pending_unique ON invite_outbox(application_id) WHERE status='pending'`
- Postgres dialect only — SQLite guard with warning (dev/test envs unaffected)
- Downgrade: `DROP INDEX ix_invite_outbox_pending_unique`

### `tests/test_invite_outbox.py` (3 new tests)
- `test_invite_worker_exhausted_pending_app_demoted` — pending app, 5 failures → `privacy_block` fired
- `test_invite_worker_exhausted_vouched_app_preserved` — `vouched` app, CAS miss → status preserved, log emitted
- `test_invite_worker_exhausted_added_app_preserved` — `added` app, same CAS miss scenario
- `test_invite_outbox_unique_pending_per_application` — IntegrityError on duplicate pending row (skips if no Postgres)

## Test results

```
8 passed, 1 skipped (constraint test — Postgres not available in sandbox)
ruff check . → All checks passed
grep update_status.*privacy_block bot/ → 0 results (only update_status_if in use)
```

## Migration status

Migration SQL inspected and validated. Local Postgres not available in Codex sandbox — migration must be applied on staging before merging to production. Run order:
```
alembic upgrade head   # applies 012 + pre-step cleanup
alembic downgrade -1   # drops index (no data restoration — dupes were a bug)
alembic upgrade head   # idempotency check
```

## Rollback plan

```
git revert 6b094c6
alembic downgrade -1
```

Co-Authored-By: Codex (gpt-5.5) <noreply@openai.com>