### PR TITLE
docs(p4): apply audit + reviewer findings to plan + stream prompts

### DIFF
--- a/PHASE4_STREAM_C_PROMPT.md
+++ b/PHASE4_STREAM_C_PROMPT.md
@@ -61,32 +61,27 @@ Same as other streams: re-read files before quoting; treat memory recall as hypo
 
 ## 4. Implementation Plan
 
-### Step 4.1 — Search shape stub (optional, only if Stream B not yet shipping)
+### Step 4.1 — Reality check: SearchHit is already canonical
 
-If Stream B has not landed `SearchHit` yet, create `bot/services/search_types.py`:
+PR #151 (merged) shipped `bot/services/search.py::SearchHit` as the canonical shape — but with **6 fields, not the planned 9**:
 
 ```python
-from __future__ import annotations
-from dataclasses import dataclass
-from datetime import datetime
-
-
+# What ships TODAY in bot/services/search.py:
 @dataclass(frozen=True)
 class SearchHit:
     message_version_id: int
-    chat_message_id: int
     chat_id: int
     message_id: int
-    user_id: int | None
     snippet: str
     ts_rank: float
     captured_at: datetime
-    message_date: datetime
 ```
 
-Stream B's PR can later move this canonical shape into `bot/services/search.py` and re-export from `search_types.py` for backwards compatibility.
+The `EvidenceItem` design in this prompt assumes the planned 9-field shape (also includes `chat_message_id`, `user_id`, `message_date`). Stream D needs `user_id` (for author rendering) and `message_date` (for date display) — without them, `/recall` cannot produce useful citations.
 
-If Stream B has already merged, import from `bot/services/search.py` directly.
+**Resolution:** there is a hardening follow-up issue (label `phase:4`, search "T4-02 hardening" / "SearchHit expansion") that expands `SearchHit` to the planned 9 fields and adds the `current_version_id = mv.id` JOIN clause Stream B's PR omitted. Coordinate so Stream C's PR lands AFTER the hardening PR. If urgent, downgrade `EvidenceItem` to 6 fields and accept that Stream D will need a per-item DB lookup to fetch `user_id` + `message_date` from `chat_messages` — surface the trade-off in your PR description.
+
+Do NOT create `bot/services/search_types.py` — the canonical shape is in `bot/services/search.py`.
 
 ### Step 4.2 — `bot/services/evidence.py`
 
@@ -98,11 +93,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Sequence
 
-# Forward-compatible import:
-try:
-    from bot.services.search import SearchHit  # type: ignore
-except ImportError:
-    from bot.services.search_types import SearchHit  # type: ignore
+from bot.services.search import SearchHit  # canonical shape (PR #151)
 
 
 @dataclass(frozen=True, slots=True)
@@ -193,10 +184,7 @@ from pathlib import Path
 import pytest
 
 from bot.services.evidence import EvidenceBundle, EvidenceItem
-try:
-    from bot.services.search import SearchHit
-except ImportError:
-    from bot.services.search_types import SearchHit
+from bot.services.search import SearchHit
 
 
 def _make_hit(idx: int) -> SearchHit:
@@ -319,7 +307,6 @@ All green. No external services touched.
 
 ```bash
 git add bot/services/evidence.py \
-        bot/services/search_types.py \
         tests/services/test_evidence.py \
         tests/fixtures/evidence_bundle_v1.json
 git commit -m "feat(p4-C): evidence bundle frozen contract (T4-03, #147)"
@@ -371,5 +358,5 @@ After merge:
 - PR URL + merge SHA.
 - Issue #147 closed.
 - Files changed (3-4 expected).
-- Decision on `search_types.py` stub vs direct import.
+- Decision on EvidenceItem field count (9-field vs 6-field SearchHit) — see §4.1.
 - Confirm "no LLM imports".

--- a/PHASE4_STREAM_D_PROMPT.md
+++ b/PHASE4_STREAM_D_PROMPT.md
@@ -37,12 +37,12 @@ Verify: `git branch --show-current` is `feat/p4-stream-d-qa-handler`. Latest `or
 5. `docs/memory-system/AUTHORIZED_SCOPE.md`.
 6. `docs/memory-system/PHASE4_PLAN.md` §5.D — your component spec.
 7. `bot/handlers/chat_messages.py` — handler pattern (advisory lock, governance, repos, no LLM).
