### PR TITLE
ci(ops): su-exec + verify in real bot container

### DIFF
--- a/.github/workflows/ops-fix-credentials-perms.yml
+++ b/.github/workflows/ops-fix-credentials-perms.yml
@@ -68,11 +68,28 @@ jobs:
               echo "=== /secrets/credentials.json ==="
               stat /secrets/credentials.json
               echo
-              echo "=== sample uid 10001 read test ==="
-              apk add --no-cache shadow >/dev/null 2>&1 || true
-              # Try reading as uid 10001 via su-exec-style: setpriv if available, else just report mode
-              command -v setpriv >/dev/null && setpriv --reuid=10001 --regid=10001 --clear-groups cat /secrets/credentials.json >/dev/null && echo "uid 10001 CAN read" || echo "uid 10001 CANNOT read"
+              echo "=== sample uid 10001 read test (su-exec) ==="
+              apk add --no-cache su-exec >/dev/null
+              su-exec 10001:10001 cat /secrets/credentials.json >/dev/null 2>&1 && echo "uid 10001 CAN read" || echo "uid 10001 CANNOT read"
             '
+
+      - name: Diagnose via real bot container (ground truth, runs as appuser)
+        shell: bash
+        run: |
+          set +e
+          BOT_CONTAINER=$(docker ps --filter "ancestor=ghcr.io/jekudy/vibe-gatekeeper-bot:main" --format '{{.Names}}' | head -1)
+          if [ -z "$BOT_CONTAINER" ]; then
+            BOT_CONTAINER=$(docker ps --format '{{.Names}}' | grep -E 'vibe-gatekeeper|shkoder' | head -1)
+          fi
+          echo "bot_container=$BOT_CONTAINER"
+          if [ -z "$BOT_CONTAINER" ]; then
+            echo "no running bot container found — skipping live verify"
+            exit 0
+          fi
+          echo "=== bot container user ==="
+          docker exec "$BOT_CONTAINER" id
+          echo "=== bot reads /app/credentials.json ==="
+          docker exec "$BOT_CONTAINER" sh -c 'head -c 1 /app/credentials.json >/dev/null && echo "OK readable" || echo "STILL NOT READABLE"'
 
       - name: Apply fix via docker (setfacl preferred, chmod fallback)
         if: ${{ inputs.mode == 'fix' }}
@@ -103,6 +120,24 @@ jobs:
               echo
               getfacl /secrets/credentials.json || true
               echo
-              echo "=== verify uid 10001 can read ==="
-              setpriv --reuid=10001 --regid=10001 --clear-groups cat /secrets/credentials.json >/dev/null && echo "OK — uid 10001 now reads" || { echo "STILL CANNOT READ — check dir traversal perms"; exit 1; }
+              echo "=== verify uid 10001 can read (su-exec) ==="
+              apk add --no-cache su-exec >/dev/null
+              su-exec 10001:10001 cat /secrets/credentials.json >/dev/null && echo "OK — uid 10001 now reads" || { echo "STILL CANNOT READ — check dir traversal perms"; exit 1; }
             '
+
+      - name: Verify via real bot container (ground truth)
+        if: ${{ inputs.mode == 'fix' }}
+        shell: bash
+        run: |
+          set -e
+          BOT_CONTAINER=$(docker ps --filter "ancestor=ghcr.io/jekudy/vibe-gatekeeper-bot:main" --format '{{.Names}}' | head -1)
+          if [ -z "$BOT_CONTAINER" ]; then
+            BOT_CONTAINER=$(docker ps --format '{{.Names}}' | grep -E 'vibe-gatekeeper|shkoder' | head -1)
+          fi
+          if [ -z "$BOT_CONTAINER" ]; then
+            echo "no running bot container — cannot verify in production. Fix applied to host file; bot will pick it up on next sync."
+            exit 0
+          fi
+          echo "verifying inside $BOT_CONTAINER"
+          docker exec "$BOT_CONTAINER" id
+          docker exec "$BOT_CONTAINER" sh -c 'head -c 1 /app/credentials.json >/dev/null && echo "OK — bot container can now read credentials.json"'


### PR DESCRIPTION
## Summary

Tweak to the ops-fix-credentials-perms workflow:

- Alpine's `setpriv` (busybox/old util-linux) doesn't accept `--reuid/--regid` long opts. Replace with `su-exec` (alpine package built exactly for this).
- Added a second verify path: `docker exec` into the running bot container (which already runs as `appuser` uid 10001) and try reading `/app/credentials.json`. Ground truth for whether `sync_google_sheets` will work after the fix. Gracefully skips if bot container not found.

## Test plan
- [ ] CI green
- [ ] After merge: trigger `Ops — Fix credentials.json perms` with `mode: diagnose` → confirm su-exec works + bot-container probe runs
- [ ] Trigger with `mode: fix` → confirm uid 10001 reads after setfacl + bot container can read
- [ ] Next 5-min container log: `sync_google_sheets` no PermissionError