### PR TITLE
[P0] fix(security): R5.2 admission gate first — close intro bypass

### DIFF
--- a/bot/handlers/chat_events.py
+++ b/bot/handlers/chat_events.py
@@ -144,7 +144,7 @@ async def _handle_join(
 ) -> None:
     now = datetime.now(timezone.utc)
 
-    # Upsert user and mark as member
+    # Upsert user before admission decisions so the reject path can track kicks.
     await UserRepo.upsert(
         session,
         telegram_id=tg_user.id,
@@ -152,6 +152,21 @@ async def _handle_join(
         first_name=tg_user.first_name,
         last_name=tg_user.last_name,
     )
+
+    is_admin = tg_user.id in settings.ADMIN_IDS
+    active_app = None
+
+    if is_admin:
+        logger.info("Admin user %s joined without gatekeeper admission", tg_user.id)
+    else:
+        # Check for active vouched application with a user-bound invite.
+        active_app = await ApplicationRepo.get_active(session, tg_user.id)
+        rejection_reason = _admission_rejection_reason(active_app, tg_user.id)
+
+        if rejection_reason is not None:
+            await _reject_join(event, session, tg_user, now, rejection_reason)
+            return
+
     await UserRepo.set_member(
         session, tg_user.id, is_member=True, joined_at=now
     )
@@ -164,16 +179,7 @@ async def _handle_join(
         )
         return
 
-    if tg_user.id in settings.ADMIN_IDS:
-        logger.info("Admin user %s joined without gatekeeper admission", tg_user.id)
-        return
-
-    # Check for active vouched application with a user-bound invite.
-    active_app = await ApplicationRepo.get_active(session, tg_user.id)
-    rejection_reason = _admission_rejection_reason(active_app, tg_user.id)
-
-    if rejection_reason is not None:
-        await _reject_join(event, session, tg_user, now, rejection_reason)
+    if is_admin:
         return
 
     await ApplicationRepo.update_status(

--- a/tests/test_invite_admission.py
+++ b/tests/test_invite_admission.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from types import SimpleNamespace
-from unittest.mock import ANY, AsyncMock, call
+from unittest.mock import ANY, AsyncMock
 
 from tests.conftest import import_module
 
@@ -54,6 +54,7 @@ def _patch_join_dependencies(
     monkeypatch,
     *,
     active_app: SimpleNamespace | None,
+    existing_intro: SimpleNamespace | None = None,
 ) -> tuple[AsyncMock, AsyncMock]:
     user_upsert = AsyncMock(return_value=_db_user())
     user_set_member = AsyncMock()
@@ -62,14 +63,22 @@ def _patch_join_dependencies(
     monkeypatch.setattr(handler.UserRepo, "upsert", user_upsert)
     monkeypatch.setattr(handler.UserRepo, "set_member", user_set_member)
     monkeypatch.setattr(handler.UserRepo, "get", user_get)
-    monkeypatch.setattr(handler.IntroRepo, "get", AsyncMock(return_value=None))
+    monkeypatch.setattr(
+        handler.IntroRepo,
+        "get",
+        AsyncMock(return_value=existing_intro),
+    )
     monkeypatch.setattr(
         handler.ApplicationRepo,
         "get_active",
         AsyncMock(return_value=active_app),
     )
     monkeypatch.setattr(handler.ApplicationRepo, "update_status", AsyncMock())
-    monkeypatch.setattr(handler.QuestionnaireRepo, "get_answers", AsyncMock(return_value=[]))
+    monkeypatch.setattr(
+        handler.QuestionnaireRepo,
+        "get_answers",
+        AsyncMock(return_value=[]),
+    )
     monkeypatch.setattr(handler.IntroRepo, "upsert", AsyncMock())
 
     return user_set_member, handler.ApplicationRepo.update_status
@@ -94,13 +103,95 @@ def test_filling_user_using_forwarded_invite_rejected(
     event.bot.ban_chat_member.assert_awaited_once_with(COMMUNITY_CHAT_ID, 222)
     event.bot.unban_chat_member.assert_awaited_once_with(COMMUNITY_CHAT_ID, 222)
     update_status.assert_not_called()
-    user_set_member.assert_has_awaits(
-        [
-            call(session, 222, is_member=True, joined_at=ANY),
-            call(session, 222, is_member=False, left_at=ANY),
-        ]
+    user_set_member.assert_awaited_once_with(
+        session, 222, is_member=False, left_at=ANY
     )
     assert "status='filling'" in caplog.text
+
+
+def test_handle_join_legit_returning_member_with_valid_vouch_passes(
+    app_env, monkeypatch
+) -> None:
+    handler = import_module("bot.handlers.chat_events")
+    session = AsyncMock()
+    event = _join_event()
+    tg_user = _user(222)
+    existing_intro = SimpleNamespace(user_id=222, intro_text="old intro")
+    user_set_member, update_status = _patch_join_dependencies(
+        handler,
+        monkeypatch,
+        active_app=_application(status="vouched", invite_user_id=222),
+        existing_intro=existing_intro,
+    )
+
+    asyncio.run(handler._handle_join(event, session, tg_user))
+
+    event.bot.ban_chat_member.assert_not_called()
+    event.bot.unban_chat_member.assert_not_called()
+    user_set_member.assert_awaited_once_with(
+        session, 222, is_member=True, joined_at=ANY
+    )
+    handler.IntroRepo.get.assert_awaited_once_with(session, 222)
+    handler.IntroRepo.upsert.assert_not_called()
+    update_status.assert_not_called()
+
+
+def test_handle_join_ex_member_with_intro_no_vouch_rejected(
+    app_env, monkeypatch, caplog
+) -> None:
+    handler = import_module("bot.handlers.chat_events")
+    session = AsyncMock()
+    event = _join_event()
+    tg_user = _user(222)
+    existing_intro = SimpleNamespace(user_id=222, intro_text="old intro")
+    user_set_member, update_status = _patch_join_dependencies(
+        handler,
+        monkeypatch,
+        active_app=_application(status="rejected", invite_user_id=222),
+        existing_intro=existing_intro,
+    )
+
+    with caplog.at_level(logging.WARNING):
+        asyncio.run(handler._handle_join(event, session, tg_user))
+
+    event.bot.ban_chat_member.assert_awaited_once_with(COMMUNITY_CHAT_ID, 222)
+    event.bot.unban_chat_member.assert_awaited_once_with(COMMUNITY_CHAT_ID, 222)
+    user_set_member.assert_awaited_once_with(
+        session, 222, is_member=False, left_at=ANY
+    )
+    handler.IntroRepo.get.assert_not_called()
+    handler.IntroRepo.upsert.assert_not_called()
+    update_status.assert_not_called()
+    assert "status='rejected'" in caplog.text
+
+
+def test_handle_join_forwarded_invite_ex_member_blocked(
+    app_env, monkeypatch, caplog
+) -> None:
+    handler = import_module("bot.handlers.chat_events")
+    session = AsyncMock()
+    event = _join_event()
+    tg_user = _user(222)
+    existing_intro = SimpleNamespace(user_id=222, intro_text="old intro")
+    user_set_member, update_status = _patch_join_dependencies(
+        handler,
+        monkeypatch,
+        active_app=None,
+        existing_intro=existing_intro,
+    )
+
+    with caplog.at_level(logging.WARNING):
+        asyncio.run(handler._handle_join(event, session, tg_user))
+
+    event.bot.ban_chat_member.assert_awaited_once_with(COMMUNITY_CHAT_ID, 222)
+    event.bot.unban_chat_member.assert_awaited_once_with(COMMUNITY_CHAT_ID, 222)
+    user_set_member.assert_awaited_once_with(
+        session, 222, is_member=False, left_at=ANY
+    )
+    handler.IntroRepo.get.assert_not_called()
+    handler.IntroRepo.upsert.assert_not_called()
+    update_status.assert_not_called()
+    assert "no active application" in caplog.text
 
 
 def test_pending_user_join_rejected(app_env, monkeypatch) -> None:


### PR DESCRIPTION
Closes #70.

## What

Reorders `_handle_join` so that `_admission_rejection_reason` executes **before** `set_member(True)` and before any intro early-return. Closes the CRIT-01-class bypass where an ex-member with an existing intro row could join without going through the vouching admission filter.

## Attack chain closed

1. Ex-member receives forwarded invite link from a vouched user
2. Joins chat → bot fires `chat_member` event
3. Old code: `set_member(True)` → `if existing_intro: return` → bypassed
4. New code: admission gate runs first → no active vouch → `_reject_join` called → `set_member` never reached

## Changes

- `bot/handlers/chat_events.py`: moved admission check + admin bypass before `set_member` and intro read
- `tests/test_invite_admission.py`: added 3 new tests

## Tests added

- `test_handle_join_legit_returning_member_with_valid_vouch_passes` (positive — intro-refresh path protected)
- `test_handle_join_ex_member_with_intro_no_vouch_rejected` (negative — no vouch → kicked)
- `test_handle_join_forwarded_invite_ex_member_blocked` (negative — forwarded invite scenario)

## Invariant

Single `set_member(is_member=True)` call site in `_handle_join`, positioned after `_admission_rejection_reason() is None`.

## Rollback

Single commit revert. No schema changes.

Co-Authored-By: Codex (gpt-5.5) <noreply@openai.com>