-8. `bot/services/feature_flag.py` (or wherever `is_enabled` lives) — flag check pattern.
-9. `bot/services/governance.py` — `detect_policy(...)` signature; you call it on the user's QUERY.
+8. `bot/db/repos/feature_flag.py` — flag check pattern. **Real API:** `await FeatureFlagRepo.get(session, "memory.qa.enabled") -> bool`. There is NO `bot/services/feature_flag.py`.
+9. `bot/services/governance.py` — `detect_policy(...)` returns `tuple[PolicyOutcome, dict | None]`, NOT a string. Always unpack the tuple.
 10. `bot/services/search.py` (Stream B) — `search_messages(...)` API.
 11. `bot/services/evidence.py` (Stream C) — `EvidenceBundle.from_hits(...)`.
 12. `bot/db/repos/qa_trace.py` (Stream E) — `QaTraceRepo.create(...)`.
-13. `bot/db/repos/user.py` — for member/admin lookup if not already done in middleware.
+13. `bot/db/repos/user.py` — for member/admin lookup. **Real API:** `UserRepo.get(session, telegram_id)` and `UserRepo.get_by_tg_id(session, tg_id)`. There is NO `UserRepo.get_by_id`.
 14. `bot/__main__.py` — router registration pattern.
 15. `tests/handlers/` — existing test structure for handlers.
 
@@ -69,7 +69,11 @@ For Stream D specifically:
 
 Same as other streams: re-read files, treat memory recall as hypothesis, verify with Grep.
 
-Specifically: before assuming a helper exists (`is_member_or_admin`, `feature_flag.is_enabled`, deep-link formatting), `Grep -n` for the function name across `bot/`. Hallucinated helpers waste a review cycle.
+Specifically: before assuming a helper exists, `Grep -n` for the function name across `bot/`. Hallucinated helpers waste a review cycle. **Verified-real APIs (use these, do NOT invent variants):**
+- Feature flag: `from bot.db.repos.feature_flag import FeatureFlagRepo` → `await FeatureFlagRepo.get(session, "memory.qa.enabled")` returns `bool`.
+- User lookup: `from bot.db.repos.user import UserRepo` → `await UserRepo.get(session, telegram_id)` or `await UserRepo.get_by_tg_id(session, tg_id)`.
+- Governance: `from bot.services.governance import detect_policy` → returns `tuple[PolicyOutcome, dict | None]`. Unpack: `policy, _payload = detect_policy(...)`.
+- Cascade: forget cascade is event-driven via `forget_events` rows + `run_cascade_worker_once(session, ...)` (`bot/services/forget_cascade.py:329`). There is NO direct `process_forget_for_user` function.
 
 ---
 
