### PR TITLE
docs(p5): cross-ref HANDOFF + link T5-* issue numbers in STATUS

### DIFF
--- a/docs/memory-system/HANDOFF.md
+++ b/docs/memory-system/HANDOFF.md
@@ -423,6 +423,8 @@ Cannot parallelize without gate:
 
 ### Phase 5 — events + observations + extraction candidates
 
+> **Note (2026-05-02):** This section describes the original full Phase 5 scope. Phase 5 implementation is a **synthesis-first slice** per `docs/memory-system/PHASE5_PLAN.md` §2 — `llm_gateway` + `llm_usage_ledger` + `/recall` LLM extension only. Extraction tables (`memory_events`, `observations`, `memory_candidates`, `reflection_runs`) are deferred to Phase 8. See PHASE5_PLAN.md for the authoritative scope.
+
 - **Objective:** create structured pre-catalog memory.
 - **Scope:** `llm_usage_ledger`, `extraction_runs`, `memory_events`, `observations`,
   `reflection_runs`, `memory_candidates`.

--- a/docs/memory-system/IMPLEMENTATION_STATUS.md
+++ b/docs/memory-system/IMPLEMENTATION_STATUS.md
@@ -235,12 +235,12 @@ All drafts open with 🚧 DRAFT — NOT AUTHORIZED banner; cite HANDOFF §1 inva
 
 | Ticket | Wave | Title | Status | Notes |
 |--------|------|-------|--------|-------|
-| T5-W0-01 | 0 | Phase 4 hotfix #164 — live v1 + import current_version_id + normalized_text + qa_traces cascade + router order | not started | Single PR (15 commits per design §6). Migration 023 backfills legacy `current_version_id IS NULL` cohort. Source: `prompts/PHASE5_WAVE0_HOTFIX164_DESIGN.md`. Blocks all Wave 1+ work. |
-| T5-01 | 1 | `bot/services/llm_gateway.py` core — `synthesize_answer`, provider abstraction, pre-call invariants, cache lookup | not started | Stream A. Parallel with T5-02. Mocks `LedgerRepo` until T5-03 lands. |
-| T5-02 | 1 | Alembic 024 — `llm_usage_ledger` + `llm_synthesis_cache` schema | not started | Stream B. Parallel with T5-01. ORM in `bot/db/models.py`. |
-| T5-03 | 2 | `LedgerRepo` + `SynthesisCacheRepo` async repos | not started | Sequential after T5-02. |
-| T5-04 | 2 | `/recall` LLM synthesis + `qa_traces` extension (alembic 025) + new cascade layers in `forget_cascade.py` | not started | Sequential after T5-03. May bundle with T5-03 in single PR per PHASE5_PLAN.md §6 / §9. Flag `memory.qa.llm_synthesis.enabled` default OFF — Phase 4 byte-for-byte preserved when OFF. |
-| T5-05 | 3 | Eval harness extension + integration fixtures | not started | Phase 11 coordination point with Orchestrator C. Real-gateway integration opt-in via `RUN_LLM_INTEGRATION=1`. |
+| T5-W0-01 | 0 | Phase 4 hotfix #164 — live v1 + import current_version_id + normalized_text + qa_traces cascade + router order | merged | Single PR (15 commits per design §6). Migration 023 backfills legacy `current_version_id IS NULL` cohort. Source: `prompts/PHASE5_WAVE0_HOTFIX164_DESIGN.md`. Blocks all Wave 1+ work. **Merged via PR #203** (issue #164 remains open until PR #204 closes it). |
+| T5-01 | 1 | `bot/services/llm_gateway.py` core — `synthesize_answer`, provider abstraction, pre-call invariants, cache lookup — GitHub: #197 | not started | Stream A. Parallel with T5-02. Mocks `LedgerRepo` until T5-03 lands. |
+| T5-02 | 1 | Alembic 024 — `llm_usage_ledger` + `llm_synthesis_cache` schema — GitHub: #198 | not started | Stream B. Parallel with T5-01. ORM in `bot/db/models.py`. |
+| T5-03 | 2 | `LedgerRepo` + `SynthesisCacheRepo` async repos — GitHub: #199 | not started | Sequential after T5-02. |
+| T5-04 | 2 | `/recall` LLM synthesis + `qa_traces` extension (alembic 025) + new cascade layers in `forget_cascade.py` — GitHub: #200 | not started | Sequential after T5-03. May bundle with T5-03 in single PR per PHASE5_PLAN.md §6 / §9. Flag `memory.qa.llm_synthesis.enabled` default OFF — Phase 4 byte-for-byte preserved when OFF. |
+| T5-05 | 3 | Eval harness extension + integration fixtures — GitHub: #201 | not started | Phase 11 coordination point with Orchestrator C. Real-gateway integration opt-in via `RUN_LLM_INTEGRATION=1`. |
 
 ## Phases 6–12
 


### PR DESCRIPTION
## Summary

Two carryover docs fixes bundled into one PR (one CI cycle / one review).

- **HANDOFF.md §Phase 5** — cross-ref note pointing readers at \`PHASE5_PLAN.md\` as authoritative synthesis-first scope. Closes M1 carryover from Sprint 0 Claude product review (HANDOFF still described old extraction-heavy Phase 5 scope; PHASE5_PLAN ratified synthesis-first slice and deferred extraction tables to Phase 8).
- **IMPLEMENTATION_STATUS.md** Phase 5 ticket table — link GitHub issue numbers (#164/#197-201) and mark T5-W0-01 status as merged via PR #203.

No code changes. ≤30 lines diff total.

## Test plan

- [ ] CI green (markdown only).
- [ ] No collision with sister-orch PRs (B/C are not editing these files).
- [ ] Independent of T5-02 schema PR / T5-01 gateway PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)