### PR TITLE
fix(p2-fhr): Phase 2 Final Holistic Review hotfix — C1 + H1 + H4

### DIFF
--- a/bot/db/repos/message.py
+++ b/bot/db/repos/message.py
@@ -102,13 +102,17 @@ class MessageRepo:
             # Build the SET clause with only the fields that were explicitly passed.
             # Immutable fields (ids, text, date, raw_json) are never updated on conflict.
             #
-            # STICKY POLICY (Codex CRITICAL / Sprint #80 fixup):
+            # STICKY POLICY (Codex CRITICAL / Sprint #80 fixup + p2-hotfix C1):
             # memory_policy and is_redacted are monotonically ratcheted toward more-restrictive
             # values. A stale duplicate original delivery (e.g. Telegram polling glitch re-delivers
-            # a message after its #offrecord edit) must NOT downgrade an existing 'offrecord' row
-            # back to 'normal'. The CASE expressions below enforce this invariant atomically in SQL:
+            # a message after its #offrecord edit) must NOT downgrade an existing 'offrecord' or
+            # 'forgotten' row back to 'normal'.
+            #
+            # The CASE expressions below enforce this invariant atomically in SQL:
             #
             #   memory_policy: if the stored value is already 'offrecord', keep 'offrecord';
+            #                  if the stored value is already 'forgotten', keep 'forgotten'
+            #                  (HANDOFF.md §1 invariant 9 — tombstones are durable);
             #                  otherwise adopt the incoming EXCLUDED.memory_policy.
             #
             #   is_redacted:   once True, stays True — OR semantics: existing OR incoming.
@@ -120,6 +124,7 @@ class MessageRepo:
             if memory_policy is not None:
                 set_clause["memory_policy"] = case(
                     (ChatMessage.memory_policy == "offrecord", "offrecord"),
+                    (ChatMessage.memory_policy == "forgotten", "forgotten"),
                     else_=insrt.excluded.memory_policy,
                 )
             if is_redacted is not None:

--- a/bot/services/forget_cascade.py
+++ b/bot/services/forget_cascade.py
@@ -249,6 +249,13 @@ async def _process_one_event(session: AsyncSession, event) -> None:
     On success, transitions the row to ``status='completed'`` with the final
     cascade_status. On exception, transitions to ``status='failed'`` with the
     exception captured under ``cascade_status['error']``.