@@ -111,15 +115,17 @@ async def run_qa(
 ```python
 from __future__ import annotations
 
+import html
+
 from aiogram import Router
-from aiogram.filters import Command
+from aiogram.filters import Command, CommandObject
 from aiogram.types import Message
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from bot.config import settings
+from bot.db.repos.feature_flag import FeatureFlagRepo  # NOT bot.services.feature_flag
 from bot.db.repos.qa_trace import QaTraceRepo
 from bot.db.repos.user import UserRepo
-from bot.services.feature_flag import is_enabled
 from bot.services.governance import detect_policy
 from bot.services.qa import run_qa
 
@@ -133,24 +139,32 @@ def _short_chat_id(chat_id: int) -> str:
 
 
 def _format_response(bundle, users_by_id: dict[int, "User"]) -> str:
+    """HTML-formatted response. ts_headline returns <b>...</b> tags natively, so HTML mode is the safest choice (Markdown would require escaping every _, *, [, ] in user content)."""
     if bundle.abstained:
         return "Не нашёл подходящих свидетельств в истории чата."
-    parts = ["**Найденные свидетельства:**\n"]
+    parts = ["<b>Найденные свидетельства:</b>\n"]
     short = _short_chat_id(bundle.chat_id)
     for item in bundle.items:
         author = users_by_id.get(item.user_id, None)
-        author_name = author.first_name if author else "—"
+        author_name = html.escape(author.first_name) if author else "—"
         date = item.message_date.strftime("%Y-%m-%d %H:%M")
-        snippet = item.snippet.replace("<b>", "**").replace("</b>", "**")
+        # ts_headline already emits <b>...</b>; do NOT escape the snippet body
+        # (the search service guarantees it is safe HTML — only <b> tags are added).
+        snippet = item.snippet
         link = f"https://t.me/c/{short}/{item.message_id}"
-        parts.append(f"> {snippet}\n> — _{author_name}, {date}_ · [→]({link})\n")
+        parts.append(
+            f"<blockquote>{snippet}</blockquote>\n"
+            f"<i>— {author_name}, {date}</i> · <a href=\"{link}\">→</a>\n"
+        )
     return "\n".join(parts)
 
 
 @router.message(Command("recall"))
-async def recall_handler(message: Message, session: AsyncSession) -> None:
+async def recall_handler(
+    message: Message, command: CommandObject, session: AsyncSession
+) -> None:
     # 1. Feature flag — silent return on OFF
-    if not await is_enabled(session, "memory.qa.enabled"):
+    if not await FeatureFlagRepo.get(session, "memory.qa.enabled"):
         return
 
     # 2. Authz: only in COMMUNITY_CHAT_ID group
@@ -162,20 +176,20 @@ async def recall_handler(message: Message, session: AsyncSession) -> None:
     # 3. Authz: member or admin
     if message.from_user is None:
         return
-    user = await UserRepo.get_by_id(session, message.from_user.id)
+    user = await UserRepo.get(session, message.from_user.id)
     if user is None or not (user.is_member or user.is_admin):
         await message.reply("Доступ только участникам сообщества.")
         return
 
-    # 4. Parse query
-    text_payload = message.text or ""
-    query = text_payload.removeprefix("/recall").strip()
+    # 4. Parse query — use aiogram's CommandObject.args (None or the post-command tail).
+    # Avoid str.removeprefix("/recall") because it would also match "/recallstuff".
+    query = (command.args or "").strip()
     if not query:
-        await message.reply("Использование: `/recall <вопрос>`", parse_mode="Markdown")
+        await message.reply("Использование: <code>/recall &lt;вопрос&gt;</code>", parse_mode="HTML")
         return
 
-    # 5. Governance on the QUERY
-    policy = detect_policy(text=query, caption=None)
+    # 5. Governance on the QUERY — detect_policy returns (PolicyOutcome, dict|None).
+    policy, _payload = detect_policy(text=query, caption=None)
     redact_query = policy != "normal"
 
     # 6. Run search + bundle
@@ -186,15 +200,15 @@ async def recall_handler(message: Message, session: AsyncSession) -> None:
         redact_query_in_audit=redact_query,
     )
 
-    # 7. Render response (NEVER echo query if redact_query)
+    # 7. Render response (NEVER echo query if redact_query — abstention/format handles this naturally)
     users_by_id: dict[int, "User"] = {}
     for item in result.bundle.items:
         if item.user_id and item.user_id not in users_by_id:
-            u = await UserRepo.get_by_id(session, item.user_id)
+            u = await UserRepo.get(session, item.user_id)
             if u:
                 users_by_id[item.user_id] = u
     response = _format_response(result.bundle, users_by_id)
-    await message.reply(response, parse_mode="Markdown", disable_web_page_preview=True)
+    await message.reply(response, parse_mode="HTML", disable_web_page_preview=True)
 
     # 8. Audit
     await QaTraceRepo.create(

--- a/PHASE4_STREAM_E_PROMPT.md
+++ b/PHASE4_STREAM_E_PROMPT.md
@@ -19,7 +19,7 @@ cd .worktrees/p4-stream-e
 
 Verify: `git branch --show-current` is `feat/p4-stream-e-qa-traces`. Latest commit equals `origin/main`.
 
-**Migration ordering:** your migration is 021. Stream A's is 020. If Stream A has not yet merged when you push, your PR can still pass CI (CI applies all migrations sequentially), but you MUST hold the merge until Stream A is on `origin/main`. Rebase if needed.
+**Migration ordering:** your migration is 021. Stream A's migration 020 **already shipped via PR #151** with revision id literal `"020"` (file `alembic/versions/020_add_message_versions_fts.py`). Your `down_revision` MUST be the literal string `"020"`, NOT `"020_add_message_version_fts_index"` as earlier-draft text in this prompt suggested.
 
 ---
 
@@ -77,7 +77,7 @@ import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
 
 revision = "021_add_qa_traces"
-down_revision = "020_add_message_version_fts_index"
+down_revision = "020"  # literal — that's the actual revision id of PR #151's migration
 branch_labels = None
 depends_on = None
 
@@ -116,7 +116,7 @@ def downgrade() -> None:
     op.drop_table("qa_traces")
 ```
 
-**If Stream A's migration 020 has not merged when you author:** set `down_revision = "019_add_ingestion_runs_rolled_back"` temporarily, then rebase to point at `"020_add_message_version_fts_index"` once Stream A merges. Coordinate via PR comment.
+**Note:** PR #151 already merged migration 020. Use `down_revision = "020"` directly. The earlier-draft fallback to 019 is no longer relevant.
 
 ### Step 4.2 — Model `bot/db/models.py`
 
@@ -245,9 +245,22 @@ async def test_evidence_ids_jsonb_round_trip(session):
     assert fetched.evidence_ids == ids
 
 
-@pytest.mark.xfail(reason="cascade wiring lives in Stream B / T4-02; flip to passing once #146 merges")
+@pytest.mark.xfail(
+    reason=(
+        "qa_traces cascade layer not yet wired into bot/services/forget_cascade.py "
+        "CASCADE_LAYER_ORDER. Tracked in T4-02 hardening follow-up. Flip to passing "
+        "once the cascade adds a `qa_traces` layer that nulls query_text + sets "
+        "query_redacted=true for forget_events with target_type='user'."
+    )
+)
 @pytest.mark.asyncio
 async def test_forget_me_cascade_redacts_query(session):
+    """Drives the existing event-driven cascade worker (no `process_forget_for_user`
+    direct API exists). Inserts a forget_event(target_type='user') and calls the
+    real worker — same path that /forget_me triggers."""
+    from bot.db.models import ForgetEvent
+    from bot.services.forget_cascade import run_cascade_worker_once
+
     trace = await QaTraceRepo.create(
         session,
         user_tg_id=42,
@@ -257,10 +270,19 @@ async def test_forget_me_cascade_redacts_query(session):
         abstained=False,
         redact_query=False,
     )
+    # Insert the forget event the same way /forget_me handler would:
+    fe = ForgetEvent(
+        target_type="user",
+        target_id="42",
+        tombstone_key="user:42",
+        authorized_by="self",
+        policy="forgotten",
+        status="pending",
+    )
+    session.add(fe)
     await session.flush()
-    # Simulate /forget_me cascade for user 42:
-    from bot.services.forget_cascade import process_forget_for_user  # noqa
-    await process_forget_for_user(session, user_tg_id=42)
+    # Drive the existing worker (event-driven; does NOT take user_tg_id directly):
+    await run_cascade_worker_once(session)
     refetch = await session.get(type(trace), trace.id)
     assert refetch.query_text is None
     assert refetch.query_redacted is True
@@ -303,7 +325,7 @@ PR body:
 - Paste pytest output.
 - Note: cascade wiring is Stream B (T4-02 / #146); the 4th test is xfail until then.
 - Confirm: no LLM imports.
-- Migration ordering: `down_revision = "020_add_message_version_fts_index"` (after Stream A merged) OR `"019_add_ingestion_runs_rolled_back"` if author-time Stream A unmerged (rebase later).
+- Migration ordering: `down_revision = "020"` (literal — PR #151 already shipped 020).
 
 Unified review:
 1. Claude product reviewer (background) — focus: schema correctness, redaction semantics.

--- a/docs/memory-system/PHASE4_PLAN.md
+++ b/docs/memory-system/PHASE4_PLAN.md
@@ -1,11 +1,41 @@
 # Phase 4 — Hybrid Search + Q&A with Citations: Design & Stream Plan
 
-**Status:** Planning — design ratified, tickets created, streams allocated
+**Status:** **In progress** — Wave 1 partially shipped via PR #151 (T4-01 + T4-02 merged with deviations); audit + corrections issued via PR following commit 5bd4888.
 **Cycle:** Memory system Phase 4
 **Date:** 2026-04-30
 **Predecessor:** Phase 2 CLOSED 2026-04-29 (20/20 issues + FHR), Phase 3 governance skeleton merged in Phase 2 wave Charlie
-**Migration window:** 020+
+**Migration window:** 020+ (020 shipped in PR #151)
 **Critical invariant for this phase:** No LLM calls in Phase 4. Pure FTS retrieval + evidence + citations + abstention. LLM generation is **Phase 5**.
+
+---
+
+## 0. Implementation Status (post PR #151 audit)
+
+PR #151 (`feat/p4-fts-infra`, merged 2026-04-30) delivered T4-01 and T4-02 in parallel with this plan, with **5 material deviations** documented below. Hardening follow-up issue tracks the gap.
+
+| Component | Plan §5 ref | Shipped? | Outstanding |
+|---|---|---|---|
+| FTS schema migration | §5.A | ✅ PR #151 (deviations: column `tsv` not `search_tsv`; index `idx_message_versions_tsv` not `ix_*_search_tsv`; source `text` not `normalized_text`; partial index `WHERE is_redacted=false` despite plan rejection) | `MessageVersion.tsv` ORM column not added; rename + source switch up for hardening discussion |
+| Search service | §5.B | ⚠️ PR #151 (functional but: `SearchHit` has 6 of 9 planned fields; `current_version_id = mv.id` JOIN missing → returns historical versions; tombstone NOT EXISTS uses single `target_type='message'` key, missing `message_hash`/`user`/`export` formats — invariant #9 weakened) | Hardening required (separate issue) |
+| Cascade `fts_rows` layer | §5.A item 5 + §5.B | ➖ Skipped status retained, but de-facto correctness preserved by existing `_cascade_message_versions` nulling `text/caption/normalized_text` (which makes generated `tsv` column auto-recompute to empty) | Status accounting cleanup recommended; not blocking |
+| Tests for T4-02 | §5.B | ⚠️ 14 of planned 9-test core landed; **missing**: russian stemmer test (`лошадь`/`лошади`), injection safety, current_version_id filter, 100-row pagination | Hardening |
+| Evidence bundle | §5.C | 🟡 Stream C (issue #147) not yet started | Wave 1 parallel — unblocked |
+| Q&A handler `/recall` | §5.D | 🟡 Stream D (issue #148) not yet started | Wave 3 — depends on Stream C + Stream E + hardening (for SearchHit fields) |
+| `qa_traces` table | §5.E | 🟡 Stream E (issue #149) not yet started | Wave 1 parallel; cascade `qa_traces` layer wiring deferred (xfail in tests until added) |
+| Eval seed cases | §5.D T4-06 | 🟡 Issue #150 not started | Inside Stream D PR |
+
+### Verbatim deviations from plan (for ratification)
+
+1. **Column name** — shipped: `message_versions.tsv`; planned: `search_tsv`. Downstream code (Stream B, C, D) must reference `tsv`.
+2. **Index name** — shipped: `idx_message_versions_tsv`; planned: `ix_message_versions_search_tsv`. Cosmetic.
+3. **tsvector source** — shipped: `to_tsvector('russian', coalesce(text,'') || ' ' || coalesce(caption,''))`; planned: `coalesce(normalized_text,'') || ' ' || coalesce(caption,'')`. Plan §5.A item 2 explicitly required `normalized_text`. **Material:** `text` is raw user input including markup/whitespace artifacts; `normalized_text` is the canonical surface. Hardening should switch the source.
+4. **Partial index** — shipped: GIN index with `postgresql_where=is_redacted=FALSE`; planned: full index, query-time filter only (§5.A item 5 explicitly rejected partial index). Material: forget cascade still works because cascade nulls `text/caption/normalized_text` AND sets `is_redacted=true`, so partial index excludes redacted rows correctly. Operational note: if `is_redacted` is updated frequently, partial index may churn. Acceptable as-is.
+5. **Tombstone exclusion key set** — shipped: `target_type='message'` + `target_id::int = c.id`; planned: three-key NOT EXISTS over `message:`, `message_hash:`, `user:` formats. **Material — invariant #9 weakened.** Forget events targeting `message_hash` or `user` (e.g., `/forget_me`, hash-collision deletion) do NOT exclude content from search results until each affected `chat_messages` row also has its own `message:`-keyed forget_event row. Hardening MUST add the three-key clause.
+
+### Outstanding work tracked
+
+- **T4-02 hardening — [#153](https://github.com/Jekudy/vibeshkoder/issues/153)** — SearchHit field expansion (6→9), `current_version_id` JOIN, three-key tombstone NOT EXISTS, russian stemmer + injection tests, optional partial-index review, `MessageVersion.tsv` ORM column.
+- **Cascade `qa_traces` layer (deferred)** — extend `bot/services/forget_cascade.py::CASCADE_LAYER_ORDER` with `qa_traces` and add `_cascade_qa_traces` to null `query_text` + set `query_redacted=true` for forget events with `target_type='user'`. Stream E xfail test will flip to passing once landed.
 
 ---
 
@@ -518,14 +548,15 @@ Wave 3 (solo):      D
 
 All tickets land as GitHub issues with label `phase:4`. Issue numbers populated after `gh issue create`.
 
-| ID | Title | Stream | Size | Deps | GitHub # |
-|---|---|---|---|---|---|
-| **T4-01** | FTS schema: tsvector generated column + GIN index on `message_versions` | A | M | — | [#145](https://github.com/Jekudy/vibeshkoder/issues/145) |
-| **T4-02** | Search service: `bot/services/search.py` with governance + tombstone filtering | B | L | T4-01, T4-03, T4-05 | [#146](https://github.com/Jekudy/vibeshkoder/issues/146) |
-| **T4-03** | Evidence bundle: frozen `EvidenceBundle`/`EvidenceItem` dataclasses + JSON contract | C | S | — | [#147](https://github.com/Jekudy/vibeshkoder/issues/147) |
-| **T4-04** | Q&A handler: `/recall` command + `memory.qa.enabled` feature flag (default OFF) | D | M | T4-02, T4-03, T4-05 | [#148](https://github.com/Jekudy/vibeshkoder/issues/148) |
-| **T4-05** | qa_traces audit table + repo (`bot/db/repos/qa_trace.py`) | E | S | — | [#149](https://github.com/Jekudy/vibeshkoder/issues/149) |
-| **T4-06** | Eval seed cases: ≥ 10 fixture cases for /recall correctness (rolled into Stream D) | D | S | T4-02, T4-04 | [#150](https://github.com/Jekudy/vibeshkoder/issues/150) |
+| ID | Title | Stream | Size | Deps | GitHub # | Status |
+|---|---|---|---|---|---|---|
+| **T4-01** | FTS schema: tsvector generated column + GIN index on `message_versions` | A | M | — | [#145](https://github.com/Jekudy/vibeshkoder/issues/145) | ✅ shipped via PR #151 (with deviations — see §0) |
+| **T4-02** | Search service: `bot/services/search.py` with governance + tombstone filtering | B | L | T4-01, T4-03, T4-05 | [#146](https://github.com/Jekudy/vibeshkoder/issues/146) | ⚠️ shipped via PR #151 (with deviations — hardening tracked in [#153](https://github.com/Jekudy/vibeshkoder/issues/153)) |
+| **T4-02H** | Hardening: SearchHit fields + current_version_id JOIN + 3-key tombstone + tests | B | M | T4-02 | [#153](https://github.com/Jekudy/vibeshkoder/issues/153) | 🟡 not started |
+| **T4-03** | Evidence bundle: frozen `EvidenceBundle`/`EvidenceItem` dataclasses + JSON contract | C | S | — | [#147](https://github.com/Jekudy/vibeshkoder/issues/147) | 🟡 not started |
+| **T4-04** | Q&A handler: `/recall` command + `memory.qa.enabled` feature flag (default OFF) | D | M | T4-02, T4-03, T4-05 (+ hardening) | [#148](https://github.com/Jekudy/vibeshkoder/issues/148) | 🟡 not started |
+| **T4-05** | qa_traces audit table + repo (`bot/db/repos/qa_trace.py`) | E | S | — | [#149](https://github.com/Jekudy/vibeshkoder/issues/149) | 🟡 not started |
+| **T4-06** | Eval seed cases: ≥ 10 fixture cases for /recall correctness (rolled into Stream D) | D | S | T4-02, T4-04 | [#150](https://github.com/Jekudy/vibeshkoder/issues/150) | 🟡 not started |
 
 ### T4-01 acceptance (testable)
 


### PR DESCRIPTION
## Summary

Apply analyst + reviewer audit findings to Phase 4 plan + stream prompts. Docs-only.

This is the corrective follow-up to PR #152 (planning), driven by two parallel audits:

1. **Analyst audit** — compared planning artifacts in PR #152 against PR #151 (which merged T4-01/T4-02 in parallel with my planning work). Found 5 material deviations between plan and ship.
2. **Reviewer audit** — found 4 hallucinated function references in Stream D + Stream E prompts that would cause autonomous agents to fail at first import.

## Changes

- **`docs/memory-system/PHASE4_PLAN.md` §0** — new "Implementation Status (post PR #151 audit)" section documenting:
  - 5 material deviations between PR #151 and the plan (column/index naming, tsvector source, partial index, missing `current_version_id` JOIN, tombstone single-key vs three-key)
  - Outstanding hardening work tracked in #153
  - Updated tickets table with status column + T4-02H row
- **`PHASE4_STREAM_C_PROMPT.md`** — drop the `search_types.py` stub idea (canonical `SearchHit` already shipped); document the 6-vs-9 field gap and point to #153.
- **`PHASE4_STREAM_D_PROMPT.md`** — fix 4 hallucinated APIs in handler code:
  - `bot.services.feature_flag.is_enabled` → `bot.db.repos.feature_flag.FeatureFlagRepo.get`
  - `UserRepo.get_by_id` → `UserRepo.get`
  - `detect_policy(...)` returns tuple, not str — unpack `policy, _payload = ...`
  - Switch query parsing from `removeprefix("/recall")` to aiogram's `CommandObject.args` (avoids `/recallstuff` mismatch)
  - Switch `parse_mode="Markdown"` to `"HTML"` (matches `ts_headline`'s native `<b>` output, avoids escaping every `_*[]` in user content)
- **`PHASE4_STREAM_E_PROMPT.md`** — fix migration ordering + cascade test:
  - `down_revision = "020"` literal (matches PR #151's shipped revision id, not `"020_add_message_version_fts_index"`)
  - Rewrite cascade xfail test to drive `run_cascade_worker_once` via a `forget_events` row insert (the real event-driven API), instead of the hallucinated `process_forget_for_user(...)` direct function

## Issue actions

- **#145 (T4-01)** — closed as completed; deviation list documented in comment.
- **#146 (T4-02)** — closed as completed; deviation list documented in comment.
- **#153 (T4-02 hardening)** — opened, covers SearchHit field expansion (6→9), `current_version_id` JOIN, three-key tombstone, missing tests, ORM column.
- **#147, #148, #149, #150** — remain open; their stream prompts are now corrected.

## Test plan

- [x] All hallucinated refs verified absent (Grep evidence in audit).
- [x] All replacement APIs verified to exist via Grep.
- [x] PHASE4_PLAN.md cross-references resolve to real issue numbers.
- [ ] CI green on this docs-only PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
