### PR TITLE
fix(p4-fts): close FTS review findings

### DIFF
--- a/alembic/versions/021_align_message_versions_search_tsv.py
+++ b/alembic/versions/021_align_message_versions_search_tsv.py
@@ -1,0 +1,74 @@
+"""align_message_versions_search_tsv
+
+T4-01 follow-up: align the FTS schema with the Phase 4 plan after PR #151.
+
+Migration 020 shipped a generated ``tsv`` column over ``text + caption`` with a
+partial index. The ratified Phase 4 plan uses ``search_tsv`` over
+``normalized_text + caption`` and keeps governance as a runtime query filter.
+
+Revision ID: 021
+Revises: 020
+Create Date: 2026-04-30
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "021"
+down_revision: Union[str, Sequence[str], None] = "020"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.drop_index("idx_message_versions_tsv", table_name="message_versions")
+    op.drop_column("message_versions", "tsv")
+
+    op.add_column(
+        "message_versions",
+        sa.Column(
+            "search_tsv",
+            postgresql.TSVECTOR(),
+            sa.Computed(
+                "to_tsvector('russian', coalesce(normalized_text,'') || ' ' || coalesce(caption,''))",
+                persisted=True,
+            ),
+            nullable=True,
+        ),
+    )
+    op.create_index(
+        "ix_message_versions_search_tsv",
+        "message_versions",
+        ["search_tsv"],
+        postgresql_using="gin",
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_message_versions_search_tsv", table_name="message_versions")
+    op.drop_column("message_versions", "search_tsv")
+
+    op.add_column(
+        "message_versions",
+        sa.Column(
+            "tsv",
+            postgresql.TSVECTOR(),
+            sa.Computed(
+                "to_tsvector('russian', coalesce(text,'') || ' ' || coalesce(caption,''))",
+                persisted=True,
+            ),
+            nullable=True,
+        ),
+    )
+    op.create_index(
+        "idx_message_versions_tsv",
+        "message_versions",
+        ["tsv"],
+        postgresql_using="gin",
+        postgresql_where=sa.text("is_redacted = FALSE"),
+    )

--- a/bot/db/models.py
+++ b/bot/db/models.py
@@ -6,6 +6,7 @@ from sqlalchemy import (
     BigInteger,
     Boolean,
     CheckConstraint,
+    Computed,
     DateTime,
     ForeignKey,
     Index,
@@ -18,8 +19,34 @@ from sqlalchemy import (
     func,
     text,
 )
-from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.dialects.postgresql import JSONB, TSVECTOR
+from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
+from sqlalchemy.sql.expression import ColumnElement
+
+
+class MessageVersionSearchVectorExpression(ColumnElement[str]):
+    """Dialect-aware generated-column expression for ``message_versions.search_tsv``."""
+
+    inherit_cache = True
+
+
+@compiles(MessageVersionSearchVectorExpression, "postgresql")
+def _compile_search_vector_postgresql(
+    element: MessageVersionSearchVectorExpression,
+    compiler,
+    **kwargs,
+) -> str:
+    return "to_tsvector('russian', coalesce(normalized_text,'') || ' ' || coalesce(caption,''))"
+
+
+@compiles(MessageVersionSearchVectorExpression)
+def _compile_search_vector_default(
+    element: MessageVersionSearchVectorExpression,
+    compiler,
+    **kwargs,
+) -> str:
+    return "coalesce(normalized_text,'') || ' ' || coalesce(caption,'')"
 
 
 class Base(DeclarativeBase):
@@ -246,6 +273,11 @@ class MessageVersion(Base):
         Index("ix_message_versions_content_hash", "content_hash"),
         Index("ix_message_versions_captured_at", "captured_at"),
         Index("ix_message_versions_chat_message_id", "chat_message_id"),
+        Index(
+            "ix_message_versions_search_tsv",
+            "search_tsv",
+            postgresql_using="gin",
+        ),
     )
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
@@ -287,6 +319,11 @@ class MessageVersion(Base):
     # FALSE for live ingestion. See docs/memory-system/import-edit-history.md.
     imported_final: Mapped[bool] = mapped_column(
         Boolean, nullable=False, default=False, server_default="false"
+    )
+    search_tsv: Mapped[str | None] = mapped_column(
+        TSVECTOR().with_variant(Text(), "sqlite"),
+        Computed(MessageVersionSearchVectorExpression(), persisted=True),
+        nullable=True,
     )
 
 

--- a/bot/services/search.py
+++ b/bot/services/search.py
@@ -2,21 +2,29 @@
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from datetime import datetime
 
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
+logger = logging.getLogger(__name__)
+
+MAX_QUERY_LENGTH = 256
+
 
 @dataclass(frozen=True)
 class SearchHit:
     message_version_id: int
+    chat_message_id: int
     chat_id: int
     message_id: int
+    user_id: int | None
     snippet: str
     ts_rank: float
     captured_at: datetime
+    message_date: datetime
 
 
 async def search_messages(
@@ -24,19 +32,32 @@ async def search_messages(
     query: str,
     *,
     chat_id: int,
-    limit: int = 10,
+    limit: int = 3,
+    headline_max_words: int = 35,
 ) -> list[SearchHit]:
     """Search visible message versions in one chat.
 