+
+    H4 fix (p2-hotfix): the entire cascade is wrapped in ``begin_nested()``
+    (SAVEPOINT). This ensures that a real PostgreSQL-level DB error in any layer
+    function aborts only this event's sub-transaction, leaving the outer
+    transaction valid so ``run_cascade_worker_once`` can continue with the next
+    event. Without the savepoint, a DB error would abort the outer transaction and
+    subsequent events would fail with InFailedSQLTransactionError.
     """
     # Snapshot current per-layer progress so we can resume.
     cascade_state: dict[str, Any] = dict(event.cascade_status or {})
@@ -283,7 +290,14 @@ async def _process_one_event(session: AsyncSession, event) -> None:
                         "reason": "target_type_not_supported_yet",
                     }
             elif layer in _LAYER_FUNCS:
-                rows = await _LAYER_FUNCS[layer](session, event)
+                # H4 fix (p2-hotfix): wrap each active layer call in a SAVEPOINT so
+                # that a real PostgreSQL-level DB error in one layer aborts only that
+                # layer's sub-transaction, leaving the outer transaction valid. Without
+                # per-layer savepoints, a DB error would abort the outer transaction and
+                # subsequent events in the batch would fail with InFailedSQLTransactionError,
+                # breaking the per-event isolation guarantee.
+                async with session.begin_nested():
+                    rows = await _LAYER_FUNCS[layer](session, event)
                 cascade_state[layer] = {"status": "completed", "rows": rows}
             else:
                 # Phase 4+ layers — table not yet present in this codebase.
@@ -304,6 +318,8 @@ async def _process_one_event(session: AsyncSession, event) -> None:
         cascade_state["error"] = repr(exc)
         # Try to record the failure; if THAT itself fails (e.g. terminal state
         # already set), let the outer exception propagate to the batch loop.
+        # The per-layer begin_nested() savepoint was rolled back on exception exit,
+        # so the outer transaction is still valid here.
         await ForgetEventRepo.mark_status(
             session, event.id, status="failed", cascade_status=cascade_state
         )

--- a/bot/services/import_apply.py
+++ b/bot/services/import_apply.py
@@ -506,7 +506,29 @@ async def _apply_one_message(
     # 8. Governance gate. The synthetic row above is the audit trail. If the
     # imported content is offrecord, do NOT call persist_message_with_policy and
     # do NOT create chat_messages/message_versions rows.
-    policy, _mark_payload = detect_policy(text_value, caption_value)
+    #
+    # H1 fix: mirror message_persistence.py broadened-scan (Sprint #89 Commit 2).
+    # TD poll dict has a top-level "poll" key with "question". TD contact dict has
+    # "first_name" / "last_name" keys at the message level (contact messages).
+    _poll_dict = msg.get("poll") if kind == "poll" else None
+    poll_question: str | None = None
+    if isinstance(_poll_dict, dict):
+        _q = _poll_dict.get("question")
+        if isinstance(_q, str) and _q:
+            poll_question = _q
+    contact_name: str | None = None
+    if kind == "contact":
+        _first = msg.get("first_name")
+        _last = msg.get("last_name")
+        parts = [p for p in [_first, _last] if isinstance(p, str) and p]
+        if parts:
+            contact_name = " ".join(parts)
+    policy, _mark_payload = detect_policy(
+        text_value,
+        caption_value,
+        poll_question=poll_question,
+        contact_name=contact_name,
+    )
     if policy == "offrecord":
         raw_row.is_redacted = True
         raw_row.redaction_reason = "offrecord"
@@ -686,6 +708,26 @@ def _build_message_duck(
         kind_attrs[message_kind] = SimpleNamespace(_imported=True)
     if message_kind == "forward":
         kind_attrs["forward_origin"] = SimpleNamespace(_imported=True)
+
+    # H1 fix: supply poll.question and contact.first_name/last_name so that
+    # persist_message_with_policy's broadened detect_policy scan (Sprint #89)
+    # sees the same content as the step-8 governance gate above.
+    # TD poll dict is nested under msg["poll"]["question"].
+    # TD contact fields are at msg level: first_name / last_name.
+    if message_kind == "poll":
+        _poll_dict = msg.get("poll")
+        _poll_question: str | None = None
+        if isinstance(_poll_dict, dict):
+            _q = _poll_dict.get("question")
+            if isinstance(_q, str):
+                _poll_question = _q or None
+        kind_attrs["poll"] = SimpleNamespace(_imported=True, question=_poll_question)
+    if message_kind == "contact":
+        _first = msg.get("first_name") if isinstance(msg.get("first_name"), str) else None
+        _last = msg.get("last_name") if isinstance(msg.get("last_name"), str) else None
+        kind_attrs["contact"] = SimpleNamespace(
+            _imported=True, first_name=_first, last_name=_last
+        )
 
     return SimpleNamespace(
         message_id=msg_id,

--- a/bot/services/import_apply.py
+++ b/bot/services/import_apply.py
@@ -508,8 +508,9 @@ async def _apply_one_message(
     # do NOT create chat_messages/message_versions rows.
     #
     # H1 fix: mirror message_persistence.py broadened-scan (Sprint #89 Commit 2).
-    # TD poll dict has a top-level "poll" key with "question". TD contact dict has
-    # "first_name" / "last_name" keys at the message level (contact messages).
+    # TD poll dict has a top-level "poll" key with "question". TD contact fields
+    # are NESTED under contact_information (not top-level) — confirmed by
+    # import_parser.py which uses msg.get("contact_information") as discriminator.
     _poll_dict = msg.get("poll") if kind == "poll" else None
     poll_question: str | None = None
     if isinstance(_poll_dict, dict):
@@ -518,11 +519,13 @@ async def _apply_one_message(
             poll_question = _q
     contact_name: str | None = None
     if kind == "contact":
-        _first = msg.get("first_name")
-        _last = msg.get("last_name")
-        parts = [p for p in [_first, _last] if isinstance(p, str) and p]
-        if parts:
-            contact_name = " ".join(parts)
+        _contact_info = msg.get("contact_information")
+        if isinstance(_contact_info, dict):
+            _first = _contact_info.get("first_name")
+            _last = _contact_info.get("last_name")
+            parts = [p for p in [_first, _last] if isinstance(p, str) and p]
+            if parts:
+                contact_name = " ".join(parts)
     policy, _mark_payload = detect_policy(
         text_value,
         caption_value,
@@ -713,7 +716,9 @@ def _build_message_duck(
     # persist_message_with_policy's broadened detect_policy scan (Sprint #89)
     # sees the same content as the step-8 governance gate above.
     # TD poll dict is nested under msg["poll"]["question"].
-    # TD contact fields are at msg level: first_name / last_name.
+    # TD contact fields are NESTED under contact_information (not top-level) —
+    # confirmed by import_parser.py which uses msg.get("contact_information") as
+    # the kind discriminator.
     if message_kind == "poll":
         _poll_dict = msg.get("poll")
         _poll_question: str | None = None
@@ -723,8 +728,9 @@ def _build_message_duck(
                 _poll_question = _q or None
         kind_attrs["poll"] = SimpleNamespace(_imported=True, question=_poll_question)
     if message_kind == "contact":
-        _first = msg.get("first_name") if isinstance(msg.get("first_name"), str) else None
-        _last = msg.get("last_name") if isinstance(msg.get("last_name"), str) else None
+        _contact_info = msg.get("contact_information") if isinstance(msg.get("contact_information"), dict) else None
+        _first = _contact_info.get("first_name") if _contact_info and isinstance(_contact_info.get("first_name"), str) else None
+        _last = _contact_info.get("last_name") if _contact_info and isinstance(_contact_info.get("last_name"), str) else None
         kind_attrs["contact"] = SimpleNamespace(
             _imported=True, first_name=_first, last_name=_last
         )

--- a/tests/db/test_message_repo.py
+++ b/tests/db/test_message_repo.py
@@ -608,3 +608,61 @@ async def test_save_duplicate_only_is_redacted_false_does_not_unflag_redacted(
         f"PRIVACY VIOLATION: is_redacted=False stale duplicate unset the redaction flag. "
         f"Got is_redacted={result.is_redacted!r}"
     )
+
+
+# ─── C1: forgotten policy is sticky (invariant 9 — tombstones are durable) ───
+
+
+async def test_save_duplicate_with_normal_does_not_downgrade_forgotten(
+    db_session,
+) -> None:
+    """Invariant 9 (HANDOFF.md §1): tombstones are durable and not casually rolled back.
+
+    Scenario: cascade worker sets memory_policy='forgotten', is_redacted=True on a row.
+    A subsequent stale Telegram redelivery calls MessageRepo.save with
+    memory_policy='normal' and is_redacted=False. The row MUST stay 'forgotten' and
+    is_redacted MUST stay True.
+
+    This is the 'forgotten' analogue of the offrecord stickiness tests above.
+    """
+    from bot.db.repos.message import MessageRepo
+
+    user_id = _random_user_id()
+    chat_id = _random_chat_id()
+    message_id = _random_message_id()
+    when = datetime.now(timezone.utc)
+
+    await _create_user(db_session, user_id)
+
+    # Step 1: cascade worker applies forget → sets forgotten + redacted.
+    await MessageRepo.save(
+        db_session,
+        message_id=message_id,
+        chat_id=chat_id,
+        user_id=user_id,
+        text=None,  # already redacted by cascade
+        date=when,
+        memory_policy="forgotten",
+        is_redacted=True,
+    )
+
+    # Step 2: stale redelivery arrives with memory_policy='normal', is_redacted=False.
+    result = await MessageRepo.save(
+        db_session,
+        message_id=message_id,
+        chat_id=chat_id,
+        user_id=user_id,
+        text="stale original text",
+        date=when,
+        memory_policy="normal",
+        is_redacted=False,
+    )
+
+    assert result.memory_policy == "forgotten", (
+        f"INVARIANT 9 VIOLATION: memory_policy='normal' stale duplicate downgraded 'forgotten' row. "
+        f"Got memory_policy='{result.memory_policy}'"
+    )
+    assert result.is_redacted is True, (
+        f"INVARIANT 9 VIOLATION: is_redacted=False stale duplicate unset redaction on 'forgotten' row. "
+        f"Got is_redacted={result.is_redacted!r}"
+    )

--- a/tests/services/test_forget_cascade.py
+++ b/tests/services/test_forget_cascade.py
@@ -786,3 +786,80 @@ async def test_scheduler_tick_processes_events_when_flag_on(db_session) -> None:
 
     ev = await ForgetEventRepo.get_by_tombstone_key(db_session, tomb_key)
     assert ev.status == "completed"
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# H4: per-event savepoint isolation — real DB error on one event must not abort
+# the outer transaction so remaining events in the batch can still be processed.
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+async def test_per_event_db_error_isolation_via_savepoint(db_session, monkeypatch) -> None:
+    """H4 fix verification: when event B's cascade causes a real SQLAlchemy DB-level
+    error (not a Python-only exception), the worker MUST still process events A and C
+    via savepoint isolation around each event.
+
+    Without ``begin_nested()`` around ``_process_one_event``, a database-level error
+    aborts the outer transaction and all subsequent DB operations in the same session
+    fail with PendingRollbackError — breaking the per-event isolation guarantee
+    documented in the worker's docstring.
+    """
+    from sqlalchemy.exc import ProgrammingError
+
+    from bot.db.repos.forget_event import ForgetEventRepo
+    from bot.services import forget_cascade
+
+    # Event A — processes normally.
+    cm_a, _, chat_a, msg_a = await _make_chat_message_with_v1(db_session, text="alpha")
+    tomb_a = f"message:{chat_a}:{msg_a}"
+    await _make_pending_forget_event(
+        db_session, target_type="message", target_id=str(cm_a), tombstone_key=tomb_a
+    )
+
+    # Event B — rigged to raise a real SQLAlchemy DB error (not a Python exception).
+    # ProgrammingError is a sqlalchemy.exc subclass that maps to a PostgreSQL ERROR.
+    # We raise it directly from the layer function; the worker must absorb it without
+    # leaving the outer transaction in an aborted state.
+    cm_b, _, chat_b, msg_b = await _make_chat_message_with_v1(db_session, text="beta")
+    tomb_b = f"message:{chat_b}:{msg_b}"
+    await _make_pending_forget_event(
+        db_session, target_type="message", target_id=str(cm_b), tombstone_key=tomb_b
+    )
+
+    # Event C — must still process even after event B's DB error.
+    cm_c, _, chat_c, msg_c = await _make_chat_message_with_v1(db_session, text="gamma")
+    tomb_c = f"message:{chat_c}:{msg_c}"
+    await _make_pending_forget_event(
+        db_session, target_type="message", target_id=str(cm_c), tombstone_key=tomb_c
+    )
+
+    original = forget_cascade._cascade_chat_messages
+
+    async def _db_error_on_b(session, event):
+        if event.target_id == str(cm_b):
+            # Execute a real invalid SQL statement so PostgreSQL itself aborts
+            # the current (sub)transaction. This is the class of error that
+            # requires savepoint isolation to contain: without begin_nested(),
+            # this aborts the OUTER transaction and all subsequent operations
+            # fail with PendingRollbackError.
+            from sqlalchemy import text as sa_text
+            await session.execute(sa_text("SELECT 1 / 0"))  # division by zero → ERROR
+        return await original(session, event)
+
+    monkeypatch.setitem(forget_cascade._LAYER_FUNCS, "chat_messages", _db_error_on_b)
+
+    stats = await forget_cascade.run_cascade_worker_once(db_session)
+
+    # All three events must be claimed.
+    assert stats["claimed"] == 3, f"expected 3 claimed, got {stats['claimed']}"
+    # Events A and C succeed; event B fails.
+    assert stats["processed"] == 2, f"expected 2 processed, got {stats['processed']}"
+    assert stats["failed"] == 1, f"expected 1 failed, got {stats['failed']}"
+
+    ev_a = await ForgetEventRepo.get_by_tombstone_key(db_session, tomb_a)
+    ev_b = await ForgetEventRepo.get_by_tombstone_key(db_session, tomb_b)
+    ev_c = await ForgetEventRepo.get_by_tombstone_key(db_session, tomb_c)
+
+    assert ev_a.status == "completed", f"event A should be completed, got {ev_a.status}"
+    assert ev_b.status == "failed", f"event B should be failed, got {ev_b.status}"
+    assert ev_c.status == "completed", f"event C should be completed, got {ev_c.status}"

--- a/tests/services/test_forget_cascade.py
+++ b/tests/services/test_forget_cascade.py
@@ -804,8 +804,6 @@ async def test_per_event_db_error_isolation_via_savepoint(db_session, monkeypatc
     fail with PendingRollbackError — breaking the per-event isolation guarantee
     documented in the worker's docstring.
     """
