### PR TITLE
feat(p11): T11-W1-02 eval_seeds.py + 22 boundary tests

### DIFF
--- a/bot/services/eval_seeds.py
+++ b/bot/services/eval_seeds.py
@@ -1,0 +1,232 @@
+"""Loader for golden-recall seed fixtures used by the offline eval harness.
+
+The seed directory layout (canonical for ``seed_v1``):
+
+    seed_v1/
+      chat_history.jsonl    — one message per line; rows feed the production
+                              ingestion path during the eval fixture
+      queries.jsonl         — one (query, expected_local_ids, expected_abstain)
+                              triple per line
+      seed_meta.yaml        — human-readable manifest (NOT parsed by this loader;
+                              ``seed_id`` / ``version`` are passed explicitly so
+                              the project does not pull in a YAML runtime dep)
+
+``seed_hash`` is sha256 over the canonical JSONL bytes of the message list and
+serves as the deterministic content fingerprint that the harness writes into
+``eval_results.jsonl`` (see PHASE11_PLAN.md §8.1).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(frozen=True, slots=True)
+class MessageRow:
+    seed_local_id: str
+    user_id_local: int
+    text: str
+    ts: datetime
+    message_kind: str
+    caption: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class QueryRow:
+    query_id: str
+    query: str
+    expected_message_version_ids: tuple[str, ...]
+    expected_abstain: bool
+
+
+@dataclass(frozen=True, slots=True)
+class SeedSpec:
+    seed_id: str
+    version: int
+    seed_hash: str
+    messages: tuple[MessageRow, ...]
+    queries: tuple[QueryRow, ...]
+
+
+CHAT_HISTORY_FILENAME = "chat_history.jsonl"
+QUERIES_FILENAME = "queries.jsonl"
+
+
+def compute_seed_hash(messages_jsonl_bytes: bytes) -> str:
+    return hashlib.sha256(messages_jsonl_bytes).hexdigest()
+
+
+def canonical_jsonl_bytes(rows: list[dict[str, Any]]) -> bytes:
+    body = "\n".join(
+        json.dumps(row, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+        for row in rows
+    )
+    return f"{body}\n".encode("utf-8")
+
+
+def load_seed_spec(seed_dir: Path, *, seed_id: str, version: int) -> SeedSpec:
+    if not seed_dir.is_dir():
+        raise FileNotFoundError(f"seed directory not found: {seed_dir}")
+    if version < 1:
+        raise ValueError(f"version must be >= 1, got {version}")
+    if not seed_id:
+        raise ValueError("seed_id must be non-empty")
+
+    history_path = seed_dir / CHAT_HISTORY_FILENAME
+    queries_path = seed_dir / QUERIES_FILENAME
+
+    raw_messages = _load_jsonl(history_path)
+    raw_queries = _load_jsonl(queries_path)
+
+    seed_hash = compute_seed_hash(canonical_jsonl_bytes(raw_messages))
+
+    messages = tuple(
+        _message_from_row(row, history_path, line_no)
+        for line_no, row in enumerate(raw_messages, start=1)
+    )
+    queries = tuple(
+        _query_from_row(row, queries_path, line_no)
+        for line_no, row in enumerate(raw_queries, start=1)
+    )
+
+    seen_message_ids = {m.seed_local_id for m in messages}
+    if len(seen_message_ids) != len(messages):
+        raise ValueError(f"{history_path}: duplicate seed_local_id detected")
+
+    seen_query_ids = {q.query_id for q in queries}
+    if len(seen_query_ids) != len(queries):
+        raise ValueError(f"{queries_path}: duplicate query_id detected")
+
+    for query in queries:
+        unknown = [mv for mv in query.expected_message_version_ids if mv not in seen_message_ids]
+        if unknown:
+            raise ValueError(
+                f"{queries_path}: query {query.query_id!r} references unknown seed_local_ids {unknown}"
+            )
+
+    return SeedSpec(
+        seed_id=seed_id,
+        version=version,
+        seed_hash=seed_hash,
+        messages=messages,
+        queries=queries,
+    )
+
+
+def resolve_expected_ids(
+    query: QueryRow,
+    seed_local_id_map: dict[str, int],
+) -> list[int]:
+    return [seed_local_id_map[seed_local_id] for seed_local_id in query.expected_message_version_ids]
+
+
+def _load_jsonl(path: Path) -> list[dict[str, Any]]:
+    if not path.is_file():
+        raise FileNotFoundError(f"seed file missing: {path}")
+    rows: list[dict[str, Any]] = []
+    with path.open("r", encoding="utf-8") as fh:
+        for line_no, line in enumerate(fh, start=1):
+            stripped = line.strip()
+            if not stripped:
+                continue
+            try:
+                row = json.loads(stripped)
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"{path}:{line_no}: invalid JSON: {exc.msg}") from exc
+            if not isinstance(row, dict):
+                raise ValueError(f"{path}:{line_no}: expected JSON object, got {type(row).__name__}")
+            rows.append(row)
+    return rows
+
+
+def _message_from_row(row: dict[str, Any], path: Path, line_no: int) -> MessageRow:
+    location = f"{path}:{line_no}"
+    seed_local_id = _required_nonempty_str(row, "seed_local_id", location)
+    user_id_local = _required_int(row, "user_id_local", location)
+    text = _required_str_field(row, "text", location)
+    ts_raw = _required_nonempty_str(row, "ts", location)
+    message_kind = _required_nonempty_str(row, "message_kind", location)
+    caption_raw = row.get("caption")
+    caption: str | None
+    if caption_raw is None:
+        caption = None
+    elif isinstance(caption_raw, str):
+        caption = caption_raw
+    else:
+        raise ValueError(f"{location}: 'caption' must be string or null, got {type(caption_raw).__name__}")
+    try:
+        ts = datetime.fromisoformat(ts_raw)
+    except ValueError as exc:
+        raise ValueError(f"{location}: invalid 'ts' iso format: {exc!s}") from exc
+    return MessageRow(
+        seed_local_id=seed_local_id,
+        user_id_local=user_id_local,
+        text=text,
+        ts=ts,
+        message_kind=message_kind,
+        caption=caption,
+    )
+
+
+def _query_from_row(row: dict[str, Any], path: Path, line_no: int) -> QueryRow:
+    location = f"{path}:{line_no}"
+    query_id = _required_nonempty_str(row, "query_id", location)
+    query = _required_nonempty_str(row, "query", location)
+    if "expected_message_version_ids" not in row:
+        raise ValueError(f"{location}: missing required field 'expected_message_version_ids'")
+    expected = row["expected_message_version_ids"]
+    if not isinstance(expected, list) or not all(isinstance(item, str) for item in expected):
+        raise ValueError(f"{location}: 'expected_message_version_ids' must be list[str]")
+    if "expected_abstain" not in row:
+        raise ValueError(f"{location}: missing required field 'expected_abstain'")
+    expected_abstain = row["expected_abstain"]
+    if not isinstance(expected_abstain, bool):
+        raise ValueError(f"{location}: 'expected_abstain' must be bool")
+    if expected_abstain and expected:
+        raise ValueError(
+            f"{location}: query {query_id!r} has expected_abstain=true but non-empty expected_message_version_ids"
+        )
+    if not expected_abstain and not expected:
+        raise ValueError(
+            f"{location}: query {query_id!r} has expected_abstain=false but empty expected_message_version_ids"
+        )
+    return QueryRow(
+        query_id=query_id,
+        query=query,
+        expected_message_version_ids=tuple(expected),
+        expected_abstain=expected_abstain,
+    )
+
+
+def _required_nonempty_str(source: dict[str, Any], key: str, location: Path | str) -> str:
+    if key not in source:
+        raise ValueError(f"{location}: missing required field '{key}'")
+    value = source[key]
+    if not isinstance(value, str):
+        raise ValueError(f"{location}: '{key}' must be string, got {type(value).__name__}")
+    if not value:
+        raise ValueError(f"{location}: '{key}' must be non-empty")
+    return value
+
+
+def _required_str_field(source: dict[str, Any], key: str, location: Path | str) -> str:
+    if key not in source:
+        raise ValueError(f"{location}: missing required field '{key}'")
+    value = source[key]
+    if not isinstance(value, str):
+        raise ValueError(f"{location}: '{key}' must be string, got {type(value).__name__}")
+    return value
+
+
+def _required_int(source: dict[str, Any], key: str, location: Path | str) -> int:
+    if key not in source:
+        raise ValueError(f"{location}: missing required field '{key}'")
+    value = source[key]
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"{location}: '{key}' must be int, got {type(value).__name__}")
+    return value

--- a/tests/services/test_eval_seeds.py
+++ b/tests/services/test_eval_seeds.py
@@ -1,0 +1,288 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from bot.services.eval_seeds import (
+    QueryRow,
+    canonical_jsonl_bytes,
+    compute_seed_hash,
+    load_seed_spec,
+    resolve_expected_ids,
+)
+
+
+FIXTURE_DIR = Path("tests/fixtures/golden_recall/seed_v1")
+
+
+def _base_messages() -> list[dict[str, Any]]:
+    return [
+        {
+            "seed_local_id": "msg_03",
+            "user_id_local": 703,
+            "text": "Postgres FTS workshop",
+            "ts": "2026-04-01T10:02:00+03:00",
+            "message_kind": "text",
+        },
+        {
+            "seed_local_id": "msg_07",
+            "user_id_local": 706,
+            "text": "Saturday breakfast",
+            "ts": "2026-04-03T08:42:00+03:00",
+            "message_kind": "text",
+            "caption": None,
+        },
+    ]
+
+
+def _base_queries() -> list[dict[str, Any]]:
+    return [
+        {
+            "query_id": "q_01",
+            "query": "When is the workshop?",
+            "expected_message_version_ids": ["msg_03"],
+            "expected_abstain": False,
+        },
+        {
+            "query_id": "q_02",
+            "query": "What was for breakfast?",
+            "expected_message_version_ids": ["msg_07"],
+            "expected_abstain": False,
+        },
+    ]
+
+
+def _write_jsonl(path: Path, rows: list[dict[str, Any]]) -> None:
+    path.write_text(
+        "".join(f"{json.dumps(row, ensure_ascii=False)}\n" for row in rows),
+        encoding="utf-8",
+    )
+
+
+def _write_seed(
+    tmp_path: Path,
+    messages: list[dict[str, Any]],
+    queries: list[dict[str, Any]],
+) -> Path:
+    seed_dir = tmp_path / "seed_v1"
+    seed_dir.mkdir()
+    _write_jsonl(seed_dir / "chat_history.jsonl", messages)
+    _write_jsonl(seed_dir / "queries.jsonl", queries)
+    return seed_dir
+
+
+def _load_raw_jsonl(path: Path) -> list[dict[str, Any]]:
+    return [
+        json.loads(line)
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+def test_load_seed_spec_happy_path_loads_real_fixture() -> None:
+    spec = load_seed_spec(FIXTURE_DIR, seed_id="golden_recall", version=1)
+    raw_messages = _load_raw_jsonl(FIXTURE_DIR / "chat_history.jsonl")
+
+    assert spec.seed_id == "golden_recall"
+    assert spec.version == 1
+    assert len(spec.messages) == 24
+    assert len(spec.queries) == 9
+    assert spec.seed_hash == compute_seed_hash(canonical_jsonl_bytes(raw_messages))
+    assert sum(query.expected_abstain for query in spec.queries) == 1
+
+
+def test_seed_hash_determinism_for_fixture_and_key_order() -> None:
+    first = load_seed_spec(FIXTURE_DIR, seed_id="golden_recall", version=1)
+    second = load_seed_spec(FIXTURE_DIR, seed_id="golden_recall", version=1)
+    raw_messages = _load_raw_jsonl(FIXTURE_DIR / "chat_history.jsonl")
+    reordered_messages = [
+        {key: row[key] for key in reversed(tuple(row.keys()))}
+        for row in raw_messages
+    ]
+
+    assert first.seed_hash == second.seed_hash
+    assert canonical_jsonl_bytes(raw_messages) == canonical_jsonl_bytes(reordered_messages)
+    assert compute_seed_hash(canonical_jsonl_bytes(raw_messages)) == first.seed_hash
+
+
+def test_canonical_jsonl_bytes_sorts_keys() -> None:
+    assert canonical_jsonl_bytes([{"b": 1, "a": 2}]) == canonical_jsonl_bytes([{"a": 2, "b": 1}])
+
+
+def test_resolve_expected_ids_preserves_order() -> None:
+    query = QueryRow(
+        query_id="q",
+        query="question",
+        expected_message_version_ids=("msg_03", "msg_07"),
+        expected_abstain=False,
+    )
+
+    assert resolve_expected_ids(query, {"msg_03": 303, "msg_07": 707}) == [303, 707]
+
+
+def test_resolve_expected_ids_raises_key_error_on_missing_id() -> None:
+    query = QueryRow(
+        query_id="q",
+        query="question",
+        expected_message_version_ids=("msg_03", "msg_missing"),
+        expected_abstain=False,
+    )
+
+    with pytest.raises(KeyError):
+        resolve_expected_ids(query, {"msg_03": 303})
+
+
+def test_load_seed_spec_missing_seed_dir_raises_file_not_found(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError, match="seed directory not found"):
+        load_seed_spec(tmp_path / "missing", seed_id="seed", version=1)
+
+
+def test_load_seed_spec_missing_chat_history_raises_file_not_found(tmp_path: Path) -> None:
+    seed_dir = tmp_path / "seed_v1"
+    seed_dir.mkdir()
+    _write_jsonl(seed_dir / "queries.jsonl", _base_queries())
+
+    with pytest.raises(FileNotFoundError, match="chat_history\\.jsonl"):
+        load_seed_spec(seed_dir, seed_id="seed", version=1)
+
+
+def test_load_seed_spec_missing_queries_raises_file_not_found(tmp_path: Path) -> None:
+    seed_dir = tmp_path / "seed_v1"
+    seed_dir.mkdir()
+    _write_jsonl(seed_dir / "chat_history.jsonl", _base_messages())
+
+    with pytest.raises(FileNotFoundError, match="queries\\.jsonl"):
+        load_seed_spec(seed_dir, seed_id="seed", version=1)
+
+
+def test_load_seed_spec_duplicate_seed_local_id_raises_value_error(tmp_path: Path) -> None:
+    messages = _base_messages()
+    messages[1]["seed_local_id"] = "msg_03"
+    seed_dir = _write_seed(tmp_path, messages, _base_queries())
+
+    with pytest.raises(ValueError, match="duplicate seed_local_id"):
+        load_seed_spec(seed_dir, seed_id="seed", version=1)
+
+
+def test_load_seed_spec_duplicate_query_id_raises_value_error(tmp_path: Path) -> None:
+    queries = _base_queries()
+    queries[1]["query_id"] = "q_01"
+    seed_dir = _write_seed(tmp_path, _base_messages(), queries)
+
+    with pytest.raises(ValueError, match="duplicate query_id"):
+        load_seed_spec(seed_dir, seed_id="seed", version=1)
+
+
+def test_load_seed_spec_query_references_unknown_seed_local_id_raises_value_error(
+    tmp_path: Path,
+) -> None:
+    queries = _base_queries()
+    queries[0]["expected_message_version_ids"] = ["msg_missing"]
+    seed_dir = _write_seed(tmp_path, _base_messages(), queries)
+
+    with pytest.raises(ValueError, match="references unknown"):
+        load_seed_spec(seed_dir, seed_id="seed", version=1)
+
+
+def test_load_seed_spec_abstain_with_expected_ids_raises_value_error(tmp_path: Path) -> None:
+    queries = _base_queries()
+    queries[0]["expected_abstain"] = True
+    seed_dir = _write_seed(tmp_path, _base_messages(), queries)
+
+    with pytest.raises(ValueError, match="expected_abstain=true"):
+        load_seed_spec(seed_dir, seed_id="seed", version=1)
+
+
+def test_load_seed_spec_non_abstain_without_expected_ids_raises_value_error(
+    tmp_path: Path,
+) -> None:
+    queries = _base_queries()
+    queries[0]["expected_message_version_ids"] = []
+    seed_dir = _write_seed(tmp_path, _base_messages(), queries)
+
+    with pytest.raises(ValueError, match="expected_abstain=false"):
+        load_seed_spec(seed_dir, seed_id="seed", version=1)
+
+
+def test_load_seed_spec_malformed_jsonl_raises_value_error(tmp_path: Path) -> None:
+    seed_dir = tmp_path / "seed_v1"
+    seed_dir.mkdir()
+    (seed_dir / "chat_history.jsonl").write_text("{not-json}\n", encoding="utf-8")
+    _write_jsonl(seed_dir / "queries.jsonl", _base_queries())
+
+    with pytest.raises(ValueError, match="invalid JSON"):
+        load_seed_spec(seed_dir, seed_id="seed", version=1)
+
+
+def test_load_seed_spec_jsonl_row_not_object_raises_value_error(tmp_path: Path) -> None:
+    seed_dir = tmp_path / "seed_v1"
+    seed_dir.mkdir()
+    (seed_dir / "chat_history.jsonl").write_text("[]\n", encoding="utf-8")
+    _write_jsonl(seed_dir / "queries.jsonl", _base_queries())
+
+    with pytest.raises(ValueError, match="expected JSON object"):
+        load_seed_spec(seed_dir, seed_id="seed", version=1)
+
+
+def test_load_seed_spec_version_zero_raises_value_error(tmp_path: Path) -> None:
+    seed_dir = _write_seed(tmp_path, _base_messages(), _base_queries())
+
+    with pytest.raises(ValueError, match="version must be >= 1"):
+        load_seed_spec(seed_dir, seed_id="seed", version=0)
+
+
+def test_load_seed_spec_empty_seed_id_raises_value_error(tmp_path: Path) -> None:
+    seed_dir = _write_seed(tmp_path, _base_messages(), _base_queries())
+
+    with pytest.raises(ValueError, match="seed_id must be non-empty"):
+        load_seed_spec(seed_dir, seed_id="", version=1)
+
+
+def test_load_seed_spec_missing_required_field_mentions_field_name(tmp_path: Path) -> None:
+    messages = _base_messages()
+    del messages[0]["text"]
+    seed_dir = _write_seed(tmp_path, messages, _base_queries())
+
+    with pytest.raises(ValueError, match="text"):
+        load_seed_spec(seed_dir, seed_id="seed", version=1)
+
+
+def test_load_seed_spec_invalid_ts_format_mentions_ts(tmp_path: Path) -> None:
+    messages = _base_messages()
+    messages[0]["ts"] = "not-a-timestamp"
+    seed_dir = _write_seed(tmp_path, messages, _base_queries())
+
+    with pytest.raises(ValueError, match="ts"):
+        load_seed_spec(seed_dir, seed_id="seed", version=1)
+
+
+def test_load_seed_spec_caption_non_null_non_string_raises_value_error(tmp_path: Path) -> None:
+    messages = _base_messages()
+    messages[0]["caption"] = 123
+    seed_dir = _write_seed(tmp_path, messages, _base_queries())
+
+    with pytest.raises(ValueError, match="caption"):
+        load_seed_spec(seed_dir, seed_id="seed", version=1)
+
+
+def test_load_seed_spec_expected_message_version_ids_must_be_list_of_strings(
+    tmp_path: Path,
+) -> None:
+    queries = _base_queries()
+    queries[0]["expected_message_version_ids"] = ["msg_03", 7]
+    seed_dir = _write_seed(tmp_path, _base_messages(), queries)
+
+    with pytest.raises(ValueError, match="expected_message_version_ids"):
+        load_seed_spec(seed_dir, seed_id="seed", version=1)
+
+
+def test_load_seed_spec_expected_abstain_must_be_bool(tmp_path: Path) -> None:
+    queries = _base_queries()
+    queries[0]["expected_abstain"] = "false"
+    seed_dir = _write_seed(tmp_path, _base_messages(), queries)
+
+    with pytest.raises(ValueError, match="expected_abstain"):
+        load_seed_spec(seed_dir, seed_id="seed", version=1)


### PR DESCRIPTION
Implements **T11-W1-02** per \`docs/memory-system/PHASE11_PLAN.md\` §4 + §10. Closes #175.

## Scope

Public seed-loader module for the offline eval harness. Pure functions, no DB / IO / async / LLM.

- \`bot/services/eval_seeds.py\` (232 lines):
  - \`MessageRow\` / \`QueryRow\` / \`SeedSpec\` frozen dataclasses
  - \`compute_seed_hash(messages_jsonl_bytes) -> str\` (sha256 hex)
  - \`canonical_jsonl_bytes(rows)\` — deterministic bytes (sort_keys + tight separators)
  - \`load_seed_spec(seed_dir, *, seed_id, version) -> SeedSpec\`
  - \`resolve_expected_ids(query, seed_local_id_map) -> list[int]\`
- \`tests/services/test_eval_seeds.py\` — 22 cases covering boundaries.

## Critic-driven fixes (Claude code-reviewer pass)

- Distinguished `_required_nonempty_str` (for ids, ts, message_kind, query) vs `_required_str_field` (for `text`, which may be empty for sticker / forwarded service messages).
- Explicit `key not in row` check before isinstance — error messages now mention "missing required field 'X'" rather than the misleading "must be list[str]" when the field is absent entirely.
- YAML stays as docs-only (seed_meta.yaml NOT parsed) so the project doesn't pull in a YAML runtime dep.

## Pattern note

This PR is the first run of the new role split per user directive 2026-05-02:
- **Claude** wrote the implementation + Claude code-reviewer agent acted as critic on the diff (4 findings: 2 medium / 2 low; medium fixed inline)
- **Codex** wrote the 22 boundary tests
- Codex final reviewer will run on this PR

## Invariants check

- ✅ Invariant 2 (no LLM): grep over diff returned empty
- ✅ No alembic migrations
- ✅ No production handlers
- ✅ Pure functions — no DB, no async, no globals

## Gate evidence

\`\`\`
ruff check bot/services/eval_seeds.py + tests/services/test_eval_seeds.py: All checks passed!
mypy bot/services/eval_seeds.py: Success: no issues found in 1 source file
pytest --timeout=60 tests/services/test_eval_seeds.py: 22 passed in 0.05s
LLM imports grep: empty
\`\`\`

## Refs

- Plan: \`docs/memory-system/PHASE11_PLAN.md\` §4 (Architecture), §10 (Backlog)
- Issue: #175
- Companion: W1-04 (PR #196 merged) seeded the canonical \`seed_v1\` fixture; this PR extracts the loader into a public module so W1-04's conftest (and future W1-05 tests) can consume the contract via \`from bot.services.eval_seeds import ...\`