### PR TITLE
fix(healing): bump healing workflows to Python 3.13

### DIFF
--- a/.github/workflows/healing.yml
+++ b/.github/workflows/healing.yml
@@ -39,7 +39,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: Install dependencies
         run: pip install -e ".[dev,healing]"

--- a/.github/workflows/healthcheck.yml
+++ b/.github/workflows/healthcheck.yml
@@ -26,7 +26,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: Install dependencies
         run: pip install -e ".[dev,healing]"


### PR DESCRIPTION
Self-hosted runner on Ubuntu 25.10 has no prebuilt setup-python 3.12. pyproject requires >=3.12 so 3.13 satisfies. Followup to PR #169.