-    from sqlalchemy.exc import ProgrammingError
-
     from bot.db.repos.forget_event import ForgetEventRepo
     from bot.services import forget_cascade
 

--- a/tests/services/test_import_apply.py
+++ b/tests/services/test_import_apply.py
@@ -1038,3 +1038,93 @@ async def test_apply_resilient_to_bad_user_resolution(db_session) -> None:
         assert int(raw_7003.scalar_one()) == 0
     finally:
         tmp.unlink(missing_ok=True)
+
+
+# ─── H1: poll.question and contact.name passed to detect_policy in import path ──
+
+
+async def test_apply_poll_with_offrecord_question_yields_offrecord_policy(db_session) -> None:
+    """H1 fix verification: TD-imported poll whose question contains #offrecord MUST
+    result in memory_policy='offrecord' (or the row being redacted/skipped).
+
+    Before the fix, import_apply called detect_policy(text, caption) without
+    poll_question, so #offrecord in a poll question was silently stored as 'normal'.
+    """
+    import json as _json
+    from pathlib import Path as _Path
+
+    from bot.services.import_apply import run_apply
+
+    chat_id = -9901
+
+    poll_export = {
+        "name": "Poll Offrecord Chat",
+        "type": "private_supergroup",
+        "id": chat_id,
+        "messages": [
+            {
+                "id": 9901,
+                "type": "message",
+                "date": "2024-03-01T10:00:00",
+                "date_unixtime": "1709287200",
+                "from": "PollUser",
+                "from_id": "user9901001",
+                # poll kind: TD format uses top-level "poll" dict (no media_type for polls)
+                "poll": {
+                    "question": "Do you agree? #offrecord",
+                    "closed": False,
+                    "answers": ["Yes", "No"],
+                },
+            }
+        ],
+    }
+
+    tmp = _Path(__file__).parents[1] / "fixtures" / "td_export" / "_tmp_poll_offrecord.json"
+    tmp.write_text(_json.dumps(poll_export), encoding="utf-8")
+    try:
+        run_id = await _create_apply_run(
+            db_session,
+            source_path=str(tmp),
+            chat_id=chat_id,
+            source_hash="hash_poll_offrecord_h1",
+        )
+
+        await db_session.execute(
+            sa_text(
+                "INSERT INTO users (id, first_name, is_imported_only) "
+                "VALUES (9901001, 'PollUser', false) "
+                "ON CONFLICT (id) DO NOTHING"
+            )
+        )
+        await db_session.flush()
+
+        report = await run_apply(
+            db_session,
+            ingestion_run_id=run_id,
+            resume_point=None,
+            chunking_config=_default_chunking(),
+        )
+
+        # The poll with #offrecord question must be skipped via governance path.
+        assert report.skipped_governance_count == 1, (
+            f"H1: expected governance skip for poll with #offrecord question; "
+            f"got skipped_governance_count={report.skipped_governance_count}, "
+            f"applied_count={report.applied_count}"
+        )
+        assert report.applied_count == 0
+
+        # Verify no chat_messages row persisted with normal policy.
+        cm_row = await db_session.execute(
+            sa_text(
+                "SELECT memory_policy FROM chat_messages "
+                "WHERE chat_id = :cid AND message_id = 9901"
+            ),
+            {"cid": chat_id},
+        )
+        row = cm_row.fetchone()
+        assert row is None, (
+            f"H1: chat_messages row should not exist for offrecord poll; "
+            f"got memory_policy={row[0] if row else None}"
+        )
+    finally:
+        tmp.unlink(missing_ok=True)