-    The governance filter is intentionally repeated here even though migration 020
-    also creates a partial GIN index for redacted versions. Search consumers must
-    not depend on index shape for privacy.
+    The governance filter is intentionally repeated here instead of depending on
+    index shape for privacy.
     """
     normalized_query = query.strip()
     if not normalized_query:
         return []
     if limit < 1:
         raise ValueError("limit must be >= 1")
+    if headline_max_words < 1:
+        raise ValueError("headline_max_words must be >= 1")
+    if len(normalized_query) > MAX_QUERY_LENGTH:
+        logger.info(
+            "search_messages: truncating overlong query",
+            extra={"query_length": len(normalized_query), "max_length": MAX_QUERY_LENGTH},
+        )
+        normalized_query = normalized_query[:MAX_QUERY_LENGTH].strip()
+        if not normalized_query:
+            return []
+    headline_options = (
+        f"MaxWords={headline_max_words},MinWords=10,ShortWord=2,HighlightAll=false"
+    )
 
     stmt = text(
         """
@@ -45,33 +66,48 @@ async def search_messages(
         )
         SELECT
             mv.id AS message_version_id,
+            mv.chat_message_id AS chat_message_id,
             c.chat_id AS chat_id,
             c.message_id AS message_id,
+            c.user_id AS user_id,
             COALESCE(
                 ts_headline(
                     'russian',
-                    concat_ws(' ', mv.text, mv.caption),
+                    concat_ws(' ', mv.normalized_text, mv.caption),
                     q.tsq,
-                    'MaxWords=20, MinWords=5'
+                    :headline_options
                 ),
                 ''
             ) AS snippet,
-            ts_rank(mv.tsv, q.tsq) AS rank,
-            mv.captured_at AS captured_at
+            ts_rank_cd(mv.search_tsv, q.tsq) AS rank,
+            mv.captured_at AS captured_at,
+            c.date AS message_date
         FROM message_versions AS mv
-        JOIN chat_messages AS c ON mv.chat_message_id = c.id
+        JOIN chat_messages AS c
+            ON c.id = mv.chat_message_id
+            AND c.current_version_id = mv.id
         CROSS JOIN q
-        LEFT JOIN forget_events AS fe
-            ON fe.target_type = 'message'
-            AND fe.target_id ~ '^[0-9]+$'
-            AND fe.target_id::int = c.id
-            AND fe.status IN ('pending', 'processing', 'completed')
         WHERE c.chat_id = :chat_id
             AND c.memory_policy = 'normal'
             AND c.is_redacted = FALSE
             AND mv.is_redacted = FALSE
