### PR TITLE
feat(p4-D): /recall handler + memory.qa.enabled flag + eval cases (T4-04, T4-06)

### DIFF
--- a/bot/__main__.py
+++ b/bot/__main__.py
@@ -17,6 +17,7 @@ from bot.handlers import (
     forget_reply,
     forward_lookup,
     questionnaire,
+    qa,
     start,
     vouch,
 )
@@ -111,6 +112,7 @@ async def main() -> None:
         edited_message.router,  # T1-14: edited_message handler (before chat_messages catch-all)
         forget_me.router,  # T3-03: /forget_me command (DM or in-chat)
         forget_reply.router,   # T3-02: /forget command handler (before chat_messages catch-all)
+        qa.router,  # T4-04: /recall q&a handler, runtime-gated by memory.qa.enabled
         forward_lookup.router,
         chat_messages.router,  # lowest priority — catches all group messages
     )

--- a/bot/handlers/qa.py
+++ b/bot/handlers/qa.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+import html
+from datetime import datetime
+
+from aiogram import Router
+from aiogram.filters import Command, CommandObject
+from aiogram.types import Message
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from bot.config import settings
+from bot.db.repos.feature_flag import FeatureFlagRepo
+from bot.db.repos.qa_trace import QaTraceRepo
+from bot.db.repos.user import UserRepo
+from bot.services.evidence import EvidenceBundle
+from bot.services.governance import detect_policy
+from bot.services.qa import run_qa
+
+router = Router(name="qa")
+
+QA_FEATURE_FLAG = "memory.qa.enabled"
+
+
+def _short_chat_id(chat_id: int) -> str:
+    chat_id_str = str(chat_id)
+    return chat_id_str.removeprefix("-100") if chat_id_str.startswith("-100") else chat_id_str
+
+
+def _format_date(value: datetime) -> str:
+    return value.astimezone().strftime("%Y-%m-%d %H:%M")
+
+
+def _safe_headline(snippet: str) -> str:
+    escaped = html.escape(snippet, quote=False)
+    return escaped.replace("&lt;b&gt;", "<b>").replace("&lt;/b&gt;", "</b>")
+
+
+def _author_name(user: object | None) -> str:
+    if user is None:
+        return "—"
+
+    first_name = getattr(user, "first_name", None)
+    last_name = getattr(user, "last_name", None)
+    username = getattr(user, "username", None)
+
+    if first_name:
+        name = str(first_name)
+        if last_name:
+            name = f"{name} {last_name}"
+        return html.escape(name)
+    if username:
+        return html.escape(f"@{username}")
+    return "—"
+
+
+def _format_response(bundle: EvidenceBundle, users_by_id: dict[int, object]) -> str:
+    if bundle.abstained:
+        return "Не нашёл подходящих свидетельств в истории чата."
+
+    parts = ["<b>Найденные свидетельства:</b>"]
+    short_chat_id = _short_chat_id(bundle.chat_id)
+    for item in bundle.items:
+        author_name = _author_name(users_by_id.get(item.user_id) if item.user_id else None)
+        date_text = _format_date(item.message_date)
+        snippet = _safe_headline(item.snippet)
+        link = f"https://t.me/c/{short_chat_id}/{item.message_id}"
+        parts.append(
+            f"<blockquote>{snippet}</blockquote>\n"
+            f"<i>— {author_name}, {date_text}</i> · "
+            f"<a href=\"{html.escape(link, quote=True)}\">сообщение</a> · "
+            f"<code>message_version_id:{item.message_version_id}</code>"
+        )
+    return "\n\n".join(parts)
+
+
+async def _write_trace(
+    session: AsyncSession,
+    *,
+    user_tg_id: int,
+    chat_id: int,
+    query: str,
+    evidence_ids: list[int],
+    abstained: bool,
+    redact_query: bool,
+) -> None:
+    await QaTraceRepo.create(
+        session,
+        user_tg_id=user_tg_id,
+        chat_id=chat_id,
+        query=query,
+        evidence_ids=evidence_ids,
+        abstained=abstained,
+        redact_query=redact_query,
+    )
+
+
+@router.message(Command("recall"))
+async def recall_handler(
+    message: Message,
+    command: CommandObject,
+    session: AsyncSession,
+) -> None:
+    if not await FeatureFlagRepo.get(session, QA_FEATURE_FLAG):
+        return
+
+    if message.from_user is None:
+        return
+
+    query = (command.args or "").strip()
+    policy, _payload = detect_policy(text=query, caption=None)
+    redact_query = policy != "normal"
+
+    async def audit_empty(abstained: bool = True) -> None:
+        await _write_trace(
+            session,
+            user_tg_id=message.from_user.id,
+            chat_id=message.chat.id,
+            query=query,
+            evidence_ids=[],
+            abstained=abstained,
+            redact_query=redact_query,
+        )
+
+    if message.chat.id != settings.COMMUNITY_CHAT_ID:
+        if message.chat.type == "private":
+            await message.reply("Команда /recall работает только в community чате.")
+        await audit_empty()
+        return
+
+    user = await UserRepo.get(session, message.from_user.id)
+    if user is None or not (user.is_member or user.is_admin):
+        await message.reply("Доступ только участникам сообщества.")
+        await audit_empty()
+        return
+
+    if not query:
+        await message.reply(
+            "Использование: <code>/recall &lt;вопрос&gt;</code>",
+            parse_mode="HTML",
+        )
+        await audit_empty()
+        return
+
+    result = await run_qa(
+        session,
+        query=query,
+        chat_id=message.chat.id,
+        redact_query_in_audit=redact_query,
+    )
+
+    users_by_id: dict[int, object] = {}
+    for item in result.bundle.items:
+        if item.user_id is None or item.user_id in users_by_id:
+            continue
+        author = await UserRepo.get(session, item.user_id)
+        if author is not None:
+            users_by_id[item.user_id] = author
+
+    await message.reply(
+        _format_response(result.bundle, users_by_id),
+        parse_mode="HTML",
+        disable_web_page_preview=True,
+    )
+    await _write_trace(
+        session,
+        user_tg_id=message.from_user.id,
+        chat_id=message.chat.id,
+        query=query,
+        evidence_ids=result.bundle.evidence_ids,
+        abstained=result.bundle.abstained,
+        redact_query=result.query_redacted,
+    )

