### PR TITLE
feat(p11-w1-06): evals workflow + eval-results-schema doc

### DIFF
--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -1,0 +1,86 @@
+name: Evals
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "15 3 * * *"
+
+jobs:
+  evals-gate:
+    runs-on: ubuntu-latest
+    outputs:
+      enabled: ${{ steps.gate.outputs.enabled }}
+    steps:
+      - name: Check eval harness gate
+        id: gate
+        shell: bash
+        env:
+          EVAL_HARNESS_ENABLED_SECRET: ${{ secrets.EVAL_HARNESS_ENABLED }}
+        run: |
+          if [ "$EVAL_HARNESS_ENABLED_SECRET" = "true" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  evals:
+    needs: evals-gate
+    if: ${{ needs.evals-gate.outputs.enabled == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: vibe
+          POSTGRES_PASSWORD: changeme
+          POSTGRES_DB: vibe_gatekeeper
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U vibe -d vibe_gatekeeper"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 10
+    env:
+      BOT_TOKEN: 123456:test-token
+      COMMUNITY_CHAT_ID: -1001234567890
+      ADMIN_IDS: '[149820031]'
+      DATABASE_URL: postgresql+asyncpg://vibe:changeme@localhost:5432/vibe_gatekeeper
+      REDIS_URL: redis://redis:6379/0
+      GOOGLE_SHEETS_CREDS_FILE: ""
+      GOOGLE_SHEET_ID: ""
+      WEB_BASE_URL: http://localhost:8080
+      WEB_BOT_USERNAME: vibeshkoder_dev_bot
+      DB_PASSWORD: changeme
+      WEB_PASSWORD: test-pass
+      WEB_SESSION_SECRET: test-session-secret
+      DEV_MODE: "true"
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install -e ".[dev,healing]"
+
+      - name: Run evals
+        shell: bash
+        run: |
+          : > eval_results.jsonl
+          if [ -d tests/evals ] && [ -n "$(find tests/evals -name 'test_*.py' -print -quit)" ]; then
+            EVAL_HARNESS_ENABLED=1 timeout 300 pytest -x --timeout=60 tests/evals/ --jsonl-report=eval_results.jsonl || true
+          else
+            echo "tests/evals/ not yet populated - skipping eval run"
+          fi
+
+      - name: Upload eval results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: eval-results
+          path: eval_results.jsonl
+          if-no-files-found: error

--- a/docs/memory-system/eval-results-schema.md
+++ b/docs/memory-system/eval-results-schema.md
@@ -1,0 +1,48 @@
+# Eval Results JSONL Schema
+
+`eval_results.jsonl` is the machine-readable Phase 11 verdict artifact produced by
+`.github/workflows/evals.yml`. The file uses JSON Lines: one complete JSON object per line,
+with a final summary object as the last line.
+
+`PHASE11_PLAN.md §8.1` defines Orch A as the consumer of this artifact for the Phase 5 closure
+verdict. Automation must read this file directly; PR comments are only a human mirror of the same
+verdict.
+
+## Per-case line
+
+Each non-summary line records one evaluated case.
+
+| Field | Type | Required | Contract |
+|-------|------|----------|----------|
+| `verdict` | string | yes | One of `PASS` or `FAIL`. |
+| `category` | string | yes | One of `leakage`, `citations`, `refusal`, `recall_precision`, `determinism`, `no_llm_imports`. |
+| `case_id` | string | yes | Stable case identifier, for example `L1`, `L2`, `C1`, `R1`, `I1`, `I2`, `I3`, `D1`, `M_recall@3`, or `M_precision@5`. |
+| `seed_hash` | string | yes | SHA-256 hex digest of the seed bundle used for this run. |
+| `harness_version` | string | yes | Git SHA of the harness at run time, equivalent to `git rev-parse HEAD`. |
+| `evidence` | object | yes | Arbitrary JSON object with assertion details, expected and actual values, or `file:line` data for import-graph cases. |
+
+`evidence` must stay JSON-serializable and must not require consumers to parse prose. Prefer
+explicit keys such as `expected`, `actual`, `line`, `path`, `metric`, `threshold`, and `details`.
+
+## Final summary line
+
+The last line must be exactly one summary object.
+
+| Field | Type | Required | Contract |
+|-------|------|----------|----------|
+| `summary` | boolean | yes | Always `true`. Distinguishes the final line from per-case lines. |
+| `total_cases` | integer | yes | Count of per-case lines written before the summary. |
+| `passed` | integer | yes | Count of per-case lines with `verdict == "PASS"`. |
+| `failed` | integer | yes | Count of per-case lines with `verdict == "FAIL"`. |
+| `seed_hash` | string | yes | SHA-256 hex digest of the seed bundle used for the run. |
+| `harness_version` | string | yes | Git SHA of the harness at run time. |
+| `wall_clock_seconds` | number | yes | End-to-end harness wall-clock runtime in seconds. |
+
+## Example
+
+```jsonl
+{"verdict":"PASS","category":"leakage","case_id":"L1","seed_hash":"a75f6f9c9f0f4d8e7e5e7be6f2e35fb5b7b7d7d15f62b23c8c7b2f4f67c4d2d1","harness_version":"970842f4acfaa7646da12fa4c7b29820e941749b","evidence":{"returned_message_version_ids":[],"blocked_message_version_ids":[101]}}
+{"verdict":"FAIL","category":"citations","case_id":"C1","seed_hash":"a75f6f9c9f0f4d8e7e5e7be6f2e35fb5b7b7d7d15f62b23c8c7b2f4f67c4d2d1","harness_version":"970842f4acfaa7646da12fa4c7b29820e941749b","evidence":{"expected":"positive message_version_id","actual":null,"path":"tests/evals/test_citations.py","line":42}}
+{"verdict":"PASS","category":"recall_precision","case_id":"M_recall@3","seed_hash":"a75f6f9c9f0f4d8e7e5e7be6f2e35fb5b7b7d7d15f62b23c8c7b2f4f67c4d2d1","harness_version":"970842f4acfaa7646da12fa4c7b29820e941749b","evidence":{"metric":1.0,"threshold":0.8,"k":3}}
+{"summary":true,"total_cases":3,"passed":2,"failed":1,"seed_hash":"a75f6f9c9f0f4d8e7e5e7be6f2e35fb5b7b7d7d15f62b23c8c7b2f4f67c4d2d1","harness_version":"970842f4acfaa7646da12fa4c7b29820e941749b","wall_clock_seconds":12.48}
+```


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/evals.yml` — daily-scheduled + manual eval workflow, **default OFF** (requires `EVAL_HARNESS_ENABLED` secret = `true` to run)
- Adds `docs/memory-system/eval-results-schema.md` — canonical JSONL schema for `eval_results.jsonl` (per-case fields + summary line)

## Default-OFF gate

The workflow uses a `evals-gate` job that reads `secrets.EVAL_HARNESS_ENABLED`. If the secret is absent or anything other than `"true"`, the gate outputs `enabled=false` and the `evals` job is skipped via `if: ${{ needs.evals-gate.outputs.enabled == 'true' }}`. Regular CI pushes never trigger eval runs until T11-W2-04 baseline freeze flips the secret.

## Test plan

- [ ] Confirm no Python files were added (`git diff --name-only HEAD~1..HEAD`)
- [ ] YAML parses: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/evals.yml'))"`
- [ ] `ruff check .` clean
- [ ] No LLM imports: `rg "anthropic|openai|langchain" bot/` → no matches
- [ ] Verify `evals` job is skipped when `EVAL_HARNESS_ENABLED` is not set (check Actions tab after CI runs)

## Files changed

```
.github/workflows/evals.yml
docs/memory-system/eval-results-schema.md
```

Closes #179

🤖 Generated with [Claude Code](https://claude.com/claude-code)