### PR TITLE
feat(p11): T11-W1-01 eval_runner.py skeleton

### DIFF
--- a/bot/services/eval_runner.py
+++ b/bot/services/eval_runner.py
@@ -1,0 +1,26 @@
+"""Offline evaluation runner for the production recall service path."""
+
+from __future__ import annotations
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from bot.db.models import QaTrace
+from bot.services.evidence import EvidenceBundle
+from bot.services.qa import run_qa
+
+
+async def run_eval_recall(
+    session: AsyncSession,
+    *,
+    query: str,
+    chat_id: int,
+    redact_query_in_audit: bool = False,
+) -> tuple[EvidenceBundle, QaTrace | None]:
+    """Call the same recall service used by production and expose its bundle."""
+    result = await run_qa(
+        session,
+        query=query,
+        chat_id=chat_id,
+        redact_query_in_audit=redact_query_in_audit,
+    )
+    return result.bundle, None

--- a/tests/evals/test_eval_runner_smoke.py
+++ b/tests/evals/test_eval_runner_smoke.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from bot.services.eval_runner import run_eval_recall
+
+pytestmark = pytest.mark.usefixtures("app_env")
+
+
+@pytest_asyncio.fixture()
+async def empty_eval_session(db_session: AsyncSession) -> AsyncIterator[AsyncSession]:
+    await db_session.execute(
+        text(
+            """
+            TRUNCATE TABLE
+                qa_traces,
+                message_versions,
+                chat_messages,
+                forget_events
+            RESTART IDENTITY CASCADE
+            """
+        )
+    )
+    yield db_session
+
+
+async def test_run_eval_recall_empty_fixture_abstains(
+    empty_eval_session: AsyncSession,
+) -> None:
+    bundle, trace = await run_eval_recall(
+        empty_eval_session,
+        query="nonexistent recall query",
+        chat_id=-1001234567890,
+    )
+
+    assert bundle.abstained is True
+    assert bundle.items == ()
+    assert trace is None


### PR DESCRIPTION
Implements **T11-W1-01** per `docs/memory-system/PHASE11_PLAN.md` §4 (architecture) + §10 (backlog). Closes #174.

## Scope

Programmatic caller for the production \`/recall\` path. NO production wiring, NO new endpoints.

- \`bot/services/eval_runner.py\` — \`run_eval_recall(session, *, query, chat_id, redact_query_in_audit=False) -> tuple[EvidenceBundle, QaTrace | None]\`. Calls \`bot.services.qa.run_qa\` unchanged; returns the production \`EvidenceBundle\`.
- \`tests/evals/__init__.py\` — empty package marker.
- \`tests/evals/test_eval_runner_smoke.py\` — async test that TRUNCATEs the eval-related tables and asserts \`bundle.abstained == True\` on an empty fixture.

## Invariants check

- ✅ Invariant 2 (no LLM): \`grep -r 'from anthropic\\|from openai\\|...' bot/\` returned empty.
- ✅ Invariant 3 (governance): no new code touches \`memory_policy\` / \`is_redacted\` / \`forget_events\` filters; calls existing \`run_qa\` unchanged.
- ✅ No alembic migrations.
- ✅ No new production handlers.

## Gate evidence

\`\`\`
ruff check: All checks passed!
mypy bot/services/eval_runner.py: clean (only pre-existing errors in qa.py / models.py on main, unrelated to this PR)
pytest --collect-only tests/evals/test_eval_runner_smoke.py: 1 test collected
LLM imports grep: empty
\`\`\`

The smoke test requires a real Postgres for the \`db_session\` fixture; it runs green in CI's test job and skips locally without a DB (by design — guarded by the existing \`app_env\` fixture marker).

## Note on QaTrace return value

Skeleton returns \`(bundle, None)\` for the trace component; \`run_qa\` does not return its trace handle directly (it only writes to \`qa_traces\` via \`QaTraceRepo.create\` inside the handler). T11-W2-02 (citation tests) will read trace state via the repo, not via this tuple. The Optional in the signature preserves room for a future direct-trace return without breaking callers.

## Refs

- Plan: \`docs/memory-system/PHASE11_PLAN.md\` §4 (architecture), §5.5 (determinism uses runner), §10 backlog.
- Issue: #174