--- a/bot/services/qa.py
+++ b/bot/services/qa.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from bot.services.evidence import EvidenceBundle
+from bot.services.search import search_messages
+
+
+@dataclass(frozen=True)
+class QaResult:
+    bundle: EvidenceBundle
+    query_redacted: bool
+
+
+async def run_qa(
+    session: AsyncSession,
+    *,
+    query: str,
+    chat_id: int,
+    redact_query_in_audit: bool,
+    limit: int = 3,
+) -> QaResult:
+    hits = await search_messages(session, query, chat_id=chat_id, limit=limit)
+    bundle = EvidenceBundle.from_hits(query, chat_id, hits)
+    return QaResult(bundle=bundle, query_redacted=redact_query_in_audit)

--- a/tests/eval/test_qa_eval_cases.py
+++ b/tests/eval/test_qa_eval_cases.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.usefixtures("app_env")
+
+EVAL_FIXTURE = Path(__file__).resolve().parents[1] / "fixtures" / "qa_eval_cases.json"
+
+
+def _parse_dt(value: str | None) -> datetime:
+    if value is None:
+        return datetime.fromisoformat("2026-04-30T12:00:00+00:00")
+    return datetime.fromisoformat(value)
+
+
+async def _create_message(db_session, case_id: str, message: dict) -> None:
+    from bot.db.models import ChatMessage, MessageVersion
+    from bot.db.repos.user import UserRepo
+
+    user_id = int(message["user_id"])
+    await UserRepo.upsert(
+        db_session,
+        telegram_id=user_id,
+        username=f"qa_eval_{user_id}",
+        first_name=f"Eval {user_id}",
+        last_name=None,
+    )
+
+    captured_at = _parse_dt(message.get("captured_at"))
+    text = message.get("text", message.get("normalized_text"))
+    caption = message.get("caption")
+    content_hash = message.get("content_hash") or f"{case_id}-{message['message_id']}"
+    is_redacted = bool(message.get("is_redacted", False))
+
+    chat_message = ChatMessage(
+        message_id=int(message["message_id"]),
+        chat_id=int(message["chat_id"]),
+        user_id=user_id,
+        text=text,
+        caption=caption,
+        date=captured_at,
+        memory_policy=message.get("memory_policy", "normal"),
+        is_redacted=is_redacted,
+        content_hash=content_hash,
+    )
+    db_session.add(chat_message)
+    await db_session.flush()
+
+    version = MessageVersion(
+        chat_message_id=chat_message.id,
+        version_seq=1,
+        text=text,
+        caption=caption,
+        normalized_text=message.get("normalized_text"),
+        content_hash=content_hash,
+        is_redacted=is_redacted,
+        captured_at=captured_at,
+    )
+    db_session.add(version)
+    await db_session.flush()
+
+    chat_message.current_version_id = version.id
+    await db_session.flush()
+
+
+async def _create_forget_event(db_session, event: dict) -> None:
+    from bot.db.repos.forget_event import ForgetEventRepo
+
+    row = await ForgetEventRepo.create(
+        db_session,
+        target_type=event["target_type"],
+        target_id=event.get("target_id"),
+        actor_user_id=None,
+        authorized_by="system",
+        tombstone_key=event["tombstone_key"],
+    )
+    status = event.get("status", "pending")
+    if status == "pending":
+        return
+
+    await ForgetEventRepo.mark_status(db_session, row.id, status="processing")
+    if status == "completed":
+        await ForgetEventRepo.mark_status(db_session, row.id, status="completed")
+
+
+async def _populate_case(db_session, case: dict) -> int:
+    for message in case["fixture_messages"]:
+        await _create_message(db_session, case["id"], message)
+    for event in case.get("fixture_forget_events", []):
+        await _create_forget_event(db_session, event)
+    return int(case["fixture_messages"][0]["chat_id"])
+
+
+CASES = json.loads(EVAL_FIXTURE.read_text())
+
+
+@pytest.mark.parametrize("case", CASES, ids=lambda item: item["id"])
+async def test_eval_case(case: dict, db_session) -> None:
+    from bot.services.qa import run_qa
+
+    chat_id = await _populate_case(db_session, case)
+    result = await run_qa(
+        db_session,
+        query=case["query"],
+        chat_id=chat_id,
+        redact_query_in_audit=False,
+    )
+
+    expected_ids = case["expected_chat_message_ids"]
+    if not case["expected_evidence_present"]:
+        assert result.bundle.abstained is True, f"{case['id']}: expected abstention"
+        assert result.bundle.items == ()
+        return
+
+    actual_ids = [item.message_id for item in result.bundle.items]
+    assert actual_ids[: len(expected_ids)] == expected_ids, (
+        f"{case['id']}: expected leading message_ids {expected_ids}, got {actual_ids}"
+    )