--- a/tests/services/test_import_apply.py
+++ b/tests/services/test_import_apply.py
@@ -1128,3 +1128,101 @@ async def test_apply_poll_with_offrecord_question_yields_offrecord_policy(db_ses
         )
     finally:
         tmp.unlink(missing_ok=True)
+
+
+async def test_apply_contact_with_offrecord_in_first_name_yields_offrecord_policy(
+    db_session,
+) -> None:
+    """H1 fix coverage: TD contact-shaped message with #offrecord in
+    contact_information.first_name must be detected as offrecord and skipped
+    (not persisted to chat_messages).
+
+    Before the fix, import_apply read msg["first_name"] / msg["last_name"] at
+    the top level — fields that do not exist in the real TD export format.  TD
+    nests them under contact_information: {"first_name": ..., "last_name": ...}.
+    """
+    import json as _json
+    from pathlib import Path as _Path
+
+    from bot.services.import_apply import run_apply
+
+    chat_id = -9902
+
+    contact_export = {
+        "name": "Contact Offrecord Chat",
+        "type": "private_supergroup",
+        "id": chat_id,
+        "messages": [
+            {
+                "id": 9902,
+                "type": "message",
+                "date": "2024-03-01T11:00:00",
+                "date_unixtime": "1709290800",
+                "from": "Sender",
+                "from_id": "user9902001",
+                # TD format: contact fields NESTED under contact_information
+                "contact_information": {
+                    "first_name": "Alice #offrecord",
+                    "last_name": "Smith",
+                    "phone_number": "+1234567890",
+                    "vcard": "",
+                },
+            }
+        ],
+    }
+
+    tmp = (
+        _Path(__file__).parents[1]
+        / "fixtures"
+        / "td_export"
+        / "_tmp_contact_offrecord.json"
+    )
+    tmp.write_text(_json.dumps(contact_export), encoding="utf-8")
+    try:
+        run_id = await _create_apply_run(
+            db_session,
+            source_path=str(tmp),
+            chat_id=chat_id,
+            source_hash="hash_contact_offrecord_h1",
+        )
+
+        await db_session.execute(
+            sa_text(
+                "INSERT INTO users (id, first_name, is_imported_only) "
+                "VALUES (9902001, 'Sender', false) "
+                "ON CONFLICT (id) DO NOTHING"
+            )
+        )
+        await db_session.flush()
+
+        report = await run_apply(
+            db_session,
+            ingestion_run_id=run_id,
+            resume_point=None,
+            chunking_config=_default_chunking(),
+        )
+
+        # The contact with #offrecord in first_name must be skipped via governance.
+        assert report.skipped_governance_count == 1, (
+            f"H1: expected governance skip for contact with #offrecord in "
+            f"contact_information.first_name; "
+            f"got skipped_governance_count={report.skipped_governance_count}, "
+            f"applied_count={report.applied_count}"
+        )
+        assert report.applied_count == 0
+
+        # Verify no chat_messages row persisted.
+        cm_row = await db_session.execute(
+            sa_text(
+                "SELECT memory_policy FROM chat_messages "
+                "WHERE chat_id = :cid AND message_id = 9902"
+            ),
+            {"cid": chat_id},
+        )
+        row = cm_row.fetchone()
+        assert row is None, (
+            f"H1: chat_messages row should not exist for offrecord contact; "
+            f"got memory_policy={row[0] if row else None}"
+        )
+    finally:
+        tmp.unlink(missing_ok=True)


