### PR TITLE
[P1] fix(security): R5.1 CAS-guard 48h nudge path

### DIFF
--- a/bot/services/scheduler.py
+++ b/bot/services/scheduler.py
@@ -35,6 +35,18 @@ def format_admin_nudge(name: str, username: str, app_id: int) -> str:
     )
 
 
+async def _log_vouch_deadline_cas_lost(session, app_id: int, branch: str) -> None:
+    observed_app = await ApplicationRepo.get(session, app_id)
+    logger.info(
+        "scheduler.cas_lost",
+        extra={
+            "app_id": app_id,
+            "branch": branch,
+            "observed_status": observed_app.status if observed_app else None,
+        },
+    )
+
+
 async def check_vouch_deadlines(bot: Bot) -> None:
     """Check pending applications for 48h nudge and 72h auto-reject."""
     async with async_session() as session:
@@ -89,12 +101,16 @@ async def check_vouch_deadlines(bot: Bot) -> None:
                     await bot.send_message(chat_id=app.user_id, text=NUDGE_MSG)
                 except Exception:
                     logger.warning("Failed to nudge user %s", app.user_id)
-                await ApplicationRepo.update_status(
+                nudged = await ApplicationRepo.update_status_if(
                     session,
                     app.id,
-                    "pending",
+                    expected_from="pending",
+                    new_status="pending",
                     nudged_newcomer_at=datetime.now(timezone.utc),
                 )
+                if not nudged:
+                    await _log_vouch_deadline_cas_lost(session, app.id, "nudge")
+                    continue
 
             # Notify admins
             if app.notified_admin_at is None:
@@ -109,12 +125,16 @@ async def check_vouch_deadlines(bot: Bot) -> None:
                         )
                     except Exception:
                         logger.warning("Failed to notify admin %s", admin_id)
-                await ApplicationRepo.update_status(
+                notified = await ApplicationRepo.update_status_if(
                     session,
                     app.id,
-                    "pending",
+                    expected_from="pending",
+                    new_status="pending",
                     notified_admin_at=datetime.now(timezone.utc),
                 )
+                if not notified:
+                    await _log_vouch_deadline_cas_lost(session, app.id, "notify")
+                    continue
 
         await session.commit()
 

--- a/tests/test_scheduler_deadlines.py
+++ b/tests/test_scheduler_deadlines.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from datetime import datetime, timedelta, timezone
 from importlib import import_module
 from types import SimpleNamespace
@@ -238,3 +239,183 @@ def test_pending_within_threshold_not_returned() -> None:
     )
 
     assert pending_ids == []
