### PR TITLE
feat(memory): T3-04 cascade worker skeleton (#96, HIGH-RISK)

### DIFF
--- a/bot/db/repos/forget_event.py
+++ b/bot/db/repos/forget_event.py
@@ -175,3 +175,49 @@ class ForgetEventRepo:
             f"{actual.status!r} → {status!r}. "
             f"Allowed from {actual.status!r}: {sorted(allowed_next) or '[]'}"
         )
+
+    @staticmethod
+    async def update_cascade_status(
+        session: AsyncSession,
+        forget_event_id: int,
+        *,
+        cascade_status: dict,
+    ) -> ForgetEvent:
+        """Checkpoint cascade progress on a row in ``status='processing'``.
+
+        Sprint 3 (#96) cascade primitive. Separate from ``mark_status`` so the cascade
+        worker can write per-layer progress mid-cascade without transitioning state.
+        ``mark_status`` rejects ``processing → processing`` (not in the state machine);
+        without this method, a worker crash mid-cascade would lose all per-layer progress.
+
+        Atomic ``UPDATE ... WHERE id = ? AND status = 'processing' RETURNING``. Rejects
+        any other current status (including ``pending`` — the row must be claimed first
+        via ``mark_status(status='processing')`` — and the terminal states).
+
+        Flushes; does not commit. Caller controls the transaction lifecycle.
+
+        Raises ``ValueError`` if the row does not exist or is not in ``processing``.
+        """
+        stmt = (
+            update(ForgetEvent)
+            .where(ForgetEvent.id == forget_event_id)
+            .where(ForgetEvent.status == "processing")
+            .values(cascade_status=cascade_status, updated_at=func.now())
+            .returning(ForgetEvent)
+        )
+        result = await session.execute(stmt)
+        row = result.scalars().first()
+        if row is not None:
+            await session.flush()
+            return row
+
+        # Either the id doesn't exist or the row is not in 'processing'.
+        actual = await session.get(
+            ForgetEvent, forget_event_id, populate_existing=True
+        )
+        if actual is None:
+            raise ValueError(f"ForgetEvent(id={forget_event_id}) not found")
+        raise ValueError(
+            f"update_cascade_status requires status='processing'; "
+            f"ForgetEvent(id={forget_event_id}) is in {actual.status!r}."
+        )

--- a/bot/services/forget_cascade.py
+++ b/bot/services/forget_cascade.py
@@ -74,38 +74,71 @@ async def _cascade_chat_messages(session: AsyncSession, event) -> int:
 
     Returns the number of rows affected.
 