-            AND fe.id IS NULL
-            AND mv.tsv @@ q.tsq
+            AND mv.search_tsv @@ q.tsq
+            AND NOT EXISTS (
+                SELECT 1
+                FROM forget_events AS fe
+                WHERE (
+                    fe.tombstone_key = 'message:' || c.chat_id::text || ':' || c.message_id::text
+                    OR (
+                        c.content_hash IS NOT NULL
+                        AND fe.tombstone_key = 'message_hash:' || c.content_hash
+                    )
+                    OR (
+                        c.user_id IS NOT NULL
+                        AND fe.tombstone_key = 'user:' || c.user_id::text
+                    )
+                )
+                AND fe.status IN ('pending', 'processing', 'completed')
+            )
         ORDER BY rank DESC, mv.captured_at DESC, mv.id DESC
         LIMIT :limit
         """
@@ -82,17 +118,21 @@ async def search_messages(
             "query": normalized_query,
             "chat_id": chat_id,
             "limit": limit,
+            "headline_options": headline_options,
         },
     )
 
     return [
         SearchHit(
             message_version_id=row["message_version_id"],
+            chat_message_id=row["chat_message_id"],
             chat_id=row["chat_id"],
             message_id=row["message_id"],
+            user_id=row["user_id"],
             snippet=row["snippet"],
             ts_rank=float(row["rank"]),
             captured_at=row["captured_at"],
+            message_date=row["message_date"],
         )
         for row in result.mappings().all()
     ]

--- a/tests/db/test_fts_schema.py
+++ b/tests/db/test_fts_schema.py
@@ -1,4 +1,4 @@
-"""Migration 020 acceptance tests.
+"""Phase 4 FTS schema acceptance tests.
 
 These tests create an isolated temporary database, run Alembic against it, and
 drop the database afterwards. They do not mutate the shared pytest database.
@@ -75,7 +75,7 @@ async def _drop_database(admin_url: URL, database_name: str) -> None:
 @pytest_asyncio.fixture()
 async def temp_database_url() -> AsyncIterator[str]:
     base_url = _base_test_url()
-    database_name = f"shkoder_migration_020_{uuid.uuid4().hex[:12]}"
+    database_name = f"shkoder_fts_schema_{uuid.uuid4().hex[:12]}"
     try:
         await _create_database(base_url, database_name)
     except Exception as exc:  # pragma: no cover - environment guard
@@ -117,22 +117,37 @@ async def _fetch_value(database_url: str, query: str, *args: object) -> object:
         await conn.close()
 
 
-async def _insert_message_version(database_url: str) -> int:
+async def _insert_message_version(
+    database_url: str,
+    *,
+    text_value: str | None,
+    caption_value: str | None,
+    normalized_text: str | None,
+    content_hash: str,
+) -> int:
     conn = await asyncpg.connect(**_asyncpg_kwargs(make_url(database_url)))
     try:
         async with conn.transaction():
             await conn.execute(
                 """
                 INSERT INTO users (id, username, first_name)
-                VALUES (910000000001, 'migration020', 'Migration')
+                VALUES (910000000001, 'fts_schema', 'FTS')
+                ON CONFLICT (id) DO NOTHING
                 """
             )
             chat_message_id = await conn.fetchval(
                 """
                 INSERT INTO chat_messages (message_id, chat_id, user_id, text, date)
-                VALUES (42001, -10042001, 910000000001, 'кошка сидит', now())
+                VALUES (
+                    (SELECT 42001 + count(*) FROM chat_messages),
+                    -10042001,
+                    910000000001,
+                    $1,
+                    now()
+                )
                 RETURNING id
-                """
+                """,
+                text_value,
             )
             return await conn.fetchval(
                 """
@@ -144,10 +159,14 @@ async def _insert_message_version(database_url: str) -> int:
                     normalized_text,
                     content_hash
                 )
-                VALUES ($1, 1, 'кошка сидит', 'рыжая кошка', 'кошка сидит', 'mig020-hash')
+                VALUES ($1, 1, $2, $3, $4, $5)
                 RETURNING id
                 """,
                 chat_message_id,
+                text_value,
+                caption_value,
+                normalized_text,
+                content_hash,
             )
     finally:
         await conn.close()
@@ -162,18 +181,27 @@ async def migrated_database_url(temp_database_url: str) -> AsyncIterator[str]:
 async def test_alembic_upgrade_head_on_clean_db_green(migrated_database_url: str) -> None:
     current = await _fetch_value(migrated_database_url, "SELECT version_num FROM alembic_version")
 
-    assert current == "020"
+    assert current == "021"
 
 
-async def test_insert_message_versions_generates_tsv(migrated_database_url: str) -> None:
-    version_id = await _insert_message_version(migrated_database_url)
+async def test_insert_message_versions_generates_search_tsv_from_normalized_text(
+    migrated_database_url: str,
+) -> None:
+    version_id = await _insert_message_version(
+        migrated_database_url,
+        text_value="ORIGINAL TEXT SHOULD NOT DRIVE SEARCH",
+        caption_value=None,
+        normalized_text="тестовое сообщение",
+        content_hash="fts-schema-normalized",
+    )
 
     row = await _fetch_one(
         migrated_database_url,
         """
         SELECT
-            tsv::text AS tsv_text,
-            tsv @@ plainto_tsquery('russian', 'кошка') AS matches_query
+            search_tsv::text AS search_tsv_text,
+            search_tsv @@ plainto_tsquery('russian', 'сообщение') AS matches_query,
+            search_tsv @@ plainto_tsquery('russian', 'original') AS text_matches
         FROM message_versions
         WHERE id = $1
         """,
@@ -181,8 +209,62 @@ async def test_insert_message_versions_generates_tsv(migrated_database_url: str)
     )
 
     assert row is not None
