### PR TITLE
feat(p4-fts): T4-01/T4-02 — FTS infrastructure for Phase 4 search

### DIFF
--- a/alembic/versions/020_add_message_versions_fts.py
+++ b/alembic/versions/020_add_message_versions_fts.py
@@ -1,0 +1,53 @@
+"""add_message_versions_fts
+
+T4-01: add PostgreSQL full-text search infrastructure for Phase 4 search.
+
+The generated vector is built from the version body, not from ``chat_messages``,
+so Phase 4 citations can continue to point at stable ``message_version_id`` rows.
+The GIN index is partial on ``is_redacted = FALSE`` because the column already
+exists on ``message_versions``; runtime queries still apply the same filter.
+
+Revision ID: 020
+Revises: 019
+Create Date: 2026-04-30
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "020"
+down_revision: Union[str, Sequence[str], None] = "019"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "message_versions",
+        sa.Column(
+            "tsv",
+            postgresql.TSVECTOR(),
+            sa.Computed(
+                "to_tsvector('russian', coalesce(text,'') || ' ' || coalesce(caption,''))",
+                persisted=True,
+            ),
+            nullable=True,
+        ),
+    )
+    op.create_index(
+        "idx_message_versions_tsv",
+        "message_versions",
+        ["tsv"],
+        postgresql_using="gin",
+        postgresql_where=sa.text("is_redacted = FALSE"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("idx_message_versions_tsv", table_name="message_versions")
+    op.drop_column("message_versions", "tsv")

--- a/bot/services/search.py
+++ b/bot/services/search.py
@@ -1,0 +1,98 @@
+"""Governance-filtered full-text search for Phase 4 memory retrieval."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+@dataclass(frozen=True)
+class SearchHit:
+    message_version_id: int
+    chat_id: int
+    message_id: int
+    snippet: str
+    ts_rank: float
+    captured_at: datetime
+
+
+async def search_messages(
+    session: AsyncSession,
+    query: str,
+    *,
+    chat_id: int,
+    limit: int = 10,
+) -> list[SearchHit]:
+    """Search visible message versions in one chat.
+
+    The governance filter is intentionally repeated here even though migration 020
+    also creates a partial GIN index for redacted versions. Search consumers must
+    not depend on index shape for privacy.
+    """
+    normalized_query = query.strip()
+    if not normalized_query:
+        return []
+    if limit < 1:
+        raise ValueError("limit must be >= 1")
+
+    stmt = text(
+        """
+        WITH q AS (
+            SELECT plainto_tsquery('russian', :query) AS tsq
+        )
+        SELECT
+            mv.id AS message_version_id,
+            c.chat_id AS chat_id,
+            c.message_id AS message_id,
+            COALESCE(
+                ts_headline(
+                    'russian',
+                    concat_ws(' ', mv.text, mv.caption),
+                    q.tsq,
+                    'MaxWords=20, MinWords=5'
+                ),
+                ''
+            ) AS snippet,
+            ts_rank(mv.tsv, q.tsq) AS rank,
+            mv.captured_at AS captured_at
+        FROM message_versions AS mv
+        JOIN chat_messages AS c ON mv.chat_message_id = c.id
+        CROSS JOIN q
+        LEFT JOIN forget_events AS fe
+            ON fe.target_type = 'message'
+            AND fe.target_id ~ '^[0-9]+$'
+            AND fe.target_id::int = c.id
+            AND fe.status IN ('pending', 'processing', 'completed')
+        WHERE c.chat_id = :chat_id
+            AND c.memory_policy = 'normal'
+            AND c.is_redacted = FALSE
+            AND mv.is_redacted = FALSE
+            AND fe.id IS NULL
+            AND mv.tsv @@ q.tsq
+        ORDER BY rank DESC, mv.captured_at DESC, mv.id DESC
+        LIMIT :limit
+        """
+    )
+    result = await session.execute(
+        stmt,
+        {
+            "query": normalized_query,
+            "chat_id": chat_id,
+            "limit": limit,
+        },
+    )
+
+    return [
+        SearchHit(
+            message_version_id=row["message_version_id"],
+            chat_id=row["chat_id"],
+            message_id=row["message_id"],
+            snippet=row["snippet"],
+            ts_rank=float(row["rank"]),
+            captured_at=row["captured_at"],
+        )
+        for row in result.mappings().all()
+    ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,10 +26,12 @@ dependencies = [
 dev = [
     "pytest>=8.3",
     "pytest-asyncio>=0.24",
+    "pytest-timeout>=2.3",
     # aiosqlite is dev-only — used by tests/test_scheduler_deadlines.py for in-memory sqlite
     # isolation. Production runtime requires postgres (T0-02; see bot/db/engine.py).
     "aiosqlite>=0.20",
     "ruff>=0.11",
+    "mypy>=1.15",
 ]
 ops = [
     "telethon>=1.39",

--- a/tests/db/test_migration_020.py
+++ b/tests/db/test_migration_020.py
@@ -1,0 +1,239 @@
+"""Migration 020 acceptance tests.
+
+These tests create an isolated temporary database, run Alembic against it, and
+drop the database afterwards. They do not mutate the shared pytest database.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import uuid
+from collections.abc import AsyncIterator
+from pathlib import Path
+
+import asyncpg
+import pytest
+import pytest_asyncio
+from sqlalchemy.engine.url import URL, make_url
+
+from tests.conftest import DEFAULT_LOCAL_POSTGRES_URL
+
+pytestmark = pytest.mark.usefixtures("app_env")
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _base_test_url() -> URL:
+    raw_url = (
+        os.environ.get("TEST_DATABASE_URL")
+        or os.environ.get("DATABASE_URL")
+        or DEFAULT_LOCAL_POSTGRES_URL
+    )
+    return make_url(raw_url)
+
+
+def _asyncpg_kwargs(url: URL, *, database: str | None = None) -> dict[str, object]:
+    return {
+        "user": url.username,
+        "password": url.password,
+        "host": url.host or "127.0.0.1",
+        "port": url.port or 5432,
+        "database": database or url.database,
+    }
+
+
+def _quote_identifier(identifier: str) -> str:
+    return '"' + identifier.replace('"', '""') + '"'
+
+
+async def _create_database(admin_url: URL, database_name: str) -> None:
+    conn = await asyncpg.connect(**_asyncpg_kwargs(admin_url, database="postgres"))
+    try:
+        await conn.execute(f"CREATE DATABASE {_quote_identifier(database_name)}")
+    finally:
+        await conn.close()
+
+
+async def _drop_database(admin_url: URL, database_name: str) -> None:
+    conn = await asyncpg.connect(**_asyncpg_kwargs(admin_url, database="postgres"))
+    try:
+        await conn.execute(
+            """
+            SELECT pg_terminate_backend(pid)
+            FROM pg_stat_activity
+            WHERE datname = $1 AND pid <> pg_backend_pid()
+            """,
+            database_name,
+        )
+        await conn.execute(f"DROP DATABASE IF EXISTS {_quote_identifier(database_name)}")
+    finally:
+        await conn.close()
+
+
+@pytest_asyncio.fixture()
+async def temp_database_url() -> AsyncIterator[str]:
+    base_url = _base_test_url()
+    database_name = f"shkoder_migration_020_{uuid.uuid4().hex[:12]}"
+    try:
+        await _create_database(base_url, database_name)
+    except Exception as exc:  # pragma: no cover - environment guard
+        pytest.skip(f"cannot create temporary postgres database: {exc!s}")
+
+    try:
+        yield base_url.set(database=database_name).render_as_string(hide_password=False)
+    finally:
+        await _drop_database(base_url, database_name)
+
+
+def _run_alembic(database_url: str, *args: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["DATABASE_URL"] = database_url
+    return subprocess.run(
+        [sys.executable, "-m", "alembic", *args],
+        cwd=PROJECT_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=120,
+        check=True,
+    )
+
+
+async def _fetch_one(database_url: str, query: str, *args: object) -> asyncpg.Record | None:
+    conn = await asyncpg.connect(**_asyncpg_kwargs(make_url(database_url)))
+    try:
+        return await conn.fetchrow(query, *args)
+    finally:
+        await conn.close()
+
+
+async def _fetch_value(database_url: str, query: str, *args: object) -> object:
+    conn = await asyncpg.connect(**_asyncpg_kwargs(make_url(database_url)))
+    try:
+        return await conn.fetchval(query, *args)
+    finally:
+        await conn.close()
+
+
+async def _insert_message_version(database_url: str) -> int:
+    conn = await asyncpg.connect(**_asyncpg_kwargs(make_url(database_url)))
+    try:
+        async with conn.transaction():
+            await conn.execute(
+                """
+                INSERT INTO users (id, username, first_name)
+                VALUES (910000000001, 'migration020', 'Migration')
+                """
+            )
+            chat_message_id = await conn.fetchval(
+                """
+                INSERT INTO chat_messages (message_id, chat_id, user_id, text, date)
+                VALUES (42001, -10042001, 910000000001, 'кошка сидит', now())
+                RETURNING id
+                """
+            )
+            return await conn.fetchval(
+                """
+                INSERT INTO message_versions (
+                    chat_message_id,
+                    version_seq,
+                    text,
+                    caption,
+                    normalized_text,
+                    content_hash
+                )
+                VALUES ($1, 1, 'кошка сидит', 'рыжая кошка', 'кошка сидит', 'mig020-hash')
+                RETURNING id
+                """,
+                chat_message_id,
+            )
+    finally:
+        await conn.close()
+
+
+@pytest_asyncio.fixture()
+async def migrated_database_url(temp_database_url: str) -> AsyncIterator[str]:
+    _run_alembic(temp_database_url, "upgrade", "head")
+    yield temp_database_url
+
+
+async def test_alembic_upgrade_head_on_clean_db_green(migrated_database_url: str) -> None:
+    current = await _fetch_value(migrated_database_url, "SELECT version_num FROM alembic_version")
+
+    assert current == "020"
+
+
+async def test_insert_message_versions_generates_tsv(migrated_database_url: str) -> None:
+    version_id = await _insert_message_version(migrated_database_url)
+
+    row = await _fetch_one(
+        migrated_database_url,
+        """
+        SELECT
+            tsv::text AS tsv_text,
+            tsv @@ plainto_tsquery('russian', 'кошка') AS matches_query
+        FROM message_versions
+        WHERE id = $1
+        """,
+        version_id,
+    )
+
+    assert row is not None
+    assert row["tsv_text"]
+    assert row["matches_query"] is True
+
+
+async def test_pg_indexes_contains_named_gin_index(migrated_database_url: str) -> None:
+    indexdef = await _fetch_value(
+        migrated_database_url,
+        """
+        SELECT indexdef
+        FROM pg_indexes
+        WHERE schemaname = 'public'
+            AND tablename = 'message_versions'
+            AND indexname = 'idx_message_versions_tsv'
+        """,
+    )
+
+    assert indexdef is not None
+    lowered = str(indexdef).lower()
+    assert "using gin" in lowered
+    assert "(tsv)" in lowered
+    assert "where (is_redacted = false)" in lowered
+
+
+async def test_alembic_downgrade_minus_one_drops_tsv(temp_database_url: str) -> None:
+    _run_alembic(temp_database_url, "upgrade", "head")
+    _run_alembic(temp_database_url, "downgrade", "-1")
+
+    column_exists = await _fetch_value(
+        temp_database_url,
+        """
+        SELECT EXISTS (
+            SELECT 1
+            FROM information_schema.columns
+            WHERE table_schema = 'public'
+                AND table_name = 'message_versions'
+                AND column_name = 'tsv'
+        )
+        """,
+    )
+    index_exists = await _fetch_value(
+        temp_database_url,
+        """
+        SELECT EXISTS (
+            SELECT 1
+            FROM pg_indexes
+            WHERE schemaname = 'public'
+                AND tablename = 'message_versions'
+                AND indexname = 'idx_message_versions_tsv'
+        )
+        """,
+    )
+    current = await _fetch_value(temp_database_url, "SELECT version_num FROM alembic_version")
+
+    assert column_exists is False
+    assert index_exists is False
+    assert current == "019"

--- a/tests/services/test_search.py
+++ b/tests/services/test_search.py
@@ -1,0 +1,296 @@
+"""Phase 4 FTS search service tests.
+
+DB-backed tests use the shared ``db_session`` fixture. The CI job runs
+``alembic upgrade head`` before pytest, so migration 020's generated ``tsv`` column
+is present for these tests.
+"""
+
+from __future__ import annotations
+
+import itertools
+from datetime import datetime, timezone
+
+import pytest
+
+pytestmark = pytest.mark.usefixtures("app_env")
+
+_user_counter = itertools.count(start=10_400_000_000)
+_message_counter = itertools.count(start=1_040_000)
+_hash_counter = itertools.count(start=1)
+
+
+async def _create_versioned_message(
+    db_session,
+    *,
+    chat_id: int = -100_400,
+    message_id: int | None = None,
+    text: str | None = "питон любит память",
+    caption: str | None = None,
+    memory_policy: str = "normal",
+    chat_is_redacted: bool = False,
+    version_is_redacted: bool = False,
+) -> tuple[int, int, int]:
+    """Create user + chat_messages + message_versions. Return (chat_pk, version_pk, msg_id)."""
+    from bot.db.models import ChatMessage, MessageVersion
+    from bot.db.repos.user import UserRepo
+
+    user_id = next(_user_counter)
+    tg_message_id = message_id if message_id is not None else next(_message_counter)
+
+    await UserRepo.upsert(
+        db_session,
+        telegram_id=user_id,
+        username=f"u{user_id}",
+        first_name="Search",
+        last_name=None,
+    )
+
+    chat_message = ChatMessage(
+        message_id=tg_message_id,
+        chat_id=chat_id,
+        user_id=user_id,
+        text=text,
+        caption=caption,
+        date=datetime.now(timezone.utc),
+        memory_policy=memory_policy,
+        is_redacted=chat_is_redacted,
+    )
+    db_session.add(chat_message)
+    await db_session.flush()
+
+    version = MessageVersion(
+        chat_message_id=chat_message.id,
+        version_seq=1,
+        text=text,
+        caption=caption,
+        normalized_text=text,
+        content_hash=f"search-hash-{next(_hash_counter)}",
+        is_redacted=version_is_redacted,
+    )
+    db_session.add(version)
+    await db_session.flush()
+
+    return chat_message.id, version.id, tg_message_id
+
+
+async def _create_forget_event(db_session, *, chat_message_id: int, status: str) -> None:
+    from bot.db.repos.forget_event import ForgetEventRepo
+
+    event = await ForgetEventRepo.create(
+        db_session,
+        target_type="message",
+        target_id=str(chat_message_id),
+        actor_user_id=None,
+        authorized_by="system",
+        tombstone_key=f"message:-100400:{chat_message_id}:{status}",
+    )
+    if status == "pending":
+        return
+
+    await ForgetEventRepo.mark_status(db_session, event.id, status="processing")
+    if status == "completed":
+        await ForgetEventRepo.mark_status(db_session, event.id, status="completed")
+
+
+async def test_search_normal_message_found(db_session) -> None:
+    from bot.services.search import search_messages
+
+    chat_id = -100_401
+    _, version_id, message_id = await _create_versioned_message(
+        db_session,
+        chat_id=chat_id,
+        text="питон помогает искать память",
+    )
+
+    hits = await search_messages(db_session, "питон", chat_id=chat_id)
+
+    assert len(hits) == 1
+    assert hits[0].message_version_id == version_id
+    assert hits[0].chat_id == chat_id
+    assert hits[0].message_id == message_id
+    assert hits[0].ts_rank > 0
+    assert hits[0].captured_at is not None
+
+
+async def test_search_offrecord_excluded(db_session) -> None:
+    from bot.services.search import search_messages
+
+    chat_id = -100_402
+    await _create_versioned_message(
+        db_session,
+        chat_id=chat_id,
+        text="секретный питон",
+        memory_policy="offrecord",
+    )
+
+    assert await search_messages(db_session, "питон", chat_id=chat_id) == []
+
+
+async def test_search_nomem_excluded(db_session) -> None:
+    from bot.services.search import search_messages
+
+    chat_id = -100_403
+    await _create_versioned_message(
+        db_session,
+        chat_id=chat_id,
+        text="nomem питон",
+        memory_policy="nomem",
+    )
+
+    assert await search_messages(db_session, "питон", chat_id=chat_id) == []
+
+
+async def test_search_forgotten_excluded(db_session) -> None:
+    from bot.services.search import search_messages
+
+    chat_id = -100_404
+    await _create_versioned_message(
+        db_session,
+        chat_id=chat_id,
+        text="забытый питон",
+        memory_policy="forgotten",
+    )
+
+    assert await search_messages(db_session, "питон", chat_id=chat_id) == []
+
+
+async def test_search_redacted_chat_message_excluded(db_session) -> None:
+    from bot.services.search import search_messages
+
+    chat_id = -100_405
+    await _create_versioned_message(
+        db_session,
+        chat_id=chat_id,
+        text="редактированный питон",
+        chat_is_redacted=True,
+    )
+
+    assert await search_messages(db_session, "питон", chat_id=chat_id) == []
+
+
+async def test_search_redacted_version_excluded(db_session) -> None:
+    from bot.services.search import search_messages
+
+    chat_id = -100_406
+    await _create_versioned_message(
+        db_session,
+        chat_id=chat_id,
+        text="версия питон",
+        version_is_redacted=True,
+    )
+
+    assert await search_messages(db_session, "питон", chat_id=chat_id) == []
+
+
+async def test_search_active_forget_event_pending_excluded(db_session) -> None:
+    from bot.services.search import search_messages
+
+    chat_id = -100_407
+    chat_message_id, _, _ = await _create_versioned_message(
+        db_session,
+        chat_id=chat_id,
+        text="pending питон",
+    )
+    await _create_forget_event(db_session, chat_message_id=chat_message_id, status="pending")
+
+    assert await search_messages(db_session, "питон", chat_id=chat_id) == []
+
+
+async def test_search_active_forget_event_completed_excluded(db_session) -> None:
+    from bot.services.search import search_messages
+
+    chat_id = -100_408
+    chat_message_id, _, _ = await _create_versioned_message(
+        db_session,
+        chat_id=chat_id,
+        text="completed питон",
+    )
+    await _create_forget_event(db_session, chat_message_id=chat_message_id, status="completed")
+
+    assert await search_messages(db_session, "питон", chat_id=chat_id) == []
+
+
+async def test_search_chat_isolation(db_session) -> None:
+    from bot.services.search import search_messages
+
+    chat_a = -100_409
+    chat_b = -100_410
+    await _create_versioned_message(db_session, chat_id=chat_a, text="изолированный питон")
+
+    assert await search_messages(db_session, "питон", chat_id=chat_b) == []
+
+
+async def test_search_ts_rank_ordering(db_session) -> None:
+    from bot.services.search import search_messages
+
+    chat_id = -100_411
+    await _create_versioned_message(
+        db_session,
+        chat_id=chat_id,
+        message_id=1_041_101,
+        text="питон память",
+    )
+    _, _, high_rank_message_id = await _create_versioned_message(
+        db_session,
+        chat_id=chat_id,
+        message_id=1_041_102,
+        text="питон питон питон память",
+    )
+
+    hits = await search_messages(db_session, "питон", chat_id=chat_id)
+
+    assert [hit.message_id for hit in hits][:2] == [high_rank_message_id, 1_041_101]
+    assert hits[0].ts_rank > hits[1].ts_rank
+
+
+async def test_search_snippet_contains_query_terms(db_session) -> None:
+    from bot.services.search import search_messages
+
+    chat_id = -100_412
+    await _create_versioned_message(
+        db_session,
+        chat_id=chat_id,
+        text="в этой строке питон находится внутри",
+    )
+
+    hits = await search_messages(db_session, "питон", chat_id=chat_id)
+
+    assert "питон" in hits[0].snippet.lower()
+
+
+async def test_search_caption_hit_has_snippet(db_session) -> None:
+    from bot.services.search import search_messages
+
+    chat_id = -100_413
+    await _create_versioned_message(
+        db_session,
+        chat_id=chat_id,
+        text=None,
+        caption="подпись содержит питон",
+    )
+
+    hits = await search_messages(db_session, "питон", chat_id=chat_id)
+
+    assert len(hits) == 1
+    assert "питон" in hits[0].snippet.lower()
+
+
+async def test_search_limit_respected(db_session) -> None:
+    from bot.services.search import search_messages
+
+    chat_id = -100_414
+    for _ in range(3):
+        await _create_versioned_message(db_session, chat_id=chat_id, text="лимит питон")
+
+    hits = await search_messages(db_session, "питон", chat_id=chat_id, limit=2)
+
+    assert len(hits) == 2
+
+
+async def test_search_empty_query_returns_empty(db_session) -> None:
+    from bot.services.search import search_messages
+
+    chat_id = -100_415
+    await _create_versioned_message(db_session, chat_id=chat_id, text="питон")
+
+    assert await search_messages(db_session, "   ", chat_id=chat_id) == []


### PR DESCRIPTION
## Summary
- alembic 020: `message_versions.tsv` generated tsvector + partial GIN index (`is_redacted = FALSE`)
- `bot/services/search.py`: `search_messages()` with governance filter (normal-only, redacted excluded, active forget_events excluded)
- 14 search regression tests + 4 migration tests covering invariant 3
- added dev deps required by the mandated self-check command: `pytest-timeout`, `mypy`

## Invariants verified
- ✅ Existing gatekeeper не затронут (no changes to `bot/handlers/`)
- ✅ No LLM calls
- ✅ FTS query joins `chat_messages` + `forget_events` and filters forbidden content
- ✅ Citations = `message_version_id`
- ✅ `message_versions.is_redacted` exists, so migration uses partial GIN index and service filters versions too

## Test evidence
```text
pytest tests/services/test_search.py tests/db/test_migration_020.py -x --timeout=120
18 passed in 7.98s

ruff check .
All checks passed!

mypy bot/services/search.py
Success: no issues found in 1 source file
```

## Self-check
- [x] pytest -x --timeout=120 green
- [x] ruff check . clean
- [x] mypy clean
- [x] alembic upgrade head + downgrade -1 verified in isolated temp DB

## Design decisions
- Used PostgreSQL `russian` text search config exactly as specified for the generated vector and query parser.
- Used a partial GIN index because `message_versions.is_redacted` exists on current `main`.
- Runtime search still applies every governance filter explicitly; the partial index is defense-in-depth only.
- Snippets use `concat_ws(' ', mv.text, mv.caption)` so caption-only matches return usable snippets while matching the tsvector input.
- Added a numeric guard before `forget_events.target_id::int` to avoid query failure on historical/non-numeric `target_id` rows.

Closes #145
Closes #146