-    Currently supports ``target_type='message'`` only — the row is selected by
-    ``ChatMessage.id == int(target_id)``. Other target types (``user``,
-    ``message_hash``, ``export``) are reserved for Sprint 4 / #105 (/forget_me)
-    and re-import prevention (#97); calling them here returns 0 rows.
+    Supported target_types:
+    - ``message``: single row by ``ChatMessage.id == int(target_id)``.
+    - ``user``: all rows by ``ChatMessage.user_id == CAST(target_id AS BIGINT)``
+      (User.id == telegram_id per codebase invariant).
+
+    Other target types (``message_hash``, ``export``) are reserved for future
+    streams (#97, #105); the caller (``_process_one_event``) must NOT invoke
+    this function for them — it skips them before reaching ``_LAYER_FUNCS``.
     """
-    if event.target_type != "message" or event.target_id is None:
-        return 0
-
-    try:
-        cm_id = int(event.target_id)
-    except (TypeError, ValueError):
-        # target_id for ``message`` MUST be an integer chat_messages.id; reject
-        # rather than silently no-op so a malformed event surfaces as failed.
+    if event.target_id is None:
         raise ValueError(
-            f"forget_event target_type='message' requires integer target_id; "
-            f"got {event.target_id!r}"
+            f"forget_event target_type={event.target_type!r} requires a non-None target_id"
         )
 
-    stmt = (
-        update(ChatMessage)
-        .where(ChatMessage.id == cm_id)
-        .values(
-            text=None,
-            caption=None,
-            raw_json=None,
-            is_redacted=True,
-            memory_policy="forgotten",
+    if event.target_type == "message":
+        try:
+            cm_id = int(event.target_id)
+        except (TypeError, ValueError):
+            raise ValueError(
+                f"forget_event target_type='message' requires integer target_id; "
+                f"got {event.target_id!r}"
+            )
+        stmt = (
+            update(ChatMessage)
+            .where(ChatMessage.id == cm_id)
+            .values(
+                text=None,
+                caption=None,
+                raw_json=None,
+                is_redacted=True,
+                memory_policy="forgotten",
+            )
         )
+        result = await session.execute(stmt)
+        await session.flush()
+        return result.rowcount or 0
+
+    if event.target_type == "user":
+        try:
+            telegram_id = int(event.target_id)
+        except (TypeError, ValueError):
+            raise ValueError(
+                f"forget_event target_type='user' requires integer target_id (telegram_id); "
+                f"got {event.target_id!r}"
+            )
+        stmt = (
+            update(ChatMessage)
+            .where(ChatMessage.user_id == telegram_id)
+            .values(
+                text=None,
+                caption=None,
+                raw_json=None,
+                is_redacted=True,
+                memory_policy="forgotten",
+            )
+        )
+        result = await session.execute(stmt)
+        await session.flush()
+        return result.rowcount or 0
+
+    # Should not reach here: _process_one_event guards unsupported target_types
+    # before calling _LAYER_FUNCS.  Raise so a regression surfaces immediately.
+    raise ValueError(
+        f"_cascade_chat_messages: unsupported target_type={event.target_type!r}"
     )
-    result = await session.execute(stmt)
-    await session.flush()
-    return result.rowcount or 0
 
 
 async def _cascade_message_versions(session: AsyncSession, event) -> int:
@@ -122,32 +155,78 @@ async def _cascade_message_versions(session: AsyncSession, event) -> int:
     PRIVACY_LEAK_CLASS_4).
 
     Returns the number of rows affected.
+
+    Supported target_types:
+    - ``message``: versions for the single chat_messages row.
+    - ``user``: versions for ALL chat_messages rows owned by the user.
+      Because ``_cascade_chat_messages`` NULLs text/caption/raw_json but does
+      NOT touch ``user_id``, the subquery ``WHERE user_id = telegram_id``
+      still resolves correctly.
     """
-    if event.target_type != "message" or event.target_id is None:
-        return 0
-
-    try:
-        cm_id = int(event.target_id)
-    except (TypeError, ValueError):
+    if event.target_id is None:
         raise ValueError(
-            f"forget_event target_type='message' requires integer target_id; "
-            f"got {event.target_id!r}"
+            f"forget_event target_type={event.target_type!r} requires a non-None target_id"
         )
 
-    stmt = (
-        update(MessageVersion)
-        .where(MessageVersion.chat_message_id == cm_id)
-        .values(
-            text=None,
-            caption=None,
-            normalized_text=None,
-            entities_json=None,
-            is_redacted=True,
+    if event.target_type == "message":
+        try:
+            cm_id = int(event.target_id)
+        except (TypeError, ValueError):
+            raise ValueError(
+                f"forget_event target_type='message' requires integer target_id; "
+                f"got {event.target_id!r}"
+            )
+        stmt = (
+            update(MessageVersion)
+            .where(MessageVersion.chat_message_id == cm_id)
+            .values(
+                text=None,
+                caption=None,
+                normalized_text=None,
+                entities_json=None,
+                is_redacted=True,
+            )
         )
+        result = await session.execute(stmt)
+        await session.flush()
+        return result.rowcount or 0
+
+    if event.target_type == "user":
+        try:
+            telegram_id = int(event.target_id)
+        except (TypeError, ValueError):
+            raise ValueError(
+                f"forget_event target_type='user' requires integer target_id (telegram_id); "
+                f"got {event.target_id!r}"
+            )
+        # Select version ids via subquery on chat_messages.user_id. The previous
+        # layer NULLed text/caption/raw_json but user_id column is untouched, so
+        # this subquery resolves correctly regardless of layer order.
+        from sqlalchemy import select as sa_select
+
+        stmt = (
+            update(MessageVersion)
+            .where(
+                MessageVersion.chat_message_id.in_(
+                    sa_select(ChatMessage.id).where(ChatMessage.user_id == telegram_id)
+                )
+            )
+            .values(
+                text=None,
+                caption=None,
+                normalized_text=None,
+                entities_json=None,
+                is_redacted=True,
+            )
+        )
+        result = await session.execute(stmt)
+        await session.flush()
+        return result.rowcount or 0
+
+    # Should not reach here: _process_one_event guards unsupported target_types.
+    raise ValueError(
+        f"_cascade_message_versions: unsupported target_type={event.target_type!r}"
     )
-    result = await session.execute(stmt)
-    await session.flush()
-    return result.rowcount or 0
 
 
 # Map layer name → cascade function. Only Phase 1 layers have functions here;
@@ -174,6 +253,12 @@ async def _process_one_event(session: AsyncSession, event) -> None:
     # Snapshot current per-layer progress so we can resume.
     cascade_state: dict[str, Any] = dict(event.cascade_status or {})
 
+    # target_types whose cascade is not yet implemented. The event still finalises
+    # as 'completed' (all layers explicitly accounted for), but each layer records
+    # status='skipped' so the audit trail shows no work was done.
+    # Stream Delta #97 (message_hash) and Bravo importer (#105) will fill these in.
+    _SKIP_TARGET_TYPES = frozenset({"message_hash", "export"})
+
     try:
         for layer in CASCADE_LAYER_ORDER:
             existing = cascade_state.get(layer)
@@ -181,7 +266,22 @@ async def _process_one_event(session: AsyncSession, event) -> None:
                 # Already done in a previous run — skip.
                 continue
 
-            if layer in _LAYER_FUNCS:
+            if event.target_type in _SKIP_TARGET_TYPES:
+                # Unsupported target_type: record skip with reason so the audit
+                # trail is explicit. Phase 4+ layers with table_not_exists also
+                # land here as skipped, but with a different reason.
+                if layer in _LAYER_FUNCS:
+                    cascade_state[layer] = {
+                        "status": "skipped",
+                        "reason": "target_type_not_supported_yet",
+                        "rows": 0,
+                    }
+                else:
+                    cascade_state[layer] = {
+                        "status": "skipped",
+                        "reason": "table_not_exists",
+                    }
+            elif layer in _LAYER_FUNCS:
                 rows = await _LAYER_FUNCS[layer](session, event)
                 cascade_state[layer] = {"status": "completed", "rows": rows}
             else:

--- a/bot/services/forget_cascade.py
+++ b/bot/services/forget_cascade.py
@@ -1,0 +1,300 @@
+"""Forget cascade worker (T3-04, issue #96).
+
+Background worker that drives ``forget_events`` rows through the cascade defined in
+HANDOFF.md §10. Phase 3 skeleton: only Phase 1 layers (``chat_messages`` and
+``message_versions``) execute; layers whose tables do not yet exist (``message_entities``,
+``message_links``, ``attachments``, ``fts_rows``) are recorded as ``skipped`` so the
+cascade is forward-compatible — when those tables land in later phases, the cascade
+order is already wired and only the per-layer functions need filling in.
+
+Durability invariants (binding for every code path here):
+
+* **Idempotent claim.** ``ForgetEventRepo.mark_status(status='processing')`` is an atomic
+  ``UPDATE ... WHERE status='pending' RETURNING``; double-claim is impossible. A
+  losing claimant gets ``ValueError`` and skips the row.
+* **Restart-safe.** Per-layer progress is checkpointed via
+  ``ForgetEventRepo.update_cascade_status``. After a crash mid-cascade, the next
+  worker run reads ``cascade_status`` and skips already-completed layers.
+* **Per-event isolation.** Each event's cascade is wrapped in its own try/except.
+  A failure in one event marks that row ``failed`` but does NOT halt other events
+  in the batch.
+* **Irreversibility doctrine** (HANDOFF.md §10, ADR-0003). The cascade for
+  ``chat_messages`` NULLs ``text``, ``caption``, ``raw_json`` and sets
+  ``is_redacted=True``, ``memory_policy='forgotten'``. The cascade for
+  ``message_versions`` NULLs ``text``, ``caption``, ``normalized_text``,
+  ``entities_json`` and sets ``is_redacted=True``. ``content_hash`` is intentionally
+  preserved so prior citations resolve; the redacted flag tells consumers to skip
+  the body.
+
+Production wiring is gated by feature flag ``memory.forget.cascade_worker.enabled``
+(default OFF) — the scheduler reads the flag every tick and no-ops when off. This
+mirrors the AUTHORIZED_SCOPE pattern for new ingestion-style paths.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from sqlalchemy import update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from bot.db.engine import async_session
+from bot.db.models import ChatMessage, MessageVersion
+from bot.db.repos.feature_flag import FeatureFlagRepo
+from bot.db.repos.forget_event import ForgetEventRepo
+
+logger = logging.getLogger(__name__)
+
+# Feature flag key — read by the scheduler tick to decide whether to run the worker.
+CASCADE_WORKER_FLAG = "memory.forget.cascade_worker.enabled"
+
+# Cascade order per HANDOFF §10. The first two layers are Phase 1 tables; the rest
+# are Phase 4+ derived layers whose tables do not yet exist. Skipped layers are
+# recorded with ``{"status": "skipped", "reason": "table_not_exists"}`` so the
+# cascade_status JSON is forward-compatible: a later phase that adds the table
+# replaces the per-layer function and existing rows are reprocessed naturally.
+CASCADE_LAYER_ORDER: tuple[str, ...] = (
+    "chat_messages",
+    "message_versions",
+    "message_entities",
+    "message_links",
+    "attachments",
+    "fts_rows",
+)
+
+
+async def _cascade_chat_messages(session: AsyncSession, event) -> int:
+    """NULL content fields on ``chat_messages`` rows targeted by this forget_event.
+
+    Per HANDOFF.md §10 irreversibility doctrine, the cascade overwrites:
+    - ``text``, ``caption``, ``raw_json`` → ``NULL``
+    - ``is_redacted`` → ``True``
+    - ``memory_policy`` → ``'forgotten'``
+
+    Returns the number of rows affected.
+
+    Currently supports ``target_type='message'`` only — the row is selected by
+    ``ChatMessage.id == int(target_id)``. Other target types (``user``,
+    ``message_hash``, ``export``) are reserved for Sprint 4 / #105 (/forget_me)
+    and re-import prevention (#97); calling them here returns 0 rows.
+    """
+    if event.target_type != "message" or event.target_id is None:
+        return 0
+
+    try:
+        cm_id = int(event.target_id)
+    except (TypeError, ValueError):
+        # target_id for ``message`` MUST be an integer chat_messages.id; reject
+        # rather than silently no-op so a malformed event surfaces as failed.
+        raise ValueError(
+            f"forget_event target_type='message' requires integer target_id; "
+            f"got {event.target_id!r}"
+        )
+
+    stmt = (
+        update(ChatMessage)
+        .where(ChatMessage.id == cm_id)
+        .values(
+            text=None,
+            caption=None,
+            raw_json=None,
+            is_redacted=True,
+            memory_policy="forgotten",
+        )
+    )
+    result = await session.execute(stmt)
+    await session.flush()
+    return result.rowcount or 0
+
+
+async def _cascade_message_versions(session: AsyncSession, event) -> int:
+    """NULL content fields on ``message_versions`` rows whose ``chat_message_id``
+    matches this forget_event's target.
+
+    Per HANDOFF.md §10 irreversibility doctrine, the cascade overwrites:
+    - ``text``, ``caption``, ``normalized_text``, ``entities_json`` → ``NULL``
+    - ``is_redacted`` → ``True``
+
+    ``content_hash`` is intentionally PRESERVED so prior citations remain
+    resolvable; the redacted flag tells consumers to skip the body. Matches the
+    T1-14 hotfix invariant (closes Codex Phase 1 final-review CRITICAL
+    PRIVACY_LEAK_CLASS_4).
+
+    Returns the number of rows affected.
+    """
+    if event.target_type != "message" or event.target_id is None:
+        return 0
+
+    try:
+        cm_id = int(event.target_id)
+    except (TypeError, ValueError):
+        raise ValueError(
+            f"forget_event target_type='message' requires integer target_id; "
+            f"got {event.target_id!r}"
+        )
+
+    stmt = (
+        update(MessageVersion)
+        .where(MessageVersion.chat_message_id == cm_id)
+        .values(
+            text=None,
+            caption=None,
+            normalized_text=None,
+            entities_json=None,
+            is_redacted=True,
+        )
+    )
+    result = await session.execute(stmt)
+    await session.flush()
+    return result.rowcount or 0
+
+
+# Map layer name → cascade function. Only Phase 1 layers have functions here;
+# the rest are recorded as skipped. When a future phase adds a layer's table,
+# add its function to this map and remove it from the implicit "skipped" set.
+_LAYER_FUNCS: dict[str, Any] = {
+    "chat_messages": _cascade_chat_messages,
+    "message_versions": _cascade_message_versions,
+}
+
+
+async def _process_one_event(session: AsyncSession, event) -> None:
+    """Run the full cascade for a single (already-claimed) forget_event row.
+
+    Resumes from ``cascade_status``: layers already marked ``completed`` are
+    skipped. Each layer's outcome is checkpointed via ``update_cascade_status``
+    BEFORE moving on, so a crash between layers leaves the worker in a state
+    the next run can resume from.
+
+    On success, transitions the row to ``status='completed'`` with the final
+    cascade_status. On exception, transitions to ``status='failed'`` with the
+    exception captured under ``cascade_status['error']``.
+    """
+    # Snapshot current per-layer progress so we can resume.
+    cascade_state: dict[str, Any] = dict(event.cascade_status or {})
+
+    try:
+        for layer in CASCADE_LAYER_ORDER:
+            existing = cascade_state.get(layer)
+            if isinstance(existing, dict) and existing.get("status") == "completed":
+                # Already done in a previous run — skip.
+                continue
+
+            if layer in _LAYER_FUNCS:
+                rows = await _LAYER_FUNCS[layer](session, event)
+                cascade_state[layer] = {"status": "completed", "rows": rows}
+            else:
+                # Phase 4+ layers — table not yet present in this codebase.
+                cascade_state[layer] = {
+                    "status": "skipped",
+                    "reason": "table_not_exists",
+                }
+
+            # Checkpoint after every layer so a crash mid-cascade is recoverable.
+            await ForgetEventRepo.update_cascade_status(
+                session, event.id, cascade_status=cascade_state
+            )
+
+        await ForgetEventRepo.mark_status(
+            session, event.id, status="completed", cascade_status=cascade_state
+        )
+    except Exception as exc:
+        cascade_state["error"] = repr(exc)
+        # Try to record the failure; if THAT itself fails (e.g. terminal state
+        # already set), let the outer exception propagate to the batch loop.
+        await ForgetEventRepo.mark_status(
+            session, event.id, status="failed", cascade_status=cascade_state
+        )
+        raise
+
+
+async def run_cascade_worker_once(
+    session: AsyncSession,
+    *,
+    batch_size: int = 10,
+) -> dict[str, int]:
+    """Process up to ``batch_size`` pending forget_events.
+
+    Returns a stats dict ``{claimed, processed, failed}``:
+    - ``claimed`` — events successfully transitioned ``pending → processing``
+    - ``processed`` — events that completed the cascade (status='completed')
+    - ``failed`` — events whose cascade raised (status='failed')
+
+    The function does NOT commit. Caller controls the transaction lifecycle.
+    Per-event isolation: a failure in one event's cascade marks ONLY that event
+    as ``failed`` and continues with the rest of the batch. The function returns
+    normally even if some events failed.
+    """
+    pending = await ForgetEventRepo.list_pending(session, limit=batch_size)
+    stats = {"claimed": 0, "processed": 0, "failed": 0}
+
+    for event in pending:
+        # Atomic claim: pending → processing. Race-safe via the repo's
+        # WHERE-status filter; if another worker already claimed this row, the
+        # repo raises ValueError and we skip silently.
+        try:
+            claimed = await ForgetEventRepo.mark_status(
+                session, event.id, status="processing"
+            )
+        except ValueError:
+            logger.debug(
+                "cascade_worker: skipping already-claimed forget_event id=%s",
+                event.id,
+            )
+            continue
+        stats["claimed"] += 1
+
+        try:
+            await _process_one_event(session, claimed)
+            stats["processed"] += 1
+        except Exception:
+            logger.exception(
+                "cascade_worker: cascade failed for forget_event id=%s "
+                "(other events in batch unaffected)",
+                claimed.id,
+            )
+            stats["failed"] += 1
+
+    return stats
+
+
+async def cascade_worker_tick(
+    session: AsyncSession | None = None,
+    *,
+    batch_size: int = 10,
+) -> dict[str, int]:
+    """Scheduler entry point for the cascade worker.
+
+    Reads the ``memory.forget.cascade_worker.enabled`` feature flag (default
+    OFF) and either runs one batch of ``run_cascade_worker_once`` or returns
+    immediately. Mirrors the AUTHORIZED_SCOPE pattern for new ingestion-style
+    paths: code lands first, the flag stays OFF in production until the
+    implementation is verified end-to-end.
+
+    Two callers:
+    - Production: APScheduler tick. ``session`` is None — the function opens
+      its own session via ``async_session()`` and commits at the end (same
+      pattern as ``process_invite_outbox`` and ``check_intro_refresh``).
+    - Tests: an explicit ``session`` is passed; the function uses it directly
+      WITHOUT committing, so outer-tx isolation is preserved.
+
+    Returns the same stats dict as ``run_cascade_worker_once`` (with all-zero
+    counts when the flag is off).
+    """
+    if session is not None:
+        if not await FeatureFlagRepo.get(session, CASCADE_WORKER_FLAG):
+            return {"claimed": 0, "processed": 0, "failed": 0}
+        return await run_cascade_worker_once(session, batch_size=batch_size)
+
+    # Production path: own session + commit on success.
+    async with async_session() as own_session:
+        if not await FeatureFlagRepo.get(own_session, CASCADE_WORKER_FLAG):
+            return {"claimed": 0, "processed": 0, "failed": 0}
+        try:
+            stats = await run_cascade_worker_once(own_session, batch_size=batch_size)
+            await own_session.commit()
+            return stats
+        except Exception:
+            await own_session.rollback()
+            raise

--- a/bot/services/forget_cascade.py
+++ b/bot/services/forget_cascade.py
@@ -267,9 +267,10 @@ async def _process_one_event(session: AsyncSession, event) -> None:
                 continue
 
             if event.target_type in _SKIP_TARGET_TYPES:
-                # Unsupported target_type: record skip with reason so the audit
-                # trail is explicit. Phase 4+ layers with table_not_exists also
-                # land here as skipped, but with a different reason.
+                # Uniform reason: target_type_not_supported_yet (regardless of whether
+                # the layer's table exists yet — the dominant reason is the outer
+                # unsupported target_type). Phase-1 layers include rows=0 for consistency
+                # with the supported-target_type completion shape.
                 if layer in _LAYER_FUNCS:
                     cascade_state[layer] = {
                         "status": "skipped",
@@ -279,7 +280,7 @@ async def _process_one_event(session: AsyncSession, event) -> None:
                 else:
                     cascade_state[layer] = {
                         "status": "skipped",
-                        "reason": "table_not_exists",
+                        "reason": "target_type_not_supported_yet",
                     }
             elif layer in _LAYER_FUNCS:
                 rows = await _LAYER_FUNCS[layer](session, event)

--- a/bot/services/scheduler.py
+++ b/bot/services/scheduler.py
@@ -14,6 +14,7 @@ from bot.db.repos.application import ApplicationRepo
 from bot.db.repos.intro import IntroRepo
 from bot.db.repos.user import UserRepo
 from bot.html_escape import html_escape
+from bot.services.forget_cascade import cascade_worker_tick
 from bot.services.invite_worker import process_invite_outbox
 from bot.texts import (
     ADMIN_NUDGE_MSG,
@@ -261,6 +262,21 @@ def start_scheduler(bot: Bot) -> None:
         minutes=5,
         id="sync_google_sheets",
         replace_existing=True,
+    )
+    # T3-04 (#96): forget cascade worker. Default 30s interval matches the
+    # invite outbox precedent (lowest-latency persistent queue we operate).
+    # Gated by feature flag ``memory.forget.cascade_worker.enabled`` (default
+    # OFF) — the tick reads the flag every fire and is a strict no-op when
+    # disabled, so this wiring is safe to land in production with the flag off.
+    scheduler.add_job(
+        cascade_worker_tick,
+        "interval",
+        seconds=30,
+        id="forget_cascade_worker",
+        replace_existing=True,
+        max_instances=1,
+        coalesce=True,
+        misfire_grace_time=60,
     )
     scheduler.start()
     logger.info("Scheduler started")

--- a/docs/memory-system/IMPLEMENTATION_STATUS.md
+++ b/docs/memory-system/IMPLEMENTATION_STATUS.md
@@ -1,6 +1,6 @@
 # Memory System — Implementation Status
 
-**Last updated:** 2026-04-27 (Phase 2 — Stream Alpha sprint #67, Stream Charlie sprint T3-01)
+**Last updated:** 2026-04-28 (Phase 2 — Stream Alpha sprint #67, Stream Charlie sprints T3-01 + T3-04)
 **Active worktrees (Phase 2):** `.worktrees/p2-alpha` (`phase/p2-alpha`), `.worktrees/p2-bravo` (`phase/p2-bravo`), `.worktrees/p2-charlie` (`phase/p2-charlie`). Phase 1 closed on `main` 2026-04-27.
 **Source of truth:** this file is updated after every PR merge into `main`.
 
@@ -103,6 +103,13 @@ Three parallel tracks possible from day 1 (no shared deps):
 | #106  | T2-NEW-H | done   | Sprint Bravo-03 / PR #TBD. New `docs/memory-system/import-edit-history.md` + binding-rule append to `AUTHORIZED_SCOPE.md` under "Telegram import rule". Decision: imported messages get `imported_final=TRUE` marker on `message_versions` row (denormalised provenance; FK chain `raw_update_id → telegram_updates.ingestion_run_id` is audit trail). Schema/migration deferred to #103. |
 | #93   | T2-NEW-B | done   | Sprint Bravo-02 / PR #TBD. New `bot/services/import_user_map.py` + 17 tests + alembic migration 015 (`users.is_imported_only` flag, sparse partial index) + new doc `docs/memory-system/import-user-mapping.md`. Three cases (known/unknown/anonymous channel) with privacy R2 mitigation: imports cannot promote themselves to live; only the gatekeeper live-registration path flips ghost→live (via `UserRepo.upsert` clearing `is_imported_only`). Display_name first-write-wins; negative export-id tails rejected (parser hardening); attribution semantics under live/import overlap explicit (imported messages permanently attributed to live member's row when overlap occurs). |
 
+### Phase 2 — Stream Charlie progress
+
+| Issue | Ticket | Status | Notes |
+|-------|--------|--------|-------|
+| #92   | T3-01  | done   | Foundation: forget_events table + repo. Sprint Charlie-01 / PR #122. 5 commits on main: `af29b25` feat (initial), `d22185f` race safety + JSONB + ordering fix (Codex round 1), `2cde618` identity-map fix in mark_status fallback (Codex round 2), `f8549b8` docs DONE, `825e6e2` stale Branch header replacement. Alembic migration `014_add_forget_events.py`. New `bot/db/repos/forget_event.py` with race-safe `create()` (INSERT ... ON CONFLICT (tombstone_key) DO NOTHING RETURNING + fallback SELECT), `get_by_tombstone_key`, `list_pending` (FIFO `(created_at ASC, id ASC)`), `mark_status` (atomic `UPDATE ... WHERE status IN (allowed_old) RETURNING`; pending → processing → {completed | failed}; terminal states are dead-ends). 14 tests in `tests/db/test_forget_event_repo.py`. 4 rounds Codex review (HIGH×2 race safety + MEDIUM JSONB + LOW ordering + HIGH identity-map fix). |
+| #96   | T3-04  | done   | Sprint Charlie-03 / PR #TBD. Three-commit branch (`2dda016` initial + `688fc26` CRITICAL fix + `1b5a07d` uniformity fix). HIGH-RISK skeleton — irreversible content destruction. New `bot/services/forget_cascade.py` (~300 lines): `run_cascade_worker_once(session, batch_size=10)` + `cascade_worker_tick()` production wrapper. Cascade order matches HANDOFF §10 EXACTLY: chat_messages → message_versions → message_entities → message_links → attachments → fts_rows. Per-event try/except, per-layer checkpoint via new `ForgetEventRepo.update_cascade_status` (atomic `UPDATE ... WHERE id=? AND status='processing' RETURNING` — Option A architecture; preserves `mark_status` state machine semantics). Restart-safe: skips layers with `status='completed'`. Cascade content semantics: `target_type='message'` NULLs text/caption/raw_json + sets is_redacted=True + memory_policy='forgotten' on chat_messages; NULLs text/caption/normalized_text/entities_json + sets is_redacted=True on message_versions; content_hash PRESERVED per ADR-0003 (citation stability). `target_type='user'` walks ALL chat_messages WHERE user_id = CAST(target_id AS BIGINT); message_versions cascaded via subquery on chat_messages.user_id (resolves correctly after layer 1 NULLs). `target_type ∈ {message_hash, export}` recorded as `{status: 'skipped', reason: 'target_type_not_supported_yet'}` per layer; event finalizes as `completed`. Phase 4+ layers (entities/links/attachments/fts_rows) recorded as `{status: 'skipped', reason: 'table_not_exists'}` for supported target_types. `bot/services/scheduler.py` (+16 lines additive): APScheduler interval 30s, `max_instances=1, coalesce=True, misfire_grace_time=60`, gated by feature flag `memory.forget.cascade_worker.enabled` (default OFF). Worker tick reads flag EVERY fire (not cached). Tests: 12 cascade + 19 repo = 31 new; full suite 274 passed (post-rebase). Reviews: deep-analyst PASS, ag-reviewer PASS, Claude product-reviewer ACCEPTED, Codex 3-round (FAIL → REQUEST_CHANGES → APPROVE — closed CRITICAL target_type fallthrough + MEDIUM concurrent test gap + LOW failed-state test gap + reason field uniformity). |
+
 ### Phase 2 — Stream Alpha progress (Phase 1 cleanup chain)
 
 | Issue | Status | Notes |
@@ -161,4 +168,4 @@ After each PR merge into `main`:
    superseded, write `superseded by T#-##` in Notes.
 5. Update `Last updated` at the top.
 
-<!-- updated-by-superflow:2026-04-27 -->
+<!-- updated-by-superflow:2026-04-28 -->

--- a/tests/db/test_forget_event_repo.py
+++ b/tests/db/test_forget_event_repo.py
@@ -416,3 +416,89 @@ async def test_failed_state_is_terminal(db_session) -> None:
     # Attempt to re-enter processing from failed must raise ValueError.
     with pytest.raises(ValueError, match="failed"):
         await ForgetEventRepo.mark_status(db_session, ev.id, status="processing")
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# update_cascade_status — cascade checkpoint primitive (Sprint 3 / #96)
+# ──────────────────────────────────────────────────────────────────────────────
+#
+# update_cascade_status is the cascade worker's checkpoint primitive. It writes a
+# new ``cascade_status`` value WHILE the row stays in ``status='processing'``. This
+# is intentionally separate from ``mark_status``: the cascade worker may need to
+# checkpoint per-layer progress mid-cascade WITHOUT transitioning state, which
+# ``mark_status`` would refuse (``processing → processing`` is not a valid state-
+# machine edge). Without this separation, mid-cascade restart-safety is impossible.
+
+
+async def test_update_cascade_status_succeeds_in_processing(db_session) -> None:
+    from bot.db.repos.forget_event import ForgetEventRepo
+
+    ev = await ForgetEventRepo.create(
+        db_session,
+        target_type="message",
+        target_id=None,
+        actor_user_id=None,
+        authorized_by="system",
+        tombstone_key=f"message:-checkpoint:{next(_key_counter)}",
+    )
+    await ForgetEventRepo.mark_status(db_session, ev.id, status="processing")
+
+    payload = {"chat_messages": {"status": "completed", "rows": 1}}
+    updated = await ForgetEventRepo.update_cascade_status(
+        db_session, ev.id, cascade_status=payload
+    )
+
+    assert updated.id == ev.id
+    assert updated.status == "processing"
+    assert updated.cascade_status == payload
+
+
+async def test_update_cascade_status_rejected_in_pending(db_session) -> None:
+    """Cannot checkpoint a row that hasn't been claimed yet."""
+    from bot.db.repos.forget_event import ForgetEventRepo
+
+    ev = await ForgetEventRepo.create(
+        db_session,
+        target_type="message",
+        target_id=None,
+        actor_user_id=None,
+        authorized_by="system",
+        tombstone_key=f"message:-pending-cp:{next(_key_counter)}",
+    )
+    assert ev.status == "pending"
+
+    with pytest.raises(ValueError, match="pending"):
+        await ForgetEventRepo.update_cascade_status(
+            db_session, ev.id, cascade_status={"x": 1}
+        )
+
+
+async def test_update_cascade_status_rejected_in_completed(db_session) -> None:
+    """Cannot rewrite cascade_status on a finished row."""
+    from bot.db.repos.forget_event import ForgetEventRepo
+
+    ev = await ForgetEventRepo.create(
+        db_session,
+        target_type="message",
+        target_id=None,
+        actor_user_id=None,
+        authorized_by="system",
+        tombstone_key=f"message:-done-cp:{next(_key_counter)}",
+    )
+    await ForgetEventRepo.mark_status(db_session, ev.id, status="processing")
+    await ForgetEventRepo.mark_status(db_session, ev.id, status="completed")
+
+    with pytest.raises(ValueError, match="completed"):
+        await ForgetEventRepo.update_cascade_status(
+            db_session, ev.id, cascade_status={"x": 1}
+        )
+
+
+async def test_update_cascade_status_rejected_on_missing_id(db_session) -> None:
+    """A non-existent id must raise (not silently no-op)."""
+    from bot.db.repos.forget_event import ForgetEventRepo
+
+    with pytest.raises(ValueError, match="not found"):
+        await ForgetEventRepo.update_cascade_status(
+            db_session, 999_999_999, cascade_status={"x": 1}
+        )

--- a/tests/db/test_forget_event_repo.py
+++ b/tests/db/test_forget_event_repo.py
@@ -502,3 +502,25 @@ async def test_update_cascade_status_rejected_on_missing_id(db_session) -> None:
         await ForgetEventRepo.update_cascade_status(
             db_session, 999_999_999, cascade_status={"x": 1}
         )
+
+
+async def test_update_cascade_status_rejected_in_failed(db_session) -> None:
+    """Cannot checkpoint a row that is already in terminal state 'failed'."""
+    from bot.db.repos.forget_event import ForgetEventRepo
+
+    ev = await ForgetEventRepo.create(
+        db_session,
+        target_type="message",
+        target_id=None,
+        actor_user_id=None,
+        authorized_by="system",
+        tombstone_key=f"message:-failed-cp:{next(_key_counter)}",
+    )
+    await ForgetEventRepo.mark_status(db_session, ev.id, status="processing")
+    await ForgetEventRepo.mark_status(db_session, ev.id, status="failed")
+    assert (await db_session.get(ev.__class__, ev.id, populate_existing=True)).status == "failed"
+
+    with pytest.raises(ValueError, match="failed"):
+        await ForgetEventRepo.update_cascade_status(
+            db_session, ev.id, cascade_status={"x": 1}
+        )

--- a/tests/services/test_forget_cascade.py
+++ b/tests/services/test_forget_cascade.py
@@ -1,0 +1,552 @@
+"""T3-04 — cascade worker skeleton (issue #96).
+
+Outer-tx isolation. Tests do NOT call ``session.commit()``.
+
+The worker drives ``forget_events`` rows through the cascade defined in HANDOFF.md §10.
+Phase 3 skeleton scope: only ``chat_messages`` and ``message_versions`` exist as Phase 1
+tables; the remaining cascade layers (``message_entities``, ``message_links``,
+``attachments``, ``fts_rows``) MUST be recorded as ``skipped`` so the cascade is forward-
+compatible without doing any work that would require non-existent tables.
+
+Critical durability invariants (from issue body):
+  A. Idempotent claim: pending → processing must be atomic; double-claim impossible.
+  B. Restart-safe: after crash mid-cascade, next run resumes from the last completed layer.
+  C. Per-event isolation: a failure in one event's cascade must NOT halt other events.
+  D. No cascade duplication: rerunning the worker over a completed event is a no-op.
+"""
+
+from __future__ import annotations
+
+import itertools
+from datetime import datetime, timezone
+
+import pytest
+
+pytestmark = pytest.mark.usefixtures("app_env")
+
+_user_counter = itertools.count(start=9_400_000_000)
+_msg_counter = itertools.count(start=970_000)
+_chat_counter = itertools.count(start=1)
+_key_counter = itertools.count(start=1)
+
+
+def _next_user() -> int:
+    return next(_user_counter)
+
+
+def _next_msg_id() -> int:
+    return next(_msg_counter)
+
+
+def _next_chat_id() -> int:
+    return -1_000_000_000_000 - next(_chat_counter)
+
+
+def _next_key(prefix: str = "message") -> str:
+    return f"{prefix}:test:{next(_key_counter)}"
+
+
+async def _make_user(db_session) -> int:
+    from bot.db.repos.user import UserRepo
+
+    uid = _next_user()
+    await UserRepo.upsert(
+        db_session,
+        telegram_id=uid,
+        username=f"u{uid}",
+        first_name="Test",
+        last_name=None,
+    )
+    return uid
+
+
+async def _make_chat_message_with_v1(
+    db_session,
+    *,
+    text: str = "secret content",
+    caption: str | None = None,
+    raw_json: dict | None = None,
+) -> tuple[int, int, int, int]:
+    """Create a ChatMessage with a v1 MessageVersion. Returns (chat_message_id,
+    message_version_id, chat_id, message_id)."""
+    from bot.db.models import ChatMessage, MessageVersion
+
+    uid = await _make_user(db_session)
+    chat_id = _next_chat_id()
+    message_id = _next_msg_id()
+    when = datetime.now(timezone.utc)
+
+    msg = ChatMessage(
+        message_id=message_id,
+        chat_id=chat_id,
+        user_id=uid,
+        text=text,
+        date=when,
+        caption=caption,
+        raw_json=raw_json or {"text": text},
+        memory_policy="normal",
+        is_redacted=False,
+    )
+    db_session.add(msg)
+    await db_session.flush()
+
+    v = MessageVersion(
+        chat_message_id=msg.id,
+        version_seq=1,
+        text=text,
+        caption=caption,
+        normalized_text=text,
+        entities_json={"entities": []},
+        content_hash="h-test-v1",
+        is_redacted=False,
+    )
+    db_session.add(v)
+    await db_session.flush()
+
+    return msg.id, v.id, chat_id, message_id
+
+
+async def _make_pending_forget_event(
+    db_session,
+    *,
+    target_type: str = "message",
+    target_id: str | None = None,
+    tombstone_key: str | None = None,
+) -> int:
+    """Create a pending forget_event row and return its id."""
+    from bot.db.repos.forget_event import ForgetEventRepo
+
+    ev = await ForgetEventRepo.create(
+        db_session,
+        target_type=target_type,
+        target_id=target_id,
+        actor_user_id=None,
+        authorized_by="admin",
+        tombstone_key=tombstone_key or _next_key(target_type),
+    )
+    return ev.id
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Acceptance #1: pending event progresses to completed; content nulled.
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+async def test_pending_event_progresses_to_completed(db_session) -> None:
+    from bot.db.models import ChatMessage, MessageVersion
+    from bot.db.repos.forget_event import ForgetEventRepo
+    from bot.services.forget_cascade import run_cascade_worker_once
+
+    cm_id, ver_id, chat_id, msg_id = await _make_chat_message_with_v1(
+        db_session, text="erase me", caption="and this caption"
+    )
+    event_id = await _make_pending_forget_event(
+        db_session,
+        target_type="message",
+        target_id=str(cm_id),
+        tombstone_key=f"message:{chat_id}:{msg_id}",
+    )
+
+    stats = await run_cascade_worker_once(db_session)
+
+    assert stats["claimed"] == 1
+    assert stats["processed"] == 1
+    assert stats["failed"] == 0
+
+    ev = await ForgetEventRepo.get_by_tombstone_key(
+        db_session, f"message:{chat_id}:{msg_id}"
+    )
+    assert ev is not None
+    assert ev.status == "completed"
+    assert ev.cascade_status is not None
+    assert ev.cascade_status["chat_messages"]["status"] == "completed"
+    assert ev.cascade_status["message_versions"]["status"] == "completed"
+
+    cm = await db_session.get(ChatMessage, cm_id)
+    assert cm.text is None
+    assert cm.caption is None
+    assert cm.raw_json is None
+    assert cm.is_redacted is True
+    assert cm.memory_policy == "forgotten"
+
+    ver = await db_session.get(MessageVersion, ver_id)
+    assert ver.text is None
+    assert ver.caption is None
+    assert ver.normalized_text is None
+    assert ver.entities_json is None
+    assert ver.is_redacted is True
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Acceptance #2: partial-cascade restartable (durability invariant B)
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+async def test_partial_cascade_restartable(db_session, monkeypatch) -> None:
+    """Simulate a worker crash AFTER chat_messages succeeds but BEFORE
+    message_versions completes. The next worker run must resume — skipping
+    chat_messages (already done) and completing message_versions.
+
+    Restart-safety is the whole point of the cascade_status checkpoint primitive.
+    Without it, a crash mid-cascade would either lose progress (cascade redoes
+    the chat_messages NULL) or stall (state stuck in 'processing' indefinitely).
+    """
+    from bot.db.models import ChatMessage, MessageVersion
+    from bot.db.repos.forget_event import ForgetEventRepo
+    from bot.services import forget_cascade
+
+    cm_id, ver_id, chat_id, msg_id = await _make_chat_message_with_v1(
+        db_session, text="resumable", caption="caption"
+    )
+    tomb_key = f"message:{chat_id}:{msg_id}"
+    await _make_pending_forget_event(
+        db_session,
+        target_type="message",
+        target_id=str(cm_id),
+        tombstone_key=tomb_key,
+    )
+
+    # First run: monkeypatch _cascade_message_versions to raise. This fires AFTER
+    # chat_messages has already nulled content + been checkpointed.
+    crash_count = {"n": 0}
+
+    async def _crash_message_versions(session, event):
+        crash_count["n"] += 1
+        raise RuntimeError("simulated mid-cascade crash")
+
+    monkeypatch.setitem(
+        forget_cascade._LAYER_FUNCS, "message_versions", _crash_message_versions
+    )
+
+    stats1 = await forget_cascade.run_cascade_worker_once(db_session)
+    assert stats1["claimed"] == 1
+    assert stats1["failed"] == 1
+    assert stats1["processed"] == 0
+    assert crash_count["n"] == 1
+
+    # After crash: chat_messages is already NULLed and checkpointed.
+    cm_after_crash = await db_session.get(ChatMessage, cm_id)
+    assert cm_after_crash.text is None
+    assert cm_after_crash.is_redacted is True
+
+    ev_after_crash = await ForgetEventRepo.get_by_tombstone_key(db_session, tomb_key)
+    assert ev_after_crash.status == "failed"
+    assert ev_after_crash.cascade_status["chat_messages"]["status"] == "completed"
+
+    # Recovery scenario: an operator (or a future re-issuer) flips the row back
+    # to pending so the worker can resume. We simulate this with a direct
+    # status update (not exposed by the repo since failed→pending is not in the
+    # state machine — the recovery path is intentionally ops-only and would be
+    # gated by an admin action in production).
+    from sqlalchemy import update as sa_update
+
+    from bot.db.models import ForgetEvent
+
+    await db_session.execute(
+        sa_update(ForgetEvent)
+        .where(ForgetEvent.id == ev_after_crash.id)
+        .values(status="pending")
+    )
+    await db_session.flush()
+
+    # Second run: undo the monkeypatch so message_versions completes.
+    monkeypatch.setitem(
+        forget_cascade._LAYER_FUNCS,
+        "message_versions",
+        forget_cascade._cascade_message_versions,
+    )
+
+    # Track that chat_messages cascade is NOT re-invoked: wrap the real func.
+    chat_messages_calls = {"n": 0}
+    original_chat_messages = forget_cascade._cascade_chat_messages
+
+    async def _counting_chat_messages(session, event):
+        chat_messages_calls["n"] += 1
+        return await original_chat_messages(session, event)
+
+    monkeypatch.setitem(
+        forget_cascade._LAYER_FUNCS, "chat_messages", _counting_chat_messages
+    )
+
+    stats2 = await forget_cascade.run_cascade_worker_once(db_session)
+    assert stats2["claimed"] == 1
+    assert stats2["processed"] == 1
+    assert stats2["failed"] == 0
+    # Restart invariant: chat_messages cascade must NOT re-run for an already-
+    # completed layer. Re-running would still be safe (the UPDATE is idempotent),
+    # but skipping is the contract — Phase 4+ layers may have non-idempotent
+    # work (vector deletions, FTS rebuilds) where re-running would matter.
+    assert chat_messages_calls["n"] == 0
+
+    ev_done = await ForgetEventRepo.get_by_tombstone_key(db_session, tomb_key)
+    assert ev_done.status == "completed"
+    assert ev_done.cascade_status["chat_messages"]["status"] == "completed"
+    assert ev_done.cascade_status["message_versions"]["status"] == "completed"
+
+    ver_done = await db_session.get(MessageVersion, ver_id)
+    assert ver_done.text is None
+    assert ver_done.is_redacted is True
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Acceptance #3: idempotent rerun on already-completed event (invariant D)
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+async def test_idempotent_rerun_already_completed_noops(db_session) -> None:
+    """A completed forget_event must NOT be re-claimed or re-cascaded.
+
+    ``list_pending`` filters by ``status='pending'``, so a completed row is
+    invisible to the worker — confirming this is the cheapest "no-op" guarantee
+    we can offer (no scan, no UPDATE attempt). Sprint 4+ may add
+    re-import / re-trigger flows that DO touch completed rows; those will
+    require their own tests.
+    """
+    from bot.db.repos.forget_event import ForgetEventRepo
+    from bot.services.forget_cascade import run_cascade_worker_once
+
+    cm_id, _ver_id, chat_id, msg_id = await _make_chat_message_with_v1(db_session)
+    tomb_key = f"message:{chat_id}:{msg_id}"
+    await _make_pending_forget_event(
+        db_session,
+        target_type="message",
+        target_id=str(cm_id),
+        tombstone_key=tomb_key,
+    )
+
+    # First run: take the event to completed.
+    stats1 = await run_cascade_worker_once(db_session)
+    assert stats1["claimed"] == 1
+    assert stats1["processed"] == 1
+
+    ev = await ForgetEventRepo.get_by_tombstone_key(db_session, tomb_key)
+    assert ev.status == "completed"
+    snapshot_cascade = ev.cascade_status
+    snapshot_updated_at = ev.updated_at
+
+    # Second run: nothing pending — worker must do nothing.
+    stats2 = await run_cascade_worker_once(db_session)
+    assert stats2 == {"claimed": 0, "processed": 0, "failed": 0}
+
+    # Row must be byte-identical (same cascade_status, same updated_at).
+    ev_again = await ForgetEventRepo.get_by_tombstone_key(db_session, tomb_key)
+    assert ev_again.status == "completed"
+    assert ev_again.cascade_status == snapshot_cascade
+    assert ev_again.updated_at == snapshot_updated_at
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Acceptance #4: no double-claim under concurrency (invariant A)
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+async def test_concurrent_workers_no_double_claim(db_session) -> None:
+    """Simulate two workers running back-to-back on the same DB session: the
+    first claim must win, the second must skip the row silently.
+
+    True asyncio concurrency in a single AsyncSession isn't possible (a session
+    serializes its own statements). We model concurrency at the API surface:
+    after the first ``mark_status('processing')`` succeeds, calling it again
+    raises ``ValueError`` — exactly what the worker's claim path catches and
+    treats as "another worker got there first".
+    """
+    from bot.db.repos.forget_event import ForgetEventRepo
+    from bot.services.forget_cascade import run_cascade_worker_once
+
+    cm_id, _ver_id, chat_id, msg_id = await _make_chat_message_with_v1(db_session)
+    tomb_key = f"message:{chat_id}:{msg_id}"
+    event_id = await _make_pending_forget_event(
+        db_session,
+        target_type="message",
+        target_id=str(cm_id),
+        tombstone_key=tomb_key,
+    )
+
+    # Worker A claims first via the same atomic UPDATE the worker uses.
+    claimed = await ForgetEventRepo.mark_status(
+        db_session, event_id, status="processing"
+    )
+    assert claimed.status == "processing"
+
+    # Worker B comes along: it sees no pending rows (the row is already in
+    # 'processing'), so its run is a no-op.
+    stats_b = await run_cascade_worker_once(db_session)
+    assert stats_b == {"claimed": 0, "processed": 0, "failed": 0}
+
+    ev = await ForgetEventRepo.get_by_tombstone_key(db_session, tomb_key)
+    assert ev.status == "processing"  # still A's claim, not double-progressed
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Acceptance #5: per-event isolation (invariant C)
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+async def test_per_event_isolation_failure_doesnt_halt_batch(
+    db_session, monkeypatch
+) -> None:
+    """Three pending events in one batch. The middle one's cascade is rigged to
+    fail. The other two must complete normally — the worker MUST NOT abort the
+    batch on a single failure.
+    """
+    from bot.db.repos.forget_event import ForgetEventRepo
+    from bot.services import forget_cascade
+
+    # Event A — completes normally.
+    cm_a, _, chat_a, msg_a = await _make_chat_message_with_v1(db_session, text="a")
+    tomb_a = f"message:{chat_a}:{msg_a}"
+    await _make_pending_forget_event(
+        db_session, target_type="message", target_id=str(cm_a), tombstone_key=tomb_a
+    )
+
+    # Event B — rigged to fail (specific cm_id matched in monkeypatch below).
+    cm_b, _, chat_b, msg_b = await _make_chat_message_with_v1(db_session, text="b")
+    tomb_b = f"message:{chat_b}:{msg_b}"
+    await _make_pending_forget_event(
+        db_session, target_type="message", target_id=str(cm_b), tombstone_key=tomb_b
+    )
+
+    # Event C — completes normally.
+    cm_c, _, chat_c, msg_c = await _make_chat_message_with_v1(db_session, text="c")
+    tomb_c = f"message:{chat_c}:{msg_c}"
+    await _make_pending_forget_event(
+        db_session, target_type="message", target_id=str(cm_c), tombstone_key=tomb_c
+    )
+
+    # Patch chat_messages cascade to raise specifically when called for event B.
+    original = forget_cascade._cascade_chat_messages
+
+    async def _selective_fail(session, event):
+        if event.target_id == str(cm_b):
+            raise RuntimeError("boom on event B")
+        return await original(session, event)
+
+    monkeypatch.setitem(
+        forget_cascade._LAYER_FUNCS, "chat_messages", _selective_fail
+    )
+
+    stats = await forget_cascade.run_cascade_worker_once(db_session)
+    assert stats["claimed"] == 3
+    assert stats["processed"] == 2
+    assert stats["failed"] == 1
+
+    ev_a = await ForgetEventRepo.get_by_tombstone_key(db_session, tomb_a)
+    ev_b = await ForgetEventRepo.get_by_tombstone_key(db_session, tomb_b)
+    ev_c = await ForgetEventRepo.get_by_tombstone_key(db_session, tomb_c)
+
+    assert ev_a.status == "completed"
+    assert ev_b.status == "failed"
+    assert ev_b.cascade_status is not None
+    assert "error" in ev_b.cascade_status
+    assert ev_c.status == "completed"
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Acceptance #6: skipped layers recorded for forward-compatibility
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+async def test_skipped_layers_recorded_in_cascade_status(db_session) -> None:
+    """The cascade order in HANDOFF.md §10 includes layers whose tables don't
+    yet exist in this codebase (Phase 4+ derived layers). The worker MUST
+    record them as ``{"status": "skipped", "reason": "table_not_exists"}``
+    so the cascade is forward-compatible: a later phase that adds the table
+    replaces the per-layer function and re-running the cascade picks up
+    where it left off.
+    """
+    from bot.db.repos.forget_event import ForgetEventRepo
+    from bot.services.forget_cascade import (
+        CASCADE_LAYER_ORDER,
+        run_cascade_worker_once,
+    )
+
+    cm_id, _, chat_id, msg_id = await _make_chat_message_with_v1(db_session)
+    tomb_key = f"message:{chat_id}:{msg_id}"
+    await _make_pending_forget_event(
+        db_session,
+        target_type="message",
+        target_id=str(cm_id),
+        tombstone_key=tomb_key,
+    )
+
+    stats = await run_cascade_worker_once(db_session)
+    assert stats["processed"] == 1
+
+    ev = await ForgetEventRepo.get_by_tombstone_key(db_session, tomb_key)
+    assert ev.status == "completed"
+
+    # Phase 1 layers: completed.
+    assert ev.cascade_status["chat_messages"]["status"] == "completed"
+    assert ev.cascade_status["message_versions"]["status"] == "completed"
+
+    # Phase 4+ layers: skipped with the canonical reason.
+    for layer in ("message_entities", "message_links", "attachments", "fts_rows"):
+        assert ev.cascade_status[layer] == {
+            "status": "skipped",
+            "reason": "table_not_exists",
+        }, f"Layer {layer} not recorded as skipped"
+
+    # All layers from CASCADE_LAYER_ORDER are present in cascade_status — none
+    # silently dropped.
+    for layer in CASCADE_LAYER_ORDER:
+        assert layer in ev.cascade_status
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Acceptance #7: scheduler tick is gated by feature flag (production safety)
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+async def test_scheduler_tick_no_op_when_flag_off(db_session) -> None:
+    """``cascade_worker_tick`` is the scheduler entry point. When the feature
+    flag ``memory.forget.cascade_worker.enabled`` is OFF (default), the tick
+    must NOT process any events — it is a strict no-op.
+
+    This mirrors the AUTHORIZED_SCOPE pattern for new ingestion-style paths
+    (cf. ``memory.ingestion.raw_updates.enabled``): code lands first, the flag
+    stays OFF in production until the implementation is verified.
+    """
+    from bot.db.repos.forget_event import ForgetEventRepo
+    from bot.services.forget_cascade import cascade_worker_tick
+
+    cm_id, _, chat_id, msg_id = await _make_chat_message_with_v1(db_session)
+    tomb_key = f"message:{chat_id}:{msg_id}"
+    await _make_pending_forget_event(
+        db_session,
+        target_type="message",
+        target_id=str(cm_id),
+        tombstone_key=tomb_key,
+    )
+    # Flag is not set — defaults to False per FeatureFlagRepo.get contract.
+
+    # Tick uses its own session via async_session() — pass our test session
+    # explicitly so the outer-tx isolation is preserved (no real commit).
+    await cascade_worker_tick(session=db_session)
+
+    ev = await ForgetEventRepo.get_by_tombstone_key(db_session, tomb_key)
+    assert ev.status == "pending"  # untouched
+    assert ev.cascade_status is None
+
+
+async def test_scheduler_tick_processes_events_when_flag_on(db_session) -> None:
+    """When ``memory.forget.cascade_worker.enabled`` is ON, the tick claims
+    and processes pending events exactly like ``run_cascade_worker_once``."""
+    from bot.db.repos.feature_flag import FeatureFlagRepo
+    from bot.db.repos.forget_event import ForgetEventRepo
+    from bot.services.forget_cascade import CASCADE_WORKER_FLAG, cascade_worker_tick
+
+    await FeatureFlagRepo.set_enabled(db_session, CASCADE_WORKER_FLAG, enabled=True)
+
+    cm_id, _, chat_id, msg_id = await _make_chat_message_with_v1(db_session)
+    tomb_key = f"message:{chat_id}:{msg_id}"
+    await _make_pending_forget_event(
+        db_session,
+        target_type="message",
+        target_id=str(cm_id),
+        tombstone_key=tomb_key,
+    )
+
+    await cascade_worker_tick(session=db_session)
+
+    ev = await ForgetEventRepo.get_by_tombstone_key(db_session, tomb_key)
+    assert ev.status == "completed"

--- a/tests/services/test_forget_cascade.py
+++ b/tests/services/test_forget_cascade.py
@@ -140,7 +140,7 @@ async def test_pending_event_progresses_to_completed(db_session) -> None:
     cm_id, ver_id, chat_id, msg_id = await _make_chat_message_with_v1(
         db_session, text="erase me", caption="and this caption"
     )
-    event_id = await _make_pending_forget_event(
+    await _make_pending_forget_event(
         db_session,
         target_type="message",
         target_id=str(cm_id),
@@ -341,14 +341,15 @@ async def test_idempotent_rerun_already_completed_noops(db_session) -> None:
 
 
 async def test_concurrent_workers_no_double_claim(db_session) -> None:
-    """Simulate two workers running back-to-back on the same DB session: the
-    first claim must win, the second must skip the row silently.
+    """Simulate the losing-worker path: pre-claim the event row (as Worker A would),
+    then run the cascade worker (Worker B). Worker B must skip silently — no
+    ValueError propagated, no crash — because ``list_pending`` filters out
+    'processing' rows and the claim path catches ValueError from ``mark_status``.
 
-    True asyncio concurrency in a single AsyncSession isn't possible (a session
-    serializes its own statements). We model concurrency at the API surface:
-    after the first ``mark_status('processing')`` succeeds, calling it again
-    raises ``ValueError`` — exactly what the worker's claim path catches and
-    treats as "another worker got there first".
+    True asyncio concurrency with a single AsyncSession is not possible (the
+    session serializes statements). Instead we exercise the loser path directly:
+    after the row is in 'processing', the worker sees no pending rows and returns
+    all-zero stats.
     """
     from bot.db.repos.forget_event import ForgetEventRepo
     from bot.services.forget_cascade import run_cascade_worker_once
@@ -362,19 +363,26 @@ async def test_concurrent_workers_no_double_claim(db_session) -> None:
         tombstone_key=tomb_key,
     )
 
-    # Worker A claims first via the same atomic UPDATE the worker uses.
+    # Worker A claims the row (simulates winning the race).
     claimed = await ForgetEventRepo.mark_status(
         db_session, event_id, status="processing"
     )
     assert claimed.status == "processing"
 
-    # Worker B comes along: it sees no pending rows (the row is already in
-    # 'processing'), so its run is a no-op.
+    # Worker B runs: row is already 'processing', not in list_pending. Must be a
+    # strict no-op — zero stats, no exception raised.
     stats_b = await run_cascade_worker_once(db_session)
     assert stats_b == {"claimed": 0, "processed": 0, "failed": 0}
 
+    # Row must remain in Worker A's claim state (not double-progressed).
     ev = await ForgetEventRepo.get_by_tombstone_key(db_session, tomb_key)
-    assert ev.status == "processing"  # still A's claim, not double-progressed
+    assert ev.status == "processing"
+
+    # Additionally: directly verify the ValueError loser path is silently caught.
+    # Attempt to claim an already-processing row raises ValueError from the repo;
+    # the worker's claim logic must swallow it and continue.
+    with pytest.raises(ValueError):
+        await ForgetEventRepo.mark_status(db_session, event_id, status="processing")
 
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -526,6 +534,227 @@ async def test_scheduler_tick_no_op_when_flag_off(db_session) -> None:
     ev = await ForgetEventRepo.get_by_tombstone_key(db_session, tomb_key)
     assert ev.status == "pending"  # untouched
     assert ev.cascade_status is None
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Acceptance #8: target_type='user' — full content wipe for all user messages
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+async def _make_user_raw(db_session, uid: int) -> None:
+    from bot.db.repos.user import UserRepo
+
+    await UserRepo.upsert(
+        db_session,
+        telegram_id=uid,
+        username=f"u{uid}",
+        first_name="Test",
+        last_name=None,
+    )
+
+
+async def _make_message_for_user(
+    db_session,
+    user_id: int,
+    *,
+    text: str = "secret",
+    caption: str | None = None,
+    raw_json: dict | None = None,
+) -> int:
+    """Create a ChatMessage for a specific user_id; return chat_message id."""
+    from bot.db.models import ChatMessage
+
+    chat_id = _next_chat_id()
+    message_id = _next_msg_id()
+    when = __import__("datetime").datetime.now(__import__("datetime").timezone.utc)
+
+    msg = ChatMessage(
+        message_id=message_id,
+        chat_id=chat_id,
+        user_id=user_id,
+        text=text,
+        date=when,
+        caption=caption,
+        raw_json=raw_json or {"text": text},
+        memory_policy="normal",
+        is_redacted=False,
+    )
+    db_session.add(msg)
+    await db_session.flush()
+    return msg.id
+
+
+async def _make_version_for_message(db_session, chat_message_id: int, *, seq: int = 1) -> int:
+    """Create a MessageVersion for a given chat_message; return version id."""
+    from bot.db.models import MessageVersion
+
+    v = MessageVersion(
+        chat_message_id=chat_message_id,
+        version_seq=seq,
+        text="secret text",
+        caption="secret cap",
+        normalized_text="secret norm",
+        entities_json={"entities": []},
+        content_hash=f"h-test-user-{chat_message_id}-{seq}",
+        is_redacted=False,
+    )
+    db_session.add(v)
+    await db_session.flush()
+    return v.id
+
+
+async def test_user_target_wipes_all_user_messages(db_session) -> None:
+    """target_type='user': 3 messages for user X + 2 for user Y.
+    After cascade: X's messages are NULLed + redacted + forgotten; Y's are untouched.
+    """
+    from bot.db.models import ChatMessage
+    from bot.services.forget_cascade import run_cascade_worker_once
+
+    uid_x = _next_user()
+    uid_y = _next_user()
+    await _make_user_raw(db_session, uid_x)
+    await _make_user_raw(db_session, uid_y)
+
+    # 3 messages for user X
+    cm_x1 = await _make_message_for_user(db_session, uid_x, text="x-secret-1")
+    cm_x2 = await _make_message_for_user(db_session, uid_x, text="x-secret-2", caption="cap")
+    cm_x3 = await _make_message_for_user(db_session, uid_x, text="x-secret-3")
+    # 2 messages for user Y — must be untouched
+    cm_y1 = await _make_message_for_user(db_session, uid_y, text="y-keep-1")
+    cm_y2 = await _make_message_for_user(db_session, uid_y, text="y-keep-2")
+
+    await _make_pending_forget_event(
+        db_session,
+        target_type="user",
+        target_id=str(uid_x),
+        tombstone_key=f"user:{uid_x}",
+    )
+
+    stats = await run_cascade_worker_once(db_session)
+    assert stats["claimed"] == 1
+    assert stats["processed"] == 1
+    assert stats["failed"] == 0
+
+    for cm_id in (cm_x1, cm_x2, cm_x3):
+        cm = await db_session.get(ChatMessage, cm_id, populate_existing=True)
+        assert cm.text is None, f"cm {cm_id} text not NULLed"
+        assert cm.caption is None, f"cm {cm_id} caption not NULLed"
+        assert cm.raw_json is None, f"cm {cm_id} raw_json not NULLed"
+        assert cm.is_redacted is True, f"cm {cm_id} not redacted"
+        assert cm.memory_policy == "forgotten", f"cm {cm_id} policy not forgotten"
+
+    for cm_id in (cm_y1, cm_y2):
+        cm = await db_session.get(ChatMessage, cm_id, populate_existing=True)
+        assert cm.text is not None, f"cm {cm_id} text was wiped (should be untouched)"
+        assert cm.is_redacted is False, f"cm {cm_id} wrongly redacted"
+
+
+async def test_user_target_wipes_all_user_versions(db_session) -> None:
+    """target_type='user': versions for X's messages are NULLed; Y's versions untouched.
+    content_hash must remain NOT NULL (citation stability).
+    """
+    from bot.db.models import MessageVersion
+    from bot.services.forget_cascade import run_cascade_worker_once
+
+    uid_x = _next_user()
+    uid_y = _next_user()
+    await _make_user_raw(db_session, uid_x)
+    await _make_user_raw(db_session, uid_y)
+
+    cm_x1 = await _make_message_for_user(db_session, uid_x, text="x-v-secret")
+    cm_y1 = await _make_message_for_user(db_session, uid_y, text="y-v-keep")
+
+    ver_x = await _make_version_for_message(db_session, cm_x1)
+    ver_y = await _make_version_for_message(db_session, cm_y1)
+
+    await _make_pending_forget_event(
+        db_session,
+        target_type="user",
+        target_id=str(uid_x),
+        tombstone_key=f"user:{uid_x}:ver",
+    )
+
+    stats = await run_cascade_worker_once(db_session)
+    assert stats["processed"] == 1
+
+    # X's version must be NULLed in all 5 content fields + is_redacted
+    vx = await db_session.get(MessageVersion, ver_x, populate_existing=True)
+    assert vx.text is None
+    assert vx.caption is None
+    assert vx.normalized_text is None
+    assert vx.entities_json is None
+    assert vx.is_redacted is True
+    # content_hash preserved for citation stability
+    assert vx.content_hash is not None
+
+    # Y's version untouched
+    vy = await db_session.get(MessageVersion, ver_y, populate_existing=True)
+    assert vy.text is not None
+    assert vy.is_redacted is False
+
+
+async def test_message_hash_target_records_skipped(db_session) -> None:
+    """target_type='message_hash': cascade finalizes as 'completed' but every layer
+    shows status='skipped' with reason='target_type_not_supported_yet'.
+    No rows in any table must be modified.
+    """
+    from bot.services.forget_cascade import run_cascade_worker_once
+
+    event_id = await _make_pending_forget_event(
+        db_session,
+        target_type="message_hash",
+        target_id="somehash",
+        tombstone_key="message_hash:somehash:test",
+    )
+
+    stats = await run_cascade_worker_once(db_session)
+    assert stats["claimed"] == 1
+    assert stats["processed"] == 1
+    assert stats["failed"] == 0
+
+    from bot.db.models import ForgetEvent
+
+    ev = await db_session.get(ForgetEvent, event_id, populate_existing=True)
+    assert ev.status == "completed"
+
+    # Phase-1 layers: skipped with the new reason
+    for layer in ("chat_messages", "message_versions"):
+        assert ev.cascade_status[layer]["status"] == "skipped", (
+            f"Layer {layer} should be skipped for message_hash target, got: {ev.cascade_status[layer]}"
+        )
+        assert ev.cascade_status[layer]["reason"] == "target_type_not_supported_yet"
+
+    # Phase-4+ layers: still skipped with table_not_exists
+    for layer in ("message_entities", "message_links", "attachments", "fts_rows"):
+        assert ev.cascade_status[layer]["status"] == "skipped"
+
+
+async def test_export_target_records_skipped(db_session) -> None:
+    """target_type='export': analogous to message_hash — all layers skipped."""
+    from bot.db.models import ForgetEvent
+    from bot.services.forget_cascade import run_cascade_worker_once
+
+    event_id = await _make_pending_forget_event(
+        db_session,
+        target_type="export",
+        target_id="export-uuid-abc",
+        tombstone_key="export:export-uuid-abc:test",
+    )
+
+    stats = await run_cascade_worker_once(db_session)
+    assert stats["claimed"] == 1
+    assert stats["processed"] == 1
+    assert stats["failed"] == 0
+
+    ev = await db_session.get(ForgetEvent, event_id, populate_existing=True)
+    assert ev.status == "completed"
+
+    for layer in ("chat_messages", "message_versions"):
+        assert ev.cascade_status[layer]["status"] == "skipped"
+        assert ev.cascade_status[layer]["reason"] == "target_type_not_supported_yet"
+
+
+# ──────────────────────────────────────────────────────────────────────────────
 
 
 async def test_scheduler_tick_processes_events_when_flag_on(db_session) -> None:

--- a/tests/services/test_forget_cascade.py
+++ b/tests/services/test_forget_cascade.py
@@ -717,16 +717,16 @@ async def test_message_hash_target_records_skipped(db_session) -> None:
     ev = await db_session.get(ForgetEvent, event_id, populate_existing=True)
     assert ev.status == "completed"
 
-    # Phase-1 layers: skipped with the new reason
-    for layer in ("chat_messages", "message_versions"):
+    # ALL 6 layers: uniformly skipped with target_type_not_supported_yet
+    from bot.services.forget_cascade import CASCADE_LAYER_ORDER
+
+    for layer in CASCADE_LAYER_ORDER:
         assert ev.cascade_status[layer]["status"] == "skipped", (
             f"Layer {layer} should be skipped for message_hash target, got: {ev.cascade_status[layer]}"
         )
-        assert ev.cascade_status[layer]["reason"] == "target_type_not_supported_yet"
-
-    # Phase-4+ layers: still skipped with table_not_exists
-    for layer in ("message_entities", "message_links", "attachments", "fts_rows"):
-        assert ev.cascade_status[layer]["status"] == "skipped"
+        assert ev.cascade_status[layer]["reason"] == "target_type_not_supported_yet", (
+            f"Layer {layer} should have reason='target_type_not_supported_yet', got: {ev.cascade_status[layer]}"
+        )
 
 
 async def test_export_target_records_skipped(db_session) -> None:
@@ -749,9 +749,16 @@ async def test_export_target_records_skipped(db_session) -> None:
     ev = await db_session.get(ForgetEvent, event_id, populate_existing=True)
     assert ev.status == "completed"
 
-    for layer in ("chat_messages", "message_versions"):
-        assert ev.cascade_status[layer]["status"] == "skipped"
-        assert ev.cascade_status[layer]["reason"] == "target_type_not_supported_yet"
+    # ALL 6 layers: uniformly skipped with target_type_not_supported_yet
+    from bot.services.forget_cascade import CASCADE_LAYER_ORDER
+
+    for layer in CASCADE_LAYER_ORDER:
+        assert ev.cascade_status[layer]["status"] == "skipped", (
+            f"Layer {layer} should be skipped for export target, got: {ev.cascade_status[layer]}"
+        )
+        assert ev.cascade_status[layer]["reason"] == "target_type_not_supported_yet", (
+            f"Layer {layer} should have reason='target_type_not_supported_yet', got: {ev.cascade_status[layer]}"
+        )
 
 
 # ──────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Closes #96 — T3-04 cascade worker skeleton (Stream Charlie / memory governance, **HIGH-RISK** — irreversible content destruction).

Cascade worker that processes `forget_events` (created by /forget reply, /forget_me, etc.) and permanently NULLs content fields per HANDOFF §10 irreversibility doctrine. Feature flag `memory.forget.cascade_worker.enabled` defaults OFF — code lands disabled until ops explicitly enable.

## Scope

- **`bot/services/forget_cascade.py`** (new, ~320 lines) — `run_cascade_worker_once(session, batch_size=10)` + `cascade_worker_tick()`. Cascade order matches HANDOFF §10 EXACTLY: `chat_messages → message_versions → message_entities → message_links → attachments → fts_rows`. Per-event try/except, per-layer checkpoint via new `ForgetEventRepo.update_cascade_status` (atomic `UPDATE ... WHERE id=? AND status='processing' RETURNING`). Restart-safe: skips `status='completed'` layers.
- **`bot/db/repos/forget_event.py`** (+update_cascade_status method) — Option A architecture preserves `mark_status` state machine semantics.
- **`bot/services/scheduler.py`** (+16 lines additive) — APScheduler interval 30s, `max_instances=1, coalesce=True, misfire_grace_time=60`. Worker tick reads flag EVERY fire (not cached at boot). Mirrors `memory.ingestion.raw_updates.enabled` operational pattern.
- **`tests/services/test_forget_cascade.py`** (new) + `tests/db/test_forget_event_repo.py` (additions) — 31 new tests.
- **`docs/memory-system/IMPLEMENTATION_STATUS.md`** — Stream Charlie progress section + T3-01/T3-04 rows.

## Cascade content semantics

- `target_type='message'` — chat_messages by id NULL'ed (text/caption/raw_json) + is_redacted=True + memory_policy='forgotten'; message_versions by chat_message_id NULL'ed (text/caption/normalized_text/entities_json) + is_redacted=True. content_hash PRESERVED per ADR-0003 (citation stability).
- `target_type='user'` — walks ALL `chat_messages WHERE user_id = CAST(target_id AS BIGINT)` (codebase invariant: `User.id == telegram_id`). message_versions cascaded via subquery on chat_messages.user_id (subquery resolves correctly even after layer 1 NULLs text/caption/raw_json — user_id column is untouched).
- `target_type ∈ {message_hash, export}` — uniformly recorded as `{status: 'skipped', reason: 'target_type_not_supported_yet'}` per layer. Event finalizes as `completed` (all layers explicitly accounted for). Stream Delta #97 + Bravo importer will implement these later.
- Phase 4+ layers (entities/links/attachments/fts_rows) — recorded as `{status: 'skipped', reason: 'table_not_exists'}` for supported target_types; uniform `target_type_not_supported_yet` reason for unsupported target_types.

## Reviews (governance=critical, dual-track Unified Review)

- ✅ deep-analyst verifier: **PASS** (acceptance + invariants A/B/C/D + cascade-content semantics verified)
- ✅ ag-reviewer (consensus): **PASS** with 1 MEDIUM (target_type fallthrough — escalated to CRITICAL by Codex; resolved in fix commit)
- ✅ Claude product-reviewer (opus): **ACCEPTED** (5 scenarios COVERED, spec fit MATCHES, irreversibility HONORED, scope WITHIN AUTHORIZED_SCOPE)
- ✅ Codex tech (xhigh) **APPROVE** (final, after 3 rounds — closed CRITICAL target_type fallthrough + MEDIUM concurrent test gap + LOW failed-state test gap + reason field uniformity)

## Test plan

- [x] 12 cascade worker tests — atomic claim, restart-safe checkpointing, per-event isolation, cascade content semantics, target_type=message/user wipe, target_type=message_hash/export skipped semantics, scheduler flag on/off
- [x] 19 repo tests — `update_cascade_status` success/pending-rejection/completed-rejection/failed-rejection/missing-id-rejection
- [x] Full suite: **274 passed** (post-rebase on origin/main)
- [x] ruff: clean
- [x] Manual: feature flag default OFF — worker tick is no-op until enabled

## Carry-over for future phases (non-blocking)

- When Stream Delta #97 lands `target_type='message_hash'`, an "upgrade pass" will be needed for events already finalized as `completed` with all layers `skipped` (status reset → pending).
- Document operator runbook: how to manually retry `failed` events (reset status, clear `cascade_status['error']`).
- Single bulk UPDATE for `target_type='user'` may create lock contention with live ingestion for users with 100K+ messages — track for Phase 4 hardening (HANDOFF §risk R3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)