+
+
+def test_check_vouch_deadlines_pending_app_nudged(app_env, monkeypatch) -> None:
+    async def run() -> None:
+        models = import_module("bot.db.models")
+        scheduler = import_module("bot.services.scheduler")
+        now = datetime.now(timezone.utc)
+        app = models.Application(
+            user_id=2004,
+            status="pending",
+            created_at=now - timedelta(hours=50),
+            submitted_at=now,
+            notified_admin_at=now,
+        )
+        engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+        sessionmaker = async_sessionmaker(engine, expire_on_commit=False)
+        try:
+            async with engine.begin() as conn:
+                await conn.run_sync(models.Base.metadata.create_all)
+
+            async with sessionmaker() as session:
+                session.add(app)
+                await session.commit()
+
+                monkeypatch.setattr(
+                    scheduler,
+                    "async_session",
+                    lambda: _AsyncSessionContext(session),
+                )
+                bot = SimpleNamespace(send_message=AsyncMock())
+
+                await scheduler.check_vouch_deadlines(bot)
+
+                await session.refresh(app)
+                assert app.status == "pending"
+                assert app.nudged_newcomer_at is not None
+                bot.send_message.assert_awaited_once_with(
+                    chat_id=app.user_id,
+                    text=scheduler.NUDGE_MSG,
+                )
+        finally:
+            await engine.dispose()
+
+    asyncio.run(run())
+
+
+def test_check_vouch_deadlines_concurrent_vouch_preserved(
+    app_env, monkeypatch, caplog
+) -> None:
+    async def run() -> None:
+        models = import_module("bot.db.models")
+        scheduler = import_module("bot.services.scheduler")
+        now = datetime.now(timezone.utc)
+        app = models.Application(
+            user_id=2005,
+            status="pending",
+            created_at=now - timedelta(hours=50),
+            submitted_at=now,
+            notified_admin_at=now,
+        )
+        engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+        sessionmaker = async_sessionmaker(engine, expire_on_commit=False)
+
+        async def lose_nudge_cas(session, app_id, **_kwargs):
+            await session.execute(
+                update(models.Application)
+                .where(models.Application.id == app_id)
+                .values(status="vouched")
+            )
+            await session.flush()
+            await session.refresh(app)
+            return False
+
+        try:
+            async with engine.begin() as conn:
+                await conn.run_sync(models.Base.metadata.create_all)
+
+            async with sessionmaker() as session:
+                session.add(app)
+                await session.commit()
+
+                monkeypatch.setattr(
+                    scheduler,
+                    "async_session",
+                    lambda: _AsyncSessionContext(session),
+                )
+                monkeypatch.setattr(
+                    scheduler.ApplicationRepo,
+                    "update_status_if",
+                    lose_nudge_cas,
+                )
+                bot = SimpleNamespace(send_message=AsyncMock())
+
+                with caplog.at_level(logging.INFO, logger="bot.services.scheduler"):
+                    await scheduler.check_vouch_deadlines(bot)
+
+                await session.refresh(app)
+                assert app.status == "vouched"
+                assert app.nudged_newcomer_at is None
+                records = [
+                    record
+                    for record in caplog.records
+                    if record.message == "scheduler.cas_lost"
+                ]
+                assert len(records) == 1
+                assert records[0].app_id == app.id
+                assert records[0].branch == "nudge"
+                assert records[0].observed_status == "vouched"
+        finally:
+            await engine.dispose()
+
+    asyncio.run(run())
+
+
+def test_check_vouch_deadlines_rejected_app_skipped(
+    app_env, monkeypatch, caplog
+) -> None:
+    async def run() -> None:
+        models = import_module("bot.db.models")
+        scheduler = import_module("bot.services.scheduler")
+        now = datetime.now(timezone.utc)
+        app = models.Application(
+            user_id=2006,
+            status="pending",
+            created_at=now - timedelta(hours=50),
+            submitted_at=now,
+            nudged_newcomer_at=now - timedelta(hours=1),
+        )
+        engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+        sessionmaker = async_sessionmaker(engine, expire_on_commit=False)
+
+        async def lose_notify_cas(session, app_id, **_kwargs):
+            await session.execute(
+                update(models.Application)
+                .where(models.Application.id == app_id)
+                .values(status="rejected")
+            )
+            await session.flush()
+            await session.refresh(app)
+            return False
+
+        try:
+            async with engine.begin() as conn:
+                await conn.run_sync(models.Base.metadata.create_all)
+
+            async with sessionmaker() as session:
+                session.add(app)
+                await session.commit()
+
+                monkeypatch.setattr(
+                    scheduler,
+                    "async_session",
+                    lambda: _AsyncSessionContext(session),
+                )
+                monkeypatch.setattr(
+                    scheduler.ApplicationRepo,
+                    "update_status_if",
+                    lose_notify_cas,
+                )
+                bot = SimpleNamespace(send_message=AsyncMock())
+
+                with caplog.at_level(logging.INFO, logger="bot.services.scheduler"):
+                    await scheduler.check_vouch_deadlines(bot)
+
+                await session.refresh(app)
+                assert app.status == "rejected"
+                assert app.notified_admin_at is None
+                records = [
+                    record
+                    for record in caplog.records
+                    if record.message == "scheduler.cas_lost"
+                ]
+                assert len(records) == 1
+                assert records[0].app_id == app.id
+                assert records[0].branch == "notify"
+                assert records[0].observed_status == "rejected"
+        finally:
+            await engine.dispose()
+
+    asyncio.run(run())


### PR DESCRIPTION
## Summary

Closes #71. P1 race-condition hotfix.

CRIT-03 (commit `66d995b`) closed only the 72h auto-reject path in `check_vouch_deadlines`. The 48h nudge path in the same scheduler tick still wrote `app.status='pending'` via unguarded `update_status` — same race-class as CRIT-03.

## Race window

1. Scheduler `SELECT` returns app #100 with status='pending'
2. Concurrent vouch handler updates app #100 to 'vouched', enqueues invite outbox
3. Scheduler reaches app #100, in-memory `app.status` is stale ('pending')
4. `update_status(app.id, "pending", nudged_newcomer_at=...)` — overwrites 'vouched' back to 'pending'
5. Invite already enqueued. Next 72h tick will auto-reject this falsely-pending app despite the vouch.

## Fix

Replace both unguarded `update_status` calls (nudge `nudged_newcomer_at` + notify `notified_admin_at`) with `update_status_if(expected_from='pending', new_status='pending', **timestamps)`. On CAS loss → extra SELECT for `observed_status`, structured log `scheduler.cas_lost` with `app_id`, `branch`, `observed_status`, then `continue`.

## Tests

- `test_check_vouch_deadlines_pending_app_nudged` — positive
- `test_check_vouch_deadlines_concurrent_vouch_preserved` — negative, vouch race
- `test_check_vouch_deadlines_rejected_app_skipped` — negative, stale read returns rejected

Full suite: 124 passed, 66 skipped, 0 failed. Ruff clean.

## Test plan

- [x] Local pytest pass
- [x] Local ruff clean
- [ ] CI green
- [ ] Claude reviewer APPROVE

🤖 Generated with [Claude Code](https://claude.com/claude-code)