### PR TITLE
feat(p5-w2): T5-03 LedgerRepo + SynthesisCacheRepo (Phase 5 Wave 2 repos)

### DIFF
--- a/bot/db/repos/llm_synthesis_cache.py
+++ b/bot/db/repos/llm_synthesis_cache.py
@@ -1,0 +1,148 @@
+"""Repository for ``llm_synthesis_cache`` (T5-03).
+
+Flush-only — NEVER calls ``session.commit()`` or ``session.rollback()``.
+The caller (gateway / handler) owns the transaction lifecycle.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from sqlalchemy import delete, func, select, text, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from bot.db.models import LlmSynthesisCache
+
+_log = logging.getLogger(__name__)
+
+
+class SynthesisCacheRepo:
+    """Data-access layer for ``llm_synthesis_cache``.
+
+    All methods are ``@staticmethod`` and flush-only. They mirror the
+    ``SynthesisCacheRepoProtocol`` defined in ``bot/services/llm_gateway.py``.
+
+    ``invalidate_by_citation`` uses PostgreSQL JSONB containment (``@>``) in
+    production.  For SQLite (used in unit tests), it falls back to a portable
+    Python-side filter because SQLite has no ``@>`` operator.
+    """
+
+    @staticmethod
+    async def get_or_none(
+        session: AsyncSession,
+        *,
+        input_hash: str,
+    ) -> LlmSynthesisCache | None:
+        """Lookup by ``input_hash``. Returns row or None. No side effects."""
+        result = await session.execute(
+            select(LlmSynthesisCache).where(LlmSynthesisCache.input_hash == input_hash)
+        )
+        return result.scalars().first()
+
+    @staticmethod
+    async def store(
+        session: AsyncSession,
+        *,
+        input_hash: str,
+        answer_text: str,
+        citation_ids: list[int],
+        model: str,
+    ) -> LlmSynthesisCache:
+        """Insert a cache row. Flushes; caller commits.
+
+        Caller MUST handle ``IntegrityError`` on UNIQUE-violation of ``input_hash``
+        (concurrent races) by falling back to ``get_or_none`` and bumping ``hit_count``.
+        Race-handling contract is in T5-01 ``STEP_CITATION_ENFORCEMENT``.
+        """
+        row = LlmSynthesisCache(
+            input_hash=input_hash,
+            answer_text=answer_text,
+            citation_ids=list(citation_ids),
+            model=model,
+        )
+        session.add(row)
+        await session.flush()
+        _log.debug("llm_synthesis_cache: inserted row id=%s input_hash=%.8s...", row.id, input_hash)
+        return row
+
+    @staticmethod
+    async def bump_hit(
+        session: AsyncSession,
+        *,
+        cache_id: int,
+    ) -> None:
+        """UPDATE last_hit_at = now(), hit_count = hit_count + 1. Flushes."""
+        stmt = (
+            update(LlmSynthesisCache)
+            .where(LlmSynthesisCache.id == cache_id)
+            .values(
+                last_hit_at=func.now(),
+                hit_count=LlmSynthesisCache.hit_count + 1,
+            )
+        )
+        await session.execute(stmt)
+        await session.flush()
+        _log.debug("llm_synthesis_cache: bumped hit_count for id=%s", cache_id)
+
+    @staticmethod
+    async def invalidate_by_citation(
+        session: AsyncSession,
+        *,
+        message_version_id: int,
+    ) -> int:
+        """DELETE every cache row whose citation_ids JSONB array contains ``message_version_id``.
+
+        Returns rowcount (number of cache rows invalidated).
+
+        PostgreSQL: uses JSONB containment operator ``@>`` via ``sqlalchemy.text()`` for
+        correctness and index-friendliness.
+
+        SQLite: falls back to a portable Python-side filter (load all rows, delete matching
+        ones). SQLite has no ``@>`` operator. This path is acceptable for tests because the
+        cache table is small in fixtures.
+
+        The dialect is detected via ``session.bind.dialect.name``.
+        """
+        # Detect dialect via the connection's dialect on the bound engine / connection.
+        # AsyncSession wraps a connection; we use get_bind() which is the sync engine/connection.
+        bind = session.get_bind()
+        dialect_name = bind.dialect.name
+
+        if dialect_name == "postgresql":
+            stmt = text(
+                "DELETE FROM llm_synthesis_cache "
+                "WHERE citation_ids @> CAST(:id AS jsonb) "
+                "RETURNING id"
+            )
+            result = await session.execute(stmt, {"id": f"[{message_version_id}]"})
+            deleted_ids = result.fetchall()
+            rowcount = len(deleted_ids)
+        else:
+            # Portable fallback for SQLite and any other dialect.
+            all_rows_result = await session.execute(select(LlmSynthesisCache))
+            all_rows = list(all_rows_result.scalars().all())
+            matching_ids = [
+                row.id
+                for row in all_rows
+                if message_version_id in (row.citation_ids or [])
+            ]
+            if matching_ids:
+                del_stmt = delete(LlmSynthesisCache).where(
+                    LlmSynthesisCache.id.in_(matching_ids)
+                )
+                del_result = await session.execute(del_stmt)
+                rowcount = del_result.rowcount
+            else:
+                rowcount = 0
+            if rowcount:
+                await session.flush()
+
+        if rowcount and dialect_name == "postgresql":
+            await session.flush()
+
+        _log.debug(
+            "llm_synthesis_cache: invalidated %s rows for message_version_id=%s",
+            rowcount,
+            message_version_id,
+        )
+        return rowcount

--- a/bot/db/repos/llm_synthesis_cache.py
+++ b/bot/db/repos/llm_synthesis_cache.py
@@ -119,12 +119,14 @@ class SynthesisCacheRepo:
             rowcount = len(deleted_ids)
         else:
             # Portable fallback for SQLite and any other dialect.
-            all_rows_result = await session.execute(select(LlmSynthesisCache))
-            all_rows = list(all_rows_result.scalars().all())
+            all_rows_result = await session.execute(
+                select(LlmSynthesisCache.id, LlmSynthesisCache.citation_ids)
+            )
+            all_rows = all_rows_result.all()  # list of (id, citation_ids) tuples
             matching_ids = [
-                row.id
-                for row in all_rows
-                if message_version_id in (row.citation_ids or [])
+                row_id
+                for row_id, citation_ids in all_rows
+                if message_version_id in (citation_ids or [])
             ]
             if matching_ids:
                 del_stmt = delete(LlmSynthesisCache).where(

--- a/bot/db/repos/llm_usage_ledger.py
+++ b/bot/db/repos/llm_usage_ledger.py
@@ -1,0 +1,165 @@
+"""Repository for ``llm_usage_ledger`` (T5-03).
+
+Flush-only — NEVER calls ``session.commit()`` or ``session.rollback()``.
+The caller (gateway / handler) owns the transaction lifecycle.
+"""
+
+from __future__ import annotations
+
+import logging
+from calendar import monthrange
+from datetime import date, datetime, time, timezone
+from decimal import Decimal
+
+from sqlalchemy import func, select, update
+
+from bot.db.models import LlmUsageLedger
+from sqlalchemy.ext.asyncio import AsyncSession
+
+_log = logging.getLogger(__name__)
+
+
+class LedgerRepo:
+    """Data-access layer for ``llm_usage_ledger``.
+
+    All methods are ``@staticmethod`` and flush-only. They mirror the
+    ``LedgerRepoProtocol`` defined in ``bot/services/llm_gateway.py`` so that
+    the gateway can accept either the real repo or a Protocol-satisfying test fake.
+    """
+
+    @staticmethod
+    async def record(
+        session: AsyncSession,
+        *,
+        qa_trace_id: int | None,
+        provider: str,
+        model: str,
+        prompt_hash: str,
+        response_hash: str | None,
+        tokens_in: int,
+        tokens_out: int,
+        cost_usd: Decimal,
+        latency_ms: int,
+        request_id: str | None,
+        cache_hit: bool,
+        error: str | None,
+    ) -> LlmUsageLedger:
+        """Insert a ledger row. Flushes; caller commits. NEVER commits internally.
+
+        Used by the cache-hit path where all fields are known up-front.
+        """
+        row = LlmUsageLedger(
+            qa_trace_id=qa_trace_id,
+            provider=provider,
+            model=model,
+            prompt_hash=prompt_hash,
+            response_hash=response_hash,
+            tokens_in=tokens_in,
+            tokens_out=tokens_out,
+            cost_usd=cost_usd,
+            latency_ms=latency_ms,
+            request_id=request_id,
+            cache_hit=cache_hit,
+            error=error,
+        )
+        session.add(row)
+        await session.flush()
+        _log.debug("llm_usage_ledger: inserted row id=%s", row.id)
+        return row
+
+    @staticmethod
+    async def daily_cost_usd(
+        session: AsyncSession,
+        *,
+        day: date,
+    ) -> Decimal:
+        """SUM(cost_usd) WHERE created_at >= day_utc_start AND < day_utc_end.
+
+        UTC-bounded; ``day`` is interpreted as a UTC calendar date. Zero rows =>
+        ``Decimal("0")`` (NEVER ``None``).
+        """
+        day_start = datetime.combine(day, time(0), tzinfo=timezone.utc)
+        next_day = date.fromordinal(day.toordinal() + 1)
+        day_end = datetime.combine(next_day, time(0), tzinfo=timezone.utc)
+
+        result = await session.execute(
+            select(func.sum(LlmUsageLedger.cost_usd)).where(
+                LlmUsageLedger.created_at >= day_start,
+                LlmUsageLedger.created_at < day_end,
+            )
+        )
+        total = result.scalar_one_or_none()
+        return Decimal(str(total)) if total is not None else Decimal("0")
+
+    @staticmethod
+    async def monthly_cost_usd(
+        session: AsyncSession,
+        *,
+        year: int,
+        month: int,
+    ) -> Decimal:
+        """SUM(cost_usd) WHERE created_at within (year, month) UTC.
+
+        UTC-bounded. Zero rows => ``Decimal("0")`` (NEVER ``None``).
+        """
+        month_start = datetime.combine(date(year, month, 1), time(0), tzinfo=timezone.utc)
+        _, days_in_month = monthrange(year, month)
+        month_end_date = date(year, month, days_in_month)
+        next_month_date = date.fromordinal(month_end_date.toordinal() + 1)
+        month_end = datetime.combine(next_month_date, time(0), tzinfo=timezone.utc)
+
+        result = await session.execute(
+            select(func.sum(LlmUsageLedger.cost_usd)).where(
+                LlmUsageLedger.created_at >= month_start,
+                LlmUsageLedger.created_at < month_end,
+            )
+        )
+        total = result.scalar_one_or_none()
+        return Decimal(str(total)) if total is not None else Decimal("0")
+
+    @staticmethod
+    async def update_placeholder(
+        session: AsyncSession,
+        *,
+        llm_call_id: int,
+        tokens_in: int,
+        tokens_out: int,
+        cost_usd: Decimal,
+        latency_ms: int,
+        request_id: str | None,
+        response_hash: str | None,
+        error: str | None,
+    ) -> int:
+        """UPDATE the placeholder row written under STEP_BUDGET_GUARD_ATOMIC.
+
+        Returns rowcount (must be 1). Flushes; caller commits. NEVER commits internally.
+
+        Raises ``LookupError`` if ``llm_call_id`` is not found (placeholder row missing).
+        This guards against process-crash scenarios where the placeholder was never written.
+
+        Note: kwarg name is ``llm_call_id`` (not ``ledger_id``) — this matches the Protocol
+        declared in ``bot/services/llm_gateway.py`` line ~150 which T5-01 PR #209 shipped.
+        The contracts.md §5.1 used ``ledger_id``; the code on main wins per task brief.
+        """
+        stmt = (
+            update(LlmUsageLedger)
+            .where(LlmUsageLedger.id == llm_call_id)
+            .values(
+                tokens_in=tokens_in,
+                tokens_out=tokens_out,
+                cost_usd=cost_usd,
+                latency_ms=latency_ms,
+                request_id=request_id,
+                response_hash=response_hash,
+                error=error,
+            )
+        )
+        result = await session.execute(stmt)
+        rowcount: int = result.rowcount
+        if rowcount == 0:
+            raise LookupError(
+                f"LlmUsageLedger(id={llm_call_id}) not found — placeholder row missing"
+            )
+        await session.flush()
+        _log.debug("llm_usage_ledger: updated placeholder id=%s rowcount=%s", llm_call_id, rowcount)
+        return rowcount

--- a/tests/db/test_llm_synthesis_cache_repo.py
+++ b/tests/db/test_llm_synthesis_cache_repo.py
@@ -8,9 +8,10 @@ Tests are skipped automatically if postgres is unreachable.
 from __future__ import annotations
 
 import itertools
+from datetime import datetime, timezone
 
 import pytest
-from sqlalchemy import select
+from sqlalchemy import select, text
 from sqlalchemy.exc import IntegrityError
 
 pytestmark = pytest.mark.usefixtures("app_env")
@@ -120,7 +121,6 @@ async def test_store_raises_integrity_error_on_duplicate_input_hash(db_session) 
 
 
 async def test_bump_hit_increments_hit_count(db_session) -> None:
-    from bot.db.models import LlmSynthesisCache
     from bot.db.repos.llm_synthesis_cache import SynthesisCacheRepo
 
     row = await SynthesisCacheRepo.store(
@@ -132,17 +132,20 @@ async def test_bump_hit_increments_hit_count(db_session) -> None:
     )
     initial_hit_count = row.hit_count  # server_default = 1
 
-    await SynthesisCacheRepo.bump_hit(db_session, cache_id=row.id)
-
-    # Reload from DB to see updated values.
-    result = await db_session.execute(
-        select(LlmSynthesisCache).where(LlmSynthesisCache.id == row.id)
+    # Backdate last_hit_at by 1 hour to make the advance observable.
+    old_ts = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+    await db_session.execute(
+        text("UPDATE llm_synthesis_cache SET last_hit_at = :old WHERE id = :id"),
+        {"old": old_ts, "id": row.id},
     )
-    updated = result.scalar_one()
-    assert updated.hit_count == initial_hit_count + 1
-    # last_hit_at must be updated (may be equal if the UPDATE runs within same
-    # millisecond, but rowcount must be 1 as a minimum guarantee)
-    assert updated.last_hit_at is not None
+    await db_session.flush()
+
+    await SynthesisCacheRepo.bump_hit(db_session, cache_id=row.id)
+    await db_session.flush()
+    await db_session.refresh(row)
+
+    assert row.hit_count == initial_hit_count + 1
+    assert row.last_hit_at > old_ts
 
 
 # ─── Test 6: invalidate_by_citation returns 0 when no rows reference the id ──

--- a/tests/db/test_llm_synthesis_cache_repo.py
+++ b/tests/db/test_llm_synthesis_cache_repo.py
@@ -1,0 +1,244 @@
+"""T5-03 acceptance tests — SynthesisCacheRepo (llm_synthesis_cache table).
+
+Uses the ``db_session`` fixture from ``tests/conftest.py`` which connects to the
+real postgres and wraps each test in a rolled-back outer transaction for isolation.
+Tests are skipped automatically if postgres is unreachable.
+"""
+
+from __future__ import annotations
+
+import itertools
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+
+pytestmark = pytest.mark.usefixtures("app_env")
+
+_counter = itertools.count(start=7_700_000_000)
+
+
+def _input_hash(n: int | None = None) -> str:
+    """Return a unique 64-char hex-like string for input_hash."""
+    suffix = str(next(_counter) if n is None else n)
+    return ("d" * (64 - len(suffix)) + suffix)[:64]
+
+
+# ─── Test 1: get_or_none returns None when no row matches ────────────────────
+
+
+async def test_get_or_none_returns_none_when_absent(db_session) -> None:
+    from bot.db.repos.llm_synthesis_cache import SynthesisCacheRepo
+
+    result = await SynthesisCacheRepo.get_or_none(db_session, input_hash=_input_hash())
+
+    assert result is None
+
+
+# ─── Test 2: get_or_none returns the row when match exists ───────────────────
+
+
+async def test_get_or_none_returns_row_when_present(db_session) -> None:
+    from bot.db.models import LlmSynthesisCache
+    from bot.db.repos.llm_synthesis_cache import SynthesisCacheRepo
+
+    h = _input_hash()
+    inserted = await SynthesisCacheRepo.store(
+        db_session,
+        input_hash=h,
+        answer_text="some answer",
+        citation_ids=[1, 2, 3],
+        model="claude-haiku",
+    )
+
+    fetched = await SynthesisCacheRepo.get_or_none(db_session, input_hash=h)
+
+    assert fetched is not None
+    assert isinstance(fetched, LlmSynthesisCache)
+    assert fetched.id == inserted.id
+    assert fetched.input_hash == h
+    assert fetched.answer_text == "some answer"
+    assert fetched.citation_ids == [1, 2, 3]
+
+
+# ─── Test 3: store inserts row with expected defaults ────────────────────────
+
+
+async def test_store_inserts_row_with_defaults(db_session) -> None:
+    from bot.db.models import LlmSynthesisCache
+    from bot.db.repos.llm_synthesis_cache import SynthesisCacheRepo
+
+    h = _input_hash()
+    row = await SynthesisCacheRepo.store(
+        db_session,
+        input_hash=h,
+        answer_text="cached answer",
+        citation_ids=[10, 20],
+        model="gpt-4o",
+    )
+
+    assert isinstance(row, LlmSynthesisCache)
+    assert row.id is not None
+    assert row.id > 0
+    assert row.input_hash == h
+    assert row.answer_text == "cached answer"
+    assert row.citation_ids == [10, 20]
+    assert row.model == "gpt-4o"
+    # Server defaults
+    assert row.created_at is not None
+    assert row.last_hit_at is not None
+    assert row.hit_count == 1
+
+
+# ─── Test 4: store raises IntegrityError on duplicate input_hash ──────────────
+
+
+async def test_store_raises_integrity_error_on_duplicate_input_hash(db_session) -> None:
+    """UNIQUE constraint on input_hash raises IntegrityError on second insert."""
+    from bot.db.repos.llm_synthesis_cache import SynthesisCacheRepo
+
+    h = _input_hash()
+    await SynthesisCacheRepo.store(
+        db_session,
+        input_hash=h,
+        answer_text="first answer",
+        citation_ids=[],
+        model="claude-haiku",
+    )
+
+    with pytest.raises(IntegrityError):
+        await SynthesisCacheRepo.store(
+            db_session,
+            input_hash=h,
+            answer_text="second answer — should fail",
+            citation_ids=[],
+            model="claude-haiku",
+        )
+
+
+# ─── Test 5: bump_hit increments hit_count and updates last_hit_at ───────────
+
+
+async def test_bump_hit_increments_hit_count(db_session) -> None:
+    from bot.db.models import LlmSynthesisCache
+    from bot.db.repos.llm_synthesis_cache import SynthesisCacheRepo
+
+    row = await SynthesisCacheRepo.store(
+        db_session,
+        input_hash=_input_hash(),
+        answer_text="bump test",
+        citation_ids=[5],
+        model="claude-haiku",
+    )
+    initial_hit_count = row.hit_count  # server_default = 1
+
+    await SynthesisCacheRepo.bump_hit(db_session, cache_id=row.id)
+
+    # Reload from DB to see updated values.
+    result = await db_session.execute(
+        select(LlmSynthesisCache).where(LlmSynthesisCache.id == row.id)
+    )
+    updated = result.scalar_one()
+    assert updated.hit_count == initial_hit_count + 1
+    # last_hit_at must be updated (may be equal if the UPDATE runs within same
+    # millisecond, but rowcount must be 1 as a minimum guarantee)
+    assert updated.last_hit_at is not None
+
+
+# ─── Test 6: invalidate_by_citation returns 0 when no rows reference the id ──
+
+
+async def test_invalidate_by_citation_returns_zero_when_no_match(db_session) -> None:
+    from bot.db.repos.llm_synthesis_cache import SynthesisCacheRepo
+
+    # Insert a cache row that does NOT cite message_version_id=999.
+    await SynthesisCacheRepo.store(
+        db_session,
+        input_hash=_input_hash(),
+        answer_text="unrelated answer",
+        citation_ids=[100, 200],
+        model="claude-haiku",
+    )
+
+    rowcount = await SynthesisCacheRepo.invalidate_by_citation(
+        db_session, message_version_id=999
+    )
+
+    assert rowcount == 0
+
+
+# ─── Test 7: invalidate_by_citation returns N>0 for matching rows ─────────────
+
+
+async def test_invalidate_by_citation_deletes_matching_rows(db_session) -> None:
+    """Two rows cite message_version_id=42; one does not. Delete returns 2."""
+    from bot.db.models import LlmSynthesisCache
+    from bot.db.repos.llm_synthesis_cache import SynthesisCacheRepo
+
+    target_mv_id = 42
+
+    row_a = await SynthesisCacheRepo.store(
+        db_session,
+        input_hash=_input_hash(),
+        answer_text="answer A cites 42",
+        citation_ids=[target_mv_id, 100],
+        model="claude-haiku",
+    )
+    row_b = await SynthesisCacheRepo.store(
+        db_session,
+        input_hash=_input_hash(),
+        answer_text="answer B cites 42",
+        citation_ids=[50, target_mv_id],
+        model="claude-haiku",
+    )
+    row_c = await SynthesisCacheRepo.store(
+        db_session,
+        input_hash=_input_hash(),
+        answer_text="answer C does NOT cite 42",
+        citation_ids=[7, 8, 9],
+        model="claude-haiku",
+    )
+
+    rowcount = await SynthesisCacheRepo.invalidate_by_citation(
+        db_session, message_version_id=target_mv_id
+    )
+
+    assert rowcount == 2
+
+    # row_a and row_b must be gone; row_c must survive.
+    result_a = await db_session.execute(
+        select(LlmSynthesisCache).where(LlmSynthesisCache.id == row_a.id)
+    )
+    assert result_a.scalar_one_or_none() is None, "row_a should have been deleted"
+
+    result_b = await db_session.execute(
+        select(LlmSynthesisCache).where(LlmSynthesisCache.id == row_b.id)
+    )
+    assert result_b.scalar_one_or_none() is None, "row_b should have been deleted"
+
+    result_c = await db_session.execute(
+        select(LlmSynthesisCache).where(LlmSynthesisCache.id == row_c.id)
+    )
+    assert result_c.scalar_one_or_none() is not None, "row_c must survive"
+
+
+# ─── Bonus: get_or_none is idempotent (multiple calls same hash) ──────────────
+
+
+async def test_get_or_none_idempotent_multiple_calls(db_session) -> None:
+    from bot.db.repos.llm_synthesis_cache import SynthesisCacheRepo
+
+    h = _input_hash()
+    await SynthesisCacheRepo.store(
+        db_session,
+        input_hash=h,
+        answer_text="idempotent check",
+        citation_ids=[],
+        model="claude-haiku",
+    )
+
+    r1 = await SynthesisCacheRepo.get_or_none(db_session, input_hash=h)
+    r2 = await SynthesisCacheRepo.get_or_none(db_session, input_hash=h)
+    assert r1 is not None
+    assert r2 is not None
+    assert r1.id == r2.id

--- a/tests/db/test_llm_usage_ledger_repo.py
+++ b/tests/db/test_llm_usage_ledger_repo.py
@@ -1,0 +1,373 @@
+"""T5-03 acceptance tests — LedgerRepo (llm_usage_ledger table).
+
+Uses the ``db_session`` fixture from ``tests/conftest.py`` which connects to the
+real postgres and wraps each test in a rolled-back outer transaction for isolation.
+Tests are skipped automatically if postgres is unreachable.
+"""
+
+from __future__ import annotations
+
+import itertools
+from datetime import date, datetime, timezone
+from decimal import Decimal
+
+import pytest
+from sqlalchemy import select
+
+pytestmark = pytest.mark.usefixtures("app_env")
+
+_counter = itertools.count(start=8_800_000_000)
+
+
+def _prompt_hash(n: int | None = None) -> str:
+    """Return a unique 64-char hex-like string for prompt_hash."""
+    suffix = str(next(_counter) if n is None else n)
+    return ("a" * (64 - len(suffix)) + suffix)[:64]
+
+
+# ─── Test 1: record inserts row + returns LlmUsageLedger with assigned id ────
+
+
+async def test_record_inserts_and_returns_row(db_session) -> None:
+    from bot.db.models import LlmUsageLedger
+    from bot.db.repos.llm_usage_ledger import LedgerRepo
+
+    row = await LedgerRepo.record(
+        db_session,
+        qa_trace_id=None,
+        provider="anthropic",
+        model="claude-haiku",
+        prompt_hash=_prompt_hash(),
+        response_hash=None,
+        tokens_in=10,
+        tokens_out=5,
+        cost_usd=Decimal("0.000012"),
+        latency_ms=123,
+        request_id="req-001",
+        cache_hit=False,
+        error=None,
+    )
+
+    assert isinstance(row, LlmUsageLedger)
+    assert row.id is not None
+    assert row.id > 0
+    assert row.provider == "anthropic"
+    assert row.model == "claude-haiku"
+    assert row.tokens_in == 10
+    assert row.tokens_out == 5
+    assert row.cost_usd == Decimal("0.000012")
+    assert row.latency_ms == 123
+    assert row.request_id == "req-001"
+    assert row.cache_hit is False
+    assert row.error is None
+
+
+# ─── Test 2: record flushes but does NOT commit ───────────────────────────────
+
+
+async def test_record_flushes_but_does_not_commit(db_session) -> None:
+    """After record(), the session is still in transaction (outer tx not committed).
+
+    We verify by rolling back and asserting the row is absent in a fresh SELECT.
+    The outer transaction in db_session fixture rolls back at teardown; here we
+    verify the state is consistent with still being inside the transaction.
+    """
+    from bot.db.repos.llm_usage_ledger import LedgerRepo
+
+    row = await LedgerRepo.record(
+        db_session,
+        qa_trace_id=None,
+        provider="openai",
+        model="gpt-4o",
+        prompt_hash=_prompt_hash(),
+        response_hash="b" * 64,
+        tokens_in=50,
+        tokens_out=25,
+        cost_usd=Decimal("0.001"),
+        latency_ms=200,
+        request_id=None,
+        cache_hit=False,
+        error=None,
+    )
+    inserted_id = row.id
+
+    # Session is still in transaction (flush does not commit).
+    assert db_session.in_transaction()
+
+    # The row IS visible inside the same session (flush made it visible to this conn).
+    from bot.db.models import LlmUsageLedger
+
+    result = await db_session.execute(
+        select(LlmUsageLedger).where(LlmUsageLedger.id == inserted_id)
+    )
+    assert result.scalar_one_or_none() is not None
+
+
+# ─── Test 3: daily_cost_usd returns Decimal("0") when zero rows ──────────────
+
+
+async def test_daily_cost_usd_returns_zero_when_no_rows(db_session) -> None:
+    from bot.db.repos.llm_usage_ledger import LedgerRepo
+
+    result = await LedgerRepo.daily_cost_usd(db_session, day=date(2099, 12, 31))
+
+    assert result == Decimal("0")
+    assert isinstance(result, Decimal)
+
+
+# ─── Test 4: daily_cost_usd sums correctly across UTC day boundary ────────────
+
+
+async def test_daily_cost_usd_respects_utc_day_boundary(db_session) -> None:
+    """Row at 23:59:59 UTC of day-1 excluded; row at 00:00:01 UTC of day included."""
+    from bot.db.models import LlmUsageLedger
+    from bot.db.repos.llm_usage_ledger import LedgerRepo
+
+    target_day = date(2030, 6, 15)
+
+    # Row at 23:59:59 UTC of the day BEFORE target_day — must NOT be counted.
+    prev_day_ts = datetime(2030, 6, 14, 23, 59, 59, tzinfo=timezone.utc)
+    prev_row = LlmUsageLedger(
+        provider="anthropic",
+        model="claude-haiku",
+        prompt_hash=_prompt_hash(),
+        tokens_in=1,
+        tokens_out=1,
+        cost_usd=Decimal("0.100000"),
+        latency_ms=10,
+        cache_hit=False,
+    )
+    db_session.add(prev_row)
+    await db_session.flush()
+    # Override created_at via raw SQL (ORM uses server_default which we can't set easily)
+    from sqlalchemy import text
+
+    await db_session.execute(
+        text("UPDATE llm_usage_ledger SET created_at = :ts WHERE id = :id"),
+        {"ts": prev_day_ts, "id": prev_row.id},
+    )
+
+    # Row at 00:00:01 UTC of target_day — must be counted.
+    target_day_ts = datetime(2030, 6, 15, 0, 0, 1, tzinfo=timezone.utc)
+    target_row = LlmUsageLedger(
+        provider="anthropic",
+        model="claude-haiku",
+        prompt_hash=_prompt_hash(),
+        tokens_in=1,
+        tokens_out=1,
+        cost_usd=Decimal("0.050000"),
+        latency_ms=10,
+        cache_hit=False,
+    )
+    db_session.add(target_row)
+    await db_session.flush()
+    await db_session.execute(
+        text("UPDATE llm_usage_ledger SET created_at = :ts WHERE id = :id"),
+        {"ts": target_day_ts, "id": target_row.id},
+    )
+    await db_session.flush()
+
+    total = await LedgerRepo.daily_cost_usd(db_session, day=target_day)
+
+    assert total == Decimal("0.050000"), f"expected 0.050000, got {total}"
+
+
+# ─── Test 5: monthly_cost_usd returns Decimal("0") when zero rows ────────────
+
+
+async def test_monthly_cost_usd_returns_zero_when_no_rows(db_session) -> None:
+    from bot.db.repos.llm_usage_ledger import LedgerRepo
+
+    result = await LedgerRepo.monthly_cost_usd(db_session, year=2099, month=11)
+
+    assert result == Decimal("0")
+    assert isinstance(result, Decimal)
+
+
+# ─── Test 6: monthly_cost_usd sums within month and excludes prev/next ────────
+
+
+async def test_monthly_cost_usd_respects_calendar_month(db_session) -> None:
+    from bot.db.models import LlmUsageLedger
+    from bot.db.repos.llm_usage_ledger import LedgerRepo
+    from sqlalchemy import text
+
+    target_year, target_month = 2031, 3  # March 2031
+
+    # Row in previous month (Feb 28 23:59:59 UTC) — must NOT be counted.
+    prev_ts = datetime(2031, 2, 28, 23, 59, 59, tzinfo=timezone.utc)
+    prev_row = LlmUsageLedger(
+        provider="openai",
+        model="gpt-4o",
+        prompt_hash=_prompt_hash(),
+        cost_usd=Decimal("1.000000"),
+        latency_ms=10,
+        cache_hit=False,
+    )
+    db_session.add(prev_row)
+    await db_session.flush()
+    await db_session.execute(
+        text("UPDATE llm_usage_ledger SET created_at = :ts WHERE id = :id"),
+        {"ts": prev_ts, "id": prev_row.id},
+    )
+
+    # Row at start of target month (Mar 1 00:00:01 UTC) — must be counted.
+    mid1_ts = datetime(2031, 3, 1, 0, 0, 1, tzinfo=timezone.utc)
+    mid1_row = LlmUsageLedger(
+        provider="openai",
+        model="gpt-4o",
+        prompt_hash=_prompt_hash(),
+        cost_usd=Decimal("0.300000"),
+        latency_ms=10,
+        cache_hit=False,
+    )
+    db_session.add(mid1_row)
+    await db_session.flush()
+    await db_session.execute(
+        text("UPDATE llm_usage_ledger SET created_at = :ts WHERE id = :id"),
+        {"ts": mid1_ts, "id": mid1_row.id},
+    )
+
+    # Row at end of target month (Mar 31 23:59:59 UTC) — must be counted.
+    mid2_ts = datetime(2031, 3, 31, 23, 59, 59, tzinfo=timezone.utc)
+    mid2_row = LlmUsageLedger(
+        provider="openai",
+        model="gpt-4o",
+        prompt_hash=_prompt_hash(),
+        cost_usd=Decimal("0.200000"),
+        latency_ms=10,
+        cache_hit=False,
+    )
+    db_session.add(mid2_row)
+    await db_session.flush()
+    await db_session.execute(
+        text("UPDATE llm_usage_ledger SET created_at = :ts WHERE id = :id"),
+        {"ts": mid2_ts, "id": mid2_row.id},
+    )
+
+    # Row in next month (Apr 1 00:00:01 UTC) — must NOT be counted.
+    next_ts = datetime(2031, 4, 1, 0, 0, 1, tzinfo=timezone.utc)
+    next_row = LlmUsageLedger(
+        provider="openai",
+        model="gpt-4o",
+        prompt_hash=_prompt_hash(),
+        cost_usd=Decimal("2.000000"),
+        latency_ms=10,
+        cache_hit=False,
+    )
+    db_session.add(next_row)
+    await db_session.flush()
+    await db_session.execute(
+        text("UPDATE llm_usage_ledger SET created_at = :ts WHERE id = :id"),
+        {"ts": next_ts, "id": next_row.id},
+    )
+    await db_session.flush()
+
+    total = await LedgerRepo.monthly_cost_usd(
+        db_session, year=target_year, month=target_month
+    )
+
+    # Only the two March rows should sum: 0.300000 + 0.200000 = 0.500000
+    assert total == Decimal("0.500000"), f"expected 0.500000, got {total}"
+
+
+# ─── Test 7: update_placeholder updates existing row and returns rowcount 1 ───
+
+
+async def test_update_placeholder_updates_row_and_returns_one(db_session) -> None:
+    from bot.db.models import LlmUsageLedger
+    from bot.db.repos.llm_usage_ledger import LedgerRepo
+
+    # Insert a placeholder row (minimal — simulates STEP_BUDGET_GUARD_ATOMIC insert).
+    placeholder = LlmUsageLedger(
+        provider="anthropic",
+        model="claude-haiku",
+        prompt_hash=_prompt_hash(),
+        tokens_in=0,
+        tokens_out=0,
+        cost_usd=Decimal("0"),
+        latency_ms=0,
+        cache_hit=False,
+        error=None,
+    )
+    db_session.add(placeholder)
+    await db_session.flush()
+    placeholder_id = placeholder.id
+
+    rowcount = await LedgerRepo.update_placeholder(
+        db_session,
+        llm_call_id=placeholder_id,
+        tokens_in=150,
+        tokens_out=75,
+        cost_usd=Decimal("0.000456"),
+        latency_ms=350,
+        request_id="req-xyz",
+        response_hash="c" * 64,
+        error=None,
+    )
+
+    assert rowcount == 1
+
+    # Verify the row was actually updated.
+    result = await db_session.execute(
+        select(LlmUsageLedger).where(LlmUsageLedger.id == placeholder_id)
+    )
+    updated = result.scalar_one()
+    assert updated.tokens_in == 150
+    assert updated.tokens_out == 75
+    assert updated.cost_usd == Decimal("0.000456")
+    assert updated.latency_ms == 350
+    assert updated.request_id == "req-xyz"
+    assert updated.response_hash == "c" * 64
+    assert updated.error is None
+
+
+# ─── Test 8: update_placeholder raises LookupError when id not found ─────────
+
+
+async def test_update_placeholder_raises_lookup_error_when_not_found(db_session) -> None:
+    from bot.db.repos.llm_usage_ledger import LedgerRepo
+
+    nonexistent_id = 999_999_999
+
+    with pytest.raises(LookupError):
+        await LedgerRepo.update_placeholder(
+            db_session,
+            llm_call_id=nonexistent_id,
+            tokens_in=10,
+            tokens_out=5,
+            cost_usd=Decimal("0.001"),
+            latency_ms=100,
+            request_id=None,
+            response_hash=None,
+            error=None,
+        )
+
+
+# ─── Bonus: record with null qa_trace_id and error field ─────────────────────
+
+
+async def test_record_with_null_qa_trace_id_and_error(db_session) -> None:
+    from bot.db.models import LlmUsageLedger
+    from bot.db.repos.llm_usage_ledger import LedgerRepo
+
+    row = await LedgerRepo.record(
+        db_session,
+        qa_trace_id=None,
+        provider="anthropic",
+        model="claude-opus",
+        prompt_hash=_prompt_hash(),
+        response_hash=None,
+        tokens_in=0,
+        tokens_out=0,
+        cost_usd=Decimal("0"),
+        latency_ms=0,
+        request_id=None,
+        cache_hit=False,
+        error="provider_transient:timeout",
+    )
+
+    assert isinstance(row, LlmUsageLedger)
+    assert row.qa_trace_id is None
+    assert row.error == "provider_transient:timeout"
+    assert row.cache_hit is False

--- a/tests/db/test_llm_usage_ledger_repo.py
+++ b/tests/db/test_llm_usage_ledger_repo.py
@@ -66,41 +66,47 @@ async def test_record_inserts_and_returns_row(db_session) -> None:
 
 
 async def test_record_flushes_but_does_not_commit(db_session) -> None:
-    """After record(), the session is still in transaction (outer tx not committed).
+    """Repo MUST NOT commit — gateway/handler owns the transaction.
 
-    We verify by rolling back and asserting the row is absent in a fresh SELECT.
-    The outer transaction in db_session fixture rolls back at teardown; here we
-    verify the state is consistent with still being inside the transaction.
+    We assert this structurally by replacing session.commit with a raise.
     """
     from bot.db.repos.llm_usage_ledger import LedgerRepo
