### PR TITLE
chore(orch): add ORCHESTRATOR_REGISTRY + authorize Phase 5/11/12

### DIFF
--- a/docs/memory-system/AUTHORIZED_SCOPE.md
+++ b/docs/memory-system/AUTHORIZED_SCOPE.md
@@ -55,21 +55,90 @@ must wait for its phase gate.
 
 ---
 
+## Authorized: Phase 5 — LLM gateway + answer synthesis (2026-04-30)
+
+Phase 5 is authorized for implementation. Predecessor (Phase 4) closed 2026-04-30 with
+6/6 tickets shipped, FHR pending. Owned by Orchestrator A per `ORCHESTRATOR_REGISTRY.md`.
+
+Authorized scope:
+- `bot/services/llm_gateway.py` — single-entry LLM call interface; ALL provider calls
+  must go through this module.
+- `bot/services/llm_usage_ledger.py` + `bot/db/repos/llm_usage_ledger.py` — every call
+  audited (provider, model, input_tokens, output_tokens, cost_usd_cents, governance
+  filter result, ts).
+- alembic migration 022+ for `llm_usage_ledger`, 023+ for `qa_traces` LLM extension
+  fields (answer_text, citation_count, llm_call_id FK).
+- Governance source-filter pre-call: refuse to send any evidence whose source row has
+  `memory_policy IN ('offrecord','forgotten')` OR `is_redacted=TRUE`.
+- Budget guard (per-day USD ceiling, configurable env var; refuse when exceeded).
+- Cache layer (cite-stable input hash → cached answer; respects governance flips).
+- `/recall` upgrade: optional LLM-synthesized answer when ≥1 evidence + flag enabled.
+
+NOT in Phase 5 scope (defer to Phase 6+):
+- Knowledge cards, extraction pipelines, daily digests, observations, reflection runs.
+- Vector / semantic search beyond the FTS already shipped in Phase 4.
+- Cross-chat or public answer surfaces.
+
+---
+
+## Authorized: Phase 11 — Shkoderbench / evals harness (2026-04-30)
+
+Phase 11 is authorized for implementation in parallel with Phase 5. Owned by
+Orchestrator C. No production runtime impact; offline / CI-only.
+
+Authorized scope:
+- `tests/evals/` — new top-level test category with golden datasets, citation quality
+  assertions, leakage tests (no `#offrecord` / forgotten content in any answer),
+  no-evidence refusal correctness, citation precision/recall.
+- `bot/services/eval_*.py` — offline harness invoked by tests; no production wiring.
+- Golden recall fixtures (`tests/fixtures/golden_recall/`, `tests/fixtures/eval_seeds/`).
+- CI nightly job (`.github/workflows/evals.yml`) gated by env var (default OFF until
+  baseline established).
+- NO new alembic migrations. NO new production handlers.
+
+Phase 11 evals must run against the live `/recall` from Phase 4 first (baseline) and
+later against Phase 5 LLM-synthesized answers (regression suite for hallucination /
+leakage / citation drift).
+
+---
+
+## Authorized: Phase 12 — Butler design docs only (2026-04-30)
+
+Phase 12 is authorized **for documentation only**. NO implementation, NO execution
+code, NO database tables. Owned by Orchestrator B as a docs side-quest.
+
+Authorized scope:
+- `docs/memory-system/PHASE12_PLAN.md` (promoted from `_DRAFT`) — design contract for
+  the future butler action layer.
+- Permission model spec, action audit log spec, abort / dry-run spec.
+
+---
+
+## Conditionally authorized: Phase 9, Phase 10 (gated)
+
+Phase 9 (wiki) and Phase 10 (graph projection) are NOT yet authorized for runtime
+implementation. Orchestrator B may:
+- Refine `PHASE9_PLAN_DRAFT.md` and `PHASE10_PLAN_DRAFT.md` into `_PLAN.md` artifacts.
+- Sketch schema designs (no migrations until ratified).
+- Build read-only experiments in `.worktrees/orch-B-experiments/` (NOT pushed to main).
+
+Promotion to "authorized for implementation" requires:
+- Orchestrator A confirms Phase 6 (cards) closed (Phase 9 + 10 both depend on stable
+  cards / relations).
+- AUTHORIZED_SCOPE.md updated by human or Orchestrator A's closing PR.
+
+---
+
 ## NOT authorized (future phases — gates not passed)
 
 Do not start, design, or write speculative code for:
 
-- Import **apply** (Phase 2b) — needs T3-01 + policy detection minimum.
-- Q&A bot (Phase 4) — needs message_versions + governance filters.
-- LLM calls of any kind — needs `llm_gateway` + ledger (Phase 5).
-- LLM extraction — Phase 5.
-- Vector search / pgvector — Phase 4+ at earliest.
-- Catalog / knowledge cards — Phase 6.
-- Daily summaries — Phase 7.
-- Weekly digest — Phase 8.
-- Wiki (member or public) — Phase 9.
-- Graph projection (Neo4j / Graphiti) — Phase 10.
-- Butler / action execution — Phase 12 (postponed; design only).
+- Phase 6 catalog / cards — Orchestrator A unblocks after Phase 5 closure.
+- Phase 7 daily summaries — depends on Phase 5 + Phase 6.
+- Phase 8 reflection / observations — depends on Phase 7.
+- Wiki (member or public) implementation — Phase 9, conditionally above.
+- Graph projection (Neo4j / Graphiti) implementation — Phase 10, conditionally above.
+- Butler / action execution — Phase 12, design-only above.
 - Person expertise pages — Phase 6+.
 - Public surfaces of any kind — Phase 9 with explicit approval.
 