--- a/tests/fixtures/qa_eval_cases.json
+++ b/tests/fixtures/qa_eval_cases.json
@@ -1,0 +1,277 @@
+[
+  {
+    "id": "rec_001",
+    "category": "morphology",
+    "query": "лошади",
+    "fixture_messages": [
+      {
+        "chat_id": -1001234567890,
+        "message_id": 1,
+        "user_id": 42001,
+        "normalized_text": "лошадь скачет по полю",
+        "memory_policy": "normal",
+        "captured_at": "2026-04-25T12:00:00+00:00"
+      }
+    ],
+    "expected_evidence_present": true,
+    "expected_chat_message_ids": [1],
+    "notes": "Russian declension match via russian stemmer"
+  },
+  {
+    "id": "rec_002",
+    "category": "recency",
+    "query": "встреча",
+    "fixture_messages": [
+      {
+        "chat_id": -1001234567890,
+        "message_id": 2,
+        "user_id": 42002,
+        "normalized_text": "встреча в субботу",
+        "memory_policy": "normal",
+        "captured_at": "2026-04-25T12:00:00+00:00"
+      },
+      {
+        "chat_id": -1001234567890,
+        "message_id": 3,
+        "user_id": 42002,
+        "normalized_text": "встреча в воскресенье",
+        "memory_policy": "normal",
+        "captured_at": "2026-04-29T12:00:00+00:00"
+      }
+    ],
+    "expected_evidence_present": true,
+    "expected_chat_message_ids": [3, 2],
+    "notes": "Equal-rank hits should prefer newer captured_at"
+  },
+  {
+    "id": "rec_003",
+    "category": "abstention",
+    "query": "квантовая физика",
+    "fixture_messages": [
+      {
+        "chat_id": -1001234567890,
+        "message_id": 4,
+        "user_id": 42003,
+        "normalized_text": "обед в столовой",
+        "memory_policy": "normal",
+        "captured_at": "2026-04-26T12:00:00+00:00"
+      }
+    ],
+    "expected_evidence_present": false,
+    "expected_chat_message_ids": [],
+    "notes": "No match should abstain"
+  },
+  {
+    "id": "rec_004",
+    "category": "governance",
+    "query": "секрет",
+    "fixture_messages": [
+      {
+        "chat_id": -1001234567890,
+        "message_id": 5,
+        "user_id": 42004,
+        "normalized_text": "секрет проекта",
+        "memory_policy": "offrecord",
+        "captured_at": "2026-04-26T13:00:00+00:00"
+      },
+      {
+        "chat_id": -1001234567890,
+        "message_id": 6,
+        "user_id": 42004,
+        "normalized_text": "большой секрет обсуждали публично",
+        "memory_policy": "normal",
+        "captured_at": "2026-04-26T14:00:00+00:00"
+      }
+    ],
+    "expected_evidence_present": true,
+    "expected_chat_message_ids": [6],
+    "notes": "Offrecord row excluded; normal row returned"
+  },
+  {
+    "id": "rec_005",
+    "category": "tombstone",
+    "query": "ошибка",
+    "fixture_messages": [
+      {
+        "chat_id": -1001234567890,
+        "message_id": 7,
+        "user_id": 42005,
+        "normalized_text": "ошибка в коде",
+        "memory_policy": "normal",
+        "captured_at": "2026-04-26T15:00:00+00:00"
+      }
+    ],
+    "fixture_forget_events": [
+      {
+        "target_type": "message",
+        "target_id": "7",
+        "tombstone_key": "message:-1001234567890:7",
+        "status": "completed"
+      }
+    ],
+    "expected_evidence_present": false,
+    "expected_chat_message_ids": [],
+    "notes": "Message tombstone excludes an otherwise matching row"
+  },
+  {
+    "id": "rec_006",
+    "category": "caption",
+    "query": "архитектура",
+    "fixture_messages": [
+      {
+        "chat_id": -1001234567890,
+        "message_id": 8,
+        "user_id": 42006,
+        "normalized_text": null,
+        "caption": "схема архитектуры памяти",
+        "memory_policy": "normal",
+        "captured_at": "2026-04-27T12:00:00+00:00"
+      }
+    ],
+    "expected_evidence_present": true,
+    "expected_chat_message_ids": [8],
+    "notes": "Caption-only messages are searchable evidence"
+  },
+  {
+    "id": "rec_007",
+    "category": "multi_token",
+    "query": "план релиза",
+    "fixture_messages": [
+      {
+        "chat_id": -1001234567890,
+        "message_id": 9,
+        "user_id": 42007,
+        "normalized_text": "план релиза согласован на пятницу",
+        "memory_policy": "normal",
+        "captured_at": "2026-04-27T13:00:00+00:00"
+      }
+    ],
+    "expected_evidence_present": true,
+    "expected_chat_message_ids": [9],
+    "notes": "Multi-token query returns the message containing both terms"
+  },
+  {
+    "id": "rec_008",
+    "category": "chat_isolation",
+    "query": "изоляция",
+    "fixture_messages": [
+      {
+        "chat_id": -1001234567890,
+        "message_id": 10,
+        "user_id": 42008,
+        "normalized_text": "изоляция работает в основном чате",
+        "memory_policy": "normal",
+        "captured_at": "2026-04-27T14:00:00+00:00"
+      },
+      {
+        "chat_id": -1009999999999,
+        "message_id": 11,
+        "user_id": 42008,
+        "normalized_text": "изоляция не должна перейти из другого чата",
+        "memory_policy": "normal",
+        "captured_at": "2026-04-29T14:00:00+00:00"
+      }
+    ],
+    "expected_evidence_present": true,
+    "expected_chat_message_ids": [10],
+    "notes": "Search stays scoped to the invocation chat_id"
+  },
+  {
+    "id": "rec_009",
+    "category": "user_tombstone",
+    "query": "профиль",
+    "fixture_messages": [
+      {
+        "chat_id": -1001234567890,
+        "message_id": 12,
+        "user_id": 42009,
+        "normalized_text": "профиль участника обновлён",
+        "memory_policy": "normal",
+        "captured_at": "2026-04-28T12:00:00+00:00"
+      }
+    ],
+    "fixture_forget_events": [
+      {
+        "target_type": "user",
+        "target_id": "42009",
+        "tombstone_key": "user:42009",
+        "status": "pending"
+      }
+    ],
+    "expected_evidence_present": false,
+    "expected_chat_message_ids": [],
+    "notes": "Pending user tombstone excludes that user's messages"
+  },
+  {
+    "id": "rec_010",
+    "category": "message_hash_tombstone",
+    "query": "хеш",
+    "fixture_messages": [
+      {
+        "chat_id": -1001234567890,
+        "message_id": 13,
+        "user_id": 42010,
+        "normalized_text": "хеш сообщения попал под удаление",
+        "memory_policy": "normal",
+        "content_hash": "qa-eval-hash-tombstone",
+        "captured_at": "2026-04-28T13:00:00+00:00"
+      }
+    ],
+    "fixture_forget_events": [
+      {
+        "target_type": "message_hash",
+        "target_id": null,
+        "tombstone_key": "message_hash:qa-eval-hash-tombstone",
+        "status": "completed"
+      }
+    ],
+    "expected_evidence_present": false,
+    "expected_chat_message_ids": [],
+    "notes": "Message-hash tombstone excludes matching content hash"
+  },
+  {
+    "id": "rec_011",
+    "category": "nomem",
+    "query": "черновик",
+    "fixture_messages": [
+      {
+        "chat_id": -1001234567890,
+        "message_id": 14,
+        "user_id": 42011,
+        "normalized_text": "черновик не для памяти",
+        "memory_policy": "nomem",
+        "captured_at": "2026-04-28T14:00:00+00:00"
+      },
+      {
+        "chat_id": -1001234567890,
+        "message_id": 15,
+        "user_id": 42011,
+        "normalized_text": "черновик можно обсудить открыто",
+        "memory_policy": "normal",
+        "captured_at": "2026-04-28T15:00:00+00:00"
+      }
+    ],
+    "expected_evidence_present": true,
+    "expected_chat_message_ids": [15],
+    "notes": "Nomem row excluded; normal row returned"
+  },
+  {
+    "id": "rec_012",
+    "category": "redacted",
+    "query": "редакция",
+    "fixture_messages": [
+      {
+        "chat_id": -1001234567890,
+        "message_id": 16,
+        "user_id": 42012,
+        "normalized_text": "редакция скрыта",
+        "memory_policy": "normal",
+        "is_redacted": true,
+        "captured_at": "2026-04-29T12:00:00+00:00"
+      }
+    ],
+    "expected_evidence_present": false,
+    "expected_chat_message_ids": [],
+    "notes": "Redacted rows are excluded from evidence"
+  }
+]