-
-    row = await LedgerRepo.record(
-        db_session,
-        qa_trace_id=None,
-        provider="openai",
-        model="gpt-4o",
-        prompt_hash=_prompt_hash(),
-        response_hash="b" * 64,
-        tokens_in=50,
-        tokens_out=25,
-        cost_usd=Decimal("0.001"),
-        latency_ms=200,
-        request_id=None,
-        cache_hit=False,
-        error=None,
-    )
-    inserted_id = row.id
-
-    # Session is still in transaction (flush does not commit).
-    assert db_session.in_transaction()
-
-    # The row IS visible inside the same session (flush made it visible to this conn).
     from bot.db.models import LlmUsageLedger
 
-    result = await db_session.execute(
-        select(LlmUsageLedger).where(LlmUsageLedger.id == inserted_id)
-    )
-    assert result.scalar_one_or_none() is not None
+    original_commit = db_session.commit
+
+    async def _forbidden_commit():  # pragma: no cover — must never run
+        raise AssertionError("LedgerRepo must not commit; caller owns the tx")
+
+    db_session.commit = _forbidden_commit  # type: ignore[method-assign]
+    try:
+        row = await LedgerRepo.record(
+            db_session,
+            qa_trace_id=None,
+            provider="openai",
+            model="gpt-4o",
+            prompt_hash=_prompt_hash(),
+            response_hash="b" * 64,
+            tokens_in=50,
+            tokens_out=25,
+            cost_usd=Decimal("0.001"),
+            latency_ms=200,
+            request_id=None,
+            cache_hit=False,
+            error=None,
+        )
+        inserted_id = row.id
+
+        # Row is visible inside the same session (flush made it readable).
+        result = await db_session.execute(
+            select(LlmUsageLedger).where(LlmUsageLedger.id == inserted_id)
+        )
+        assert result.scalar_one_or_none() is not None
+
+        # Still inside outer tx (commit was not called, otherwise we'd have asserted).
+        assert db_session.in_transaction()
+    finally:
+        db_session.commit = original_commit  # type: ignore[method-assign]
 
 
 # ─── Test 3: daily_cost_usd returns Decimal("0") when zero rows ──────────────