--- a/docs/memory-system/ORCHESTRATOR_REGISTRY.md
+++ b/docs/memory-system/ORCHESTRATOR_REGISTRY.md
@@ -1,0 +1,179 @@
+# Orchestrator Registry — Memory System Phase 5+
+
+**Purpose.** Coordinate 3 parallel paranoid orchestrators working on Memory System Phase 5–12 implementation. This file is the **shared coordination ground truth**. Each orchestrator MUST read it on `main` before any sprint kickoff and after every 30-min heartbeat.
+
+**Update protocol.** Edit only inside your owned worktree → commit → push → PR → merge. Never edit on `main` directly. Conflicts at merge time → rebase, re-verify your claim against the current state, re-push.
+
+---
+
+## §1. Active orchestrators
+
+| ID | Phase chain | Branch namespace | Worktree | Owned alembic range | Started |
+|----|-------------|------------------|----------|----------------------|---------|
+| **A — Synthesis chain** | Phase 5 → 6 → 7 → 8 (sequential) | `feat/p5-*`, `feat/p6-*`, `feat/p7-*`, `feat/p8-*`, `fix/p{5,6,7,8}-*`, `hotfix/p{5,6,7,8}-*`, `plan/p{5,6,7,8}-*` | `.worktrees/orch-A` (create on first use) | 022–049 | TBD |
+| **B — Lateral expansion** | Phase 9 (wiki) + Phase 10 (graph) + Phase 12 (butler docs only) | `feat/p9-*`, `feat/p10-*`, `feat/p12-*`, `fix/p{9,10,12}-*`, `plan/p{9,10,12}-*` | `.worktrees/orch-B` | 050–069 (only if Phase 9/10 ratified by AUTHORIZED_SCOPE.md and after Orchestrator A unblocks dependency) | TBD |
+| **C — Evaluation harness** | Phase 11 (Shkoderbench / evals) | `feat/p11-*`, `fix/p11-*`, `plan/p11-*` | `.worktrees/orch-C` | none (no schema changes; read-only on DB) | TBD |
+
+---
+
+## §2. Owned files (collision boundaries)
+
+### Orchestrator A — exclusive write
+- `bot/services/llm_gateway.py`, `bot/services/llm_*.py`, `bot/services/extraction*.py`, `bot/services/cards*.py`, `bot/services/digest*.py`, `bot/services/observations*.py`, `bot/services/reflection*.py`
+- `bot/db/repos/llm_*.py`, `bot/db/repos/card*.py`, `bot/db/repos/digest*.py`, `bot/db/repos/observation*.py`, `bot/db/repos/extraction*.py`, `bot/db/repos/memory_event*.py`, `bot/db/repos/memory_candidate*.py`
+- `bot/handlers/cards*.py`, `bot/handlers/digest*.py`
+- alembic versions `022_*.py` through `049_*.py`
+- `tests/services/test_llm_*`, `tests/services/test_extraction*`, `tests/services/test_cards*`, `tests/services/test_digest*`, `tests/services/test_observations*`
+- `docs/memory-system/PHASE5_PLAN.md`, `PHASE6_PLAN.md`, `PHASE7_PLAN.md`, `PHASE8_PLAN.md` (ratified — drop the `_DRAFT` suffix when promoted)
+
+### Orchestrator B — exclusive write
+- `bot/services/wiki*.py`, `bot/services/graph*.py`, `bot/web/wiki/*`, `web/templates/wiki/*`
+- `bot/db/repos/wiki*.py`, `bot/db/repos/graph*.py`
+- alembic versions `050_*.py` through `069_*.py` (only after Phase 9/10 authorization in AUTHORIZED_SCOPE.md AND after Orchestrator A confirms cards/relations stable)
+- `tests/services/test_wiki*`, `tests/services/test_graph*`
+- `docs/memory-system/PHASE9_PLAN.md`, `PHASE10_PLAN.md`, `PHASE12_PLAN.md`
+
+### Orchestrator C — exclusive write
+- `tests/evals/*` (new top-level test category)
+- `bot/services/eval_*.py` (offline harness, no production wiring)
+- `tests/fixtures/golden_recall/*`, `tests/fixtures/eval_seeds/*`
+- `docs/memory-system/PHASE11_PLAN.md`, `docs/memory-system/eval-*.md`
+- No alembic migrations
+
+### Shared (must serialize via PR — pull-immediately-before-edit)
+- `bot/db/models.py`
+- `bot/services/forget_cascade.py` (specifically the `CASCADE_LAYER_ORDER` constant + `_LAYER_FUNCS` dict — every new content table requires a cascade layer; failure to add = privacy invariant 9 violation)
+- `bot/services/governance.py` (rare; only if introducing new policy types)
+- `docs/memory-system/IMPLEMENTATION_STATUS.md`
+- `docs/memory-system/ROADMAP.md`
+- `docs/memory-system/AUTHORIZED_SCOPE.md`
+- `docs/memory-system/HANDOFF.md` (only structural updates; per-phase notes go to phase-specific PLAN.md)
+- `CLAUDE.md` (root)
+- `bot/__main__.py` (`_ALLOWED_UPDATES` for new Telegram update types — see ROADMAP allowed_updates rollout rule)
+- `pyproject.toml` (new deps must be reviewed by all 3 orchestrators via comment on PR)
+- `.github/workflows/*.yml`
+
+---
+
+## §3. Coordination protocol
+
+### §3.1 Sprint kickoff (paranoid pre-flight)
+Before opening **any** new sprint:
+
+1. `git -C <project_root> fetch --all --prune` (NOT `--depth` shallow; we need full history)
+2. Read this file on `main` (`git show main:docs/memory-system/ORCHESTRATOR_REGISTRY.md`).
+3. Verify your worktree base: `git -C <worktree> log --oneline -1` should be ≤ 5 commits behind `origin/main`. If older — rebase your worktree on `main`.
+4. Scan §4 active sprints: if any active sprint touches a file you intend to write, STOP. Comment on the active orchestrator's tracking GitHub issue requesting handoff or scope-split. Do not race.
+5. Run `gh pr list --state open --search "head:feat/p<your_phase>-"` — if any open PR is yours from a previous session, finish or close it first.
+6. Append your sprint to §4 (PR — see §3.4).
+
+### §3.2 During sprint (heartbeat, every ≤ 30 min)
+1. `git fetch --all --prune`. If `origin/main` advanced, run `git diff main..your_branch -- docs/memory-system/IMPLEMENTATION_STATUS.md docs/memory-system/AUTHORIZED_SCOPE.md CLAUDE.md bot/db/models.py bot/services/forget_cascade.py` — if those files were touched on main since you forked, **rebase immediately** before pushing your next commit.
+2. Read `gh issue list --label phase:5 --label phase:9 --label phase:10 --label phase:11 --label phase:12 --state open --limit 30` (use whichever apply to you) for fresh tickets created by humans or other orchestrators.
+3. If you spot another orchestrator's PR touching the SAME file you have open in a local commit — comment on both PRs immediately, do not push, escalate to human.
+
+### §3.3 Shared-file edit discipline
+For files in §2 "Shared":
+1. `git checkout main && git pull --rebase origin main` (or worktree equivalent).
+2. Make edit → commit → push → PR.
+3. Wait for CI green, then merge. Do not bundle shared-file edits with feature commits unless the feature directly requires the change in the same atomic transaction (e.g., a new model + alembic migration).
+4. After merge, other orchestrators MUST re-pull main before their next commit.
+
+### §3.4 REGISTRY edit (this file)
+- Open a PR titled `chore(orch-<ID>): registry update — <what>`
+- One section edit per PR (don't batch §1 + §4 + §6 unless intra-related).
+- Other orchestrators are encouraged but not required to comment.
+
+### §3.5 PR & merge rules (per Superflow charter)
+- `governance_mode = critical` for all 3 orchestrators (privacy invariants binding; we are inside the memory system).
+- `git_workflow_mode = parallel_wave_prs` (per-sprint PR with auto-merge on CI green; Final Holistic Review obligatory at end of every multi-sprint phase).
+- Per-PR PAR review: 1 product reviewer (Claude `claude -p` since the orchestrator is in Codex) + 1 technical reviewer (Codex own session via task delegation OR a separate subagent invocation). NEVER skip review citing time pressure.
+- Merge command: `gh pr merge <num> --rebase --delete-branch`. **NEVER `--admin`**. CI red ⇒ fix CI, don't bypass.
+- Final Holistic Review at end of every Phase: 2 reviewers do a holistic pass over the entire phase's PR-set (not per PR). Required for any phase ≥ 4 PRs.
+
+### §3.6 Codex dual-agent invocation (since orchestrators run inside Codex)
+When the orchestrator IS Codex itself, the secondary independent reviewer is invoked as:
+```bash
+$TIMEOUT_CMD 600 claude -p "<reviewer prompt with diff context>" 2>&1
+```
+- Use `claude -p` for product/spec reviews (Claude's strength).
+- Use Codex own subagent / `spawn_agent` for technical reviews if the orchestrator can self-fork.
+- Never use raw recursive `codex exec` from inside Codex (causes shell-wrapper recursion per memory note).
+
+See `docs/memory-system/prompts/CODEX_DUAL_AGENT_PATTERN.md` for the canonical prompt skeleton.
+
+---
+
+## §4. Active sprints
+
+Update this section at sprint start (in your sprint-kickoff PR) and at sprint close (in your closing PR).
+
+| Orch | Sprint label | Tickets | Started (UTC) | Status | PRs | Notes |
+|------|--------------|---------|---------------|--------|-----|-------|
+| (none yet) | | | | | | |
+
+---
+
+## §5. Cross-orchestrator known dependencies
+
+| Producer | Output | Consumer | Phase gate |
+|----------|--------|----------|------------|
+| Orch A (Phase 5) | `llm_gateway` + ledger + governance source-filter | Orch C (Phase 11) for LLM-eval cases; Orch B (Phase 10) for entity extraction | Phase 5 closure |
+| Orch A (Phase 5) | `EvidenceBundle` cited synthesis API | Orch B (Phase 9) wiki page rendering; Orch C (Phase 11) citation-quality eval | Phase 5 closure |
+| Orch A (Phase 6) | `knowledge_cards` + `card_sources` stable | Orch B (Phase 9) wiki content; Orch B (Phase 10) graph entity nodes | Phase 6 closure |
+| Orch A (Phase 8) | `observations` table | Orch B (Phase 10) graph projection of observations | Phase 8 closure |
+| Orch A (any phase) | New content table | Orch A self: must add to `forget_cascade.CASCADE_LAYER_ORDER` in same sprint | Privacy invariant 9 |
+| Orch C | Phase 4 baseline evals | Orch A (Phase 5) regression baseline before LLM enables | Phase 11 sprint 1 closure |
+
+---
+
+## §6. Collision history & lessons
+
+Record collisions and their resolution. Each entry: orchestrators involved, file/scope, what triggered it, how resolved, what the protocol learned. Future orchestrators must read this section before sprint kickoff.
+
+| Date (UTC) | Orchestrators | Conflict | Resolution | Protocol delta |
+|------------|---------------|----------|------------|----------------|
+| (none yet) | | | | |
+
+---
+
+## §7. Stop / escalate signals
+
+If any of the below — pause your work, comment on a tracking issue, ping the human:
+
+1. Two orchestrators' PRs touch the same file in `§2 Shared` and the second cannot rebase cleanly.
+2. An invariant from `HANDOFF.md §1` (privacy / governance / no-LLM-outside-gateway / tombstone-durability) appears at risk in your scope.
+3. AUTHORIZED_SCOPE.md does not yet authorize the work you are about to do.
+4. Your subagent reports success but you cannot independently verify the claim (see §8 paranoid mode).
+5. CI on `main` is red because of someone else's merge — do not push your work until red is resolved.
+6. The Phase you are about to start has no `_DRAFT.md` ratified into `_PLAN.md` yet.
+
+---
+
+## §8. Paranoid mode (binding for all 3 orchestrators)
+
+Per memory note `feedback-paranoid-orchestrator-mode` (2026-04-30) and `feedback-codex-hallucinated-citations` and `feedback-codex-bg-task-monitoring`:
+
+1. **Distrust executor reports.** A subagent saying "tests pass, ruff clean, mypy clean" is hearsay until you re-run those commands yourself in the worktree.
+2. **Verify file references.** Codex (and sometimes Claude) hallucinates `file:line` citations and method/symbol names. Before acting on any review finding, `grep` and `Read` the actual file. If the citation does not match, downgrade the finding to "needs investigation" and re-prompt.
+3. **Background agents may return early.** A `codex:codex-rescue` or other background tool may return "launched bg task X" without delivering. Always check the worktree, branch, and PR after ~30 min. If no commit / no PR — assume stuck, take over yourself.
+4. **Independent verifier per merge.** Each PR's CI green is necessary but not sufficient. Run an independent reviewer (Claude `-p`) with the diff before merge. The reviewer must confirm: scope match, invariants intact, tests cover the bug class, no hallucinated citations remain.
+5. **Never claim phase closed without proof.** "Phase X closed" requires (a) all tickets CLOSED on GitHub, (b) all PRs MERGED, (c) IMPLEMENTATION_STATUS.md reflects every ticket, (d) FHR reviewers gave ACCEPTED + APPROVE, (e) post-merge `pytest -x` on a fresh main checkout passes. Anything less = "in progress".
+6. **Worktree collision check before any branch creation.** `git worktree list` before `git worktree add`. If your target path exists with a different branch — STOP, escalate.
+7. **Branch namespace check before creating branch.** Verify your branch prefix matches §1; if not, fix the prefix or escalate.
+8. **REGISTRY drift detection.** Every heartbeat: `git diff main:docs/memory-system/ORCHESTRATOR_REGISTRY.md $(git show -s --format=%H main^):docs/memory-system/ORCHESTRATOR_REGISTRY.md`. If the file changed since your last read — re-read it fully.
+
+---
+
+## §9. Glossary (cross-orchestrator vocabulary)
+
+- **PAR review** = post-implementation, pre-merge dual review (1 product + 1 technical).
+- **FHR** = Final Holistic Review, performed at end of every multi-sprint phase across all PRs in that phase.
+- **Wave** = group of streams that can run in parallel within a single phase (e.g., Phase 4 had Wave 1 = Streams A, C, E).
+- **Stream** = single thread of execution inside a phase, owned by one subagent / one branch.
+- **Sprint** = one PR-shipped chunk of work; usually one sprint = one stream's deliverable.
+- **Hub** = the orchestrator's main coordinating context; does not write code, only reads / dispatches / verifies / merges.
+
+---
+
+**Last updated:** 2026-04-30 (created at orchestrator-registry kickoff).

--- a/docs/superpowers/specs/2026-04-30-autonomous-healing-design.md
+++ b/docs/superpowers/specs/2026-04-30-autonomous-healing-design.md
@@ -1,0 +1,291 @@
+# Autonomous Healing System for shkoderbot — Design
+
+**Status:** draft, awaiting review
+**Date:** 2026-04-30
+**Author:** brainstormed with eekudryavtsev (jekudy)
+**Trigger:** 3-day outage 2026-04-26 → 2026-04-29 caused by stricter config validators in commit `ade13b3` deployed without env update; crash loop went undetected because `health_check_enabled=false` on the Coolify app and there was no liveness probe outside the box.
+
+## 1. Goal
+
+Keep shkoderbot prod constantly working through (a) frequent composite healthcheck and (b) autonomous remediation by a Claude CLI session running on a self-hosted GitHub Actions runner on the VPS. Optimise for: outage detection within one cadence cycle, fix attempt without waking the operator, hard guardrails so the autonomous loop cannot make production worse than it found it.
+
+## 2. Non-goals
+
+- Replacing operator judgement on architectural decisions, schema migrations, or security-sensitive code.
+- Replacing Coolify/CI/CD. Healing system *uses* both, doesn't replace them.
+- Multi-tenant or generic "self-healing platform". This is shkoderbot-specific; transferable lessons may emerge but are not in scope.
+- Solving alert fatigue across other Vibe projects. Single project, single bot.
+
+## 3. Architecture
+
+```
+GH Actions cron (ubuntu-latest, every 3h)
+  └─ healthcheck.yml
+       ├─ run 4 composite checks in parallel
+       ├─ append result to healing-state branch healthcheck-log.jsonl
+       └─ if any check red →
+              workflow_dispatch healing.yml with signal payload
+                                    ↓
+       GH Actions self-hosted runner on VPS (label: shkoder-vps, user: runner)
+         └─ healing.yml (concurrency: healing-singleton)
+              ├─ pre-flight: check .healing/disabled flag → abort if present
+              ├─ acquire lock (commit .healing/in-progress to healing-state branch)
+              ├─ snapshot: SHA + env hash (sha256 of sorted keys+values) + restart_count → snapshot.json
+              ├─ collect context bundle (signal + git log -50 + container logs 500 lines + Coolify state)
+              ├─ Claude session via claude CLI (auth-based, not API key)
+              ├─ if Claude opens PR → codex review gate → APPROVE required
+              ├─ if PR approved → gh pr merge --rebase → wait for deploy
+              ├─ post-fix watch: 10 min × healthcheck poll
+              ├─ green → audit GH issue "succeeded" (closed) + TG notify (info)
+              ├─ red after watch → auto-rollback to snapshot (SHA + env restore) → retry++
+              └─ after retry == 3 → escalate (TG sendMessage + open ALERT issue) + drop .healing/disabled
+```
+
+## 4. Healthcheck
+
+Implemented as `ops/healing/healthcheck.py`, run by `.github/workflows/healthcheck.yml` cron every 3 hours.
+
+Four signals, parallel:
+
+| Signal | What | Red condition |
+|---|---|---|
+| `coolify_status` | `GET /api/v1/applications/{uuid}` | status == `exited:*`, OR restart_count Δ > 2 vs previous run |
+| `telegram_pending` | `getWebhookInfo` | `pending_update_count` > 50 AND growing vs previous run |
+| `db_roundtrip` | `psycopg.connect(DATABASE_URL_RO).execute("SELECT 1")` | timeout >5s OR exception |
+| `e2e_ping` (deferred) | Service account sends `/healthcheck@vibeshkoder_bot`, awaits reply 30s | no reply / wrong reply |
+
+`e2e_ping` is implemented later — requires a `bot/handlers/healthcheck.py` handler that responds `OK <utc_iso>` to admin_ids only, plus a service-account TG client. Initial cut runs only the first three.
+
+History: every run appends a JSON line to `healthcheck-log.jsonl` on orphan branch `healing-state`. Trend analysis (e.g., "restart_count keeps creeping") is enabled by reading recent lines.
+
+If any signal is red, workflow does:
+```
+gh workflow run healing.yml -f signal_payload="$JSON"
+```
+
+## 5. Healing session
+
+Implemented as `.github/workflows/healing.yml`, runs on self-hosted runner with label `shkoder-vps`.
+
+### 5.1 Concurrency & lock
+
+`concurrency: { group: healing-singleton, cancel-in-progress: false }`. Plus file-based lock `.healing/in-progress` committed to `healing-state` branch — guards against concurrent healing if the GH concurrency primitive ever drifts.
+
+### 5.2 Snapshot
+
+Before any change, write `snapshot.json`:
+```json
+{
+  "ts": "2026-04-30T...",
+  "prod_image_sha": "sha-caebb519",
+  "env_hash": "sha256:...",
+  "env_dump_encrypted": "<encrypted with healing-state key>",
+  "restart_count": 12,
+  "trigger_signal": {...}
+}
+```
+
+`env_dump_encrypted` enables full env restore on rollback. Encryption key lives in GH Secrets (`HEALING_ENV_KEY`), decryptable only inside the runner.
+
+### 5.3 Context bundle
+
+`context-bundle.md` assembled by a script before invoking Claude:
+
+- `## Signal` — full failure JSON from healthcheck
+- `## Healthcheck history (24h)` — last 8 entries from `healthcheck-log.jsonl`
+- `## Recent commits` — `git log --oneline -50`
+- `## Last 5 commit diffs (stat only)` — quick scan for size
+- `## Coolify state` — apps + statuses + restart_count + last_online_at + env keys (no values)
+- `## Container logs` — last 500 lines via `docker logs --tail 500 <bot-container>`
+- `## Last 3 deployments` — Coolify deployments API output
+- `## Snapshot reference` — pointer to snapshot.json for rollback
+
+### 5.4 Claude invocation
+
+```bash
+claude -p \
+  --model claude-opus-4-7 \
+  --append-system-prompt "$(cat ops/healing/INVARIANTS.md)" \
+  --max-turns 50 \
+  < context-bundle.md > session.log
+```
+
+Auth comes from `/home/runner/.claude/` (one-time `claude login` during VPS setup). No `ANTHROPIC_API_KEY` env var.
+
+Claude has access to:
+- Bash with PreToolUse hook (`ops/healing/preToolUse-hook.sh`) blocking forbidden commands
+- `gh` CLI (token in env)
+- `curl` (Coolify API token in env)
+- `docker` via runner user's docker group membership: read-only verbs only (`ps`, `logs`, `inspect`). `exec`/`run`/`rm`/`kill` blocked by hook.
+- `psql` against read-only DB user
+
+Auto-loaded skills (set in runner's `~/.claude/CLAUDE.md`):
+- `superpowers:systematic-debugging` — mandatory for diagnosis
+- `superpowers:test-driven-development` — required when writing code fix
+- `superpowers:writing-plans` — when fix needs >1 step
+
+### 5.5 Codex review gate
+
+If Claude opens a PR, before merge:
+```bash
+codex exec review --base main -m gpt-5.5 -c model_reasoning_effort=high --ephemeral
+```
+Auth via `codex login`. If verdict ≠ `APPROVE`, healing reads codex feedback, returns control to Claude for attempt #2 (counts toward retry budget).
+
+Rationale: dual-model review per superflow-enforcement rule 6. Single autonomous reviewer can convince itself. Codex is independent and free under subscription.
+
+### 5.6 Post-fix watch
+
+After merge + Coolify deploy completes:
+- 10 minutes, healthcheck every 2 minutes (5 polls)
+- All 5 must be green for "fix succeeded" verdict
+- Any red → trigger rollback
+
+### 5.7 Rollback
+
+If watch fails:
+- `gh api PATCH /api/v1/applications/{uuid} -f docker_registry_image_tag=sha-<snapshot.prod_image_sha>` (assumes `:sha-<commit>` pinning is set up — see N5 handoff; if not, use rollback to previous Coolify deployment)
+- Restore env: decrypt `snapshot.env_dump_encrypted`, PATCH each env back to snapshot value
+- The PR Claude opened: `gh pr close <num> --comment "auto-reverted; root cause not resolved"` and revert commit pushed
+
+After rollback, retry counter increments. If retries < 3, return to context-bundle step (Claude gets new bundle including the failed attempt summary).
+
+## 6. Invariants
+
+Stored in `ops/healing/INVARIANTS.md`, injected as Claude system prompt suffix and enforced by `preToolUse-hook.sh`.
+
+### Hard NEVER (hook-enforced where possible)
+
+1. No direct push to `main`. PR-only.
+2. No `--admin`, `--no-verify`, `--force` flags on git/gh.
+3. No alembic migrations autonomously.
+4. No `DROP`, `DELETE FROM` without `WHERE id = …`, no `rm -rf` outside `/tmp`.
+5. No edits to security-sensitive paths: `bot/web/auth.py`, `bot/services/sheets.py`, anything matching `*crypto*` / `*token*` / `*secret*` (case-insensitive).
+6. No rotation of `BOT_TOKEN`, `WEB_PASSWORD`, `WEB_SESSION_SECRET`, `DB_PASSWORD`.
+7. No Hostinger API calls (no VPS reboot/destroy).
+8. No Coolify network/firewall/Tailscale config changes.
+
+### Hard MUST
+
+9. Snapshot before any change.
+10. PR diff ≤ 300 lines. Bigger → escalate.
+11. PR includes red→green test reproducing the bug.
+12. 10-min watch after deploy. Red → auto-rollback.
+13. Max 3 retries per incident.
+14. 15-min cooldown between retries.
+15. Same root cause appearing twice → escalate immediately (no retry #3).
+16. 30-min wall-clock budget per incident.
+
+### Soft (documented exception in PR description allowed)
+
+17. Trunk-based, one small PR.
+18. CHANGELOG updated.
+
+Hook implementation: `preToolUse-hook.sh` reads tool input JSON, regex-matches against forbidden patterns, exits 1 with explanation if matched. Wired in `~/.claude/settings.json` on runner.
+
+## 7. Escalation & audit
+
+Escalation triggers: retries == 3, or hard-fail invariant tripped (e.g., diff > 300 lines), or wall-clock exceeded.
+
+**Channel 1 — Telegram:**
+```python
+requests.post(
+    f"https://api.telegram.org/bot{BOT_TOKEN}/sendMessage",
+    json={
+        "chat_id": 149820031,  # jekudy
+        "text": f"⚠️ healing escalation\nincident #{N}\nattempts: {retries}\nverdict: {verdict}\nlast_error: {last_err}\nissue: {issue_url}",
+    },
+)
+```
+Works as long as `BOT_TOKEN` is valid and Telegram API is reachable. Independent of bot's polling state.
+
+**Channel 2 — GitHub Issue (always):**
+- Title: `[ALERT] healing escalation #N — <signal_summary>`
+- Body: full session.log, snapshot.json, all retry transcripts, codex review verdicts.
+- Labels: `healing`, `incident`, `priority:high`.
+- Opens regardless of TG outcome — always-on audit trail.
+
+After escalation, runner writes `.healing/disabled` to `healing-state` branch. Subsequent healthcheck failures will skip healing and only escalate (open issue), preventing endless retries while operator investigates. Operator clears the flag manually after fix.
+
+**Audit log per session (success or failure):**
+- GH issue `[healing] run #N — <verdict>` always created.
+- Success → closed automatically with summary.
+- Escalation → kept open, requires user ack.
+
+## 8. State storage
+
+Orphan git branch `healing-state` holds all runtime state:
+- `healthcheck-log.jsonl` — append-only history.
+- `snapshots/<incident-id>.json` — per-incident snapshot.
+- `.healing/in-progress` — concurrency lock.
+- `.healing/disabled` — manual circuit breaker.
+- `.healing/last-restart-count.json` — for trend comparison.
+
+Why orphan branch and not S3 / dedicated DB: zero extra infra, free, naturally version-controlled, GH-Actions-friendly. Tradeoff: not suitable for high-frequency writes — fine here (cadence is 3h, healing sessions are rare).
+
+## 9. Components inventory
+
+| Path | Purpose |
+|---|---|
+| `.github/workflows/healthcheck.yml` | 3h cron, 4 composite checks, dispatch healing on red |
+| `.github/workflows/healing.yml` | Self-hosted runner job, full session lifecycle |
+| `ops/healing/healthcheck.py` | Composite check implementation |
+| `ops/healing/context-bundle.py` | Assembles context-bundle.md |
+| `ops/healing/snapshot.py` | Snapshot create/restore (with env encryption) |
+| `ops/healing/preToolUse-hook.sh` | Claude tool-use guard |
+| `ops/healing/INVARIANTS.md` | System prompt for Claude session |
+| `ops/healing/SETUP.md` | One-time VPS runner setup runbook |
+| `bot/handlers/healthcheck.py` (later) | E2E ping responder for admin_ids |
+
+## 10. One-time setup (operator)
+
+1. **GH PAT**: create with `repo, workflow, packages:write` → `gh secret set HEALING_GITHUB_TOKEN`.
+2. **GH Secrets**: `COOLIFY_API_TOKEN`, `BOT_TOKEN`, `DATABASE_URL_RO` (separate read-only PG user — needs new role created in PG), `HEALING_ENV_KEY` (32-byte random for env encryption).
+3. **Service account TG ID**: hardcoded `149820031` in workflow (can move to secret if rotation needed).
+4. **VPS runner setup** (per `ops/healing/SETUP.md`):
+   - `useradd -m -G docker runner`
+   - download `actions-runner-linux-x64`, configure with label `shkoder-vps`
+   - enable systemd `actions-runner.service` under `runner` user
+   - `sudo -u runner claude login` (interactive, browser auth)
+   - `sudo -u runner codex login` (interactive, ChatGPT auth)
+   - drop `INVARIANTS.md` symlink into `/home/runner/.claude/agents/system-suffix.md`
+5. **Read-only DB user**: `CREATE USER healing_ro WITH PASSWORD '...'; GRANT CONNECT ON DATABASE vibe_gatekeeper TO healing_ro; GRANT USAGE ON SCHEMA public TO healing_ro;` — write `DATABASE_URL_RO` from this.
+6. **Coolify cleanup**: enable health_check on bot app (`/health` endpoint or TCP 3000) — independent of healing system but related; would have caught the 2026-04-26 outage faster on its own.
+
+## 11. Cost & risks
+
+**Cost:** Claude/Codex via subscription auth (no per-token billing). Marginal cost is GH Actions minutes — ubuntu-latest cron `0 */3 * * *` = ~8 runs/day ≈ 4 min/day; self-hosted runner cron usage doesn't count toward GH minutes; healing sessions rare (~1/month). Effectively free.
+
+**Risks:**
+- *Bad fix passes codex review.* Mitigation: 10-min watch + auto-rollback. Fail-safe.
+- *Healing keeps trying despite escalation.* Mitigation: `.healing/disabled` flag + retry counter persistence in `healing-state` branch.
+- *Auth expiry on VPS.* Claude/Codex CLI tokens may expire; healing job must detect auth failure (`claude -p` exits non-zero) and escalate without retry. Add watchdog test in healthcheck (call `claude -p "echo OK"` on runner, alert if fails).
+- *Compromised runner.* Has BOT_TOKEN, COOLIFY_API_TOKEN, GH PAT in env per-run. Mitigation: secrets scoped to healing job only, not shared with other workflows; runner user is non-root, no Tailscale config access.
+- *Telegram message lands in deleted chat.* Mitigation: secondary GH Issue channel always opens.
+- *Codex review hallucination.* See `feedback-codex-hallucinated-citations.md` — codex verdicts directionally correct but file:line refs may be wrong. Healing reads only verdict and high-level feedback, doesn't blindly apply codex suggestions.
+
+## 12. Testing strategy
+
+- **Unit tests**: `ops/healing/healthcheck.py`, `snapshot.py`, `context-bundle.py` — pure Python, mockable.
+- **Integration test**: end-to-end dry-run mode (`HEALING_DRY_RUN=true`) where Claude session is replaced by a stub that returns a canned PR. Verifies workflow plumbing, codex gate, watch, rollback paths.
+- **Chaos test (manual)**: introduce known-broken commit on a feature branch deployed to a test Coolify app; trigger healing manually; verify it diagnoses correctly and either fixes or escalates appropriately.
+- **Invariant tests**: `preToolUse-hook.sh` has its own test suite — feed forbidden commands, expect exit 1.
+
+## 13. Open questions / deferred
+
+- E2E `/healthcheck` handler: deferred to separate ticket. Initial cut uses 3 signals.
+- E2E TG service account: how to authenticate without exposing real session string. Options: separate burner bot (`@shkoder_healthcheck_bot`) sending to `@vibeshkoder_bot`; or MTProto session for a dedicated test account. Decision deferred until E2E gets prioritised.
+- Coolify deployment SHA pinning (`:sha-<commit>` tag): documented in handoff `2026-04-26_20-05_n5-sha-pin.md`, partially in flight. Healing rollback assumes this is in place — if not, falls back to "redeploy previous successful Coolify deployment" path.
+- Multi-region or HA: out of scope; single-VPS architecture by design for this product.
+
+## 14. Decision log (this brainstorm)
+
+| Question | Choice | Why |
+|---|---|---|
+| Autonomy level | Full incl. code (C) | User explicitly chose; bounded by invariants & dual review |
+| Where Claude runs | GH self-hosted runner on VPS (B) | Centralised secrets, PR flow, ops access via localhost |
+| Healthcheck signals | Composite, 4-signal (D) | Single signal can't catch all failure modes; today's outage needed `restart_count` trend |
+| Codex review gate | Mandatory before merge (A) | Independent eyes prevent echo chamber |
+| Auth | CLI auth, not API key | User direction; subscription cost only |
+| Cadence | Every 3 hours | User direction |
+| Escalation | TG via shkoderbot to jekudy + GH Issue fallback | TG primary, Issue always-on audit |


### PR DESCRIPTION
Setup for 3 parallel paranoid orchestrators (A/B/C) per ORCHESTRATOR_REGISTRY.md.

## Files

- **`docs/memory-system/ORCHESTRATOR_REGISTRY.md`** — coordination ground truth.
  - §1 Active orchestrators with branch namespace + worktree + alembic range
  - §2 Owned files + shared (collision) boundaries
  - §3 Coordination protocol (sprint kickoff, heartbeat, shared-file edits, REGISTRY edits, PR/merge rules)
  - §4 Active sprints
  - §5 Cross-orchestrator dependencies
  - §6 Collision history
  - §7 Stop / escalate signals
  - §8 Paranoid mode (binding rules from memory feedback notes)
  - §9 Glossary

- **`docs/memory-system/AUTHORIZED_SCOPE.md`** — Phase 5, 11, 12 now authorized.
  Phase 9/10 conditionally (design refinement only, impl blocked on Phase 6).

## Orchestrator allocation

| Orch | Phase chain | Branch namespace | Owned alembic |
|------|-------------|------------------|---------------|
| A | Phase 5 → 6 → 7 → 8 (sequential synthesis chain) | feat/p{5,6,7,8}-* | 022–049 |
| B | Phase 9 (wiki) + Phase 10 (graph) + Phase 12 (butler docs) | feat/p{9,10,12}-* | 050–069 (gated) |
| C | Phase 11 (Shkoderbench / evals) | feat/p11-* | none |

## Charter

- governance_mode = critical
- git_workflow_mode = parallel_wave_prs
- per-PR PAR review (Claude product + Codex technical)
- FHR mandatory at end of every multi-sprint phase
- paranoid mode binding (distrust executor reports, independent verifier per merge,
  worktree collision check, REGISTRY drift detection on heartbeat)