-    assert row["tsv_text"]
+    assert row["search_tsv_text"]
     assert row["matches_query"] is True
+    assert row["text_matches"] is False
+
+
+async def test_insert_message_versions_generates_search_tsv_from_caption(
+    migrated_database_url: str,
+) -> None:
+    version_id = await _insert_message_version(
+        migrated_database_url,
+        text_value=None,
+        caption_value="русская подпись",
+        normalized_text=None,
+        content_hash="fts-schema-caption",
+    )
+
+    row = await _fetch_one(
+        migrated_database_url,
+        """
+        SELECT search_tsv @@ plainto_tsquery('russian', 'подпись') AS matches_query
+        FROM message_versions
+        WHERE id = $1
+        """,
+        version_id,
+    )
+
+    assert row is not None
+    assert row["matches_query"] is True
+
+
+async def test_insert_message_versions_null_content_generates_empty_search_tsv(
+    migrated_database_url: str,
+) -> None:
+    version_id = await _insert_message_version(
+        migrated_database_url,
+        text_value=None,
+        caption_value=None,
+        normalized_text=None,
+        content_hash="fts-schema-empty",
+    )
+
+    row = await _fetch_one(
+        migrated_database_url,
+        """
+        SELECT
+            search_tsv::text AS search_tsv_text,
+            search_tsv @@ plainto_tsquery('russian', 'anything') AS matches_query
+        FROM message_versions
+        WHERE id = $1
+        """,
+        version_id,
+    )
+
+    assert row is not None
+    assert row["search_tsv_text"] == ""
+    assert row["matches_query"] is False
 
 
 async def test_pg_indexes_contains_named_gin_index(migrated_database_url: str) -> None:
@@ -191,20 +273,30 @@ async def test_pg_indexes_contains_named_gin_index(migrated_database_url: str) -
         """
         SELECT indexdef
         FROM pg_indexes
-        WHERE schemaname = 'public'
-            AND tablename = 'message_versions'
-            AND indexname = 'idx_message_versions_tsv'
-        """,
+            WHERE schemaname = 'public'
+                AND tablename = 'message_versions'
+                AND indexname = 'ix_message_versions_search_tsv'
+            """,
     )
 
     assert indexdef is not None
     lowered = str(indexdef).lower()
     assert "using gin" in lowered
-    assert "(tsv)" in lowered
-    assert "where (is_redacted = false)" in lowered
+    assert "(search_tsv)" in lowered
+    assert "where" not in lowered
 
 
-async def test_alembic_downgrade_minus_one_drops_tsv(temp_database_url: str) -> None:
+def test_message_version_metadata_includes_search_tsv(app_env) -> None:
+    from tests.conftest import import_module
+
+    models = import_module("bot.db.models")
+    table = models.Base.metadata.tables["message_versions"]
+
+    assert "search_tsv" in table.columns
+    assert "ix_message_versions_search_tsv" in {ix.name for ix in table.indexes}
+
+
+async def test_alembic_downgrade_minus_one_drops_search_tsv(temp_database_url: str) -> None:
     _run_alembic(temp_database_url, "upgrade", "head")
     _run_alembic(temp_database_url, "downgrade", "-1")
 
@@ -214,11 +306,11 @@ async def test_alembic_downgrade_minus_one_drops_tsv(temp_database_url: str) -> 
         SELECT EXISTS (
             SELECT 1
             FROM information_schema.columns
-            WHERE table_schema = 'public'
-                AND table_name = 'message_versions'
-                AND column_name = 'tsv'
-        )
-        """,
+                WHERE table_schema = 'public'
+                    AND table_name = 'message_versions'
+                    AND column_name = 'search_tsv'
+            )
+            """,
     )
     index_exists = await _fetch_value(
         temp_database_url,
@@ -226,14 +318,14 @@ async def test_alembic_downgrade_minus_one_drops_tsv(temp_database_url: str) -> 
         SELECT EXISTS (
             SELECT 1
             FROM pg_indexes
-            WHERE schemaname = 'public'
-                AND tablename = 'message_versions'
-                AND indexname = 'idx_message_versions_tsv'
-        )
-        """,
+                WHERE schemaname = 'public'
+                    AND tablename = 'message_versions'
+                    AND indexname = 'ix_message_versions_search_tsv'
+            )
+            """,
     )
     current = await _fetch_value(temp_database_url, "SELECT version_num FROM alembic_version")
 
     assert column_exists is False
     assert index_exists is False
-    assert current == "019"
+    assert current == "020"

--- a/tests/db/test_message_version_repo.py
+++ b/tests/db/test_message_version_repo.py
@@ -280,6 +280,7 @@ def test_message_version_metadata_smoke(app_env) -> None:
         "raw_update_id",
         "is_redacted",
         "imported_final",
+        "search_tsv",
     } == cols
 
     constraint_names = {c.name for c in table.constraints if c.name}

--- a/tests/services/test_search.py
+++ b/tests/services/test_search.py
@@ -1,12 +1,13 @@
 """Phase 4 FTS search service tests.
 
 DB-backed tests use the shared ``db_session`` fixture. The CI job runs