### PR DESCRIPTION
## Summary

Hotfix from Phase 2 Final Holistic Review (5 findings из dual-review Claude product + Codex technical). 3 verified-and-fixed, 2 verified-clean.

### Findings addressed

| ID | Severity | Status | Notes |
|----|----------|--------|-------|
| C1 | CRITICAL | ✅ FIXED | `forgotten` sticky policy в `MessageRepo.save` (HANDOFF §1 invariant 9) |
| H1 | HIGH | ✅ FIXED | poll.question + contact_information.{first_name,last_name} в detect_policy (invariant 8 import==live) |
| H2 | HIGH | ✅ VERIFIED CLEAN | per-message SAVEPOINT уже есть; partial apply — intentional design |
| H3 | HIGH | ✅ VERIFIED CLEAN | rollback deletes synthetic orphan rows; no permanent skip |
| H4 | HIGH | ✅ FIXED | per-layer SAVEPOINT в cascade worker; preserves restart-safe semantics |

### Commits
- 86f9487 C1 — forgotten sticky in MessageRepo.save
- 7ca28a8 H1 — poll/contact passed to detect_policy
- d488561 H4 — per-layer savepoint in cascade worker
- da55de6 cleanup unused import
- 0a7eced H1 — extract contact from contact_information dict (codex catch)

### PAR review
- Claude product-reviewer: ACCEPTED
- Codex technical: APPROVE C1/H2/H3/H4; REQUEST_CHANGES H1 contact → addressed in 0a7eced