### PR TITLE
fix(healing): run healthcheck on self-hosted runner + git identity

### DIFF
--- a/.github/workflows/healing.yml
+++ b/.github/workflows/healing.yml
@@ -44,5 +44,10 @@ jobs:
       - name: Install dependencies
         run: pip install -e ".[dev,healing]"
 
+      - name: Configure git identity for state branch
+        run: |
+          git config user.name "healing-bot[bot]"
+          git config user.email "healing-bot@users.noreply.github.com"
+
       - name: Run autonomous healing orchestrator
         run: python -m ops.healing.orchestrator --signal-payload "$SIGNAL_PAYLOAD"

--- a/.github/workflows/healthcheck.yml
+++ b/.github/workflows/healthcheck.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   healthcheck:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, shkoder-vps]
     env:
       COOLIFY_BASE_URL: ${{ vars.COOLIFY_BASE_URL }}
       COOLIFY_APP_UUID: ${{ vars.COOLIFY_APP_UUID }}
@@ -30,6 +30,11 @@ jobs:
 
       - name: Install dependencies
         run: pip install -e ".[dev,healing]"
+
+      - name: Configure git identity for state branch
+        run: |
+          git config user.name "healing-bot[bot]"
+          git config user.email "healing-bot@users.noreply.github.com"
 
       - name: Run composite healthcheck
         id: check

--- a/ops/healing/SETUP.md
+++ b/ops/healing/SETUP.md
@@ -22,7 +22,7 @@ export HEALING_GITHUB_TOKEN
 ## 2. Set GitHub Secrets
 
 ```bash
-REPO="Jekudy/vibe-gatekeeper"
+REPO="Jekudy/vibeshkoder"
 
 gh secret set HEALING_GITHUB_TOKEN --repo "$REPO" --body "$HEALING_GITHUB_TOKEN"
 gh secret set COOLIFY_API_TOKEN --repo "$REPO" --body "$COOLIFY_API_TOKEN"
@@ -44,7 +44,7 @@ PY
 ## 3. Set GitHub repository variables
 
 ```bash
-REPO="Jekudy/vibe-gatekeeper"
+REPO="Jekudy/vibeshkoder"
 
 gh variable set COOLIFY_BASE_URL --repo "$REPO" --body "$COOLIFY_BASE_URL"
 gh variable set COOLIFY_APP_UUID --repo "$REPO" --body "$COOLIFY_APP_UUID"
@@ -68,8 +68,8 @@ sudo chown -R runner:runner /home/runner/actions-runner
 ## 5. Install GitHub Actions runner on VPS
 
 ```bash
-REPO="Jekudy/vibe-gatekeeper"
-RUNNER_VERSION="2.328.0"
+REPO="Jekudy/vibeshkoder"
+RUNNER_VERSION="2.334.0"
 RUNNER_TOKEN="$(gh api -X POST "repos/$REPO/actions/runners/registration-token" --jq .token)"
 
 sudo -u runner bash -lc "
@@ -140,7 +140,7 @@ sudo -u runner -H tee /home/runner/.claude/settings.json >/dev/null <<'JSON'
         "hooks": [
           {
             "type": "command",
-            "command": "/home/runner/actions-runner/_work/vibe-gatekeeper/vibe-gatekeeper/ops/healing/preToolUse_hook.sh"
+            "command": "/home/runner/actions-runner/_work/vibeshkoder/vibeshkoder/ops/healing/preToolUse_hook.sh"
           }
         ]
       }
@@ -171,7 +171,7 @@ postgresql://healing_ro:${HEALING_RO_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}
 ## 11. Verify runner labels and auth
 
 ```bash
-REPO="Jekudy/vibe-gatekeeper"
+REPO="Jekudy/vibeshkoder"
 
 gh api "repos/$REPO/actions/runners" --jq '.runners[] | select(.labels[].name == "shkoder-vps") | .name'
 sudo -u runner -H bash -lc 'claude -p "echo OK"'


### PR DESCRIPTION
## Summary
Activation of the autonomous healing system surfaced two blockers in the
first dispatched healthcheck run (#25214345225):

- `runs-on: ubuntu-latest` cannot reach Coolify (Tailscale 100.101.196.21:8100)
  or the bot Postgres (private 172.24.0.10:5432) → both probes RED with
  "timed out" / "connection timeout expired".
- `state_branch._prepare_orphan_branch` calls `git commit --allow-empty`
  without git identity configured → exit 128 in `Append healthcheck history`.

## Changes
- `healthcheck.yml` → `runs-on: [self-hosted, shkoder-vps]` (matches healing.yml,
  free of GitHub Actions minutes, and reaches the VPS-internal endpoints).
- Both workflows: pre-step that sets `git config user.name/email`.
- `ops/healing/SETUP.md`: canonical repo name `Jekudy/vibeshkoder` and bumped
  runner version `2.328.0 → 2.334.0`.

## Test plan
- [x] Self-hosted runner online (`gh api repos/.../actions/runners`)
- [ ] Re-dispatch `Healing Healthcheck` after merge — expect green for
      coolify_status, db_roundtrip, telegram_pending; healing-state branch
      created on origin with first JSONL entry