### PR TITLE
ci(ops): healing workflows Python 3.12 + credentials.json perm fix

### DIFF
--- a/.github/workflows/healing.yml
+++ b/.github/workflows/healing.yml
@@ -39,7 +39,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.12"
 
       - name: Install dependencies
         run: pip install -e ".[dev,healing]"

--- a/.github/workflows/healthcheck.yml
+++ b/.github/workflows/healthcheck.yml
@@ -26,7 +26,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.12"
 
       - name: Install dependencies
         run: pip install -e ".[dev,healing]"

--- a/.github/workflows/ops-fix-credentials-perms.yml
+++ b/.github/workflows/ops-fix-credentials-perms.yml
@@ -1,0 +1,92 @@
+name: Ops — Fix credentials.json perms
+
+# One-shot maintenance workflow. Manually triggered.
+# Fixes Sheets sync regression introduced by non-root container (26ee7d4, 2026-04-26):
+# /srv/secrets/vibe-gatekeeper/credentials.json on host is not readable by container uid 10001 (appuser).
+# Strategy: prefer ACL (`setfacl -m u:10001:r`), fall back to chmod o+r if setfacl unavailable.
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "diagnose | fix"
+        required: true
+        default: "diagnose"
+        type: choice
+        options:
+          - diagnose
+          - fix
+
+permissions:
+  contents: read
+
+jobs:
+  fix-perms:
+    runs-on: [self-hosted, shkoder-vps]
+    timeout-minutes: 5
+    env:
+      HOST_FILE: /srv/secrets/vibe-gatekeeper/credentials.json
+      CONTAINER_UID: "10001"
+    steps:
+      - name: Diagnose current state
+        shell: bash
+        run: |
+          set +e
+          echo "=== runner identity ==="
+          id
+          echo
+          echo "=== file stat ==="
+          if [ -e "$HOST_FILE" ]; then
+            stat "$HOST_FILE"
+          else
+            echo "MISSING: $HOST_FILE"
+            exit 1
+          fi
+          echo
+          echo "=== ACL (if available) ==="
+          command -v getfacl >/dev/null && getfacl "$HOST_FILE" || echo "getfacl not installed"
+          echo
+          echo "=== test read as uid $CONTAINER_UID via setpriv (if available) ==="
+          if command -v setpriv >/dev/null; then
+            sudo -n setpriv --reuid="$CONTAINER_UID" --regid="$CONTAINER_UID" --clear-groups cat "$HOST_FILE" > /dev/null 2>&1
+            echo "setpriv result: $?"
+          else
+            echo "setpriv not available"
+          fi
+
+      - name: Apply fix
+        if: ${{ inputs.mode == 'fix' }}
+        shell: bash
+        run: |
+          set -e
+          echo "=== attempt setfacl (preferred) ==="
+          if command -v setfacl >/dev/null; then
+            if setfacl -m u:${CONTAINER_UID}:r "$HOST_FILE" 2>/dev/null; then
+              echo "setfacl OK (no sudo)"
+            elif sudo -n setfacl -m u:${CONTAINER_UID}:r "$HOST_FILE" 2>/dev/null; then
+              echo "setfacl OK (sudo)"
+            else
+              echo "setfacl failed, falling through to chmod"
+              false
+            fi
+          else
+            echo "setfacl not installed, using chmod"
+            false
+          fi || {
+            echo "=== fallback: chmod o+r ==="
+            if chmod o+r "$HOST_FILE" 2>/dev/null; then
+              echo "chmod OK (no sudo)"
+            elif sudo -n chmod o+r "$HOST_FILE" 2>/dev/null; then
+              echo "chmod OK (sudo)"
+            else
+              echo "FATAL: cannot chmod $HOST_FILE — need owner or sudo on runner user"
+              exit 1
+            fi
+          }
+
+          echo
+          echo "=== post-fix stat ==="
+          stat "$HOST_FILE"
+          echo
+          echo "=== post-fix ACL ==="
+          command -v getfacl >/dev/null && getfacl "$HOST_FILE" || true


### PR DESCRIPTION
## Summary

Two-part operational hotfix:

1. **CI healthcheck pin to Python 3.12.** `Healing Healthcheck` workflow has been failing every 3 hours since `2026-05-10 06:06` because `actions/setup-python@v5` cannot find a prebuilt Python 3.13 for the new Ubuntu 25.10 self-hosted runner image. Pin both `healthcheck.yml` and `healing.yml` to `3.12` (matches container runtime + `pyproject.toml requires-python = ">=3.12"`). `lint-privacy.yml` left at 3.13 — runs on `ubuntu-latest` where 3.13 is still prebuilt.

2. **One-shot `ops-fix-credentials-perms.yml`** workflow_dispatch for fixing the Sheets sync regression. After 26ee7d4 (2026-04-26) introduced non-root container (`appuser` uid 10001), `/srv/secrets/vibe-gatekeeper/credentials.json` host file became unreadable to the container user. `sync_google_sheets` has been logging `PermissionError: [Errno 13] Permission denied: '/app/credentials.json'` every 5 min. Workflow prefers `setfacl -m u:10001:r` (surgical), falls back to `chmod o+r`. Default mode is `diagnose` — actual fix requires explicit `mode: fix` input.

## Context

- Bot core was alive throughout (Telegram polling fine, `restart_count=0`, schedulers ticking). User-visible chat handlers unaffected.
- Same security wave as the 2026-04-29 `WEB_PASSWORD` outage — non-root user introduced without host-side perm reconciliation.

## Test plan
- [ ] CI green
- [ ] After merge: trigger `Healing Healthcheck` workflow_dispatch → green
- [ ] Then: trigger `Ops — Fix credentials.json perms` with `mode: diagnose` → inspect output
- [ ] Then: trigger with `mode: fix` → verify post-fix stat shows ACL/perms allow uid 10001 read
- [ ] Verify in container logs: `sync_google_sheets` next 5-min tick no longer errors