### PR TITLE
feat(p5-w1-02): alembic 024 + llm_usage_ledger + llm_synthesis_cache schema

### DIFF
--- a/alembic/versions/024_add_llm_usage_ledger_and_cache.py
+++ b/alembic/versions/024_add_llm_usage_ledger_and_cache.py
@@ -27,7 +27,7 @@ def upgrade() -> None:
     op.create_table(
         "llm_usage_ledger",
         sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
-        sa.Column("qa_trace_id", sa.Integer(), nullable=True),
+        sa.Column("qa_trace_id", sa.BigInteger(), nullable=True),
         sa.Column("provider", sa.String(64), nullable=False),
         sa.Column("model", sa.String(128), nullable=False),
         sa.Column("prompt_hash", sa.CHAR(64), nullable=False),

--- a/alembic/versions/024_add_llm_usage_ledger_and_cache.py
+++ b/alembic/versions/024_add_llm_usage_ledger_and_cache.py
@@ -1,0 +1,135 @@
+"""add_llm_usage_ledger_and_cache
+
+T5-02: Phase 5 Wave 1 schema — llm_usage_ledger (per-call audit) and
+llm_synthesis_cache (DB-backed answer cache with GDPR cascade support).
+
+Revision ID: 024
+Revises: 023
+Create Date: 2026-05-02
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
+
+revision: str = "024"
+down_revision: Union[str, Sequence[str], None] = "023"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # ── llm_usage_ledger ────────────────────────────────────────────────────
+    op.create_table(
+        "llm_usage_ledger",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("qa_trace_id", sa.Integer(), nullable=True),
+        sa.Column("provider", sa.String(64), nullable=False),
+        sa.Column("model", sa.String(128), nullable=False),
+        sa.Column("prompt_hash", sa.CHAR(64), nullable=False),
+        sa.Column("response_hash", sa.CHAR(64), nullable=True),
+        sa.Column(
+            "tokens_in",
+            sa.Integer(),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+        sa.Column(
+            "tokens_out",
+            sa.Integer(),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+        sa.Column(
+            "cost_usd",
+            sa.Numeric(10, 6),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+        sa.Column(
+            "latency_ms",
+            sa.Integer(),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+        sa.Column("request_id", sa.String(128), nullable=True),
+        sa.Column(
+            "cache_hit",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+        sa.Column("error", sa.String(255), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.ForeignKeyConstraint(
+            ["qa_trace_id"],
+            ["qa_traces.id"],
+            name="fk_llm_usage_ledger_qa_trace_id",
+            ondelete="SET NULL",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_llm_usage_ledger_qa_trace_id",
+        "llm_usage_ledger",
+        ["qa_trace_id"],
+    )
+    op.create_index(
+        "ix_llm_usage_ledger_model_created_at",
+        "llm_usage_ledger",
+        ["model", "created_at"],
+    )
+    op.create_index(
+        "ix_llm_usage_ledger_created_at",
+        "llm_usage_ledger",
+        ["created_at"],
+    )
+
+    # ── llm_synthesis_cache ─────────────────────────────────────────────────
+    op.create_table(
+        "llm_synthesis_cache",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("input_hash", sa.CHAR(64), nullable=False),
+        sa.Column("answer_text", sa.Text(), nullable=False),
+        sa.Column("citation_ids", JSONB(), nullable=False),
+        sa.Column("model", sa.String(128), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "last_hit_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "hit_count",
+            sa.Integer(),
+            nullable=False,
+            server_default=sa.text("1"),
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("input_hash", name="uq_llm_synthesis_cache_input_hash"),
+    )
+
+
+def downgrade() -> None:
+    # Drop cache first (no FK dependencies), then ledger.
+    op.drop_table("llm_synthesis_cache")
+
+    op.drop_index("ix_llm_usage_ledger_created_at", table_name="llm_usage_ledger")
+    op.drop_index("ix_llm_usage_ledger_model_created_at", table_name="llm_usage_ledger")
+    op.drop_index("ix_llm_usage_ledger_qa_trace_id", table_name="llm_usage_ledger")
+    op.drop_table("llm_usage_ledger")

--- a/bot/db/models.py
+++ b/bot/db/models.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime
+from decimal import Decimal
 
 from sqlalchemy import (
     BigInteger,
@@ -12,6 +13,7 @@ from sqlalchemy import (
     Index,
     Integer,
     JSON,
+    Numeric,
     SmallInteger,
     String,
     Text,
@@ -752,4 +754,101 @@ class TelegramUpdate(Base):
     redaction_reason: Mapped[str | None] = mapped_column(String(255), nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=func.now(), server_default=func.now()
+    )
+
+
+class LlmUsageLedger(Base):
+    """Per-call audit log for every LLM gateway invocation (T5-02 / alembic 024).
+
+    Written by ``bot/services/llm_gateway.py`` for every call outcome, including
+    cache hits, abstentions, budget refusals, and errors. Never committed by the
+    gateway itself — the caller (handler) owns the transaction.
+
+    All numeric fields (tokens, cost, latency) use server defaults of 0 so that
+    partial rows created for budget-guard placeholders are self-consistent.
+
+    ``prompt_hash`` and ``response_hash`` are SHA-256 hex digests (64 chars each).
+    The Phase 5 cascade layer ``_cascade_llm_usage_ledger`` NULLs both on a
+    forget-me event while preserving the row for budget reconciliation.
+    """
+
+    __tablename__ = "llm_usage_ledger"
+    __table_args__ = (
+        Index("ix_llm_usage_ledger_qa_trace_id", "qa_trace_id"),
+        Index("ix_llm_usage_ledger_model_created_at", "model", "created_at"),
+        Index("ix_llm_usage_ledger_created_at", "created_at"),
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    qa_trace_id: Mapped[int | None] = mapped_column(
+        Integer,
+        ForeignKey(
+            "qa_traces.id",
+            name="fk_llm_usage_ledger_qa_trace_id",
+            ondelete="SET NULL",
+        ),
+        nullable=True,
+    )
+    provider: Mapped[str] = mapped_column(String(64), nullable=False)
+    model: Mapped[str] = mapped_column(String(128), nullable=False)
+    prompt_hash: Mapped[str] = mapped_column(String(64), nullable=False)
+    response_hash: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    tokens_in: Mapped[int] = mapped_column(Integer, nullable=False, server_default=text("0"))
+    tokens_out: Mapped[int] = mapped_column(Integer, nullable=False, server_default=text("0"))
+    cost_usd: Mapped[Decimal] = mapped_column(Numeric(10, 6), nullable=False, server_default=text("0"))
+    latency_ms: Mapped[int] = mapped_column(Integer, nullable=False, server_default=text("0"))
+    request_id: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    cache_hit: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=text("false"))
+    error: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )
+
+    qa_trace: Mapped[QaTrace | None] = relationship(
+        "QaTrace",
+        foreign_keys=[qa_trace_id],
+    )
+
+
+class LlmSynthesisCache(Base):
+    """DB-backed answer cache for LLM synthesis results (T5-02 / alembic 024).
+
+    Keyed by ``input_hash`` = sha256(query_normalized || sorted(citation_ids)
+    || model_id || prompt_template_version). Cache rows are invalidated (deleted)
+    by ``SynthesisCacheRepo.invalidate_by_citation`` when a forget event covers any
+    cited ``message_version_id`` in ``citation_ids``.
+
+    ``citation_ids`` is a JSONB array of ``message_version_id`` integers — the same
+    ids returned by ``EvidenceBundle.evidence_ids``.
+    """
+
+    __tablename__ = "llm_synthesis_cache"
+    __table_args__ = (
+        UniqueConstraint("input_hash", name="uq_llm_synthesis_cache_input_hash"),
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    input_hash: Mapped[str] = mapped_column(String(64), nullable=False)
+    answer_text: Mapped[str] = mapped_column(Text, nullable=False)
+    citation_ids: Mapped[list] = mapped_column(
+        JSONB(),
+        nullable=False,
+    )
+    model: Mapped[str] = mapped_column(String(128), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )
+    last_hit_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )
+    hit_count: Mapped[int] = mapped_column(
+        Integer,
+        nullable=False,
+        server_default=text("1"),
     )

--- a/bot/db/models.py
+++ b/bot/db/models.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from decimal import Decimal
 
 from sqlalchemy import (
+    CHAR,
     BigInteger,
     Boolean,
     CheckConstraint,
@@ -781,7 +782,7 @@ class LlmUsageLedger(Base):
 
     id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
     qa_trace_id: Mapped[int | None] = mapped_column(
-        Integer,
+        BigInteger,
         ForeignKey(
             "qa_traces.id",
             name="fk_llm_usage_ledger_qa_trace_id",
@@ -791,8 +792,8 @@ class LlmUsageLedger(Base):
     )
     provider: Mapped[str] = mapped_column(String(64), nullable=False)
     model: Mapped[str] = mapped_column(String(128), nullable=False)
-    prompt_hash: Mapped[str] = mapped_column(String(64), nullable=False)
-    response_hash: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    prompt_hash: Mapped[str] = mapped_column(CHAR(64), nullable=False)
+    response_hash: Mapped[str | None] = mapped_column(CHAR(64), nullable=True)
     tokens_in: Mapped[int] = mapped_column(Integer, nullable=False, server_default=text("0"))
     tokens_out: Mapped[int] = mapped_column(Integer, nullable=False, server_default=text("0"))
     cost_usd: Mapped[Decimal] = mapped_column(Numeric(10, 6), nullable=False, server_default=text("0"))
@@ -830,10 +831,11 @@ class LlmSynthesisCache(Base):
     )
 
     id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
-    input_hash: Mapped[str] = mapped_column(String(64), nullable=False)
+    input_hash: Mapped[str] = mapped_column(CHAR(64), nullable=False)
     answer_text: Mapped[str] = mapped_column(Text, nullable=False)
-    citation_ids: Mapped[list] = mapped_column(
-        JSONB(),
+    citation_ids: Mapped[list[int]] = mapped_column(
+        # JSONB on postgres (enables @> containment ops); JSON elsewhere for sqlite test compat.
+        JSON().with_variant(JSONB(), "postgresql"),
         nullable=False,
     )
     model: Mapped[str] = mapped_column(String(128), nullable=False)

--- a/tests/db/test_fts_schema.py
+++ b/tests/db/test_fts_schema.py
@@ -298,8 +298,8 @@ def test_message_version_metadata_includes_search_tsv(app_env) -> None:
 
 async def test_alembic_downgrade_minus_one_drops_search_tsv(temp_database_url: str) -> None:
     _run_alembic(temp_database_url, "upgrade", "head")
-    # Head is now 023 (backfill); -3 reaches 020 where search_tsv was added by 021.
-    _run_alembic(temp_database_url, "downgrade", "-3")
+    # Head is now 024 (llm_usage_ledger + cache); -4 reaches 020 where search_tsv was added by 021.
+    _run_alembic(temp_database_url, "downgrade", "-4")
 
     column_exists = await _fetch_value(
         temp_database_url,

--- a/tests/db/test_fts_schema.py
+++ b/tests/db/test_fts_schema.py
@@ -181,7 +181,7 @@ async def migrated_database_url(temp_database_url: str) -> AsyncIterator[str]:
 async def test_alembic_upgrade_head_on_clean_db_green(migrated_database_url: str) -> None:
     current = await _fetch_value(migrated_database_url, "SELECT version_num FROM alembic_version")
 
-    assert current == "023"
+    assert current == "024"
 
 
 async def test_insert_message_versions_generates_search_tsv_from_normalized_text(

--- a/tests/db/test_llm_synthesis_cache_schema.py
+++ b/tests/db/test_llm_synthesis_cache_schema.py
@@ -1,0 +1,324 @@
+"""T5-02 acceptance tests — llm_synthesis_cache schema.
+
+Isolated temporary database pattern (same as test_fts_schema.py and
+test_llm_usage_ledger_schema.py).
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import uuid
+from collections.abc import AsyncIterator
+from pathlib import Path
+
+import asyncpg
+import pytest
+import pytest_asyncio
+from sqlalchemy.engine.url import URL, make_url
+
+from tests.conftest import DEFAULT_LOCAL_POSTGRES_URL
+
+pytestmark = pytest.mark.usefixtures("app_env")
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _base_test_url() -> URL:
+    raw_url = (
+        os.environ.get("TEST_DATABASE_URL")
+        or os.environ.get("DATABASE_URL")
+        or DEFAULT_LOCAL_POSTGRES_URL
+    )
+    return make_url(raw_url)
+
+
+def _asyncpg_kwargs(url: URL, *, database: str | None = None) -> dict[str, object]:
+    return {
+        "user": url.username,
+        "password": url.password,
+        "host": url.host or "127.0.0.1",
+        "port": url.port or 5432,
+        "database": database or url.database,
+    }
+
+
+def _quote_identifier(identifier: str) -> str:
+    return '"' + identifier.replace('"', '""') + '"'
+
+
+async def _create_database(admin_url: URL, database_name: str) -> None:
+    conn = await asyncpg.connect(**_asyncpg_kwargs(admin_url, database="postgres"))
+    try:
+        await conn.execute(f"CREATE DATABASE {_quote_identifier(database_name)}")
+    finally:
+        await conn.close()
+
+
+async def _drop_database(admin_url: URL, database_name: str) -> None:
+    conn = await asyncpg.connect(**_asyncpg_kwargs(admin_url, database="postgres"))
+    try:
+        await conn.execute(
+            """
+            SELECT pg_terminate_backend(pid)
+            FROM pg_stat_activity
+            WHERE datname = $1 AND pid <> pg_backend_pid()
+            """,
+            database_name,
+        )
+        await conn.execute(f"DROP DATABASE IF EXISTS {_quote_identifier(database_name)}")
+    finally:
+        await conn.close()
+
+
+def _run_alembic(database_url: str, *args: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["DATABASE_URL"] = database_url
+    return subprocess.run(
+        [sys.executable, "-m", "alembic", *args],
+        cwd=PROJECT_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=120,
+        check=True,
+    )
+
+
+async def _fetch_value(database_url: str, query: str, *args: object) -> object:
+    conn = await asyncpg.connect(**_asyncpg_kwargs(make_url(database_url)))
+    try:
+        return await conn.fetchval(query, *args)
+    finally:
+        await conn.close()
+
+
+async def _fetch_row(database_url: str, query: str, *args: object) -> asyncpg.Record | None:
+    conn = await asyncpg.connect(**_asyncpg_kwargs(make_url(database_url)))
+    try:
+        return await conn.fetchrow(query, *args)
+    finally:
+        await conn.close()
+
+
+@pytest_asyncio.fixture()
+async def temp_database_url() -> AsyncIterator[str]:
+    base_url = _base_test_url()
+    database_name = f"shkoder_cache_schema_{uuid.uuid4().hex[:12]}"
+    try:
+        await _create_database(base_url, database_name)
+    except Exception as exc:  # pragma: no cover - environment guard
+        pytest.skip(f"cannot create temporary postgres database: {exc!s}")
+
+    try:
+        yield base_url.set(database=database_name).render_as_string(hide_password=False)
+    finally:
+        await _drop_database(base_url, database_name)
+
+
+@pytest_asyncio.fixture()
+async def migrated_database_url(temp_database_url: str) -> AsyncIterator[str]:
+    _run_alembic(temp_database_url, "upgrade", "head")
+    yield temp_database_url
+
+
+# ─── Test 1: Table exists with all 8 columns ────────────────────────────────
+
+
+async def test_llm_synthesis_cache_all_columns_exist(migrated_database_url: str) -> None:
+    """All 8 columns exist in llm_synthesis_cache with correct data types."""
+    expected_columns = {
+        "id": "bigint",
+        "input_hash": "character",
+        "answer_text": "text",
+        "citation_ids": "jsonb",
+        "model": "character varying",
+        "created_at": "timestamp with time zone",
+        "last_hit_at": "timestamp with time zone",
+        "hit_count": "integer",
+    }
+
+    for col_name, expected_type in expected_columns.items():
+        actual_type = await _fetch_value(
+            migrated_database_url,
+            """
+            SELECT data_type
+            FROM information_schema.columns
+            WHERE table_schema = 'public'
+              AND table_name = 'llm_synthesis_cache'
+              AND column_name = $1
+            """,
+            col_name,
+        )
+        assert actual_type == expected_type, (
+            f"Column '{col_name}': expected type '{expected_type}', got '{actual_type}'"
+        )
+
+
+# ─── Test 2: UNIQUE on input_hash enforced ──────────────────────────────────
+
+
+async def test_llm_synthesis_cache_unique_input_hash_enforced(migrated_database_url: str) -> None:
+    """Duplicate INSERT on input_hash raises a unique violation."""
+    conn = await asyncpg.connect(**_asyncpg_kwargs(make_url(migrated_database_url)))
+    try:
+        input_hash = "d" * 64
+
+        await conn.execute(
+            """
+            INSERT INTO llm_synthesis_cache (input_hash, answer_text, citation_ids, model)
+            VALUES ($1, 'first answer', '[1, 2]', 'claude-haiku')
+            """,
+            input_hash,
+        )
+
+        with pytest.raises(asyncpg.UniqueViolationError):
+            await conn.execute(
+                """
+                INSERT INTO llm_synthesis_cache (input_hash, answer_text, citation_ids, model)
+                VALUES ($1, 'second answer', '[3]', 'claude-haiku')
+                """,
+                input_hash,
+            )
+    finally:
+        await conn.close()
+
+
+# ─── Test 3: citation_ids JSONB round-trips arrays ──────────────────────────
+
+
+async def test_llm_synthesis_cache_citation_ids_jsonb_roundtrip(migrated_database_url: str) -> None:
+    """citation_ids [1, 2, 3] → inserted → queried back as [1, 2, 3]."""
+    import json
+
+    conn = await asyncpg.connect(**_asyncpg_kwargs(make_url(migrated_database_url)))
+    try:
+        input_hash = "e" * 64
+        citation_ids_in = [1, 2, 3]
+
+        cache_id = await conn.fetchval(
+            """
+            INSERT INTO llm_synthesis_cache (input_hash, answer_text, citation_ids, model)
+            VALUES ($1, 'some answer', $2::jsonb, 'claude-haiku')
+            RETURNING id
+            """,
+            input_hash,
+            json.dumps(citation_ids_in),
+        )
+
+        row = await conn.fetchrow(
+            "SELECT citation_ids FROM llm_synthesis_cache WHERE id = $1",
+            cache_id,
+        )
+        assert row is not None
+        # asyncpg returns JSONB as Python objects
+        citation_ids_out = row["citation_ids"]
+        if isinstance(citation_ids_out, str):
+            citation_ids_out = json.loads(citation_ids_out)
+        assert citation_ids_out == [1, 2, 3]
+    finally:
+        await conn.close()
+
+
+# ─── Test 4: JSONB containment query ────────────────────────────────────────
+
+
+async def test_llm_synthesis_cache_jsonb_containment_query(migrated_database_url: str) -> None:
+    """WHERE citation_ids @> '[1]'::jsonb finds row with [1, 2, 3]."""
+    conn = await asyncpg.connect(**_asyncpg_kwargs(make_url(migrated_database_url)))
+    try:
+        input_hash = "f" * 64
+
+        inserted_id = await conn.fetchval(
+            """
+            INSERT INTO llm_synthesis_cache (input_hash, answer_text, citation_ids, model)
+            VALUES ($1, 'containment answer', '[1, 2, 3]'::jsonb, 'claude-haiku')
+            RETURNING id
+            """,
+            input_hash,
+        )
+
+        found_id = await conn.fetchval(
+            """
+            SELECT id FROM llm_synthesis_cache
+            WHERE citation_ids @> '[1]'::jsonb
+              AND id = $1
+            """,
+            inserted_id,
+        )
+        assert found_id == inserted_id
+    finally:
+        await conn.close()
+
+
+# ─── Test 5: Server defaults populate on minimal INSERT ─────────────────────
+
+
+async def test_llm_synthesis_cache_server_defaults(migrated_database_url: str) -> None:
+    """created_at, last_hit_at, hit_count populate from server defaults on minimal INSERT."""
+    conn = await asyncpg.connect(**_asyncpg_kwargs(make_url(migrated_database_url)))
+    try:
+        row = await conn.fetchrow(
+            """
+            INSERT INTO llm_synthesis_cache (input_hash, answer_text, citation_ids, model)
+            VALUES ($1, 'defaults test', '[]'::jsonb, 'claude-haiku')
+            RETURNING created_at, last_hit_at, hit_count
+            """,
+            "g" * 64,
+        )
+    finally:
+        await conn.close()
+
+    assert row is not None
+    assert row["created_at"] is not None
+    assert row["last_hit_at"] is not None
+    assert row["hit_count"] == 1
+
+
+# ─── Test 6: ORM round-trip + metadata smoke ────────────────────────────────
+
+
+async def test_llm_synthesis_cache_orm_round_trip(migrated_database_url: str) -> None:
+    """ORM insert + select verifies all fields, plus tablename registered in metadata."""
+    from sqlalchemy import select
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+    engine = create_async_engine(migrated_database_url, echo=False)
+    try:
+        Session = async_sessionmaker(bind=engine, class_=AsyncSession, expire_on_commit=False)
+        async with Session() as session:
+            from bot.db.models import LlmSynthesisCache
+
+            cache = LlmSynthesisCache(
+                input_hash="h" * 64,
+                answer_text="The answer is 42.",
+                citation_ids=[10, 20, 30],
+                model="claude-haiku",
+            )
+            session.add(cache)
+            await session.flush()
+
+            result = await session.execute(
+                select(LlmSynthesisCache).where(LlmSynthesisCache.id == cache.id)
+            )
+            fetched = result.scalar_one()
+
+            assert fetched.input_hash == "h" * 64
+            assert fetched.answer_text == "The answer is 42."
+            assert fetched.citation_ids == [10, 20, 30]
+            assert fetched.model == "claude-haiku"
+            assert fetched.created_at is not None
+            assert fetched.last_hit_at is not None
+            assert fetched.hit_count == 1
+    finally:
+        await engine.dispose()
+
+
+def test_llm_synthesis_cache_tablename_registered(app_env) -> None:
+    """LlmSynthesisCache.__tablename__ is 'llm_synthesis_cache' and in Base.metadata."""
+    from tests.conftest import import_module
+
+    models = import_module("bot.db.models")
+    assert models.LlmSynthesisCache.__tablename__ == "llm_synthesis_cache"
+    assert "llm_synthesis_cache" in models.Base.metadata.tables

--- a/tests/db/test_llm_synthesis_cache_schema.py
+++ b/tests/db/test_llm_synthesis_cache_schema.py
@@ -123,27 +123,31 @@ async def migrated_database_url(temp_database_url: str) -> AsyncIterator[str]:
     yield temp_database_url
 
 
-# ─── Test 1: Table exists with all 8 columns ────────────────────────────────
+# ─── Test 1: Table exists with all 8 columns + correct types/lengths ────────
 
 
 async def test_llm_synthesis_cache_all_columns_exist(migrated_database_url: str) -> None:
-    """All 8 columns exist in llm_synthesis_cache with correct data types."""
-    expected_columns = {
-        "id": "bigint",
-        "input_hash": "character",
-        "answer_text": "text",
-        "citation_ids": "jsonb",
-        "model": "character varying",
-        "created_at": "timestamp with time zone",
-        "last_hit_at": "timestamp with time zone",
-        "hit_count": "integer",
+    """All 8 columns exist in llm_synthesis_cache with correct types and lengths.
+
+    Tuple: (data_type, character_maximum_length, numeric_precision, numeric_scale).
+    None means 'not applicable / not reported by information_schema' for that slot.
+    """
+    expected_columns: dict[str, tuple[str, int | None, int | None, int | None]] = {
+        "id":           ("bigint",                   None, 64,   0),
+        "input_hash":   ("character",                64,   None, None),
+        "answer_text":  ("text",                     None, None, None),
+        "citation_ids": ("jsonb",                    None, None, None),
+        "model":        ("character varying",        128,  None, None),
+        "created_at":   ("timestamp with time zone", None, None, None),
+        "last_hit_at":  ("timestamp with time zone", None, None, None),
+        "hit_count":    ("integer",                  None, 32,   0),
     }
 
-    for col_name, expected_type in expected_columns.items():
-        actual_type = await _fetch_value(
+    for col_name, (exp_type, exp_char_len, exp_num_prec, exp_num_scale) in expected_columns.items():
+        row = await _fetch_row(
             migrated_database_url,
             """
-            SELECT data_type
+            SELECT data_type, character_maximum_length, numeric_precision, numeric_scale
             FROM information_schema.columns
             WHERE table_schema = 'public'
               AND table_name = 'llm_synthesis_cache'
@@ -151,8 +155,21 @@ async def test_llm_synthesis_cache_all_columns_exist(migrated_database_url: str)
             """,
             col_name,
         )
-        assert actual_type == expected_type, (
-            f"Column '{col_name}': expected type '{expected_type}', got '{actual_type}'"
+        assert row is not None, f"Column '{col_name}' not found in llm_synthesis_cache"
+        assert row["data_type"] == exp_type, (
+            f"Column '{col_name}': expected data_type '{exp_type}', got '{row['data_type']}'"
+        )
+        assert row["character_maximum_length"] == exp_char_len, (
+            f"Column '{col_name}': expected character_maximum_length {exp_char_len!r},"
+            f" got {row['character_maximum_length']!r}"
+        )
+        assert row["numeric_precision"] == exp_num_prec, (
+            f"Column '{col_name}': expected numeric_precision {exp_num_prec!r},"
+            f" got {row['numeric_precision']!r}"
+        )
+        assert row["numeric_scale"] == exp_num_scale, (
+            f"Column '{col_name}': expected numeric_scale {exp_num_scale!r},"
+            f" got {row['numeric_scale']!r}"
         )
 
 
@@ -322,3 +339,32 @@ def test_llm_synthesis_cache_tablename_registered(app_env) -> None:
     models = import_module("bot.db.models")
     assert models.LlmSynthesisCache.__tablename__ == "llm_synthesis_cache"
     assert "llm_synthesis_cache" in models.Base.metadata.tables
+
+
+# ─── Test 8: CHAR(64) boundary on input_hash ────────────────────────────────
+
+
+async def test_llm_synthesis_cache_input_hash_char_64_boundary(migrated_database_url: str) -> None:
+    """input_hash CHAR(64): exactly 64 chars succeeds; 65 chars raises DataError."""
+    conn = await asyncpg.connect(**_asyncpg_kwargs(make_url(migrated_database_url)))
+    try:
+        # Exactly 64 chars — must succeed
+        await conn.execute(
+            """
+            INSERT INTO llm_synthesis_cache (input_hash, answer_text, citation_ids, model)
+            VALUES ($1, 'boundary test', '[]'::jsonb, 'claude-haiku')
+            """,
+            "i" * 64,
+        )
+
+        # 65 chars — must fail with a truncation error
+        with pytest.raises(asyncpg.exceptions.StringDataRightTruncationError):
+            await conn.execute(
+                """
+                INSERT INTO llm_synthesis_cache (input_hash, answer_text, citation_ids, model)
+                VALUES ($1, 'over boundary', '[]'::jsonb, 'claude-haiku')
+                """,
+                "j" * 65,
+            )
+    finally:
+        await conn.close()

--- a/tests/db/test_llm_usage_ledger_schema.py
+++ b/tests/db/test_llm_usage_ledger_schema.py
@@ -124,33 +124,37 @@ async def migrated_database_url(temp_database_url: str) -> AsyncIterator[str]:
     yield temp_database_url
 
 
-# ─── Test 1: Table exists with all 14 columns + correct types ───────────────
+# ─── Test 1: Table exists with all 14 columns + correct types/lengths ───────
 
 
 async def test_llm_usage_ledger_all_columns_exist(migrated_database_url: str) -> None:
-    """All 14 columns exist in llm_usage_ledger with correct data types."""
-    expected_columns = {
-        "id": "bigint",
-        "qa_trace_id": "integer",
-        "provider": "character varying",
-        "model": "character varying",
-        "prompt_hash": "character",
-        "response_hash": "character",
-        "tokens_in": "integer",
-        "tokens_out": "integer",
-        "cost_usd": "numeric",
-        "latency_ms": "integer",
-        "request_id": "character varying",
-        "cache_hit": "boolean",
-        "error": "character varying",
-        "created_at": "timestamp with time zone",
+    """All 14 columns exist in llm_usage_ledger with correct types and lengths.
+
+    Tuple: (data_type, character_maximum_length, numeric_precision, numeric_scale).
+    None means 'not applicable / not reported by information_schema' for that slot.
+    """
+    expected_columns: dict[str, tuple[str, int | None, int | None, int | None]] = {
+        "id":         ("bigint",                   None, 64,  0),
+        "qa_trace_id": ("bigint",                  None, 64,  0),
+        "provider":   ("character varying",        64,   None, None),
+        "model":      ("character varying",        128,  None, None),
+        "prompt_hash": ("character",               64,   None, None),
+        "response_hash": ("character",             64,   None, None),
+        "tokens_in":  ("integer",                  None, 32,  0),
+        "tokens_out": ("integer",                  None, 32,  0),
+        "cost_usd":   ("numeric",                  None, 10,  6),
+        "latency_ms": ("integer",                  None, 32,  0),
+        "request_id": ("character varying",        128,  None, None),
+        "cache_hit":  ("boolean",                  None, None, None),
+        "error":      ("character varying",        255,  None, None),
+        "created_at": ("timestamp with time zone", None, None, None),
     }
 
-    for col_name, expected_type in expected_columns.items():
-        actual_type = await _fetch_value(
+    for col_name, (exp_type, exp_char_len, exp_num_prec, exp_num_scale) in expected_columns.items():
+        row = await _fetch_row(
             migrated_database_url,
             """
-            SELECT data_type
+            SELECT data_type, character_maximum_length, numeric_precision, numeric_scale
             FROM information_schema.columns
             WHERE table_schema = 'public'
               AND table_name = 'llm_usage_ledger'
@@ -158,8 +162,21 @@ async def test_llm_usage_ledger_all_columns_exist(migrated_database_url: str) ->
             """,
             col_name,
         )
-        assert actual_type == expected_type, (
-            f"Column '{col_name}': expected type '{expected_type}', got '{actual_type}'"
+        assert row is not None, f"Column '{col_name}' not found in llm_usage_ledger"
+        assert row["data_type"] == exp_type, (
+            f"Column '{col_name}': expected data_type '{exp_type}', got '{row['data_type']}'"
+        )
+        assert row["character_maximum_length"] == exp_char_len, (
+            f"Column '{col_name}': expected character_maximum_length {exp_char_len!r},"
+            f" got {row['character_maximum_length']!r}"
+        )
+        assert row["numeric_precision"] == exp_num_prec, (
+            f"Column '{col_name}': expected numeric_precision {exp_num_prec!r},"
+            f" got {row['numeric_precision']!r}"
+        )
+        assert row["numeric_scale"] == exp_num_scale, (
+            f"Column '{col_name}': expected numeric_scale {exp_num_scale!r},"
+            f" got {row['numeric_scale']!r}"
         )
 
 
@@ -349,3 +366,181 @@ async def test_llm_usage_ledger_downgrade_drops_table(temp_database_url: str) ->
         """,
     )
     assert exists_after is False
+
+
+# ─── Test 8: migration roundtrip (downgrade -1 + upgrade head) ──────────────
+
+
+async def test_migration_024_upgrade_downgrade_roundtrip(migrated_database_url: str) -> None:
+    """Downgrade -1 drops both tables; upgrade head restores them + accepts rows."""
+    # Step 1: downgrade -1 — both tables must vanish
+    _run_alembic(migrated_database_url, "downgrade", "-1")
+
+    for table_name in ("llm_usage_ledger", "llm_synthesis_cache"):
+        exists = await _fetch_value(
+            migrated_database_url,
+            """
+            SELECT EXISTS (
+                SELECT 1 FROM information_schema.tables
+                WHERE table_schema = 'public' AND table_name = $1
+            )
+            """,
+            table_name,
+        )
+        assert exists is False, f"Expected '{table_name}' to be absent after downgrade -1"
+
+    # Step 2: upgrade head — both tables must reappear
+    _run_alembic(migrated_database_url, "upgrade", "head")
+
+    for table_name in ("llm_usage_ledger", "llm_synthesis_cache"):
+        exists = await _fetch_value(
+            migrated_database_url,
+            """
+            SELECT EXISTS (
+                SELECT 1 FROM information_schema.tables
+                WHERE table_schema = 'public' AND table_name = $1
+            )
+            """,
+            table_name,
+        )
+        assert exists is True, f"Expected '{table_name}' to be present after upgrade head"
+
+    # Step 3: minimal row inserts into each table succeed
+    conn = await asyncpg.connect(**_asyncpg_kwargs(make_url(migrated_database_url)))
+    try:
+        await conn.execute(
+            """
+            INSERT INTO llm_usage_ledger (provider, model, prompt_hash)
+            VALUES ('anthropic', 'claude-haiku', $1)
+            """,
+            "a" * 64,
+        )
+        await conn.execute(
+            """
+            INSERT INTO llm_synthesis_cache (input_hash, answer_text, citation_ids, model)
+            VALUES ($1, 'roundtrip answer', '[]'::jsonb, 'claude-haiku')
+            """,
+            "b" * 64,
+        )
+    finally:
+        await conn.close()
+
+
+# ─── Test 9: CHAR(64) boundary on prompt_hash ───────────────────────────────
+
+
+async def test_llm_usage_ledger_char_64_boundary(migrated_database_url: str) -> None:
+    """prompt_hash CHAR(64): exactly 64 chars succeeds; 65 chars raises DataError."""
+    conn = await asyncpg.connect(**_asyncpg_kwargs(make_url(migrated_database_url)))
+    try:
+        # Exactly 64 chars — must succeed
+        await conn.execute(
+            """
+            INSERT INTO llm_usage_ledger (provider, model, prompt_hash)
+            VALUES ('anthropic', 'claude-haiku', $1)
+            """,
+            "c" * 64,
+        )
+
+        # 65 chars — must fail with a truncation / string data error
+        with pytest.raises(asyncpg.exceptions.StringDataRightTruncationError):
+            await conn.execute(
+                """
+                INSERT INTO llm_usage_ledger (provider, model, prompt_hash)
+                VALUES ('anthropic', 'claude-haiku', $1)
+                """,
+                "d" * 65,
+            )
+    finally:
+        await conn.close()
+
+
+# ─── Test 10: NUMERIC(10,6) boundary on cost_usd ────────────────────────────
+
+
+async def test_llm_usage_ledger_cost_usd_numeric_boundary(migrated_database_url: str) -> None:
+    """cost_usd NUMERIC(10,6): 9999.999999 round-trips exact; 99999.999999 overflows."""
+    from decimal import Decimal
+
+    conn = await asyncpg.connect(**_asyncpg_kwargs(make_url(migrated_database_url)))
+    try:
+        # 9999.999999 = 10 total digits, 6 after decimal — fits NUMERIC(10,6)
+        row_id = await conn.fetchval(
+            """
+            INSERT INTO llm_usage_ledger (provider, model, prompt_hash, cost_usd)
+            VALUES ('anthropic', 'claude-haiku', $1, $2::numeric)
+            RETURNING id
+            """,
+            "e" * 64,
+            "9999.999999",
+        )
+        cost_back = await conn.fetchval(
+            "SELECT cost_usd FROM llm_usage_ledger WHERE id = $1",
+            row_id,
+        )
+        assert Decimal(str(cost_back)) == Decimal("9999.999999")
+
+        # 99999.999999 = 11 total digits — must overflow NUMERIC(10,6)
+        with pytest.raises(asyncpg.exceptions.NumericValueOutOfRangeError):
+            await conn.execute(
+                """
+                INSERT INTO llm_usage_ledger (provider, model, prompt_hash, cost_usd)
+                VALUES ('anthropic', 'claude-haiku', $1, $2::numeric)
+                """,
+                "f" * 64,
+                "99999.999999",
+            )
+    finally:
+        await conn.close()
+
+
+# ─── Test 11: FK ON DELETE SET NULL real behavior ───────────────────────────
+
+
+async def test_llm_usage_ledger_fk_on_delete_set_null_real_behavior(
+    migrated_database_url: str,
+) -> None:
+    """DELETE parent qa_traces row → ledger row survives with qa_trace_id = NULL."""
+    conn = await asyncpg.connect(**_asyncpg_kwargs(make_url(migrated_database_url)))
+    try:
+        # Insert a qa_traces row (raw SQL — no ORM/session available in this fixture)
+        qa_trace_id = await conn.fetchval(
+            """
+            INSERT INTO qa_traces (user_tg_id, chat_id, query_text, evidence_ids, abstained)
+            VALUES (9000000001, -1000000000001, 'test query', '[]'::jsonb, false)
+            RETURNING id
+            """,
+        )
+
+        # Insert a ledger row referencing it
+        ledger_id = await conn.fetchval(
+            """
+            INSERT INTO llm_usage_ledger (provider, model, prompt_hash, qa_trace_id)
+            VALUES ('anthropic', 'claude-haiku', $1, $2)
+            RETURNING id
+            """,
+            "g" * 64,
+            qa_trace_id,
+        )
+
+        # Confirm the FK is set
+        linked = await conn.fetchval(
+            "SELECT qa_trace_id FROM llm_usage_ledger WHERE id = $1",
+            ledger_id,
+        )
+        assert linked == qa_trace_id
+
+        # Delete the parent qa_traces row
+        await conn.execute("DELETE FROM qa_traces WHERE id = $1", qa_trace_id)
+
+        # Ledger row must still exist, qa_trace_id must be NULL
+        row = await conn.fetchrow(
+            "SELECT id, qa_trace_id FROM llm_usage_ledger WHERE id = $1",
+            ledger_id,
+        )
+        assert row is not None, "Ledger row was deleted — expected SET NULL, not CASCADE"
+        assert row["qa_trace_id"] is None, (
+            f"Expected qa_trace_id=NULL after parent delete, got {row['qa_trace_id']!r}"
+        )
+    finally:
+        await conn.close()

--- a/tests/db/test_llm_usage_ledger_schema.py
+++ b/tests/db/test_llm_usage_ledger_schema.py
@@ -1,0 +1,351 @@
+"""T5-02 acceptance tests — llm_usage_ledger schema.
+
+These tests use the same pattern as test_fts_schema.py: a temporary isolated
+database is created, Alembic upgrade head is run, then schema-shape assertions
+are executed via asyncpg. The temporary database is dropped after each test.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import uuid
+from collections.abc import AsyncIterator
+from pathlib import Path
+
+import asyncpg
+import pytest
+import pytest_asyncio
+from sqlalchemy.engine.url import URL, make_url
+
+from tests.conftest import DEFAULT_LOCAL_POSTGRES_URL
+
+pytestmark = pytest.mark.usefixtures("app_env")
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _base_test_url() -> URL:
+    raw_url = (
+        os.environ.get("TEST_DATABASE_URL")
+        or os.environ.get("DATABASE_URL")
+        or DEFAULT_LOCAL_POSTGRES_URL
+    )
+    return make_url(raw_url)
+
+
+def _asyncpg_kwargs(url: URL, *, database: str | None = None) -> dict[str, object]:
+    return {
+        "user": url.username,
+        "password": url.password,
+        "host": url.host or "127.0.0.1",
+        "port": url.port or 5432,
+        "database": database or url.database,
+    }
+
+
+def _quote_identifier(identifier: str) -> str:
+    return '"' + identifier.replace('"', '""') + '"'
+
+
+async def _create_database(admin_url: URL, database_name: str) -> None:
+    conn = await asyncpg.connect(**_asyncpg_kwargs(admin_url, database="postgres"))
+    try:
+        await conn.execute(f"CREATE DATABASE {_quote_identifier(database_name)}")
+    finally:
+        await conn.close()
+
+
+async def _drop_database(admin_url: URL, database_name: str) -> None:
+    conn = await asyncpg.connect(**_asyncpg_kwargs(admin_url, database="postgres"))
+    try:
+        await conn.execute(
+            """
+            SELECT pg_terminate_backend(pid)
+            FROM pg_stat_activity
+            WHERE datname = $1 AND pid <> pg_backend_pid()
+            """,
+            database_name,
+        )
+        await conn.execute(f"DROP DATABASE IF EXISTS {_quote_identifier(database_name)}")
+    finally:
+        await conn.close()
+
+
+def _run_alembic(database_url: str, *args: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["DATABASE_URL"] = database_url
+    return subprocess.run(
+        [sys.executable, "-m", "alembic", *args],
+        cwd=PROJECT_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=120,
+        check=True,
+    )
+
+
+async def _fetch_value(database_url: str, query: str, *args: object) -> object:
+    conn = await asyncpg.connect(**_asyncpg_kwargs(make_url(database_url)))
+    try:
+        return await conn.fetchval(query, *args)
+    finally:
+        await conn.close()
+
+
+async def _fetch_row(database_url: str, query: str, *args: object) -> asyncpg.Record | None:
+    conn = await asyncpg.connect(**_asyncpg_kwargs(make_url(database_url)))
+    try:
+        return await conn.fetchrow(query, *args)
+    finally:
+        await conn.close()
+
+
+@pytest_asyncio.fixture()
+async def temp_database_url() -> AsyncIterator[str]:
+    base_url = _base_test_url()
+    database_name = f"shkoder_ledger_schema_{uuid.uuid4().hex[:12]}"
+    try:
+        await _create_database(base_url, database_name)
+    except Exception as exc:  # pragma: no cover - environment guard
+        pytest.skip(f"cannot create temporary postgres database: {exc!s}")
+
+    try:
+        yield base_url.set(database=database_name).render_as_string(hide_password=False)
+    finally:
+        await _drop_database(base_url, database_name)
+
+
+@pytest_asyncio.fixture()
+async def migrated_database_url(temp_database_url: str) -> AsyncIterator[str]:
+    _run_alembic(temp_database_url, "upgrade", "head")
+    yield temp_database_url
+
+
+# ─── Test 1: Table exists with all 14 columns + correct types ───────────────
+
+
+async def test_llm_usage_ledger_all_columns_exist(migrated_database_url: str) -> None:
+    """All 14 columns exist in llm_usage_ledger with correct data types."""
+    expected_columns = {
+        "id": "bigint",
+        "qa_trace_id": "integer",
+        "provider": "character varying",
+        "model": "character varying",
+        "prompt_hash": "character",
+        "response_hash": "character",
+        "tokens_in": "integer",
+        "tokens_out": "integer",
+        "cost_usd": "numeric",
+        "latency_ms": "integer",
+        "request_id": "character varying",
+        "cache_hit": "boolean",
+        "error": "character varying",
+        "created_at": "timestamp with time zone",
+    }
+
+    for col_name, expected_type in expected_columns.items():
+        actual_type = await _fetch_value(
+            migrated_database_url,
+            """
+            SELECT data_type
+            FROM information_schema.columns
+            WHERE table_schema = 'public'
+              AND table_name = 'llm_usage_ledger'
+              AND column_name = $1
+            """,
+            col_name,
+        )
+        assert actual_type == expected_type, (
+            f"Column '{col_name}': expected type '{expected_type}', got '{actual_type}'"
+        )
+
+
+# ─── Test 2: FK qa_trace_id → qa_traces.id ON DELETE SET NULL ───────────────
+
+
+async def test_llm_usage_ledger_fk_qa_trace_id_set_null(migrated_database_url: str) -> None:
+    """FK constraint qa_trace_id → qa_traces.id with ON DELETE SET NULL."""
+    row = await _fetch_row(
+        migrated_database_url,
+        """
+        SELECT
+            ccu.table_name AS ref_table,
+            rc.delete_rule
+        FROM information_schema.table_constraints tc
+        JOIN information_schema.key_column_usage kcu
+          ON tc.constraint_name = kcu.constraint_name
+          AND tc.table_schema = kcu.table_schema
+        JOIN information_schema.referential_constraints rc
+          ON tc.constraint_name = rc.constraint_name
+        JOIN information_schema.constraint_column_usage ccu
+          ON rc.unique_constraint_name = ccu.constraint_name
+          AND rc.unique_constraint_schema = ccu.table_schema
+        WHERE tc.constraint_type = 'FOREIGN KEY'
+          AND tc.table_schema = 'public'
+          AND tc.table_name = 'llm_usage_ledger'
+          AND kcu.column_name = 'qa_trace_id'
+        """,
+    )
+    assert row is not None, "FK constraint on qa_trace_id not found"
+    assert row["ref_table"] == "qa_traces"
+    assert row["delete_rule"] == "SET NULL"
+
+
+# ─── Test 3: Three indexes present ──────────────────────────────────────────
+
+
+async def test_llm_usage_ledger_indexes_exist(migrated_database_url: str) -> None:
+    """All three expected indexes exist on llm_usage_ledger."""
+    expected_indexes = [
+        "ix_llm_usage_ledger_qa_trace_id",
+        "ix_llm_usage_ledger_model_created_at",
+        "ix_llm_usage_ledger_created_at",
+    ]
+    for index_name in expected_indexes:
+        exists = await _fetch_value(
+            migrated_database_url,
+            """
+            SELECT EXISTS (
+                SELECT 1
+                FROM pg_indexes
+                WHERE schemaname = 'public'
+                  AND tablename = 'llm_usage_ledger'
+                  AND indexname = $1
+            )
+            """,
+            index_name,
+        )
+        assert exists is True, f"Index '{index_name}' not found on llm_usage_ledger"
+
+
+# ─── Test 4: Server defaults populate on minimal INSERT ─────────────────────
+
+
+async def test_llm_usage_ledger_server_defaults(migrated_database_url: str) -> None:
+    """Server defaults populate correctly when only required columns are provided."""
+    conn = await asyncpg.connect(**_asyncpg_kwargs(make_url(migrated_database_url)))
+    try:
+        row = await conn.fetchrow(
+            """
+            INSERT INTO llm_usage_ledger (provider, model, prompt_hash)
+            VALUES ('anthropic', 'claude-haiku', $1)
+            RETURNING
+                tokens_in, tokens_out, cost_usd, latency_ms,
+                cache_hit, created_at, qa_trace_id, response_hash, request_id, error
+            """,
+            "a" * 64,
+        )
+    finally:
+        await conn.close()
+
+    assert row is not None
+    assert row["tokens_in"] == 0
+    assert row["tokens_out"] == 0
+    assert float(row["cost_usd"]) == 0.0
+    assert row["latency_ms"] == 0
+    assert row["cache_hit"] is False
+    assert row["created_at"] is not None
+    assert row["qa_trace_id"] is None
+    assert row["response_hash"] is None
+    assert row["request_id"] is None
+    assert row["error"] is None
+
+
+# ─── Test 5: ORM round-trip ──────────────────────────────────────────────────
+
+
+async def test_llm_usage_ledger_orm_round_trip(migrated_database_url: str) -> None:
+    """ORM insert + select round-trip verifies all fields persist correctly."""
+    from decimal import Decimal
+
+    from sqlalchemy import select
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+    engine = create_async_engine(migrated_database_url, echo=False)
+    try:
+        Session = async_sessionmaker(bind=engine, class_=AsyncSession, expire_on_commit=False)
+        async with Session() as session:
+            from bot.db.models import LlmUsageLedger
+
+            ledger = LlmUsageLedger(
+                provider="openai",
+                model="gpt-4o",
+                prompt_hash="b" * 64,
+                response_hash="c" * 64,
+                tokens_in=100,
+                tokens_out=50,
+                cost_usd=Decimal("0.000123"),
+                latency_ms=250,
+                request_id="req-123",
+                cache_hit=True,
+                error=None,
+            )
+            session.add(ledger)
+            await session.flush()
+
+            result = await session.execute(
+                select(LlmUsageLedger).where(LlmUsageLedger.id == ledger.id)
+            )
+            fetched = result.scalar_one()
+
+            assert fetched.provider == "openai"
+            assert fetched.model == "gpt-4o"
+            assert fetched.prompt_hash == "b" * 64
+            assert fetched.response_hash == "c" * 64
+            assert fetched.tokens_in == 100
+            assert fetched.tokens_out == 50
+            assert fetched.cost_usd == Decimal("0.000123")
+            assert fetched.latency_ms == 250
+            assert fetched.request_id == "req-123"
+            assert fetched.cache_hit is True
+            assert fetched.error is None
+    finally:
+        await engine.dispose()
+
+
+# ─── Test 6: ORM metadata smoke ─────────────────────────────────────────────
+
+
+def test_llm_usage_ledger_tablename_registered(app_env) -> None:
+    """LlmUsageLedger.__tablename__ is 'llm_usage_ledger' and in Base.metadata."""
+    from tests.conftest import import_module
+
+    models = import_module("bot.db.models")
+    assert models.LlmUsageLedger.__tablename__ == "llm_usage_ledger"
+    assert "llm_usage_ledger" in models.Base.metadata.tables
+
+
+# ─── Test 7: downgrade drops tables cleanly ─────────────────────────────────
+
+
+async def test_llm_usage_ledger_downgrade_drops_table(temp_database_url: str) -> None:
+    """alembic downgrade -1 from 024 drops llm_usage_ledger."""
+    _run_alembic(temp_database_url, "upgrade", "head")
+
+    # Verify table exists
+    exists_before = await _fetch_value(
+        temp_database_url,
+        """
+        SELECT EXISTS (
+            SELECT 1 FROM information_schema.tables
+            WHERE table_schema = 'public' AND table_name = 'llm_usage_ledger'
+        )
+        """,
+    )
+    assert exists_before is True
+
+    _run_alembic(temp_database_url, "downgrade", "-1")
+
+    exists_after = await _fetch_value(
+        temp_database_url,
+        """
+        SELECT EXISTS (
+            SELECT 1 FROM information_schema.tables
+            WHERE table_schema = 'public' AND table_name = 'llm_usage_ledger'
+        )
+        """,
+    )
+    assert exists_after is False


### PR DESCRIPTION
## Summary

T5-02 (Wave 1 Stream B) — Phase 5 schema foundation. Ships migration 024 + ORM models for the LLM gateway's audit ledger and answer cache.

- **Alembic 024** creates \`llm_usage_ledger\` (14 columns, FK to qa_traces ON DELETE SET NULL, 3 indexes) and \`llm_synthesis_cache\` (8 columns, UNIQUE on input_hash, JSONB citation_ids).
- **ORM** in \`bot/db/models.py\`: \`LlmUsageLedger\` + \`LlmSynthesisCache\` with cross-dialect JSONB pattern (\`JSON().with_variant(JSONB(), "postgresql")\`) for sqlite test compat.
- **\`down_revision = "023"\`** — linear chain after Wave 0 backfill (single alembic head verified via \`alembic heads\`).
- **19 schema-shape + RBC tests** across two files; 100% pass.

## PAR review trail

This PR underwent staged review per memory \`feedback-roles-claude-impl-codex-review\`:

| Round | Reviewer | Verdict | Findings closed |
|-------|----------|---------|-----------------|
| Initial | Claude critic (deep-code-reviewer) | APPROVE | 2 MEDIUM + 4 LOW |
| Initial | Codex (gpt-5.5 xhigh) | REQUEST_CHANGES | 1 HIGH + 2 MEDIUM + 1 LOW |
| Initial | Codex coverage | RBC tests advisory | 4 real-bug-catcher tests added |
| Polish commit | n/a | applied: CHAR ORM + JSONB variant + qa_trace_id BigInteger + 4 RBC tests + LOW-2 length asserts | All HIGH/MEDIUM/critic-MEDIUM closed |

Per project rule: Codex re-review on this PR will gate merge.

## Findings closed in polish

- **Codex HIGH** — \`JSONB()\` directly broke sqlite \`Base.metadata.create_all\` → fixed via \`JSON().with_variant(JSONB(), "postgresql")\` (existing project pattern).
- **Codex MED-2** — \`qa_trace_id Integer\` vs \`qa_traces.id BigInteger\` mismatch → both ORM and migration now \`BigInteger\`.
- **Critic MED-1** — \`String(64)\` vs migration \`CHAR(64)\` drift → ORM uses \`CHAR(64)\` for hash columns.
- **Critic LOW-2** — column-shape tests didn't assert \`character_maximum_length\` / \`numeric_precision\` / \`numeric_scale\` → expanded to 4-tuple per column.
- **Codex coverage (a/c/d/e)** — added migration roundtrip, CHAR(64) boundary, NUMERIC(10,6) boundary, FK ON DELETE SET NULL real-behavior tests.

## Test plan

- [x] \`uv run pytest -x tests/db/test_llm_usage_ledger_schema.py tests/db/test_llm_synthesis_cache_schema.py\` → 19/19 passed.
- [x] \`alembic heads\` → single head 024.
- [x] \`alembic upgrade head\` → \`alembic downgrade -1\` → \`alembic upgrade head\` clean.
- [x] ruff clean.
- [ ] CI green.
- [ ] Codex re-review APPROVE (post-PR).

## Plan reference

- \`docs/memory-system/PHASE5_PLAN.md\` §5.B (SQL spec) + §7 Wave 1 ticket table.
- Issue: #198.

🤖 Generated with [Claude Code](https://claude.com/claude-code)