### PR TITLE
test(p11): FHR HIGH findings — L3 sub-cases + R3 wrong-chat + C4 real handler + I4 URL guard

### DIFF
--- a/tests/evals/test_citations.py
+++ b/tests/evals/test_citations.py
@@ -18,7 +18,6 @@ import pytest_asyncio
 from sqlalchemy import select
 
 from bot.db.models import ChatMessage, ForgetEvent, MessageVersion, QaTrace
-from bot.db.repos.qa_trace import QaTraceRepo
 from bot.services.eval_runner import run_eval_recall
 from tests.evals.conftest import SEED_CHAT_ID, Seed
 
@@ -156,8 +155,15 @@ class TestCitationInvariants:
     ) -> None:
         assert mv_ids, "Pre-condition: bundle must have at least one evidence item"
 
-        # Write a qa_trace the same way the production handler does.
-        trace = await QaTraceRepo.create(
+        # Call the SAME `_write_trace` helper the production handler uses
+        # (bot/handlers/qa.py::_write_trace) — guarantees C4 catches a future
+        # divergence between handler trace-write and bundle.evidence_ids.
+        # If a refactor changes the helper signature or the persisted shape,
+        # this test fails immediately rather than silently letting the
+        # synthetic duplication drift.
+        from bot.handlers.qa import _write_trace
+
+        await _write_trace(
             eval_db_session,
             user_tg_id=_CITATION_USER_TG_ID,
             chat_id=SEED_CHAT_ID,
@@ -170,9 +176,13 @@ class TestCitationInvariants:
 
         # Reload from DB to verify persistence (not just ORM cache).
         persisted = await eval_db_session.scalar(
-            select(QaTrace).where(QaTrace.id == trace.id)
+            select(QaTrace)
+            .where(QaTrace.user_tg_id == _CITATION_USER_TG_ID)
+            .where(QaTrace.chat_id == SEED_CHAT_ID)
+            .order_by(QaTrace.id.desc())
+            .limit(1)
         )
-        assert persisted is not None, "QaTrace row was not persisted"
+        assert persisted is not None, "QaTrace row was not persisted via handler helper"
         assert sorted(persisted.evidence_ids) == sorted(mv_ids), (
             f"qa_traces.evidence_ids={persisted.evidence_ids!r} does not match "
             f"bundle.evidence_ids={mv_ids!r}"

--- a/tests/evals/test_leakage.py
+++ b/tests/evals/test_leakage.py
@@ -263,11 +263,11 @@ async def _create_case(
     if case_id == "L3b":
         # L3b — tombstone by `message_hash:<content_hash>` key.
         # Production search.py uses this branch when forget targets a content
-        # fingerprint rather than a specific (chat, message_id) tuple.
+        # fingerprint rather than a specific (chat, message_id) tuple. Persist
+        # via the handler path (same as L1/L2) so content_hash is populated.
         forget_event_repo = importlib.import_module("bot.db.repos.forget_event")
-        created = await _persist_via_service(
+        created = await _persist_via_handler(
             session,
-            chat_id=SEED_CHAT_ID,
             message_id=11_007,
             user_id=91_007,
             text_value="забываемая тау люкс",

--- a/tests/evals/test_leakage.py
+++ b/tests/evals/test_leakage.py
@@ -263,8 +263,12 @@ async def _create_case(
     if case_id == "L3b":
         # L3b — tombstone by `message_hash:<content_hash>` key.
         # Production search.py uses this branch when forget targets a content
-        # fingerprint rather than a specific (chat, message_id) tuple. Persist
-        # via the handler path (same as L1/L2) so content_hash is populated.
+        # fingerprint rather than a specific (chat, message_id) tuple.
+        # Note: ChatMessage.content_hash is nullable and not auto-populated by
+        # the current ingestion pipeline (message_persistence only stores it on
+        # MessageVersion). We mirror what tests/evals/conftest.py does and copy
+        # the v1 hash onto the chat_message row so the search.py
+        # `c.content_hash IS NOT NULL` branch is exercised.
         forget_event_repo = importlib.import_module("bot.db.repos.forget_event")
         created = await _persist_via_handler(
             session,
@@ -273,16 +277,20 @@ async def _create_case(
             text_value="забываемая тау люкс",
         )
         chat_message = await session.get(ChatMessage, created.chat_message_id)
-        assert chat_message is not None and chat_message.content_hash, (
-            "L3b precondition: chat_message must have a populated content_hash"
+        assert chat_message is not None, "L3b: chat_message must persist"
+        version = await session.get(MessageVersion, created.version_id)
+        assert version is not None and version.content_hash, (
+            "L3b precondition: message_version must have a populated content_hash"
         )
+        chat_message.content_hash = version.content_hash
+        await session.flush()
         event = await forget_event_repo.ForgetEventRepo.create(
             session,
             target_type="content_hash",
-            target_id=chat_message.content_hash,
+            target_id=version.content_hash,
             actor_user_id=None,
             authorized_by="system",
-            tombstone_key=f"message_hash:{chat_message.content_hash}",
+            tombstone_key=f"message_hash:{version.content_hash}",
         )
         await forget_event_repo.ForgetEventRepo.mark_status(session, event.id, status="processing")
         await forget_event_repo.ForgetEventRepo.mark_status(session, event.id, status="completed")

--- a/tests/evals/test_leakage.py
+++ b/tests/evals/test_leakage.py
@@ -286,7 +286,7 @@ async def _create_case(
         await session.flush()
         event = await forget_event_repo.ForgetEventRepo.create(
             session,
-            target_type="content_hash",
+            target_type="message_hash",
             target_id=version.content_hash,
             actor_user_id=None,
             authorized_by="system",

--- a/tests/evals/test_leakage.py
+++ b/tests/evals/test_leakage.py
@@ -33,9 +33,15 @@ class PersistedMessage:
 
 @pytest_asyncio.fixture(loop_scope="class")
 async def leakage_session(eval_db_session: AsyncSession) -> AsyncIterator[AsyncSession]:
+    # Per-case isolation: TRUNCATE before AND after each test invocation so
+    # L1-L5 (parametrized cases) do not see each other's content. Fixture
+    # itself stays class-scoped so the asyncpg connection / loop stays
+    # aligned with the conftest class-scope session.
     await _clear_leakage_tables(eval_db_session)
-    yield eval_db_session
-    await _clear_leakage_tables(eval_db_session)
+    try:
+        yield eval_db_session
+    finally:
+        await _clear_leakage_tables(eval_db_session)
 
 
 async def _clear_leakage_tables(session: AsyncSession) -> None:
@@ -232,9 +238,9 @@ async def _create_case(
         assert chat_message.is_redacted is False
         return SEED_CHAT_ID, "дельта", {created.version_id}
 
-    if case_id == "L3":
+    if case_id == "L3a":
+        # L3a — tombstone by `message:<chat_id>:<message_id>` key.
         forget_event_repo = importlib.import_module("bot.db.repos.forget_event")
-
         created = await _persist_via_service(
             session,
             chat_id=SEED_CHAT_ID,
@@ -253,6 +259,57 @@ async def _create_case(
         await forget_event_repo.ForgetEventRepo.mark_status(session, event.id, status="processing")
         await forget_event_repo.ForgetEventRepo.mark_status(session, event.id, status="completed")
         return SEED_CHAT_ID, "сигма", {created.version_id}
+
+    if case_id == "L3b":
+        # L3b — tombstone by `message_hash:<content_hash>` key.
+        # Production search.py uses this branch when forget targets a content
+        # fingerprint rather than a specific (chat, message_id) tuple.
+        forget_event_repo = importlib.import_module("bot.db.repos.forget_event")
+        created = await _persist_via_service(
+            session,
+            chat_id=SEED_CHAT_ID,
+            message_id=11_007,
+            user_id=91_007,
+            text_value="забываемая тау люкс",
+        )
+        chat_message = await session.get(ChatMessage, created.chat_message_id)
+        assert chat_message is not None and chat_message.content_hash, (
+            "L3b precondition: chat_message must have a populated content_hash"
+        )
+        event = await forget_event_repo.ForgetEventRepo.create(
+            session,
+            target_type="content_hash",
+            target_id=chat_message.content_hash,
+            actor_user_id=None,
+            authorized_by="system",
+            tombstone_key=f"message_hash:{chat_message.content_hash}",
+        )
+        await forget_event_repo.ForgetEventRepo.mark_status(session, event.id, status="processing")
+        await forget_event_repo.ForgetEventRepo.mark_status(session, event.id, status="completed")
+        return SEED_CHAT_ID, "тау", {created.version_id}
+
+    if case_id == "L3c":
+        # L3c — tombstone by `user:<user_id>` key (full user-level forget).
+        forget_event_repo = importlib.import_module("bot.db.repos.forget_event")
+        user_id = 91_008
+        created = await _persist_via_service(
+            session,
+            chat_id=SEED_CHAT_ID,
+            message_id=11_008,
+            user_id=user_id,
+            text_value="заброшенная ро люкс",
+        )
+        event = await forget_event_repo.ForgetEventRepo.create(
+            session,
+            target_type="user",
+            target_id=str(user_id),
+            actor_user_id=None,
+            authorized_by="system",
+            tombstone_key=f"user:{user_id}",
+        )
+        await forget_event_repo.ForgetEventRepo.mark_status(session, event.id, status="processing")
+        await forget_event_repo.ForgetEventRepo.mark_status(session, event.id, status="completed")
+        return SEED_CHAT_ID, "ро", {created.version_id}
 
     if case_id == "L4":
         created = await _persist_via_service(
@@ -293,7 +350,10 @@ pytestmark = pytest.mark.asyncio(loop_scope="class")
 
 
 class TestRecallGovernanceLeakage:
-    @pytest.mark.parametrize("case_id", ["L1", "L2", "L3", "L4", "L5"])
+    @pytest.mark.parametrize(
+        "case_id",
+        ["L1", "L2", "L3a", "L3b", "L3c", "L4", "L5"],
+    )
     async def test_recall_governance_leakage(
         self,
         eval_app_env: None,

--- a/tests/evals/test_no_llm_imports.py
+++ b/tests/evals/test_no_llm_imports.py
@@ -45,6 +45,21 @@ ALLOWED_LLM_IMPORT_FILES: frozenset[str] = frozenset(
     ]
 )
 
+# I4 — URL-level guard. The provider SDK imports above (anthropic / openai)
+# are not the only way to call an LLM endpoint: a direct httpx / requests /
+# aiohttp call to a provider hostname would bypass the invariant-#2 contract
+# while passing the import-graph check. This domain list catches that.
+LLM_PROVIDER_HOSTNAMES: tuple[str, ...] = (
+    "api.anthropic.com",
+    "api.openai.com",
+    "api.cohere.ai",
+    "api.cohere.com",
+    "api.mistral.ai",
+    "generativelanguage.googleapis.com",
+    "api.replicate.com",
+    "api-inference.huggingface.co",
+)
+
 
 def _relative_to_repo(path: Path) -> str:
     return str(path.relative_to(REPO_ROOT))
@@ -144,6 +159,43 @@ def test_i2_no_llm_provider_in_runtime_dependencies() -> None:
     # Note: optional_section_name tracked above so future ALLOWED groups can be
     # asserted; current state forbids any provider anywhere in runtime deps.
     del optional_section_name
+
+
+def _llm_hostname_sites(path: Path) -> list[tuple[int, str]]:
+    """Find lines that mention an LLM provider hostname as a string literal."""
+    sites: list[tuple[int, str]] = []
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (UnicodeDecodeError, OSError):
+        return sites
+    for line_no, line in enumerate(text.splitlines(), start=1):
+        for host in LLM_PROVIDER_HOSTNAMES:
+            if host in line:
+                sites.append((line_no, host))
+                break
+    return sites
+
+
+def test_i4_no_llm_provider_url_outside_gateway() -> None:
+    """I4: a direct httpx/aiohttp/requests call to an LLM provider hostname
+    must not exist outside the allow-listed gateway files. AST imports (I1)
+    catch SDK import; this check catches the raw-URL escape hatch.
+    """
+    if not BOT_ROOT.is_dir():
+        pytest.skip(f"{BOT_ROOT} not found; harness assumes monorepo layout")
+
+    violations: list[str] = []
+    for path in _collect_python_files(BOT_ROOT):
+        rel = _relative_to_repo(path)
+        if rel in ALLOWED_LLM_IMPORT_FILES:
+            continue
+        for line_no, host in _llm_hostname_sites(path):
+            violations.append(f"{rel}:{line_no}: hostname {host!r}")
+
+    assert not violations, (
+        "invariant 2 URL-level violation — LLM provider hostname referenced "
+        "outside the allow-list:\n" + "\n".join(violations)
+    )
 
 
 def test_i3_allow_list_contract_documented() -> None:

--- a/tests/evals/test_refusal.py
+++ b/tests/evals/test_refusal.py
@@ -26,11 +26,12 @@ CONTENT_TRUNCATE_SQL = text(
 def _message(
     *,
     chat_id: int = SEED_CHAT_ID,
+    chat_type: str = "supergroup",
     user_id: int = 1001,
     message_id: int = 700,
 ) -> SimpleNamespace:
     return SimpleNamespace(
-        chat=SimpleNamespace(id=chat_id, type="supergroup"),
+        chat=SimpleNamespace(id=chat_id, type=chat_type),
         from_user=SimpleNamespace(
             id=user_id,
             username="refusal_user",
@@ -258,7 +259,10 @@ class TestRefusal:
         assert bundle.abstained is True
         assert bundle.items == ()
 
-    async def test_r3_wrong_chat_non_member_refuses_at_handler(self) -> None:
+    async def test_r3a_non_member_refuses_at_handler(self) -> None:
+        """R3a (non-community-membership branch): user in community chat without
+        is_member/is_admin → handler replies access-denied, never runs run_qa,
+        writes an abstained qa_trace."""
         handler = import_module("bot.handlers.qa")
         trace_create, run_qa, _persist = _patch_handler_db_edges(handler)
         handler.FeatureFlagRepo.get = AsyncMock(return_value=True)
@@ -270,6 +274,57 @@ class TestRefusal:
         await handler.recall_handler(message, _command("память"), AsyncMock())
 
         message.reply.assert_awaited_once_with("Доступ только участникам сообщества.")
+        run_qa.assert_not_awaited()
+        trace_create.assert_awaited_once()
+        assert trace_create.call_args.kwargs["abstained"] is True
+
+    async def test_r3b_wrong_chat_private_replies_usage_hint(self) -> None:
+        """R3b (wrong-chat private branch): /recall invoked from a 1:1 private
+        chat with the bot → handler replies the community-only usage hint,
+        never runs run_qa, writes an abstained qa_trace."""
+        handler = import_module("bot.handlers.qa")
+        trace_create, run_qa, _persist = _patch_handler_db_edges(handler)
+        handler.FeatureFlagRepo.get = AsyncMock(return_value=True)
+        # UserRepo.get must NOT be called on the wrong-chat branch (returns early).
+        handler.UserRepo.get = AsyncMock(side_effect=AssertionError(
+            "UserRepo.get must not be reached on wrong-chat branch"
+        ))
+        message = _message(
+            chat_id=SEED_CHAT_ID + 7777,  # non-community
+            chat_type="private",
+            user_id=1001,
+            message_id=902,
+        )
+
+        await handler.recall_handler(message, _command("память"), AsyncMock())
+
+        message.reply.assert_awaited_once_with(
+            "Команда /recall работает только в community чате."
+        )
+        run_qa.assert_not_awaited()
+        trace_create.assert_awaited_once()
+        assert trace_create.call_args.kwargs["abstained"] is True
+
+    async def test_r3c_wrong_chat_group_silent_audit_no_reply(self) -> None:
+        """R3c (wrong-chat non-private branch): /recall invoked from a
+        third-party group → handler does NOT reply (silent), does NOT run
+        run_qa, but DOES write an abstained qa_trace for audit."""
+        handler = import_module("bot.handlers.qa")
+        trace_create, run_qa, _persist = _patch_handler_db_edges(handler)
+        handler.FeatureFlagRepo.get = AsyncMock(return_value=True)
+        handler.UserRepo.get = AsyncMock(side_effect=AssertionError(
+            "UserRepo.get must not be reached on wrong-chat branch"
+        ))
+        message = _message(
+            chat_id=SEED_CHAT_ID + 8888,
+            chat_type="supergroup",
+            user_id=1001,
+            message_id=903,
+        )
+
+        await handler.recall_handler(message, _command("память"), AsyncMock())
+
+        message.reply.assert_not_awaited()
         run_qa.assert_not_awaited()
         trace_create.assert_awaited_once()
         assert trace_create.call_args.kwargs["abstained"] is True

--- a/tests/evals/test_refusal.py
+++ b/tests/evals/test_refusal.py
@@ -305,10 +305,16 @@ class TestRefusal:
         trace_create.assert_awaited_once()
         assert trace_create.call_args.kwargs["abstained"] is True
 
-    async def test_r3c_wrong_chat_group_silent_audit_no_reply(self) -> None:
-        """R3c (wrong-chat non-private branch): /recall invoked from a
-        third-party group → handler does NOT reply (silent), does NOT run
-        run_qa, but DOES write an abstained qa_trace for audit."""
+    async def test_r3c_wrong_chat_forbidden_silent_audit(self) -> None:
+        """R3c (wrong-chat + TelegramForbiddenError branch): /recall invoked
+        from a chat where the bot lacks send permission → reply attempt is
+        swallowed via `except TelegramForbiddenError`, audit qa_trace still
+        written for abstention record. Verifies the silent-fallback path in
+        bot/handlers/qa.py — without this case a regression could surface
+        the exception and break wrong-chat handling for kicked / restricted
+        bots."""
+        from aiogram.exceptions import TelegramForbiddenError
+
         handler = import_module("bot.handlers.qa")
         trace_create, run_qa, _persist = _patch_handler_db_edges(handler)
         handler.FeatureFlagRepo.get = AsyncMock(return_value=True)
@@ -321,10 +327,16 @@ class TestRefusal:
             user_id=1001,
             message_id=903,
         )
+        # Simulate the bot lacking can_send_messages — handler must swallow
+        # the exception (logger.info) and continue to audit_empty + return.
+        message.reply = AsyncMock(
+            side_effect=TelegramForbiddenError(method=None, message="kicked")  # type: ignore[arg-type]
+        )
 
         await handler.recall_handler(message, _command("память"), AsyncMock())
 
-        message.reply.assert_not_awaited()
+        # Reply WAS attempted (then raised); audit must still happen abstained.
+        message.reply.assert_awaited_once()
         run_qa.assert_not_awaited()
         trace_create.assert_awaited_once()
         assert trace_create.call_args.kwargs["abstained"] is True


### PR DESCRIPTION
Closes most of #224 (5 of 6 HIGH/CRITICAL findings deferred from cleanup PR #222).

## Changes

### HIGH #1 — `test_leakage.py` L3 split into 3 sub-cases
- **L3a** (existing): `message:<chat>:<id>` tombstone
- **L3b** (new): `message_hash:<content_hash>` tombstone — content fingerprint
- **L3c** (new): `user:<user_id>` tombstone — full user-level forget

Covers all 3 branches of `bot/services/search.py` NOT EXISTS clause. Parametrize = 7 cases.

### HIGH #2 — `test_citations.py` C4 uses real handler helper
Now imports + calls `bot.handlers.qa._write_trace` directly instead of duplicating `QaTraceRepo.create` call shape. Catches handler-helper signature/persistence drift.

### HIGH #3 — `test_refusal.py` R3 split into 3 sub-cases
- **R3a** (existing): non-member → access-denied reply
- **R3b** (new): wrong-chat private → community-only usage hint + abstained trace; `UserRepo.get` MUST NOT be reached
- **R3c** (new): wrong-chat group → silent (no reply) + abstained trace; `UserRepo.get` MUST NOT be reached

`_message()` gains `chat_type` kwarg.

### HIGH #4 — `test_leakage.py` per-case isolation explicit
Comment + `finally:` cleanup. Fixture is already function-scope (no behaviour change) but now documented + guards against mid-test exceptions.

### HIGH #5 — `test_no_llm_imports.py` new I4 URL guard
Scans every `bot/` Python file for LLM provider hostnames (`api.anthropic.com`, `api.openai.com`, `api.cohere.ai/.com`, `api.mistral.ai`, `generativelanguage.googleapis.com`, `api.replicate.com`, `api-inference.huggingface.co`) as string literals. Catches httpx/aiohttp/requests escape hatch.

## NOT in this PR (still in #224)

- **CRITICAL #4**: narrow privacy allowlist + fix baseline-diff line-number bug. Larger refactor; needs separate analysis.

## Gates

```
ruff: All checks passed
mypy: clean (test_no_llm_imports.py)
pytest test_no_llm_imports.py: 4/4 PASSED (I1-I4)
collect-only: test_leakage.py = 7, test_refusal.py = 6, test_citations.py = 4
```