### PR TITLE
feat(p11): T11-W1-03 eval_metrics.py recall@K / precision@K

### DIFF
--- a/bot/services/eval_metrics.py
+++ b/bot/services/eval_metrics.py
@@ -1,0 +1,36 @@
+"""Deterministic offline evaluation metrics for Phase 11."""
+
+from __future__ import annotations
+
+
+def recall_at_k(returned: list[int], expected: list[int], k: int) -> float:
+    """Return recall@K for returned message_version_ids.
+
+    The metric is ``|returned[:k] intersection expected| / |expected|``.
+    ``expected == []`` is undefined for recall, so this function returns ``0.0``.
+    Both inputs are treated as sets for matching, so duplicate ids in either list
+    do not double-count a hit or increase the expected denominator.
+    """
+    _validate_k(k)
+    expected_ids = set(expected)
+    if not expected_ids:
+        return 0.0
+
+    hits = len(set(returned[:k]) & expected_ids)
+    return hits / len(expected_ids)
+
+
+def precision_at_k(returned: list[int], expected: list[int], k: int) -> float:
+    """Return precision@K for returned message_version_ids.
+
+    The metric is ``|returned[:k] intersection expected| / k``. Inputs are treated
+    as sets for matching, so duplicate ids in either list do not double-count a hit.
+    """
+    _validate_k(k)
+    hits = len(set(returned[:k]) & set(expected))
+    return hits / k
+
+
+def _validate_k(k: int) -> None:
+    if k < 1:
+        raise ValueError("k must be >= 1")

--- a/tests/evals/__init__.py
+++ b/tests/evals/__init__.py
@@ -1,1 +1,1 @@
-
+"""Phase 11 offline evaluation tests."""

--- a/tests/evals/test_eval_metrics.py
+++ b/tests/evals/test_eval_metrics.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import pytest
+
+from bot.services.eval_metrics import precision_at_k, recall_at_k
+
+
+@pytest.mark.parametrize("k", [1, 3, 5])
+def test_full_overlap_returns_one(k: int) -> None:
+    expected = list(range(1, k + 1))
+    returned = [*expected, 100, 101]
+
+    assert recall_at_k(returned, expected, k) == 1.0
+    assert precision_at_k(returned, expected, k) == 1.0
+
+
+@pytest.mark.parametrize("k", [1, 3, 5])
+def test_zero_overlap_returns_zero(k: int) -> None:
+    returned = list(range(1, k + 1))
+    expected = [100, 101]
+
+    assert recall_at_k(returned, expected, k) == 0.0
+    assert precision_at_k(returned, expected, k) == 0.0
+
+
+@pytest.mark.parametrize(
+    ("k", "expected_recall", "expected_precision"),
+    [
+        (1, 0.25, 1.0),
+        (3, 0.5, 2 / 3),
+        (5, 0.5, 0.4),
+    ],
+)
+def test_partial_overlap(k: int, expected_recall: float, expected_precision: float) -> None:
+    returned = [1, 2, 9, 10, 11]
+    expected = [1, 2, 3, 4]
+
+    assert recall_at_k(returned, expected, k) == expected_recall
+    assert precision_at_k(returned, expected, k) == expected_precision
+
+
+def test_empty_expected_boundary() -> None:
+    assert recall_at_k([1, 2, 3], [], 3) == 0.0
+    assert precision_at_k([1, 2, 3], [], 3) == 0.0
+
+
+def test_empty_returned_boundary() -> None:
+    assert recall_at_k([], [1, 2], 3) == 0.0
+    assert precision_at_k([], [1, 2], 3) == 0.0
+
+
+def test_k_greater_than_returned_length_uses_available_results() -> None:
+    assert recall_at_k([1, 2], [1, 2, 3, 4], 5) == 0.5
+    assert precision_at_k([1, 2], [1, 2, 3, 4], 5) == 0.4
+
+
+@pytest.mark.parametrize("k", [0, -1])
+def test_k_less_than_one_raises_value_error(k: int) -> None:
+    with pytest.raises(ValueError, match="k must be >= 1"):
+        recall_at_k([1], [1], k)
+
+    with pytest.raises(ValueError, match="k must be >= 1"):
+        precision_at_k([1], [1], k)
+
+
+def test_duplicate_returned_ids_count_each_expected_element_once() -> None:
+    returned = [1, 1, 2]
+    expected = [1, 2]
+
+    assert recall_at_k(returned, expected, 3) == 1.0
+    assert precision_at_k(returned, expected, 3) == 2 / 3
+
+
+def test_duplicate_expected_ids_do_not_increase_recall_denominator() -> None:
+    returned = [1, 2]
+    expected = [1, 1, 2]
+
+    assert recall_at_k(returned, expected, 2) == 1.0
+    assert precision_at_k(returned, expected, 2) == 1.0


### PR DESCRIPTION
Implements **T11-W1-03** per \`docs/memory-system/PHASE11_PLAN.md\` §5.4 + §10. Closes #176.

## Scope

Pure-function deterministic metrics for the eval harness. NO DB, NO I/O, NO async, NO global state.

- \`bot/services/eval_metrics.py\`:
  - \`recall_at_k(returned, expected, k) -> float\` — \`|set(returned[:k]) ∩ set(expected)| / |set(expected)|\` (returns \`0.0\` when \`expected == []\`).
  - \`precision_at_k(returned, expected, k) -> float\` — \`|set(returned[:k]) ∩ set(expected)| / k\`.
  - \`_validate_k(k)\` raises \`ValueError\` when \`k < 1\`.
- \`tests/evals/test_eval_metrics.py\` — 16 tests across K∈{1,3,5}, full/zero/partial overlap, empty boundaries, k-out-of-range, and duplicate-id semantics.
- \`tests/evals/__init__.py\` — empty package marker.

## Invariants check

- ✅ Invariant 2 (no LLM): grep empty.
- ✅ No DB / I/O / module-level side effects.
- ✅ No alembic migrations / no production handlers.

## Gate evidence

\`\`\`
ruff check: All checks passed!
mypy bot/services/eval_metrics.py: Success: no issues found in 1 source file
pytest --timeout=60 tests/evals/test_eval_metrics.py: 16 passed in 0.03s
LLM imports grep: empty
\`\`\`

## Refs

- Plan: \`docs/memory-system/PHASE11_PLAN.md\` §5.4 (recall@K/precision@K), §10 backlog.
- Issue: #176