-``alembic upgrade head`` before pytest, so migration 020's generated ``tsv`` column
+``alembic upgrade head`` before pytest, so the generated ``search_tsv`` column
 is present for these tests.
 """
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 import itertools
 from datetime import datetime, timezone
 
@@ -19,6 +20,16 @@ _message_counter = itertools.count(start=1_040_000)
 _hash_counter = itertools.count(start=1)
 
 
+@dataclass(frozen=True)
+class CreatedMessage:
+    chat_message_id: int
+    version_id: int
+    message_id: int
+    chat_id: int
+    user_id: int
+    content_hash: str
+
+
 async def _create_versioned_message(
     db_session,
     *,
@@ -29,13 +40,14 @@ async def _create_versioned_message(
     memory_policy: str = "normal",
     chat_is_redacted: bool = False,
     version_is_redacted: bool = False,
-) -> tuple[int, int, int]:
-    """Create user + chat_messages + message_versions. Return (chat_pk, version_pk, msg_id)."""
+) -> CreatedMessage:
+    """Create user + current message version."""
     from bot.db.models import ChatMessage, MessageVersion
     from bot.db.repos.user import UserRepo
 
     user_id = next(_user_counter)
     tg_message_id = message_id if message_id is not None else next(_message_counter)
+    content_hash = f"search-hash-{next(_hash_counter)}"
 
     await UserRepo.upsert(
         db_session,
@@ -54,6 +66,7 @@ async def _create_versioned_message(
         date=datetime.now(timezone.utc),
         memory_policy=memory_policy,
         is_redacted=chat_is_redacted,
+        content_hash=content_hash,
     )
     db_session.add(chat_message)
     await db_session.flush()
@@ -64,25 +77,42 @@ async def _create_versioned_message(
         text=text,
         caption=caption,
         normalized_text=text,
-        content_hash=f"search-hash-{next(_hash_counter)}",
+        content_hash=content_hash,
         is_redacted=version_is_redacted,
     )
     db_session.add(version)
     await db_session.flush()
 
-    return chat_message.id, version.id, tg_message_id
+    chat_message.current_version_id = version.id
+    await db_session.flush()
+
+    return CreatedMessage(
+        chat_message_id=chat_message.id,
+        version_id=version.id,
+        message_id=tg_message_id,
+        chat_id=chat_id,
+        user_id=user_id,
+        content_hash=content_hash,
+    )
 
 
-async def _create_forget_event(db_session, *, chat_message_id: int, status: str) -> None:
+async def _create_forget_event(
+    db_session,
+    *,
+    tombstone_key: str,
+    target_type: str = "message",
+    target_id: str | None = None,
+    status: str,
+) -> None:
     from bot.db.repos.forget_event import ForgetEventRepo
 
     event = await ForgetEventRepo.create(
         db_session,
-        target_type="message",
-        target_id=str(chat_message_id),
+        target_type=target_type,
+        target_id=target_id,
         actor_user_id=None,
         authorized_by="system",
-        tombstone_key=f"message:-100400:{chat_message_id}:{status}",
+        tombstone_key=tombstone_key,
     )
     if status == "pending":
         return
@@ -96,7 +126,7 @@ async def test_search_normal_message_found(db_session) -> None:
     from bot.services.search import search_messages
 
     chat_id = -100_401
-    _, version_id, message_id = await _create_versioned_message(
+    created = await _create_versioned_message(
         db_session,
         chat_id=chat_id,
         text="питон помогает искать память",
@@ -105,11 +135,14 @@ async def test_search_normal_message_found(db_session) -> None:
     hits = await search_messages(db_session, "питон", chat_id=chat_id)
 
     assert len(hits) == 1
-    assert hits[0].message_version_id == version_id
+    assert hits[0].message_version_id == created.version_id
+    assert hits[0].chat_message_id == created.chat_message_id
     assert hits[0].chat_id == chat_id
-    assert hits[0].message_id == message_id
+    assert hits[0].message_id == created.message_id
+    assert hits[0].user_id == created.user_id
     assert hits[0].ts_rank > 0
     assert hits[0].captured_at is not None
+    assert hits[0].message_date is not None
 
 
 async def test_search_offrecord_excluded(db_session) -> None:
@@ -186,12 +219,17 @@ async def test_search_active_forget_event_pending_excluded(db_session) -> None:
     from bot.services.search import search_messages
 
     chat_id = -100_407
-    chat_message_id, _, _ = await _create_versioned_message(
+    created = await _create_versioned_message(
         db_session,
         chat_id=chat_id,
         text="pending питон",
     )
-    await _create_forget_event(db_session, chat_message_id=chat_message_id, status="pending")
+    await _create_forget_event(
+        db_session,
+        tombstone_key=f"message:{created.chat_id}:{created.message_id}",
+        target_id=str(created.chat_message_id),
+        status="pending",
+    )
 
     assert await search_messages(db_session, "питон", chat_id=chat_id) == []
 
@@ -200,14 +238,86 @@ async def test_search_active_forget_event_completed_excluded(db_session) -> None
     from bot.services.search import search_messages
 
     chat_id = -100_408
-    chat_message_id, _, _ = await _create_versioned_message(
+    created = await _create_versioned_message(
         db_session,
         chat_id=chat_id,
         text="completed питон",
     )
-    await _create_forget_event(db_session, chat_message_id=chat_message_id, status="completed")
+    await _create_forget_event(
+        db_session,
+        tombstone_key=f"message:{created.chat_id}:{created.message_id}",
+        target_id=str(created.chat_message_id),
+        status="completed",
+    )
 
     assert await search_messages(db_session, "питон", chat_id=chat_id) == []
+
+
+async def test_search_active_user_forget_event_pending_excluded(db_session) -> None:
+    from bot.services.search import search_messages
+
+    chat_id = -100_416
+    created = await _create_versioned_message(
+        db_session,
+        chat_id=chat_id,
+        text="user tombstone питон",
+    )
+    await _create_forget_event(
+        db_session,
+        tombstone_key=f"user:{created.user_id}",
+        target_type="user",
+        target_id=str(created.user_id),
+        status="pending",
+    )
+
+    assert await search_messages(db_session, "питон", chat_id=chat_id) == []
+
+
+async def test_search_active_message_hash_forget_event_excluded(db_session) -> None:
+    from bot.services.search import search_messages
+
+    chat_id = -100_417
+    created = await _create_versioned_message(
+        db_session,
+        chat_id=chat_id,
+        text="hash tombstone питон",
+    )
+    await _create_forget_event(
+        db_session,
+        tombstone_key=f"message_hash:{created.content_hash}",
+        target_type="message_hash",
+        status="pending",
+    )
+
+    assert await search_messages(db_session, "питон", chat_id=chat_id) == []
+
+
+async def test_search_empty_message_hash_tombstone_does_not_match_null_hash(
+    db_session,
+) -> None:
+    from bot.db.models import ChatMessage
+    from bot.services.search import search_messages
+
+    chat_id = -100_421
+    created = await _create_versioned_message(
+        db_session,
+        chat_id=chat_id,
+        text="null hash питон",
+    )
+    chat_message = await db_session.get(ChatMessage, created.chat_message_id)
+    assert chat_message is not None
+    chat_message.content_hash = None
+    await _create_forget_event(
+        db_session,
+        tombstone_key="message_hash:",
+        target_type="message_hash",
+        status="pending",
+    )
+    await db_session.flush()
+
+    hits = await search_messages(db_session, "питон", chat_id=chat_id)
+
+    assert [hit.message_version_id for hit in hits] == [created.version_id]
 
 
 async def test_search_chat_isolation(db_session) -> None:
@@ -220,6 +330,30 @@ async def test_search_chat_isolation(db_session) -> None:
     assert await search_messages(db_session, "питон", chat_id=chat_b) == []
 
 
+async def test_search_only_current_version(db_session) -> None:
+    from bot.db.models import MessageVersion
+    from bot.services.search import search_messages
+
+    chat_id = -100_418
+    created = await _create_versioned_message(
+        db_session,
+        chat_id=chat_id,
+        text="текущая память",
+    )
+    db_session.add(
+        MessageVersion(
+            chat_message_id=created.chat_message_id,
+            version_seq=2,
+            text="старая некуррентная версия",
+            normalized_text="старая некуррентная версия",
+            content_hash=f"old-version-{created.content_hash}",
+        )
+    )
+    await db_session.flush()
+
+    assert await search_messages(db_session, "некуррентная", chat_id=chat_id) == []
+
+
 async def test_search_ts_rank_ordering(db_session) -> None:
     from bot.services.search import search_messages
 
@@ -230,7 +364,7 @@ async def test_search_ts_rank_ordering(db_session) -> None:
         message_id=1_041_101,
         text="питон память",
     )
-    _, _, high_rank_message_id = await _create_versioned_message(
+    high_rank = await _create_versioned_message(
         db_session,
         chat_id=chat_id,
         message_id=1_041_102,
@@ -239,8 +373,23 @@ async def test_search_ts_rank_ordering(db_session) -> None:
 
     hits = await search_messages(db_session, "питон", chat_id=chat_id)
 
-    assert [hit.message_id for hit in hits][:2] == [high_rank_message_id, 1_041_101]
+    assert [hit.message_id for hit in hits][:2] == [high_rank.message_id, 1_041_101]
     assert hits[0].ts_rank > hits[1].ts_rank
+
+
+async def test_search_russian_stemmer_matches_inflection(db_session) -> None:
+    from bot.services.search import search_messages
+
+    chat_id = -100_419
+    await _create_versioned_message(
+        db_session,
+        chat_id=chat_id,
+        text="лошадь скачет быстро",
+    )
+
+    hits = await search_messages(db_session, "лошади", chat_id=chat_id)
+
+    assert len(hits) == 1
 
 
 async def test_search_snippet_contains_query_terms(db_session) -> None:
@@ -294,3 +443,24 @@ async def test_search_empty_query_returns_empty(db_session) -> None:
     await _create_versioned_message(db_session, chat_id=chat_id, text="питон")
 
     assert await search_messages(db_session, "   ", chat_id=chat_id) == []
+
+
+async def test_search_query_injection_attempt_is_safe(db_session) -> None:
+    from sqlalchemy import text
+
+    from bot.services.search import search_messages
+
+    chat_id = -100_420
+    await _create_versioned_message(db_session, chat_id=chat_id, text="питон")
+
+    hits = await search_messages(
+        db_session,
+        "питон'; DROP TABLE chat_messages; --",
+        chat_id=chat_id,
+    )
+    table_exists = await db_session.execute(
+        text("SELECT to_regclass('public.chat_messages') IS NOT NULL")
+    )
+
+    assert isinstance(hits, list)
+    assert table_exists.scalar_one() is True


### PR DESCRIPTION
## Summary
- add Alembic 021 follow-up: replace shipped `tsv` with Phase 4 `search_tsv` over `normalized_text + caption`
- sync `MessageVersion` SQLAlchemy metadata with the generated FTS column and GIN index
- expand `SearchHit` to the Stream C/D evidence contract fields
- harden `search_messages()` governance with current-version filtering and active `message:` / `message_hash:` / `user:` tombstone exclusion
- add regression coverage for user/hash tombstones, current-version filtering, Russian stemming, SQL injection safety, and schema metadata

## Review findings addressed
- P1: active user/hash tombstones can no longer leak into search before cascade completes
- P2: `SearchHit` now includes `chat_message_id`, `user_id`, and `message_date`
- P2: `Base.metadata.create_all` now declares `message_versions.search_tsv`

## Test evidence
```text
pytest tests/services/test_search.py tests/db/test_fts_schema.py tests/db/test_message_version_repo.py -x --timeout=120
40 passed in 14.57s

ruff check .
All checks passed!

mypy bot/services/search.py
Success: no issues found in 1 source file
```

Closes #145
Closes #146