--- a/tests/handlers/test_qa.py
+++ b/tests/handlers/test_qa.py
@@ -1,0 +1,264 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from tests.conftest import import_module
+
+pytestmark = pytest.mark.usefixtures("app_env")
+
+COMMUNITY_CHAT_ID = -1001234567890
+
+
+def _message(
+    *,
+    chat_id: int = COMMUNITY_CHAT_ID,
+    chat_type: str = "supergroup",
+    user_id: int = 1001,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        chat=SimpleNamespace(id=chat_id, type=chat_type),
+        from_user=SimpleNamespace(id=user_id),
+        reply=AsyncMock(),
+    )
+
+
+def _command(args: str | None) -> SimpleNamespace:
+    return SimpleNamespace(args=args)
+
+
+def _user(
+    *,
+    user_id: int = 1001,
+    is_member: bool = True,
+    is_admin: bool = False,
+    first_name: str = "Member",
+    username: str | None = "member",
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=user_id,
+        is_member=is_member,
+        is_admin=is_admin,
+        first_name=first_name,
+        last_name=None,
+        username=username,
+    )
+
+
+def _qa_result(*, abstained: bool, query_redacted: bool = False):
+    from bot.services.evidence import EvidenceBundle, EvidenceItem
+    from bot.services.qa import QaResult
+
+    now = datetime(2026, 4, 30, 12, 0, tzinfo=timezone.utc)
+    items = ()
+    if not abstained:
+        items = (
+            EvidenceItem(
+                message_version_id=500,
+                chat_message_id=50,
+                chat_id=COMMUNITY_CHAT_ID,
+                message_id=77,
+                user_id=2002,
+                snippet="обсуждали <b>память</b>",
+                ts_rank=0.8,
+                captured_at=now,
+                message_date=now,
+            ),
+        )
+    bundle = EvidenceBundle(
+        query="память",
+        chat_id=COMMUNITY_CHAT_ID,
+        items=items,
+        abstained=abstained,
+        created_at=now,
+    )
+    return QaResult(bundle=bundle, query_redacted=query_redacted)
+
+
+async def test_flag_off_silent_return(monkeypatch) -> None:
+    handler = import_module("bot.handlers.qa")
+    message = _message()
+    session = AsyncMock()
+    trace_create = AsyncMock()
+    run_qa = AsyncMock()
+
+    monkeypatch.setattr(handler.FeatureFlagRepo, "get", AsyncMock(return_value=False))
+    monkeypatch.setattr(handler.QaTraceRepo, "create", trace_create)
+    monkeypatch.setattr(handler, "run_qa", run_qa)
+
+    await handler.recall_handler(message, _command("память"), session)
+
+    message.reply.assert_not_awaited()
+    run_qa.assert_not_awaited()
+    trace_create.assert_not_awaited()
+
+
+async def test_dm_invocation_refuses_and_audits(monkeypatch) -> None:
+    handler = import_module("bot.handlers.qa")
+    message = _message(chat_id=1001, chat_type="private")
+    session = AsyncMock()
+    trace_create = AsyncMock()
+
+    monkeypatch.setattr(handler.FeatureFlagRepo, "get", AsyncMock(return_value=True))
+    monkeypatch.setattr(handler.QaTraceRepo, "create", trace_create)
+    monkeypatch.setattr(handler, "run_qa", AsyncMock())
+
+    await handler.recall_handler(message, _command("память"), session)
+
+    message.reply.assert_awaited_once_with(
+        "Команда /recall работает только в community чате."
+    )
+    trace_create.assert_awaited_once()
+    assert trace_create.call_args.kwargs["query"] == "память"
+    assert trace_create.call_args.kwargs["evidence_ids"] == []
+    assert trace_create.call_args.kwargs["abstained"] is True
+
+
+async def test_non_member_refuses_and_audits(monkeypatch) -> None:
+    handler = import_module("bot.handlers.qa")
+    message = _message()
+    session = AsyncMock()
+    trace_create = AsyncMock()
+
+    monkeypatch.setattr(handler.FeatureFlagRepo, "get", AsyncMock(return_value=True))
+    monkeypatch.setattr(
+        handler.UserRepo,
+        "get",
+        AsyncMock(return_value=_user(is_member=False, is_admin=False)),
+    )
+    monkeypatch.setattr(handler.QaTraceRepo, "create", trace_create)
+    monkeypatch.setattr(handler, "run_qa", AsyncMock())
+
+    await handler.recall_handler(message, _command("память"), session)
+
+    message.reply.assert_awaited_once_with("Доступ только участникам сообщества.")
+    trace_create.assert_awaited_once()
+    assert trace_create.call_args.kwargs["query"] == "память"
+    assert trace_create.call_args.kwargs["abstained"] is True
+
+
+async def test_empty_query_usage_hint_and_audits(monkeypatch) -> None:
+    handler = import_module("bot.handlers.qa")
+    message = _message()
+    session = AsyncMock()
+    trace_create = AsyncMock()
+
+    monkeypatch.setattr(handler.FeatureFlagRepo, "get", AsyncMock(return_value=True))
+    monkeypatch.setattr(handler.UserRepo, "get", AsyncMock(return_value=_user()))
+    monkeypatch.setattr(handler.QaTraceRepo, "create", trace_create)
+    monkeypatch.setattr(handler, "run_qa", AsyncMock())
+
+    await handler.recall_handler(message, _command("   "), session)
+
+    message.reply.assert_awaited_once_with(
+        "Использование: <code>/recall &lt;вопрос&gt;</code>",
+        parse_mode="HTML",
+    )
+    trace_create.assert_awaited_once()
+    assert trace_create.call_args.kwargs["query"] == ""
+    assert trace_create.call_args.kwargs["abstained"] is True
+
+
+async def test_member_with_results_renders_response(monkeypatch) -> None:
+    handler = import_module("bot.handlers.qa")
+    message = _message()
+    session = AsyncMock()
+    trace_create = AsyncMock()
+    run_qa = AsyncMock(return_value=_qa_result(abstained=False))
+
+    monkeypatch.setattr(handler.FeatureFlagRepo, "get", AsyncMock(return_value=True))
+    monkeypatch.setattr(
+        handler.UserRepo,
+        "get",
+        AsyncMock(side_effect=[_user(), _user(user_id=2002, first_name="Author")]),
+    )
+    monkeypatch.setattr(handler.QaTraceRepo, "create", trace_create)
+    monkeypatch.setattr(handler, "run_qa", run_qa)
+
+    await handler.recall_handler(message, _command("память"), session)
+
+    run_qa.assert_awaited_once()
+    assert run_qa.call_args.kwargs["redact_query_in_audit"] is False
+    message.reply.assert_awaited_once()
+    response = message.reply.call_args.args[0]
+    assert "<b>Найденные свидетельства:</b>" in response
+    assert "обсуждали <b>память</b>" in response
+    assert "Author" in response
+    assert "https://t.me/c/1234567890/77" in response
+    assert "message_version_id:500" in response
+    assert message.reply.call_args.kwargs["parse_mode"] == "HTML"
+    trace_create.assert_awaited_once()
+    assert trace_create.call_args.kwargs["evidence_ids"] == [500]
+    assert trace_create.call_args.kwargs["abstained"] is False
+
+
+async def test_member_no_results_abstains(monkeypatch) -> None:
+    handler = import_module("bot.handlers.qa")
+    message = _message()
+    session = AsyncMock()
+    trace_create = AsyncMock()
+
+    monkeypatch.setattr(handler.FeatureFlagRepo, "get", AsyncMock(return_value=True))
+    monkeypatch.setattr(handler.UserRepo, "get", AsyncMock(return_value=_user()))
+    monkeypatch.setattr(handler.QaTraceRepo, "create", trace_create)
+    monkeypatch.setattr(handler, "run_qa", AsyncMock(return_value=_qa_result(abstained=True)))
+
+    await handler.recall_handler(message, _command("ничего"), session)
+
+    message.reply.assert_awaited_once()
+    assert message.reply.call_args.args[0] == "Не нашёл подходящих свидетельств в истории чата."
+    assert message.reply.call_args.kwargs["parse_mode"] == "HTML"
+    trace_create.assert_awaited_once()
+    assert trace_create.call_args.kwargs["evidence_ids"] == []
+    assert trace_create.call_args.kwargs["abstained"] is True
+
+
+async def test_offrecord_query_not_echoed_and_audit_redacted(monkeypatch) -> None:
+    handler = import_module("bot.handlers.qa")
+    message = _message()
+    session = AsyncMock()
+    trace_create = AsyncMock()
+    run_qa = AsyncMock(return_value=_qa_result(abstained=True, query_redacted=True))
+    query = "секретный запрос #offrecord"
+
+    monkeypatch.setattr(handler.FeatureFlagRepo, "get", AsyncMock(return_value=True))
+    monkeypatch.setattr(handler.UserRepo, "get", AsyncMock(return_value=_user()))
+    monkeypatch.setattr(handler.QaTraceRepo, "create", trace_create)
+    monkeypatch.setattr(handler, "run_qa", run_qa)
+
+    await handler.recall_handler(message, _command(query), session)
+
+    assert run_qa.call_args.kwargs["redact_query_in_audit"] is True
+    response = message.reply.call_args.args[0]
+    assert query not in response
+    trace_create.assert_awaited_once()
+    assert trace_create.call_args.kwargs["query"] == query
+    assert trace_create.call_args.kwargs["redact_query"] is True
+
+
+async def test_audit_row_written_once_for_processed_invocation(monkeypatch) -> None:
+    handler = import_module("bot.handlers.qa")
+    message = _message(user_id=3030)
+    session = AsyncMock()
+    trace_create = AsyncMock()
+
+    monkeypatch.setattr(handler.FeatureFlagRepo, "get", AsyncMock(return_value=True))
+    monkeypatch.setattr(handler.UserRepo, "get", AsyncMock(return_value=_user(user_id=3030)))
+    monkeypatch.setattr(handler.QaTraceRepo, "create", trace_create)
+    monkeypatch.setattr(handler, "run_qa", AsyncMock(return_value=_qa_result(abstained=True)))
+
+    await handler.recall_handler(message, _command("история"), session)
+
+    trace_create.assert_awaited_once()
+    assert trace_create.call_args.args == (session,)
+    assert trace_create.call_args.kwargs == {
+        "user_tg_id": 3030,
+        "chat_id": COMMUNITY_CHAT_ID,
+        "query": "история",
+        "evidence_ids": [],
+        "abstained": True,
+        "redact_query": False,
+    }


