### PR TITLE
ci(ops): system Python via venv + docker-based credentials chmod (follow-up to #212)

### DIFF
--- a/.github/workflows/healing.yml
+++ b/.github/workflows/healing.yml
@@ -37,9 +37,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
+      - name: Set up Python venv (system python; setup-python@v5 has no prebuilt for Ubuntu 25.10)
+        run: |
+          python3 --version
+          python3 -m venv /tmp/healing-venv
+          /tmp/healing-venv/bin/pip install --upgrade pip
+          echo "/tmp/healing-venv/bin" >> "$GITHUB_PATH"
 
       - name: Install dependencies
         run: pip install -e ".[dev,healing]"

--- a/.github/workflows/healthcheck.yml
+++ b/.github/workflows/healthcheck.yml
@@ -24,9 +24,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
+      - name: Set up Python venv (system python; setup-python@v5 has no prebuilt for Ubuntu 25.10)
+        run: |
+          python3 --version
+          python3 -m venv /tmp/healing-venv
+          /tmp/healing-venv/bin/pip install --upgrade pip
+          echo "/tmp/healing-venv/bin" >> "$GITHUB_PATH"
 
       - name: Install dependencies
         run: pip install -e ".[dev,healing]"

--- a/.github/workflows/ops-fix-credentials-perms.yml
+++ b/.github/workflows/ops-fix-credentials-perms.yml
@@ -2,8 +2,13 @@ name: Ops — Fix credentials.json perms
 
 # One-shot maintenance workflow. Manually triggered.
 # Fixes Sheets sync regression introduced by non-root container (26ee7d4, 2026-04-26):
-# /srv/secrets/vibe-gatekeeper/credentials.json on host is not readable by container uid 10001 (appuser).
-# Strategy: prefer ACL (`setfacl -m u:10001:r`), fall back to chmod o+r if setfacl unavailable.
+# /srv/secrets/vibe-gatekeeper/credentials.json on host is mode 0400 root:root,
+# unreadable by container uid 10001 (appuser).
+#
+# Runner user is uid=1002(runner), no sudo, but member of `docker` group.
+# Strategy: docker-exec a throwaway root container with the host secrets dir
+# bind-mounted, run setfacl (preferred) or chmod (fallback) inside. The docker
+# daemon executes the container as root, which lets us chmod a root-owned host file.
 
 on:
   workflow_dispatch:
@@ -26,16 +31,17 @@ jobs:
     timeout-minutes: 5
     env:
       HOST_FILE: /srv/secrets/vibe-gatekeeper/credentials.json
+      HOST_DIR: /srv/secrets/vibe-gatekeeper
       CONTAINER_UID: "10001"
     steps:
-      - name: Diagnose current state
+      - name: Diagnose current state (host view)
         shell: bash
         run: |
           set +e
           echo "=== runner identity ==="
           id
           echo
-          echo "=== file stat ==="
+          echo "=== host file stat ==="
           if [ -e "$HOST_FILE" ]; then
             stat "$HOST_FILE"
           else
@@ -43,50 +49,60 @@ jobs:
             exit 1
           fi
           echo
-          echo "=== ACL (if available) ==="
-          command -v getfacl >/dev/null && getfacl "$HOST_FILE" || echo "getfacl not installed"
-          echo
-          echo "=== test read as uid $CONTAINER_UID via setpriv (if available) ==="
-          if command -v setpriv >/dev/null; then
-            sudo -n setpriv --reuid="$CONTAINER_UID" --regid="$CONTAINER_UID" --clear-groups cat "$HOST_FILE" > /dev/null 2>&1
-            echo "setpriv result: $?"
-          else
-            echo "setpriv not available"
-          fi
+          echo "=== host dir stat ==="
+          stat "$HOST_DIR" 2>&1 | sed -n '1,5p' || echo "(cannot stat dir as runner — likely 0700 root)"
 
-      - name: Apply fix
+      - name: Diagnose via docker (root view inside throwaway container)
+        shell: bash
+        run: |
+          set -e
+          docker run --rm \
+            -v "${HOST_DIR}":/secrets:ro \
+            alpine:3.20 sh -c '
+              echo "=== container identity ==="
+              id
+              echo
+              echo "=== /secrets dir ==="
+              ls -la /secrets
+              echo
+              echo "=== /secrets/credentials.json ==="
+              stat /secrets/credentials.json
+              echo
+              echo "=== sample uid 10001 read test ==="
+              apk add --no-cache shadow >/dev/null 2>&1 || true
+              # Try reading as uid 10001 via su-exec-style: setpriv if available, else just report mode
+              command -v setpriv >/dev/null && setpriv --reuid=10001 --regid=10001 --clear-groups cat /secrets/credentials.json >/dev/null && echo "uid 10001 CAN read" || echo "uid 10001 CANNOT read"
+            '
+
+      - name: Apply fix via docker (setfacl preferred, chmod fallback)
         if: ${{ inputs.mode == 'fix' }}
         shell: bash
         run: |
           set -e
-          echo "=== attempt setfacl (preferred) ==="
-          if command -v setfacl >/dev/null; then
-            if setfacl -m u:${CONTAINER_UID}:r "$HOST_FILE" 2>/dev/null; then
-              echo "setfacl OK (no sudo)"
-            elif sudo -n setfacl -m u:${CONTAINER_UID}:r "$HOST_FILE" 2>/dev/null; then
-              echo "setfacl OK (sudo)"
-            else
-              echo "setfacl failed, falling through to chmod"
-              false
-            fi
-          else
-            echo "setfacl not installed, using chmod"
-            false
-          fi || {
-            echo "=== fallback: chmod o+r ==="
-            if chmod o+r "$HOST_FILE" 2>/dev/null; then
-              echo "chmod OK (no sudo)"
-            elif sudo -n chmod o+r "$HOST_FILE" 2>/dev/null; then
-              echo "chmod OK (sudo)"
-            else
-              echo "FATAL: cannot chmod $HOST_FILE — need owner or sudo on runner user"
-              exit 1
-            fi
-          }
-
-          echo
-          echo "=== post-fix stat ==="
-          stat "$HOST_FILE"
-          echo
-          echo "=== post-fix ACL ==="
-          command -v getfacl >/dev/null && getfacl "$HOST_FILE" || true
+          # Mount RW so we can change perms. The container runs as root via docker daemon,
+          # which lets it chmod the root-owned host file.
+          docker run --rm \
+            -v "${HOST_DIR}":/secrets \
+            -e CONTAINER_UID="${CONTAINER_UID}" \
+            alpine:3.20 sh -ec '
+              apk add --no-cache acl >/dev/null
+              echo "=== before ==="
+              stat /secrets/credentials.json
+              echo
+              echo "=== applying setfacl u:${CONTAINER_UID}:r ==="
+              if setfacl -m u:"${CONTAINER_UID}":r /secrets/credentials.json; then
+                echo "setfacl OK"
+              else
+                echo "setfacl failed, falling back to chmod o+r"
+                chmod o+r /secrets/credentials.json
+                echo "chmod OK"
+              fi
+              echo
+              echo "=== after ==="
+              stat /secrets/credentials.json
+              echo
+              getfacl /secrets/credentials.json || true
+              echo
+              echo "=== verify uid 10001 can read ==="
+              setpriv --reuid=10001 --regid=10001 --clear-groups cat /secrets/credentials.json >/dev/null && echo "OK — uid 10001 now reads" || { echo "STILL CANNOT READ — check dir traversal perms"; exit 1; }
+            '


### PR DESCRIPTION
## Summary

Follow-up to #212. Previous fix did not work — `actions/setup-python@v5` has no prebuilt Python for Ubuntu 25.10 self-hosted runner at ALL (3.13 failed; 3.12 also failed).

- Drop `setup-python` step in `healthcheck.yml` and `healing.yml`. Use system `python3` (Ubuntu 25.10 ships 3.13 natively, satisfies `requires-python = ">=3.12"`) via a `/tmp/healing-venv` so `pip install` doesn't hit PEP-668.
- Rewrite `ops-fix-credentials-perms.yml` to use the docker socket. Diagnose (run 25658036754) showed `/srv/secrets/vibe-gatekeeper/credentials.json` is mode `0400 root:root` and runner is `uid=1002(runner)` with no sudo but in `docker` group. Workflow now docker-runs a throwaway alpine that bind-mounts the secrets dir; docker daemon executes the container as root, letting it `setfacl -m u:10001:r` (with `chmod o+r` fallback) on the root-owned host file. Verifies uid 10001 can read after the change.

## Test plan
- [ ] CI green
- [ ] After merge: trigger `Healing Healthcheck` workflow_dispatch → green
- [ ] Trigger `Ops — Fix credentials.json perms` with `mode: diagnose` → confirm docker-view diagnostics
- [ ] Trigger with `mode: fix` → confirm setfacl applied + uid 10001 verified
- [ ] Verify container logs: next 5-min `sync_google_sheets` tick has no PermissionError