### PR DESCRIPTION
## Summary

Ships **T5-03** for Phase 5 Wave 2 — async repositories that satisfy the Protocols already mocked in `bot/services/llm_gateway.py` (T5-01, PR #209) and back the Phase 5 LLM synthesis path with the schema from T5-02 (PR #207, alembic 024).

- `bot/db/repos/llm_usage_ledger.py::LedgerRepo` — 4 `@staticmethod async` methods:
  - `record(...)` — flush-only ledger insert (cache-hit path)
  - `daily_cost_usd(day)` — UTC half-open `[start, end)` sum; zero rows → `Decimal("0")` (never `None`)
  - `monthly_cost_usd(year, month)` — UTC half-open calendar-month sum
  - `update_placeholder(llm_call_id, ...)` — post-dispatch UPDATE; rowcount return; raises `LookupError` if id missing (per contracts.md §12.2 **REVISED**)
- `bot/db/repos/llm_synthesis_cache.py::SynthesisCacheRepo` — 4 methods:
  - `get_or_none(input_hash)` — pure lookup
  - `store(...)` — INSERT; lets `IntegrityError` propagate (UNIQUE input_hash race handled by gateway `STEP_CITATION_ENFORCEMENT`)
  - `bump_hit(cache_id)` — `last_hit_at = now(), hit_count += 1`
  - `invalidate_by_citation(message_version_id)` — PostgreSQL JSONB `@>` containment in production; portable SQLite fallback selects only `(id, citation_ids)` (privacy hygiene — never hydrates `answer_text`)

All methods are flush-only — never `commit()` / `rollback()`. Caller (gateway + handler) owns the transaction.

## Protocol parity

Byte-for-byte matches `bot/services/llm_gateway.py::LedgerRepoProtocol` + `SynthesisCacheRepoProtocol` (lines 118–217). Where `contracts.md §5.1` and `§10.1` use `ledger_id`, the actual Protocol on main uses `llm_call_id` — **code wins** per Wave 1 merged surface (T5-01 PR #209). Documented inline (`bot/db/repos/llm_usage_ledger.py:140-142`); contracts.md follow-up flagged for next docs sweep.

## Tests — 17 total (≥15 gate)

`tests/db/test_llm_usage_ledger_repo.py` — 9 tests:
- record returns row with id
- record flushes but **does not commit** (monkey-patches `session.commit` → AssertionError to prove structurally)
- `daily_cost_usd` zero-rows → `Decimal("0")`
- `daily_cost_usd` UTC day boundary (rows at 23:59:59 prev-day vs 00:00:01 day → only `day` counted)
- `monthly_cost_usd` zero-rows
- `monthly_cost_usd` calendar-month boundary (excludes prev/next month)
- `update_placeholder` updates + returns rowcount 1
- `update_placeholder` raises `LookupError` when not found
- `record` with null qa_trace_id + null error (success path)

`tests/db/test_llm_synthesis_cache_repo.py` — 8 tests:
- `get_or_none` returns None when absent
- `get_or_none` returns row when present
- `store` inserts with defaults (`hit_count=1`, `created_at`, `last_hit_at`)
- `store` raises `IntegrityError` on duplicate `input_hash` (UNIQUE race)
- `bump_hit` increments `hit_count` + **strictly advances `last_hit_at`** (backdates via raw SQL to make advance observable)
- `invalidate_by_citation` returns 0 when no match
- `invalidate_by_citation` deletes matching rows + returns honest rowcount
- `get_or_none` idempotent across multiple calls

## PAR review

Per `feedback-roles-claude-impl-codex-review`:
- **Claude `deep-code-reviewer` (Opus high)** — verdict **ACCEPTED**. No CRITICAL; 1 HIGH (docs-vs-code on `update_placeholder` return type — code wins; doc follow-up filed); MEDIUM/LOW = test-strengthening + style nits.
- **Codex `gpt-5.5` `model_reasoning_effort=high`** — verdict **REQUEST_CHANGES** on round 1: F-H1 (rollback proof too weak — `in_transaction()` doesn't prove no-commit) + F-M1 (SQLite fallback hydrates `answer_text` — privacy-adjacent).
- **Fix commit `e5bc5ea`** addresses BOTH Codex findings + Claude's matching MEDIUM nits. Re-review dispatched in parallel with this PR; orchestrator independently re-ran `pytest tests/db/ tests/services/test_llm_gateway.py` = **204/204 pass** + `ruff check` = clean.

## Verification commands

```bash
ruff check bot/db/repos/llm_usage_ledger.py bot/db/repos/llm_synthesis_cache.py tests/db/test_llm_usage_ledger_repo.py tests/db/test_llm_synthesis_cache_repo.py
# All checks passed!

pytest tests/db/test_llm_usage_ledger_repo.py tests/db/test_llm_synthesis_cache_repo.py -v
# 17 passed in 2.25s

pytest tests/db/ tests/services/test_llm_gateway.py -q
# 204 passed in 43.20s
```

## Contracts source-of-truth

- `docs/memory-system/phase5/contracts.md` §5 + §10 + §12.2 (REVISED)
- `docs/memory-system/PHASE5_PLAN.md` §5.C
- `docs/memory-system/AUTHORIZED_SCOPE.md` §"Authorized: Phase 5"
- `docs/memory-system/HANDOFF.md` §1 invariants #2 + #9

## Test plan

- [x] 17 new tests pass
- [x] Regression slice (204 tests, db + gateway) passes
- [x] ruff clean
- [x] Protocol parity with `llm_gateway.py` Protocols
- [x] Flush-only invariant proved structurally (monkey-patched commit)
- [ ] CI green on PR
- [ ] Codex re-review on `e5bc5ea` delta → APPROVE
- [ ] Merge with `gh pr merge --rebase --delete-branch`

Closes #199.

🤖 Generated with [Claude Code](https://claude.com/claude-code)