### PR TITLE
fix(p11-fu): narrow privacy allowlist + multiset baseline (#224 Critical #4)

### DIFF
--- a/scripts/lint_privacy_check.sh
+++ b/scripts/lint_privacy_check.sh
@@ -138,23 +138,43 @@ main() {
   trap 'rm -f "${baseline_file:-}"' EXIT
   write_baseline_matches "$base_ref" "$pattern" "$baseline_file" "${files[@]}"
 
-  local has_violation=0
+  # Build an allowed-path-filtered version of current matches for multiset
+  # comparison.  Lines whose path is in the formal allowlist are excluded
+  # before the count comparison so they don't inflate the current count.
+  local current_file
+  current_file="$(mktemp)"
+  trap 'rm -f "${baseline_file:-}" "${current_file:-}"' EXIT
+
   local line
   local path
   while IFS= read -r line; do
     [[ -z "$line" ]] && continue
     path="${line%%:*}"
-    if is_allowed_path "$path"; then
-      continue
-    fi
-    if grep -F -x -q -- "$line" "$baseline_file"; then
-      continue
-    fi
-    printf '%s\n' "$line"
-    has_violation=1
+    is_allowed_path "$path" && continue
+    printf '%s\n' "$line" >>"$current_file"
   done <<<"$grep_output"
 
-  return "$has_violation"
+  # Multiset comparison: report lines where current_count > baseline_count.
+  # Uses FILENAME-based file discrimination (not NR==FNR) so that an empty
+  # baseline file does not cause current lines to be misclassified as baseline.
+  local violations
+  violations="$(awk -v bfile="$baseline_file" '
+    FILENAME == bfile { baseline[$0]++; next }
+    {
+      if (baseline[$0] > 0) {
+        baseline[$0]--
+      } else {
+        print
+      }
+    }
+  ' "$baseline_file" "$current_file")"
+
+  if [[ -n "$violations" ]]; then
+    printf '%s\n' "$violations"
+    return 1
+  fi
+
+  return 0
 }
 
 main "$@"

--- a/scripts/lint_privacy_check.sh
+++ b/scripts/lint_privacy_check.sh
@@ -4,37 +4,12 @@ set -euo pipefail
 is_allowed_path() {
   local path="$1"
 
+  # §7 #5 formal allowlist: only the four leakage-test fixture globs.
+  # Everything else must be clean or appear in the baseline-diff.
   [[ "$path" =~ ^tests/fixtures/eval_seeds/leakage_offrecord.*\.jsonl$ ]] && return 0
   [[ "$path" =~ ^tests/fixtures/eval_seeds/leakage_nomem.*\.jsonl$ ]] && return 0
   [[ "$path" =~ ^tests/fixtures/eval_seeds/leakage_forgotten.*\.jsonl$ ]] && return 0
   [[ "$path" =~ ^tests/fixtures/eval_seeds/leakage_redacted.*\.jsonl$ ]] && return 0
-  [[ "$path" =~ ^docs/.*\.md$ ]] && return 0
-  [[ "$path" =~ ^CLAUDE\.md$ ]] && return 0
-  [[ "$path" =~ ^bot/services/governance\.py$ ]] && return 0
-  [[ "$path" =~ ^bot/services/message_persistence\.py$ ]] && return 0
-  [[ "$path" =~ ^bot/services/forget_cascade\.py$ ]] && return 0
-  [[ "$path" =~ ^bot/services/llm_gateway\.py$ ]] && return 0
-  [[ "$path" =~ ^bot/services/llm_providers/.*\.py$ ]] && return 0
-  [[ "$path" =~ ^bot/handlers/edited_message\.py$ ]] && return 0
-  [[ "$path" =~ ^bot/db/models\.py$ ]] && return 0
-  [[ "$path" =~ ^tests/services/test_governance\.py$ ]] && return 0
-  [[ "$path" =~ ^tests/handlers/.*test_chat_messages.*\.py$ ]] && return 0
-  [[ "$path" =~ ^tests/handlers/test_qa\.py$ ]] && return 0
-  [[ "$path" =~ ^tests/handlers/test_qa_llm_synthesis\.py$ ]] && return 0
-  [[ "$path" =~ ^tests/handlers/test_qa_recall_phase4_preserved\.py$ ]] && return 0
-  [[ "$path" =~ ^tests/services/test_forget_cascade\.py$ ]] && return 0
-  # Phase 6 / T6-01 — P6 cascade tests reference the cascade semantics in docstrings.
-  [[ "$path" =~ ^tests/services/test_p6_card_sources_cascade\.py$ ]] && return 0
-  [[ "$path" =~ ^tests/services/test_p6_advisory_lock\.py$ ]] && return 0
-  [[ "$path" =~ ^tests/services/test_llm_gateway\.py$ ]] && return 0
-  [[ "$path" =~ ^tests/services/test_ingestion.*\.py$ ]] && return 0
-  [[ "$path" =~ ^tests/services/test_import_apply\.py$ ]] && return 0
-  [[ "$path" =~ ^tests/services/test_message_persistence\.py$ ]] && return 0
-  [[ "$path" =~ ^tests/db/test_qa_trace\.py$ ]] && return 0
-  [[ "$path" =~ ^tests/eval/test_qa_eval_cases\.py$ ]] && return 0
-  [[ "$path" =~ ^tests/fixtures/qa_eval_cases\.json$ ]] && return 0
-  [[ "$path" =~ ^tests/integration/.*\.py$ ]] && return 0
-  [[ "$path" =~ ^\.github/workflows/lint-privacy\.yml$ ]] && return 0
 
   return 1
 }
@@ -85,6 +60,8 @@ find_base_ref() {
   return 1
 }
 
+# Writes baseline matches (path:content, no line numbers) so that line-number
+# shifts caused by rebases or unrelated inserts do not produce false positives.
 write_baseline_matches() {
   local base_ref="$1"
   local pattern="$2"
@@ -98,7 +75,7 @@ write_baseline_matches() {
   local grep_output
   local grep_status
   set +e
-  grep_output="$(git grep -I -n -E "$pattern" "$base_ref" -- "${files[@]}")"
+  grep_output="$(git grep -I -E "$pattern" "$base_ref" -- "${files[@]}")"
   grep_status=$?
   set -e
 
@@ -113,6 +90,7 @@ write_baseline_matches() {
   local line
   while IFS= read -r line; do
     [[ -z "$line" ]] && continue
+    # Strip the "base_ref:" prefix that git grep prepends when given a treeish.
     printf '%s\n' "${line#"$base_ref:"}" >>"$output_path"
   done <<<"$grep_output"
 }
@@ -139,7 +117,9 @@ main() {
   local grep_output
   local grep_status
   set +e
-  grep_output="$(git grep -I -n -E "$pattern" -- "${files[@]}")"
+  # No -n: output is path:content (no line numbers) so baseline comparison is
+  # resilient to line-number shifts caused by rebases or unrelated inserts.
+  grep_output="$(git grep -I -E "$pattern" -- "${files[@]}")"
   grep_status=$?
   set -e
 

--- a/scripts/precommit-privacy-allowlist.sh
+++ b/scripts/precommit-privacy-allowlist.sh
@@ -6,34 +6,12 @@ set -euo pipefail
 is_allowed_path() {
   local path="$1"
 
+  # §7 #5 formal allowlist: only the four leakage-test fixture globs.
+  # Everything else must be clean or appear in the baseline-diff (HEAD).
   [[ "$path" =~ ^tests/fixtures/eval_seeds/leakage_offrecord.*\.jsonl$ ]] && return 0
   [[ "$path" =~ ^tests/fixtures/eval_seeds/leakage_nomem.*\.jsonl$ ]] && return 0
   [[ "$path" =~ ^tests/fixtures/eval_seeds/leakage_forgotten.*\.jsonl$ ]] && return 0
   [[ "$path" =~ ^tests/fixtures/eval_seeds/leakage_redacted.*\.jsonl$ ]] && return 0
-  [[ "$path" =~ ^docs/.*\.md$ ]] && return 0
-  [[ "$path" =~ ^bot/services/governance\.py$ ]] && return 0
-  [[ "$path" =~ ^bot/services/message_persistence\.py$ ]] && return 0
-  [[ "$path" =~ ^bot/services/forget_cascade\.py$ ]] && return 0
-  [[ "$path" =~ ^bot/handlers/edited_message\.py$ ]] && return 0
-  [[ "$path" =~ ^bot/db/models\.py$ ]] && return 0
-  [[ "$path" =~ ^tests/services/test_governance\.py$ ]] && return 0
-  [[ "$path" =~ ^tests/handlers/.*test_chat_messages.*\.py$ ]] && return 0
-  [[ "$path" =~ ^tests/handlers/test_qa\.py$ ]] && return 0
-  [[ "$path" =~ ^tests/handlers/test_qa_llm_synthesis\.py$ ]] && return 0
-  [[ "$path" =~ ^tests/handlers/test_qa_recall_phase4_preserved\.py$ ]] && return 0
-  [[ "$path" =~ ^tests/services/test_forget_cascade\.py$ ]] && return 0
-  # Phase 6 / T6-01 — P6 cascade tests reference the cascade semantics in docstrings.
-  [[ "$path" =~ ^tests/services/test_p6_card_sources_cascade\.py$ ]] && return 0
-  [[ "$path" =~ ^tests/services/test_p6_advisory_lock\.py$ ]] && return 0
-  [[ "$path" =~ ^tests/services/test_llm_gateway\.py$ ]] && return 0
-  [[ "$path" =~ ^tests/services/test_ingestion.*\.py$ ]] && return 0
-  [[ "$path" =~ ^tests/services/test_import_apply\.py$ ]] && return 0
-  [[ "$path" =~ ^tests/services/test_message_persistence\.py$ ]] && return 0
-  [[ "$path" =~ ^tests/db/test_qa_trace\.py$ ]] && return 0
-  [[ "$path" =~ ^tests/eval/test_qa_eval_cases\.py$ ]] && return 0
-  [[ "$path" =~ ^tests/fixtures/qa_eval_cases\.json$ ]] && return 0
-  [[ "$path" =~ ^tests/integration/.*\.py$ ]] && return 0
-  [[ "$path" =~ ^\.github/workflows/lint-privacy\.yml$ ]] && return 0
 
   return 1
 }
@@ -70,7 +48,8 @@ write_baseline_matches() {
   local grep_output
   local grep_status
   set +e
-  grep_output="$(git grep -I -n -E "$pattern" HEAD -- "${files[@]}")"
+  # No -n: path:content format so line-number shifts don't break matching.
+  grep_output="$(git grep -I -E "$pattern" HEAD -- "${files[@]}")"
   grep_status=$?
   set -e
 
@@ -111,7 +90,8 @@ main() {
   local grep_output
   local grep_status
   set +e
-  grep_output="$(git grep --cached -I -n -E "$pattern" -- "${files[@]}")"
+  # No -n: path:content format so line-number shifts don't break matching.
+  grep_output="$(git grep --cached -I -E "$pattern" -- "${files[@]}")"
   grep_status=$?
   set -e
 

--- a/scripts/precommit-privacy-allowlist.sh
+++ b/scripts/precommit-privacy-allowlist.sh
@@ -108,23 +108,43 @@ main() {
   trap 'rm -f "${baseline_file:-}"' EXIT
   write_baseline_matches "$pattern" "$baseline_file" "${files[@]}"
 
-  local has_violation=0
+  # Build an allowed-path-filtered version of current matches for multiset
+  # comparison.  Lines whose path is in the formal allowlist are excluded
+  # before the count comparison so they don't inflate the current count.
+  local current_file
+  current_file="$(mktemp)"
+  trap 'rm -f "${baseline_file:-}" "${current_file:-}"' EXIT
+
   local line
   local path
   while IFS= read -r line; do
     [[ -z "$line" ]] && continue
     path="${line%%:*}"
-    if is_allowed_path "$path"; then
-      continue
-    fi
-    if grep -F -x -q -- "$line" "$baseline_file"; then
-      continue
-    fi
-    printf '%s\n' "$line"
-    has_violation=1
+    is_allowed_path "$path" && continue
+    printf '%s\n' "$line" >>"$current_file"
   done <<<"$grep_output"
 
-  return "$has_violation"
+  # Multiset comparison: report lines where current_count > baseline_count.
+  # Uses FILENAME-based file discrimination (not NR==FNR) so that an empty
+  # baseline file does not cause current lines to be misclassified as baseline.
+  local violations
+  violations="$(awk -v bfile="$baseline_file" '
+    FILENAME == bfile { baseline[$0]++; next }
+    {
+      if (baseline[$0] > 0) {
+        baseline[$0]--
+      } else {
+        print
+      }
+    }
+  ' "$baseline_file" "$current_file")"
+
+  if [[ -n "$violations" ]]; then
+    printf '%s\n' "$violations"
+    return 1
+  fi
+
+  return 0
 }
 
 main "$@"

--- a/tests/lint/test_privacy_allowlist.py
+++ b/tests/lint/test_privacy_allowlist.py
@@ -162,3 +162,41 @@ def test_narrowed_allowlist_only_permits_four_leakage_globs(tmp_path: Path) -> N
         + result.stdout
         + result.stderr
     )
+
+
+def test_duplicate_markers_in_same_file_are_counted(tmp_path: Path) -> None:
+    """When baseline has 1 occurrence of a marker in a file and the PR adds 2 more,
+    the lint must fail (count-semantics / multiset comparison).
+
+    With the old set-membership check (grep -F -x -q), all occurrences after the
+    first are silently exempted because the set already contains that path:content
+    string. This test guards against that regression.
+
+    Setup:
+    - commit 1 (base): 1 line with the marker in alembic/versions/001_init.py
+    - commit 2 (HEAD): 3 lines with the same marker in the same file (+2 new copies)
+
+    Expected: lint exits 1 and mentions at least one extra occurrence.
+    """
+    init_repo(tmp_path)
+
+    marker = "#" + "off" + "record"
+    base_line = f'COMMENT = "{marker} example"\n'
+
+    # Commit 1 (base): 1 occurrence.
+    write_file(tmp_path, "alembic/versions/001_init.py", base_line)
+    commit_all(tmp_path)
+
+    # Commit 2 (HEAD): 3 identical occurrences (+2 new copies).
+    write_file(tmp_path, "alembic/versions/001_init.py", base_line * 3)
+    commit_all(tmp_path)
+
+    result = run_lint(tmp_path)
+
+    assert result.returncode == 1, (
+        "duplicate markers in same file should fail (count semantics) but passed:\n"
+        + result.stdout
+        + result.stderr
+    )
+    # The output must mention the violation line at least once.
+    assert "alembic/versions/001_init.py:" in result.stdout

--- a/tests/lint/test_privacy_allowlist.py
+++ b/tests/lint/test_privacy_allowlist.py
@@ -73,7 +73,9 @@ def test_unauthorized_source_file_fails(tmp_path: Path) -> None:
     result = run_lint(tmp_path)
 
     assert result.returncode == 1
-    assert "bot/handlers/echo.py:1:" in result.stdout
+    # Output format is path:content (no line number) after the line-number-
+    # resilience fix.  The path prefix is sufficient to confirm the violation.
+    assert "bot/handlers/echo.py:" in result.stdout
 
 
 def test_word_boundary_avoids_substring_false_positive(tmp_path: Path) -> None:
@@ -84,3 +86,79 @@ def test_word_boundary_avoids_substring_false_positive(tmp_path: Path) -> None:
     result = run_lint(tmp_path)
 
     assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_line_shift_does_not_trigger_false_positive(tmp_path: Path) -> None:
+    """Inserting a line before an existing marker must NOT cause a false-positive
+    violation.  The baseline comparison must be resilient to line-number changes
+    (path:content match, not path:lineno:content match).
+
+    This requires two commits so that find_base_ref can resolve a real base_ref:
+    - commit 1 (base): file has marker at line 1
+    - commit 2 (HEAD): a new innocent line is prepended → marker shifts to line 2
+
+    With path:lineno:content comparison, the shifted marker won't match the
+    baseline and will be reported as a new violation.  With path:content
+    comparison, it matches and no violation is reported.
+
+    Uses alembic/versions/ which is not in the narrowed allowlist (only the
+    4 leakage globs are), so the baseline-diff path is exercised.
+    """
+    init_repo(tmp_path)
+
+    # Commit 1 (base): marker at line 1 in a path outside the 4-glob allowlist.
+    # Split the word across concatenation so this test file itself does not match
+    # the privacy pattern (same technique used in build_pattern for the regex).
+    marker = "for" + "gotten"
+    write_file(
+        tmp_path,
+        "alembic/versions/001_init.py",
+        f'COMMENT = "The policy is {marker} here"\n',
+    )
+    commit_all(tmp_path)
+
+    # Commit 2 (HEAD): insert an innocent line before — marker shifts to line 2.
+    write_file(
+        tmp_path,
+        "alembic/versions/001_init.py",
+        f'# header\nCOMMENT = "The policy is {marker} here"\n',
+    )
+    commit_all(tmp_path)
+
+    result = run_lint(tmp_path)
+
+    assert result.returncode == 0, (
+        "line shift caused a false-positive violation:\n" + result.stdout + result.stderr
+    )
+
+
+def test_narrowed_allowlist_only_permits_four_leakage_globs(tmp_path: Path) -> None:
+    """docs/ and source paths must NOT be in the allowlist; they must fail if they
+    contain a new marker that is not in the baseline.
+
+    The new file must be committed (tracked) so that git ls-files includes it.
+    We use two commits so find_base_ref resolves HEAD^ as the base:
+    - commit 1 (base): empty repo
+    - commit 2 (HEAD): docs file with new marker
+    """
+    init_repo(tmp_path)
+    # Commit 1 (base): empty repo.
+    commit_all(tmp_path)
+
+    # Commit 2 (HEAD): NEW marker in a docs file — not in allowlist, not in base.
+    # Split the word so this test file itself does not match the privacy pattern.
+    marker = "for" + "gotten"
+    write_file(
+        tmp_path,
+        "docs/some-doc.md",
+        f"This policy is {marker}.\n",
+    )
+    commit_all(tmp_path)
+
+    result = run_lint(tmp_path)
+
+    assert result.returncode == 1, (
+        "docs/ path with new marker should fail but passed:\n"
+        + result.stdout
+        + result.stderr
+    )


### PR DESCRIPTION
Closes Phase 11 follow-up issue #224 **Critical #4** — narrow privacy allowlist per PHASE11_PLAN §7 #5 + fix baseline-diff line-number sensitivity bug + multiset count semantics.

## Changes

- `scripts/lint_privacy_check.sh` + `scripts/precommit-privacy-allowlist.sh`:
  - Removed broad allowlist (`docs/**/*.md`, `bot/**`, `tests/**`)
  - Kept exactly 4 globs per spec: `leakage_offrecord*.jsonl`, `leakage_nomem*.jsonl`, `leakage_forgotten*.jsonl`, `leakage_redacted*.jsonl`
  - Removed `-n` from git grep — baseline now `path:content` (line-shift resilient)
  - Replaced set-membership `grep -F -x` with awk multiset (handles duplicate-line edge case + empty baseline)
- `tests/lint/test_privacy_allowlist.py` +3 new tests: line-shift resilience, narrowed allowlist enforcement, multiset duplicate detection

## PAR

- Claude product reviewer (standard-product-reviewer): **ACCEPTED** — PHASE11_PLAN §7 #5 contract met verbatim
- Codex tech reviewer (gpt-5.5 high) round 1: REQUEST_CHANGES (1 HIGH multiset) → fix → round 2: **APPROVE** — multiset awk correct, FILENAME pattern handles empty baseline, both scripts in sync

## Test plan

- [x] `bash scripts/lint_privacy_check.sh` exit 0
- [x] 7/7 lint tests pass (6 existing + 1 multiset regression)
- [x] Phase 11 binding 21/21 green
- [x] Ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)