### PR DESCRIPTION
## Summary

Wave 3 of Phase 4. /recall Telegram command + memory.qa.enabled feature flag + 12 eval cases.

Closes #148 + #150.

## Quality gates

- pytest tests/handlers/test_qa.py tests/eval/test_qa_eval_cases.py: **20/20 passed** (8 handler + 12 eval, 4.68s)
- ruff check: clean
- no LLM imports: grep empty
- Verified-real APIs: FeatureFlagRepo.get, UserRepo.get, detect_policy tuple unpack, CommandObject.args, parse_mode=HTML

## Six invariants (verbatim, HANDOFF.md §1)

1. Existing gatekeeper must not break.
2. No LLM calls outside \`llm_gateway\`.
3. No extraction / search / q&a over \`#nomem\` / \`#offrecord\` / forgotten.
4. Citations point to \`message_version_id\` or approved card sources.
8. Import apply must go through the same normalization / governance path as live updates.
9. Tombstones are durable and not casually rolled back.

## Phase 4 closure

This PR closes Phase 4 active implementation:
- ✅ T4-01 (#145) FTS schema — PR #151
- ✅ T4-02 (#146) Search service — PR #151 + hardening via PR #156
- ✅ T4-03 (#147) Evidence bundle — PR #157
- ✅ T4-04 (#148) /recall handler — **this PR**
- ✅ T4-05 (#149) qa_traces audit — PR #158
- ✅ T4-06 (#150) Eval cases — **this PR**
- ✅ T4-02H (#153) closed as duplicate of PR #156

After merge: trigger Final Holistic Review per superflow Rule 9 (≥4 sprints with parallel execution).

🤖 Generated by Codex (gpt-5.5) executor + Claude orchestrator