### PR TITLE
feat(p6-t6-02): extractor service + admin handler + migration 035 operator_user_id

### DIFF
--- a/alembic/versions/035_add_extraction_runs_operator_user_id.py
+++ b/alembic/versions/035_add_extraction_runs_operator_user_id.py
@@ -1,0 +1,56 @@
+"""add_extraction_runs_operator_user_id
+
+T6-02 / Phase 6 (Codex HIGH #5): durable audit marker for the admin who
+triggered an extraction pass via ``/admin_extract``. Previously
+``operator_user_id`` lived only in structured logs, which are not
+reliable for long-lived audit trails (rotation, retention, third-party
+collection). PHASE6_PLAN.md §5.C requires a DB-level marker so reviewers
+can attribute an extraction back to the operator who ran it.
+
+Schema:
+
+* New nullable column ``extraction_runs.operator_user_id BIGINT``.
+* NULL = scheduler-driven tick (no operator). Non-NULL = admin handler
+  invocation; value is the Telegram user id of the requester.
+
+No FK to ``users.id`` is added intentionally — the value is the
+operator's Telegram id (``users.telegram_id`` in this codebase, NOT
+``users.id``), and ``users`` rows may be soft-deleted; the audit shadow
+must survive that. If a future ticket wants strict referential integrity
+it would join via ``telegram_id`` lookup at read time.
+
+Migration numbering: 030-034 are reserved for the T6-01 schema landings
+(extraction_runs / candidates / cards / card_sources / decisions). 035
+is the next free slot.
+
+Revision ID: 035
+Revises: 034
+Create Date: 2026-05-12
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "035"
+down_revision: Union[str, Sequence[str], None] = "034"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "extraction_runs",
+        sa.Column(
+            "operator_user_id",
+            sa.BigInteger(),
+            nullable=True,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("extraction_runs", "operator_user_id")

--- a/bot/db/models.py
+++ b/bot/db/models.py
@@ -978,6 +978,12 @@ class ExtractionRun(Base):
         ),
         nullable=True,
     )
+    # Admin who triggered the pass via /admin_extract (alembic 035).
+    # NULL when the pass was scheduler-driven (no operator). Stored as
+    # Telegram user id (no FK to users.id — see migration 035 rationale).
+    operator_user_id: Mapped[int | None] = mapped_column(
+        BigInteger, nullable=True
+    )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,

--- a/bot/handlers/admin_extract.py
+++ b/bot/handlers/admin_extract.py
@@ -1,0 +1,219 @@
+"""Admin Telegram handler ``/admin/extract`` (T6-02).
+
+PHASE6_PLAN.md §7 T6-02 acceptance criteria:
+
+* Admin-only handler invoked via ``/admin/extract --window
+  <ISO8601-start>..<ISO8601-end>``.
+* Window parser validates ISO8601 + range non-empty + length ≤ 30 days
+  (LLM budget guard).
+* Calls ``run_extraction_pass`` directly, **bypassing the scheduler
+  flag** (operator-explicit backfill per Q5).
+* Records the ExtractionRun with the operator's user_id as a structured
+  audit marker.
+* Replies to admin with a summary: ``candidate_count``, ``run_status``,
+  ``llm_usage_ledger_id``.
+
+The handler reuses the same admin gating pattern as ``bot/handlers/admin.py``
+(``message.from_user.id in settings.ADMIN_IDS``, ``PrivateChatFilter``).
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta
+
+from aiogram import Router
+from aiogram.filters import Command, CommandObject
+from aiogram.types import Message
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from bot.config import settings
+from bot.filters.chat_type import PrivateChatFilter
+from bot.services.extractor import (
+    ExtractCandidatesGateway,
+    run_extraction_pass,
+)
+
+logger = logging.getLogger(__name__)
+
+router = Router(name="admin_extract")
+
+
+MAX_WINDOW_DAYS = 30
+
+
+class WindowParseError(ValueError):
+    """Raised when ``--window <ISO8601>..<ISO8601>`` fails validation."""
+
+
+def parse_extract_window(raw: str) -> tuple[datetime, datetime]:
+    """Parse ``<ISO8601-start>..<ISO8601-end>`` and validate.
+
+    Validation rules (PHASE6_PLAN.md §7 T6-02):
+
+    * Both halves must parse via ``datetime.fromisoformat`` (post-Python
+      3.11, this accepts the ``Z`` suffix and full ISO8601 variants).
+    * The range must be non-empty: ``end > start``.
+    * The length must be ≤ ``MAX_WINDOW_DAYS`` (30 days).
+
+    Returns a ``(start, end)`` tuple of timezone-aware datetimes.
+
+    Raises ``WindowParseError`` on any failure. The error message is
+    human-readable so the admin handler can surface it directly.
+    """
+    if not raw or ".." not in raw:
+        raise WindowParseError(
+            "expected '<ISO8601-start>..<ISO8601-end>'"
+        )
+    parts = raw.split("..", 1)
+    if len(parts) != 2 or not parts[0] or not parts[1]:
+        raise WindowParseError("missing start or end of window range")
+
+    raw_start, raw_end = parts[0].strip(), parts[1].strip()
+
+    try:
+        start = _parse_iso8601(raw_start)
+    except ValueError as exc:
+        raise WindowParseError(f"invalid ISO8601 start: {raw_start!r}: {exc}") from exc
+    try:
+        end = _parse_iso8601(raw_end)
+    except ValueError as exc:
+        raise WindowParseError(f"invalid ISO8601 end: {raw_end!r}: {exc}") from exc
+
+    if end <= start:
+        raise WindowParseError(
+            f"window range is empty or inverted: end={end.isoformat()} "
+            f"<= start={start.isoformat()}"
+        )
+
+    if (end - start) > timedelta(days=MAX_WINDOW_DAYS):
+        raise WindowParseError(
+            f"window exceeds maximum {MAX_WINDOW_DAYS} days; got "
+            f"{(end - start).days} days (LLM budget guard)"
+        )
+
+    return start, end
+
+
+def _parse_iso8601(raw: str) -> datetime:
+    """Normalize ``Z`` suffix → ``+00:00`` and call ``fromisoformat``.
+
+    Python 3.11+ ``fromisoformat`` accepts ``Z``; this helper keeps the
+    code robust on older minor versions in case the runtime drifts.
+    """
+    cleaned = raw.replace("Z", "+00:00") if raw.endswith("Z") else raw
+    dt = datetime.fromisoformat(cleaned)
+    if dt.tzinfo is None:
+        # Reject naive datetimes — admin must supply UTC explicitly to
+        # avoid timezone ambiguity in the audit trail.
+        raise ValueError(
+            "datetime missing timezone offset; supply '+00:00' or 'Z'"
+        )
+    return dt
+
+
+@router.message(Command("admin_extract"), PrivateChatFilter())
+async def cmd_admin_extract(
+    message: Message,
+    command: CommandObject,
+    session: AsyncSession,
+    gateway: ExtractCandidatesGateway,
+) -> None:
+    """Admin-only ``/admin_extract --window <start>..<end>`` handler.
+
+    NOTE: The Telegram command word is ``admin_extract`` (underscore) —
+    Telegram does not allow slashes in command names, so the
+    ``/admin/extract`` syntax from PHASE6_PLAN.md §5.C maps to
+    ``/admin_extract --window ...`` at the wire layer. The semantic
+    behaviour matches the plan exactly.
+
+    Wiring:
+
+    * Admin guard: ``message.from_user.id in settings.ADMIN_IDS`` (same
+      pattern as ``/stats`` and ``/force_refresh`` in
+      ``bot/handlers/admin.py``).
+    * Private chat only (``PrivateChatFilter``).
+    * Window parser → ``run_extraction_pass`` direct invocation
+      (scheduler flag is NOT checked here — operator-explicit backfill
+      per PHASE6_PLAN.md Q5).
+    * Returns summary text with ``candidate_count`` + ``run_status`` +
+      ``llm_usage_ledger_id``.
+    """
+    if message.from_user is None:
+        return
+
+    if message.from_user.id not in settings.ADMIN_IDS:
+        # Silent no-op (same shape as /stats handler) — non-admin
+        # discoverability is intentionally suppressed.
+        return
+
+    raw_args = (command.args or "").strip()
+    if not raw_args:
+        await message.answer(
+            "Использование: <code>/admin_extract --window "
+            "&lt;ISO8601-start&gt;..&lt;ISO8601-end&gt;</code>",
+            parse_mode="HTML",
+        )
+        return
+
+    # Strip ``--window `` prefix if present (we accept both
+    # ``/admin_extract --window X..Y`` and ``/admin_extract X..Y``).
+    window_raw = raw_args
+    if window_raw.startswith("--window"):
+        window_raw = window_raw[len("--window") :].strip()
+    if not window_raw:
+        await message.answer(
+            "Ошибка: ожидалось значение --window. Использование: "
+            "<code>/admin_extract --window "
+            "&lt;ISO8601-start&gt;..&lt;ISO8601-end&gt;</code>",
+            parse_mode="HTML",
+        )
+        return
+
+    try:
+        window_start, window_end = parse_extract_window(window_raw)
+    except WindowParseError as exc:
+        await message.answer(
+            f"Ошибка окна: {exc}", parse_mode=None
+        )
+        logger.info(
+            "admin_extract_window_parse_failed",
+            extra={
+                "admin_user_id": message.from_user.id,
+                "raw_args": raw_args,
+                "error": str(exc),
+            },
+        )
+        return
+
+    logger.info(
+        "admin_extract_invoked",
+        extra={
+            "admin_user_id": message.from_user.id,
+            "window_start": window_start.isoformat(),
+            "window_end": window_end.isoformat(),
+        },
+    )
+
+    result = await run_extraction_pass(
+        session,
+        window_start=window_start,
+        window_end=window_end,
+        gateway=gateway,
+        operator_user_id=message.from_user.id,
+    )
+
+    summary_lines = [
+        "<b>Extraction pass</b>",
+        f"window: <code>{window_start.isoformat()}</code> .. "
+        f"<code>{window_end.isoformat()}</code>",
+        f"run_status: <code>{result.run_status}</code>",
+        f"candidate_count: <code>{result.candidate_count}</code>",
+        f"llm_usage_ledger_id: <code>{result.llm_usage_ledger_id}</code>",
+        f"extraction_run_id: <code>{result.extraction_run_id}</code>",
+    ]
+    if result.failure_reason:
+        summary_lines.append(
+            f"failure_reason: <code>{result.failure_reason}</code>"
+        )
+    await message.answer("\n".join(summary_lines), parse_mode="HTML")

--- a/bot/services/extractor.py
+++ b/bot/services/extractor.py
@@ -507,28 +507,74 @@ async def run_extraction_pass(
             candidate_count=0,
         )
 
-    source_payload = [row.to_gateway_payload() for row in rows]
-    gateway_result = await gateway.extract_candidates(
-        session,
-        source_versions=source_payload,
-        prompt_template_version=prompt_template_version,
+    # ─── Atomic 3-stage lifecycle (Codex HIGH #3) ─────────────────────────
+    # Stage 1: INSERT ExtractionRun with run_status='running' BEFORE the
+    # gateway call. The running row lives in the outer transaction so it
+    # survives a savepoint rollback below.
+    run = ExtractionRun(
+        ingestion_window_start=window_start,
+        ingestion_window_end=window_end,
+        candidate_count=0,
+        run_status="running",
     )
+    session.add(run)
+    await session.flush()
+
+    # Stage 2: gateway call wrapped in a SAVEPOINT. A raised exception
+    # rolls back the savepoint (no half-written candidates) but the
+    # running row inserted above remains visible in the outer
+    # transaction, so we can update it to 'failed' and surface the
+    # failure durably in the audit table.
+    source_payload = [row.to_gateway_payload() for row in rows]
+    try:
+        async with session.begin_nested():
+            gateway_result = await gateway.extract_candidates(
+                session,
+                source_versions=source_payload,
+                prompt_template_version=prompt_template_version,
+            )
+    except Exception as exc:
+        # Update running → failed, then re-raise so the caller knows
+        # the LLM call died. The audit row is intact.
+        run.run_status = "failed"
+        await session.flush()
+        logger.warning(
+            "extraction_pass_gateway_crashed",
+            extra={
+                "extraction_run_id": str(run.id),
+                "window_start": window_start.isoformat(),
+                "window_end": window_end.isoformat(),
+                "operator_user_id": operator_user_id,
+                "exception": repr(exc),
+            },
+        )
+        raise
+
     candidates_raw = gateway_result.get("candidates", []) or []
     llm_usage_ledger_id = gateway_result.get("llm_usage_ledger_id")
 
     # Privacy invariant #4 (PHASE6_PLAN.md §8): an extraction run that
     # actually invoked the gateway MUST be associated with an
-    # llm_usage_ledger entry. The empty-bundle short-circuit above already
-    # returned without reaching this point — so here we're guaranteed a
-    # real gateway call happened. If the gateway returns no ledger id,
-    # the audit linkage is missing and the pass MUST fail closed (no
-    # candidates persisted, run_status='failed').
+    # llm_usage_ledger entry. If the gateway returns no ledger id, fail
+    # the existing running row in place — no orphan rows.
     if llm_usage_ledger_id is None:
-        return await _persist_failed_run(
-            session,
-            window_start=window_start,
-            window_end=window_end,
+        run.run_status = "failed"
+        await session.flush()
+        logger.warning(
+            "extraction_pass_aborted",
+            extra={
+                "extraction_run_id": str(run.id),
+                "failure_reason": "no_llm_ledger_entry",
+                "window_start": window_start.isoformat(),
+                "window_end": window_end.isoformat(),
+            },
+        )
+        return ExtractionResult(
+            extraction_run_id=run.id,
+            run_status="failed",
+            candidate_count=0,
             failure_reason="no_llm_ledger_entry",
+            llm_usage_ledger_id=None,
         )
 
     candidate_objs: list[ExtractionCandidate] = []
@@ -543,14 +589,11 @@ async def run_extraction_pass(
             )
         )
 
-    run = ExtractionRun(
-        ingestion_window_start=window_start,
-        ingestion_window_end=window_end,
-        candidate_count=len(candidate_objs),
-        run_status="completed",
-        llm_usage_ledger_id=llm_usage_ledger_id,
-    )
-    session.add(run)
+    # Stage 3: UPDATE running → completed, populate stats, then INSERT
+    # candidate rows pointing at the now-completed run.
+    run.run_status = "completed"
+    run.candidate_count = len(candidate_objs)
+    run.llm_usage_ledger_id = llm_usage_ledger_id
     await session.flush()
 
     for cand in candidate_objs:

--- a/bot/services/extractor.py
+++ b/bot/services/extractor.py
@@ -290,10 +290,9 @@ async def _select_eligible_sources(
     if force_include_chat_message_ids:
         # Test-only path. Rows joined by id are forwarded raw — exactly the
         # bypass that lets the defense-in-depth guard fire in tests.
-        # nosemgrep: python.sqlalchemy.security.audit.avoid-sqlalchemy-text.avoid-sqlalchemy-text
         # SAFE: base_predicate is a module-level constant SQL string (lines 196-288).
         # No user input is interpolated; runtime values use bound :params.
-        stmt = text(
+        stmt = text(  # nosemgrep: python.sqlalchemy.security.audit.avoid-sqlalchemy-text.avoid-sqlalchemy-text
             f"""
             SELECT
                 c.id AS chat_message_id,
@@ -338,10 +337,9 @@ async def _select_eligible_sources(
             "force_ids": force_include_chat_message_ids,
         }
     else:
-        # nosemgrep: python.sqlalchemy.security.audit.avoid-sqlalchemy-text.avoid-sqlalchemy-text
         # SAFE: base_predicate is a module-level constant SQL string (lines 196-288).
         # No user input is interpolated; runtime values use bound :params.
-        stmt = text(
+        stmt = text(  # nosemgrep: python.sqlalchemy.security.audit.avoid-sqlalchemy-text.avoid-sqlalchemy-text
             f"""
             SELECT
                 c.id AS chat_message_id,

--- a/bot/services/extractor.py
+++ b/bot/services/extractor.py
@@ -41,7 +41,7 @@ import struct
 import uuid as _uuid_module
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any, Protocol
+from typing import Any, Protocol, runtime_checkable
 
 from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -110,6 +110,7 @@ MEMORY_EXTRACTION_SCHEDULER_ENABLED_FLAG = "memory.extraction.scheduler.enabled"
 # ─── Protocol seam — concrete impl lands in T6-03 ────────────────────────────
 
 
+@runtime_checkable
 class ExtractCandidatesGateway(Protocol):
     """Typed contract for the Phase 6 LLM gateway extraction entry point.
 
@@ -121,6 +122,12 @@ class ExtractCandidatesGateway(Protocol):
     invariant #2: "no LLM calls outside ``llm_gateway``"). The extractor
     builds a privacy-cleared evidence bundle, hands it off, and persists
     whatever candidates the gateway emits — no raw provider SDK use.
+
+    ``@runtime_checkable`` enables T6-03 DI middleware to validate gateway
+    instances with ``isinstance(gw, ExtractCandidatesGateway)`` at wire
+    time. Note: ``isinstance`` checks only attribute presence, NOT
+    signatures — call-site contract enforcement still relies on static
+    typing.
     """
 
     async def extract_candidates(

--- a/bot/services/extractor.py
+++ b/bot/services/extractor.py
@@ -37,7 +37,7 @@ from __future__ import annotations
 
 import logging
 import uuid as _uuid_module
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Protocol
 
@@ -45,10 +45,8 @@ from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from bot.db.models import (
-    ChatMessage,
     ExtractionCandidate,
     ExtractionRun,
-    MessageVersion,
 )
 from bot.db.repos.feature_flag import FeatureFlagRepo
 

--- a/bot/services/extractor.py
+++ b/bot/services/extractor.py
@@ -299,7 +299,9 @@ async def _select_eligible_sources(
     ]
 
 
-def _bundle_is_clean(rows: list[_SourceRow]) -> tuple[bool, str | None]:
+async def _bundle_is_clean(
+    session: AsyncSession, rows: list[_SourceRow]
+) -> tuple[bool, str | None]:
     """Defense-in-depth re-check after SELECT.
 
     Returns ``(True, None)`` when every row is eligible. Otherwise
@@ -308,6 +310,19 @@ def _bundle_is_clean(rows: list[_SourceRow]) -> tuple[bool, str | None]:
     PHASE6_PLAN.md §5.B "Invariant: the LLM call is forbidden whenever ANY
     source row in the evidence bundle has memory_policy != 'normal'. The
     guard runs BEFORE llm_gateway.extract_candidates() is invoked."
+
+    Two layers of defense:
+
+    1. **Materialized fast-path.** The SELECT already filtered out
+       offrecord / redacted rows; this loop re-confirms the snapshotted
+       fields before forwarding. Cheap (in-memory only).
+
+    2. **Fresh forget_events re-query.** SAME CLASS OF RACE AS H-Cdx-2:
+       between ``_select_eligible_sources`` and the gateway call, a new
+       ``forget_events`` row can land that targets a bundle row. The
+       materialized snapshot would miss it, so we re-query the live
+       ``forget_events`` table for any tombstone matching the bundle's
+       chat_message ids. If a fresh tombstone exists, refuse the call.
     """
     for row in rows:
         if row.memory_policy != "normal":
@@ -319,6 +334,48 @@ def _bundle_is_clean(rows: list[_SourceRow]) -> tuple[bool, str | None]:
             return False, f"source_redacted:cm_id={row.chat_message_id}"
         if row.version_is_redacted:
             return False, f"source_version_redacted:mv_id={row.message_version_id}"
+
+    if not rows:
+        return True, None
+
+    # Fresh forget_events re-query — closes the SELECT→gateway race window.
+    # The join clauses match the cascade's tombstone_key construction
+    # (see bot/services/forget_cascade.py): forget_reply emits
+    # ``message:<chat>:<msg>``, /forget-me emits ``user:<tg_id>``, and
+    # message_hash tombstones use chat_messages.content_hash (the same
+    # hash value is also stored on message_versions.content_hash; both
+    # tables share the hash so filtering on c.content_hash is sufficient).
+    chat_msg_ids = [row.chat_message_id for row in rows]
+    result = await session.execute(
+        text(
+            """
+            SELECT c.id AS chat_message_id
+            FROM chat_messages AS c
+            JOIN forget_events AS fe ON (
+                fe.tombstone_key = 'message:' || c.chat_id::text || ':' || c.message_id::text
+                OR (
+                    c.content_hash IS NOT NULL
+                    AND fe.tombstone_key = 'message_hash:' || c.content_hash
+                )
+                OR (
+                    c.user_id IS NOT NULL
+                    AND fe.tombstone_key = 'user:' || c.user_id::text
+                )
+            )
+            WHERE c.id = ANY(:chat_msg_ids)
+              AND fe.status IN ('pending', 'processing', 'completed')
+            LIMIT 1
+            """
+        ),
+        {"chat_msg_ids": chat_msg_ids},
+    )
+    raced_row = result.first()
+    if raced_row is not None:
+        return (
+            False,
+            f"fresh_forget_event_during_extraction:cm_id={raced_row[0]}",
+        )
+
     return True, None
 
 
@@ -417,7 +474,7 @@ async def run_extraction_pass(
         force_include_chat_message_ids=_force_include_chat_message_ids,
     )
 
-    clean, reason = _bundle_is_clean(rows)
+    clean, reason = await _bundle_is_clean(session, rows)
     if not clean:
         return await _persist_failed_run(
             session,

--- a/bot/services/extractor.py
+++ b/bot/services/extractor.py
@@ -238,6 +238,20 @@ async def _select_eligible_sources(
     ``run_extraction_pass`` invariant guard catches the leakage in that
     case and records the run as failed.
     """
+    # Tombstone matching mirrors bot/services/search.py and the cascade's
+    # tombstone_key construction in bot/services/forget_cascade.py +
+    # bot/services/import_tombstone.py:
+    #
+    #   * ``message:<chat_id>:<message_id>``   — emitted by /forget reply
+    #   * ``message_hash:<content_hash>``      — emitted on cross-chat dedup
+    #   * ``user:<telegram_id>``               — emitted by /forget me
+    #
+    # The ``message_hash:`` key uses the same hash value stored on BOTH
+    # ``chat_messages.content_hash`` and ``message_versions.content_hash``
+    # (idempotency contract — same content → same SHA-256). Filtering on
+    # ``c.content_hash`` is therefore sufficient; no MV-level OR-clause
+    # needed. Keep this comment in sync with search.py / llm_gateway.py
+    # if any of the three target_type → tombstone_key conventions changes.
     base_predicate = """
         c.current_version_id = mv.id
         AND c.memory_policy = 'normal'
@@ -690,6 +704,16 @@ async def _get_phase_6_enabled_at(session: AsyncSession) -> datetime | None:
     This is the forward-only lower bound (PHASE6_PLAN.md §5.B Q5). Missing
     row → no phase_6_enabled_at and the tick must skip (the flag is OFF
     by default).
+
+    Known semantic (Codex MED #1, deferred to T6-03 / Phase 6 follow-up):
+    the value here is ``FeatureFlag.updated_at``, which is NOT monotonic
+    — toggling the flag OFF → ON regresses the watermark to the latest
+    enable timestamp. This is intentional for the operator-explicit
+    backfill workflow (PHASE6_PLAN.md Q5): re-enabling the flag is
+    treated as "start fresh from this point". Operators who need to
+    cover the OFF window must use ``/admin_extract --window`` for the
+    gap. A future durable monotonic watermark may be added separately
+    if a non-overlapping append-only audit is required.
     """
     from bot.db.models import FeatureFlag
 

--- a/bot/services/extractor.py
+++ b/bot/services/extractor.py
@@ -1,0 +1,578 @@
+"""Phase 6 extraction service (T6-02).
+
+PHASE6_PLAN.md §5.B + §7 T6-02 acceptance criteria.
+
+This module owns the extractor pass that reads eligible ``chat_messages``
+(via current ``message_versions``), builds a privacy-filtered evidence
+bundle, calls an LLM gateway through the ``ExtractCandidatesGateway``
+Protocol seam (concrete impl lands in T6-03), and writes
+``extraction_runs`` + ``extraction_candidates`` rows.
+
+Public surface:
+
+* ``run_extraction_pass(session, *, window_start, window_end, gateway,
+  operator_user_id=None)`` — single pass over a time window.
+* ``MEMORY_EXTRACTION_SCHEDULER_ENABLED_FLAG`` — feature flag key.
+* ``extraction_scheduler_tick(session, *, gateway)`` — flag-gated
+  scheduler entry-point. Default OFF.
+* ``ExtractCandidatesGateway`` — Protocol the gateway must implement.
+* ``ExtractionResult`` / ``ExtractedCandidate`` / ``SchedulerTickResult``
+  — return-value dataclasses.
+
+Privacy invariants (PHASE6_PLAN.md §1 #3, §5.B Stop Conditions):
+
+* ``memory_policy != 'normal'`` rows MUST be excluded from the bundle.
+* ``message_versions.is_redacted=true`` rows MUST be excluded.
+* Rows matched by any ``forget_events`` tombstone MUST be excluded.
+* Defense-in-depth: if a bundle assembled by the SELECT contains ANY
+  ineligible row, the pass refuses to call the gateway and records the
+  ExtractionRun as ``failed`` with a structured reason.
+
+The gateway call is forbidden whenever ANY source row in the evidence
+bundle fails the governance pre-check (PHASE6_PLAN.md §5.B invariant
+paragraph).
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid as _uuid_module
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Protocol
+
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from bot.db.models import (
+    ChatMessage,
+    ExtractionCandidate,
+    ExtractionRun,
+    MessageVersion,
+)
+from bot.db.repos.feature_flag import FeatureFlagRepo
+
+logger = logging.getLogger(__name__)
+
+
+# ─── Feature flag key (PHASE6_PLAN.md §7 T6-02) ──────────────────────────────
+
+
+MEMORY_EXTRACTION_SCHEDULER_ENABLED_FLAG = "memory.extraction.scheduler.enabled"
+
+
+# ─── Protocol seam — concrete impl lands in T6-03 ────────────────────────────
+
+
+class ExtractCandidatesGateway(Protocol):
+    """Typed contract for the Phase 6 LLM gateway extraction entry point.
+
+    T6-02 ships only the seam; T6-03 (Stream B follow-up) provides the
+    concrete implementation under ``bot/services/llm_gateway.py::
+    extract_candidates``. Tests inject fakes that satisfy this Protocol.
+
+    The gateway is the ONLY allowed LLM call site for extraction (HANDOFF
+    invariant #2: "no LLM calls outside ``llm_gateway``"). The extractor
+    builds a privacy-cleared evidence bundle, hands it off, and persists
+    whatever candidates the gateway emits — no raw provider SDK use.
+    """
+
+    async def extract_candidates(
+        self,
+        session: Any,
+        *,
+        source_versions: list[dict[str, Any]],
+        prompt_template_version: str = "v0.1.0",
+    ) -> dict[str, Any]:
+        """Return ``{"candidates": [...], "llm_usage_ledger_id": int | None}``.
+
+        Each candidate is ``{"candidate_json": <jsonb-compatible dict>,
+        "source_message_version_ids": [int, ...]}``. The
+        ``llm_usage_ledger_id`` references the Phase 5 ``llm_usage_ledger``
+        row the gateway wrote for this call (or ``None`` on abstention
+        paths that still produced audit metadata).
+        """
+        ...
+
+
+# ─── Dataclasses ─────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class ExtractedCandidate:
+    """One LLM-emitted candidate ready for persistence."""
+
+    candidate_json: dict[str, Any]
+    source_message_version_ids: list[int]
+
+
+@dataclass(frozen=True)
+class ExtractionResult:
+    """Outcome of a single ``run_extraction_pass`` call."""
+
+    extraction_run_id: _uuid_module.UUID
+    run_status: str  # 'completed' | 'failed'
+    candidate_count: int
+    failure_reason: str | None = None
+    llm_usage_ledger_id: int | None = None
+
+
+@dataclass(frozen=True)
+class SchedulerTickResult:
+    """Outcome of one scheduler tick (`extraction_scheduler_tick`)."""
+
+    skipped: bool
+    extraction_result: ExtractionResult | None = None
+    reason: str | None = None
+
+
+# ─── Source-row dataclass for bundle assembly ────────────────────────────────
+
+
+@dataclass(frozen=True)
+class _SourceRow:
+    chat_message_id: int
+    message_version_id: int
+    chat_id: int
+    message_id: int
+    user_id: int | None
+    text: str | None
+    caption: str | None
+    normalized_text: str | None
+    memory_policy: str
+    is_redacted: bool
+    version_is_redacted: bool
+    created_at: datetime
+
+    def to_gateway_payload(self) -> dict[str, Any]:
+        """Render for the gateway. NO forbidden fields included."""
+        return {
+            "chat_message_id": self.chat_message_id,
+            "message_version_id": self.message_version_id,
+            "chat_id": self.chat_id,
+            "message_id": self.message_id,
+            "user_id": self.user_id,
+            "text": self.text,
+            "caption": self.caption,
+            "normalized_text": self.normalized_text,
+        }
+
+
+# ─── Internal helpers ────────────────────────────────────────────────────────
+
+
+async def _select_eligible_sources(
+    session: AsyncSession,
+    *,
+    window_start: datetime,
+    window_end: datetime,
+    force_include_chat_message_ids: list[int] | None,
+) -> list[_SourceRow]:
+    """SELECT chat_messages + current message_versions that pass governance.
+
+    Filters (PHASE6_PLAN.md §5.B):
+
+    * ``chat_messages.memory_policy = 'normal'``
+    * ``chat_messages.is_redacted = FALSE``
+    * ``message_versions.is_redacted = FALSE``
+    * ``chat_messages.current_version_id = message_versions.id`` (current only)
+    * ``chat_messages.created_at >= window_start AND < window_end``
+    * NOT matched by any ``forget_events`` row (defense via NOT EXISTS).
+
+    ``force_include_chat_message_ids`` is a test-only escape hatch that
+    re-INCLUDES rows by ``chat_messages.id`` even if they'd otherwise be
+    filtered out. Production callers MUST NOT set it — the
+    ``run_extraction_pass`` invariant guard catches the leakage in that
+    case and records the run as failed.
+    """
+    base_predicate = """
+        c.current_version_id = mv.id
+        AND c.memory_policy = 'normal'
+        AND c.is_redacted = FALSE
+        AND mv.is_redacted = FALSE
+        AND c.created_at >= :window_start
+        AND c.created_at < :window_end
+        AND NOT EXISTS (
+            SELECT 1
+            FROM forget_events AS fe
+            WHERE (
+                fe.tombstone_key = 'message:' || c.chat_id::text || ':' || c.message_id::text
+                OR (
+                    c.content_hash IS NOT NULL
+                    AND fe.tombstone_key = 'message_hash:' || c.content_hash
+                )
+                OR (
+                    c.user_id IS NOT NULL
+                    AND fe.tombstone_key = 'user:' || c.user_id::text
+                )
+            )
+            AND fe.status IN ('pending', 'processing', 'completed')
+        )
+    """
+
+    if force_include_chat_message_ids:
+        # Test-only path. Rows joined by id are forwarded raw — exactly the
+        # bypass that lets the defense-in-depth guard fire in tests.
+        stmt = text(
+            f"""
+            SELECT
+                c.id AS chat_message_id,
+                mv.id AS message_version_id,
+                c.chat_id AS chat_id,
+                c.message_id AS message_id,
+                c.user_id AS user_id,
+                mv.text AS text,
+                mv.caption AS caption,
+                mv.normalized_text AS normalized_text,
+                c.memory_policy AS memory_policy,
+                c.is_redacted AS is_redacted,
+                mv.is_redacted AS version_is_redacted,
+                c.created_at AS created_at
+            FROM chat_messages AS c
+            JOIN message_versions AS mv ON mv.chat_message_id = c.id
+            WHERE c.id = ANY(:force_ids)
+              AND mv.id = c.current_version_id
+            UNION
+            SELECT
+                c.id AS chat_message_id,
+                mv.id AS message_version_id,
+                c.chat_id AS chat_id,
+                c.message_id AS message_id,
+                c.user_id AS user_id,
+                mv.text AS text,
+                mv.caption AS caption,
+                mv.normalized_text AS normalized_text,
+                c.memory_policy AS memory_policy,
+                c.is_redacted AS is_redacted,
+                mv.is_redacted AS version_is_redacted,
+                c.created_at AS created_at
+            FROM chat_messages AS c
+            JOIN message_versions AS mv ON mv.chat_message_id = c.id
+            WHERE {base_predicate}
+            ORDER BY created_at ASC, message_version_id ASC
+            """
+        )
+        params = {
+            "window_start": window_start,
+            "window_end": window_end,
+            "force_ids": force_include_chat_message_ids,
+        }
+    else:
+        stmt = text(
+            f"""
+            SELECT
+                c.id AS chat_message_id,
+                mv.id AS message_version_id,
+                c.chat_id AS chat_id,
+                c.message_id AS message_id,
+                c.user_id AS user_id,
+                mv.text AS text,
+                mv.caption AS caption,
+                mv.normalized_text AS normalized_text,
+                c.memory_policy AS memory_policy,
+                c.is_redacted AS is_redacted,
+                mv.is_redacted AS version_is_redacted,
+                c.created_at AS created_at
+            FROM chat_messages AS c
+            JOIN message_versions AS mv ON mv.chat_message_id = c.id
+            WHERE {base_predicate}
+            ORDER BY c.created_at ASC, mv.id ASC
+            """
+        )
+        params = {"window_start": window_start, "window_end": window_end}
+
+    result = await session.execute(stmt, params)
+    return [
+        _SourceRow(
+            chat_message_id=row["chat_message_id"],
+            message_version_id=row["message_version_id"],
+            chat_id=row["chat_id"],
+            message_id=row["message_id"],
+            user_id=row["user_id"],
+            text=row["text"],
+            caption=row["caption"],
+            normalized_text=row["normalized_text"],
+            memory_policy=row["memory_policy"],
+            is_redacted=bool(row["is_redacted"]),
+            version_is_redacted=bool(row["version_is_redacted"]),
+            created_at=row["created_at"],
+        )
+        for row in result.mappings().all()
+    ]
+
+
+def _bundle_is_clean(rows: list[_SourceRow]) -> tuple[bool, str | None]:
+    """Defense-in-depth re-check after SELECT.
+
+    Returns ``(True, None)`` when every row is eligible. Otherwise
+    ``(False, <reason>)`` with a structured-log-friendly reason string.
+
+    PHASE6_PLAN.md §5.B "Invariant: the LLM call is forbidden whenever ANY
+    source row in the evidence bundle has memory_policy != 'normal'. The
+    guard runs BEFORE llm_gateway.extract_candidates() is invoked."
+    """
+    for row in rows:
+        if row.memory_policy != "normal":
+            return (
+                False,
+                f"source_memory_policy_not_normal:cm_id={row.chat_message_id}",
+            )
+        if row.is_redacted:
+            return False, f"source_redacted:cm_id={row.chat_message_id}"
+        if row.version_is_redacted:
+            return False, f"source_version_redacted:mv_id={row.message_version_id}"
+    return True, None
+
+
+async def _persist_failed_run(
+    session: AsyncSession,
+    *,
+    window_start: datetime,
+    window_end: datetime,
+    failure_reason: str,
+) -> ExtractionResult:
+    """Insert a ``run_status='failed'`` ExtractionRun row and return."""
+    run = ExtractionRun(
+        ingestion_window_start=window_start,
+        ingestion_window_end=window_end,
+        candidate_count=0,
+        run_status="failed",
+    )
+    session.add(run)
+    await session.flush()
+    logger.warning(
+        "extraction_pass_aborted",
+        extra={
+            "extraction_run_id": str(run.id),
+            "failure_reason": failure_reason,
+            "window_start": window_start.isoformat(),
+            "window_end": window_end.isoformat(),
+        },
+    )
+    return ExtractionResult(
+        extraction_run_id=run.id,
+        run_status="failed",
+        candidate_count=0,
+        failure_reason=failure_reason,
+        llm_usage_ledger_id=None,
+    )
+
+
+# ─── Public API ──────────────────────────────────────────────────────────────
+
+
+async def run_extraction_pass(
+    session: AsyncSession,
+    *,
+    window_start: datetime,
+    window_end: datetime,
+    gateway: ExtractCandidatesGateway,
+    operator_user_id: int | None = None,
+    prompt_template_version: str = "v0.1.0",
+    _force_include_chat_message_ids: list[int] | None = None,
+) -> ExtractionResult:
+    """Run one extraction pass over ``[window_start, window_end)``.
+
+    The function:
+
+    1. SELECTs eligible chat_messages + current message_versions
+       (governance-filtered per PHASE6_PLAN §5.B).
+    2. Re-checks the bundle (defense-in-depth) before any gateway call.
+       Any non-normal / redacted row → record ``run_status='failed'`` and
+       return WITHOUT invoking the gateway.
+    3. If the bundle is empty, write a ``completed`` run with
+       ``candidate_count=0`` and NO gateway call (empty-bundle short-circuit
+       mirrors ``llm_gateway.synthesize_answer`` invariant #1).
+    4. Else, call ``gateway.extract_candidates`` and persist each emitted
+       candidate as an ``extraction_candidates`` row with ``status='pending'``.
+
+    ``operator_user_id`` is opaque audit metadata stored only in structured
+    logs for now (no dedicated column on ``extraction_runs`` per
+    PHASE6_PLAN.md §5.A migration spec).
+
+    ``_force_include_chat_message_ids`` is a TEST-ONLY hook that adds rows
+    to the bundle that would otherwise be filtered. Production callers
+    MUST leave it ``None``; if it surfaces an offrecord row in tests, the
+    invariant guard at step 2 fires.
+    """
+    if window_end <= window_start:
+        # Defensive: empty/inverted ranges produce no work. Still write a
+        # completed run so audit captures the no-op.
+        run = ExtractionRun(
+            ingestion_window_start=window_start,
+            ingestion_window_end=window_end,
+            candidate_count=0,
+            run_status="completed",
+        )
+        session.add(run)
+        await session.flush()
+        return ExtractionResult(
+            extraction_run_id=run.id,
+            run_status="completed",
+            candidate_count=0,
+        )
+
+    rows = await _select_eligible_sources(
+        session,
+        window_start=window_start,
+        window_end=window_end,
+        force_include_chat_message_ids=_force_include_chat_message_ids,
+    )
+
+    clean, reason = _bundle_is_clean(rows)
+    if not clean:
+        return await _persist_failed_run(
+            session,
+            window_start=window_start,
+            window_end=window_end,
+            failure_reason=reason or "governance_violation",
+        )
+
+    if not rows:
+        run = ExtractionRun(
+            ingestion_window_start=window_start,
+            ingestion_window_end=window_end,
+            candidate_count=0,
+            run_status="completed",
+        )
+        session.add(run)
+        await session.flush()
+        logger.info(
+            "extraction_pass_empty_window",
+            extra={
+                "extraction_run_id": str(run.id),
+                "window_start": window_start.isoformat(),
+                "window_end": window_end.isoformat(),
+                "operator_user_id": operator_user_id,
+            },
+        )
+        return ExtractionResult(
+            extraction_run_id=run.id,
+            run_status="completed",
+            candidate_count=0,
+        )
+
+    source_payload = [row.to_gateway_payload() for row in rows]
+    gateway_result = await gateway.extract_candidates(
+        session,
+        source_versions=source_payload,
+        prompt_template_version=prompt_template_version,
+    )
+    candidates_raw = gateway_result.get("candidates", []) or []
+    llm_usage_ledger_id = gateway_result.get("llm_usage_ledger_id")
+
+    candidate_objs: list[ExtractionCandidate] = []
+    for c in candidates_raw:
+        candidate_objs.append(
+            ExtractionCandidate(
+                candidate_json=dict(c.get("candidate_json") or {}),
+                source_message_version_ids=list(
+                    c.get("source_message_version_ids") or []
+                ),
+                status="pending",
+            )
+        )
+
+    run = ExtractionRun(
+        ingestion_window_start=window_start,
+        ingestion_window_end=window_end,
+        candidate_count=len(candidate_objs),
+        run_status="completed",
+        llm_usage_ledger_id=llm_usage_ledger_id,
+    )
+    session.add(run)
+    await session.flush()
+
+    for cand in candidate_objs:
+        cand.extraction_run_id = run.id
+        session.add(cand)
+    if candidate_objs:
+        await session.flush()
+
+    logger.info(
+        "extraction_pass_completed",
+        extra={
+            "extraction_run_id": str(run.id),
+            "candidate_count": len(candidate_objs),
+            "window_start": window_start.isoformat(),
+            "window_end": window_end.isoformat(),
+            "operator_user_id": operator_user_id,
+            "llm_usage_ledger_id": llm_usage_ledger_id,
+        },
+    )
+
+    return ExtractionResult(
+        extraction_run_id=run.id,
+        run_status="completed",
+        candidate_count=len(candidate_objs),
+        llm_usage_ledger_id=llm_usage_ledger_id,
+    )
+
+
+async def _get_phase_6_enabled_at(session: AsyncSession) -> datetime | None:
+    """Return the ``updated_at`` of the scheduler flag row.
+
+    This is the forward-only lower bound (PHASE6_PLAN.md §5.B Q5). Missing
+    row → no phase_6_enabled_at and the tick must skip (the flag is OFF
+    by default).
+    """
+    from bot.db.models import FeatureFlag
+
+    stmt = (
+        select(FeatureFlag.updated_at, FeatureFlag.enabled)
+        .where(
+            FeatureFlag.flag_key == MEMORY_EXTRACTION_SCHEDULER_ENABLED_FLAG,
+            FeatureFlag.scope_type.is_(None),
+            FeatureFlag.scope_id.is_(None),
+        )
+        .limit(1)
+    )
+    result = await session.execute(stmt)
+    row = result.one_or_none()
+    if row is None:
+        return None
+    updated_at, enabled = row
+    if not enabled:
+        return None
+    return updated_at
+
+
+async def extraction_scheduler_tick(
+    session: AsyncSession,
+    *,
+    gateway: ExtractCandidatesGateway,
+    now: datetime | None = None,
+) -> SchedulerTickResult:
+    """Scheduler entry-point — reads the flag, runs the pass if enabled.
+
+    PHASE6_PLAN.md §4 + §7 T6-02 acceptance:
+
+    * Default (flag missing OR False) → return ``skipped=True`` without
+      side effects.
+    * Flag True → call ``run_extraction_pass`` with
+      ``window_start = phase_6_enabled_at`` (the flag row's ``updated_at``)
+      and ``window_end = now`` (UTC).
+
+    The admin handler `/admin/extract` calls ``run_extraction_pass``
+    directly and bypasses this entry-point (no flag check, explicit window).
+    """
+    if not await FeatureFlagRepo.get(
+        session, MEMORY_EXTRACTION_SCHEDULER_ENABLED_FLAG
+    ):
+        return SchedulerTickResult(skipped=True, reason="flag_disabled")
+
+    phase_6_enabled_at = await _get_phase_6_enabled_at(session)
+    if phase_6_enabled_at is None:
+        # Flag.get says enabled, but row vanished — defensive skip.
+        return SchedulerTickResult(skipped=True, reason="flag_row_missing")
+
+    if now is None:
+        now = datetime.now(tz=phase_6_enabled_at.tzinfo)
+
+    result = await run_extraction_pass(
+        session,
+        window_start=phase_6_enabled_at,
+        window_end=now,
+        gateway=gateway,
+    )
+    return SchedulerTickResult(skipped=False, extraction_result=result)

--- a/bot/services/extractor.py
+++ b/bot/services/extractor.py
@@ -255,7 +255,7 @@ async def _select_eligible_sources(
     #     path (``bot/db/repos/message.py::MessageRepo.save``) never sets it —
     #     only the import path (``bot/services/import_apply.py``) populates it.
     #     Filtering on ``c.content_hash`` silently no-op's every
-    #     ``message_hash:`` tombstone for live messages, letting forgotten
+    #     ``message_hash:`` tombstone for live messages, letting tombstoned
     #     content leak to the LLM.
     #
     # Keep this comment in sync with search.py / llm_gateway.py if any of the

--- a/bot/services/extractor.py
+++ b/bot/services/extractor.py
@@ -35,7 +35,9 @@ paragraph).
 
 from __future__ import annotations
 
+import hashlib
 import logging
+import struct
 import uuid as _uuid_module
 from dataclasses import dataclass
 from datetime import datetime
@@ -51,6 +53,52 @@ from bot.db.models import (
 from bot.db.repos.feature_flag import FeatureFlagRepo
 
 logger = logging.getLogger(__name__)
+
+
+# ─── Scheduler-tick advisory lock (Codex HIGH #4) ────────────────────────────
+
+
+def _p6_scheduler_lock_id() -> int:
+    """Derive the Phase 6 scheduler-tick advisory lock id.
+
+    Two concurrent ``extraction_scheduler_tick`` calls would otherwise
+    race on the same window: the SELECT, gateway call, and audit-row
+    writes are not idempotent under concurrency. A
+    ``pg_try_advisory_xact_lock`` keyed by a constant
+    ``p6:extraction_scheduler`` namespace gates the tick — second
+    concurrent tick gets ``False`` from try-lock and short-circuits
+    with ``reason='locked'``.
+
+    The namespace prefix ``"p6:extraction_scheduler"`` is disjoint from
+    the per-mvid ``"p6:mvid:"`` namespace used by /approve + the
+    forget-cascade orchestrator (see
+    ``bot.services.forget_cascade._p6_mvid_advisory_lock_id``), so the
+    scheduler lock cannot collide with an in-flight cascade lock for
+    any numeric id.
+
+    Returns a value in the signed-int64 range expected by
+    ``pg_advisory_xact_lock(bigint)``.
+    """
+    payload = b"p6:extraction_scheduler"
+    digest = hashlib.sha256(payload).digest()
+    (lock_id,) = struct.unpack(">q", digest[:8])
+    return lock_id
+
+
+async def _try_acquire_scheduler_lock(session: AsyncSession) -> bool:
+    """Attempt to acquire the scheduler-tick advisory lock; non-blocking.
+
+    Returns ``True`` if acquired (the current transaction now holds the
+    lock for its remaining lifetime), ``False`` if another transaction
+    already holds it. Skipping on ``False`` keeps semantics simple — the
+    next tick on the next schedule will pick up any pending work.
+    """
+    result = await session.execute(
+        text("SELECT pg_try_advisory_xact_lock(:lock_id)"),
+        {"lock_id": _p6_scheduler_lock_id()},
+    )
+    locked = result.scalar()
+    return bool(locked)
 
 
 # ─── Feature flag key (PHASE6_PLAN.md §7 T6-02) ──────────────────────────────
@@ -673,6 +721,16 @@ async def extraction_scheduler_tick(
         session, MEMORY_EXTRACTION_SCHEDULER_ENABLED_FLAG
     ):
         return SchedulerTickResult(skipped=True, reason="flag_disabled")
+
+    # Idempotency gate (Codex HIGH #4): only one tick may run at a time.
+    # Acquired non-blocking so the second concurrent tick exits cleanly
+    # rather than queueing up duplicate gateway calls.
+    if not await _try_acquire_scheduler_lock(session):
+        logger.info(
+            "extraction_scheduler_tick_locked",
+            extra={"reason": "another_tick_in_progress"},
+        )
+        return SchedulerTickResult(skipped=True, reason="locked")
 
     phase_6_enabled_at = await _get_phase_6_enabled_at(session)
     if phase_6_enabled_at is None:

--- a/bot/services/extractor.py
+++ b/bot/services/extractor.py
@@ -598,10 +598,23 @@ async def run_extraction_pass(
             candidate_count=0,
         )
 
-    # ─── Atomic 3-stage lifecycle (Codex HIGH #3) ─────────────────────────
-    # Stage 1: INSERT ExtractionRun with run_status='running' BEFORE the
-    # gateway call. The running row lives in the outer transaction so it
-    # survives a savepoint rollback below.
+    # ─── Atomic 3-stage lifecycle (Codex HIGH #3 + round 3 HIGH) ──────────
+    # Stage 1: INSERT ExtractionRun with run_status='running' AND commit
+    # BEFORE the gateway call. Commit is required for crash-safety
+    # (Codex round 3 HIGH): a flushed-but-uncommitted row vanishes if
+    # the process is killed / OOMs / loses its connection mid-gateway,
+    # leaving no audit trail of the attempted pass. ``session.commit()``
+    # makes the row durable; the SAVEPOINT below isolates the gateway
+    # call so a gateway-side exception still leaves the durable
+    # 'running' row in place for the failed-status UPDATE.
+    #
+    # The same commit pattern is used by ``bot/services/import_apply.py``
+    # (per-chunk commits inside a longer logical run). It is compatible
+    # with the test fixture's outer-tx rollback semantics
+    # (``bind=conn`` + outer connection-level transaction in
+    # ``tests/conftest.py::db_session``): commits inside the function
+    # land at the connection level and are still unwound by the outer
+    # rollback at fixture teardown.
     run = ExtractionRun(
         ingestion_window_start=window_start,
         ingestion_window_end=window_end,
@@ -611,11 +624,16 @@ async def run_extraction_pass(
     )
     session.add(run)
     await session.flush()
+    # Crash-safety commit. Subsequent ORM access on ``run`` continues to
+    # work because both production (``bot/db/engine.py``) and tests
+    # (``tests/conftest.py``) configure ``expire_on_commit=False`` —
+    # ``run``'s attributes remain attached for the lifecycle UPDATEs.
+    await session.commit()
 
     # Stage 2: gateway call wrapped in a SAVEPOINT. A raised exception
     # rolls back the savepoint (no half-written candidates) but the
-    # running row inserted above remains visible in the outer
-    # transaction, so we can update it to 'failed' and surface the
+    # running row inserted above remains visible (and durable) in the
+    # outer transaction, so we can update it to 'failed' and surface the
     # failure durably in the audit table.
     source_payload = [row.to_gateway_payload() for row in rows]
     try:

--- a/bot/services/extractor.py
+++ b/bot/services/extractor.py
@@ -246,12 +246,22 @@ async def _select_eligible_sources(
     #   * ``message_hash:<content_hash>``      — emitted on cross-chat dedup
     #   * ``user:<telegram_id>``               — emitted by /forget me
     #
-    # The ``message_hash:`` key uses the same hash value stored on BOTH
-    # ``chat_messages.content_hash`` and ``message_versions.content_hash``
-    # (idempotency contract — same content → same SHA-256). Filtering on
-    # ``c.content_hash`` is therefore sufficient; no MV-level OR-clause
-    # needed. Keep this comment in sync with search.py / llm_gateway.py
-    # if any of the three target_type → tombstone_key conventions changes.
+    # The ``message_hash:`` key MUST match ``message_versions.content_hash``,
+    # NOT ``chat_messages.content_hash`` (Codex round 3 CRITICAL):
+    #
+    #   * ``MessageVersion.content_hash`` is NOT NULL (DB-enforced) — every
+    #     live message has it populated by ``MessageVersionRepo.insert_version``.
+    #   * ``ChatMessage.content_hash`` is nullable AND the live persistence
+    #     path (``bot/db/repos/message.py::MessageRepo.save``) never sets it —
+    #     only the import path (``bot/services/import_apply.py``) populates it.
+    #     Filtering on ``c.content_hash`` silently no-op's every
+    #     ``message_hash:`` tombstone for live messages, letting forgotten
+    #     content leak to the LLM.
+    #
+    # Keep this comment in sync with search.py / llm_gateway.py if any of the
+    # three target_type → tombstone_key conventions changes. Note: search.py
+    # has the same live-message bug (filed as a separate follow-up; out of
+    # scope for T6-02).
     base_predicate = """
         c.current_version_id = mv.id
         AND c.memory_policy = 'normal'
@@ -265,8 +275,8 @@ async def _select_eligible_sources(
             WHERE (
                 fe.tombstone_key = 'message:' || c.chat_id::text || ':' || c.message_id::text
                 OR (
-                    c.content_hash IS NOT NULL
-                    AND fe.tombstone_key = 'message_hash:' || c.content_hash
+                    mv.content_hash IS NOT NULL
+                    AND fe.tombstone_key = 'message_hash:' || mv.content_hash
                 )
                 OR (
                     c.user_id IS NOT NULL
@@ -411,20 +421,26 @@ async def _bundle_is_clean(
     # The join clauses match the cascade's tombstone_key construction
     # (see bot/services/forget_cascade.py): forget_reply emits
     # ``message:<chat>:<msg>``, /forget-me emits ``user:<tg_id>``, and
-    # message_hash tombstones use chat_messages.content_hash (the same
-    # hash value is also stored on message_versions.content_hash; both
-    # tables share the hash so filtering on c.content_hash is sufficient).
+    # message_hash tombstones MUST match against ``message_versions.content_hash``
+    # (NOT NULL by schema), not ``chat_messages.content_hash`` (NULL for
+    # live messages — see _select_eligible_sources comment for the
+    # full Codex round 3 CRITICAL rationale). We pin the JOIN to the
+    # row's CURRENT version via ``mv.id = c.current_version_id`` so the
+    # tombstone check sees exactly the same MV the bundle forwarded.
     chat_msg_ids = [row.chat_message_id for row in rows]
     result = await session.execute(
         text(
             """
             SELECT c.id AS chat_message_id
             FROM chat_messages AS c
+            JOIN message_versions AS mv
+              ON mv.chat_message_id = c.id
+             AND mv.id = c.current_version_id
             JOIN forget_events AS fe ON (
                 fe.tombstone_key = 'message:' || c.chat_id::text || ':' || c.message_id::text
                 OR (
-                    c.content_hash IS NOT NULL
-                    AND fe.tombstone_key = 'message_hash:' || c.content_hash
+                    mv.content_hash IS NOT NULL
+                    AND fe.tombstone_key = 'message_hash:' || mv.content_hash
                 )
                 OR (
                     c.user_id IS NOT NULL

--- a/bot/services/extractor.py
+++ b/bot/services/extractor.py
@@ -459,6 +459,21 @@ async def run_extraction_pass(
     candidates_raw = gateway_result.get("candidates", []) or []
     llm_usage_ledger_id = gateway_result.get("llm_usage_ledger_id")
 
+    # Privacy invariant #4 (PHASE6_PLAN.md §8): an extraction run that
+    # actually invoked the gateway MUST be associated with an
+    # llm_usage_ledger entry. The empty-bundle short-circuit above already
+    # returned without reaching this point — so here we're guaranteed a
+    # real gateway call happened. If the gateway returns no ledger id,
+    # the audit linkage is missing and the pass MUST fail closed (no
+    # candidates persisted, run_status='failed').
+    if llm_usage_ledger_id is None:
+        return await _persist_failed_run(
+            session,
+            window_start=window_start,
+            window_end=window_end,
+            failure_reason="no_llm_ledger_entry",
+        )
+
     candidate_objs: list[ExtractionCandidate] = []
     for c in candidates_raw:
         candidate_objs.append(

--- a/bot/services/extractor.py
+++ b/bot/services/extractor.py
@@ -290,6 +290,9 @@ async def _select_eligible_sources(
     if force_include_chat_message_ids:
         # Test-only path. Rows joined by id are forwarded raw — exactly the
         # bypass that lets the defense-in-depth guard fire in tests.
+        # nosemgrep: python.sqlalchemy.security.audit.avoid-sqlalchemy-text.avoid-sqlalchemy-text
+        # SAFE: base_predicate is a module-level constant SQL string (lines 196-288).
+        # No user input is interpolated; runtime values use bound :params.
         stmt = text(
             f"""
             SELECT
@@ -335,6 +338,9 @@ async def _select_eligible_sources(
             "force_ids": force_include_chat_message_ids,
         }
     else:
+        # nosemgrep: python.sqlalchemy.security.audit.avoid-sqlalchemy-text.avoid-sqlalchemy-text
+        # SAFE: base_predicate is a module-level constant SQL string (lines 196-288).
+        # No user input is interpolated; runtime values use bound :params.
         stmt = text(
             f"""
             SELECT

--- a/bot/services/extractor.py
+++ b/bot/services/extractor.py
@@ -433,6 +433,7 @@ async def _persist_failed_run(
     window_start: datetime,
     window_end: datetime,
     failure_reason: str,
+    operator_user_id: int | None = None,
 ) -> ExtractionResult:
     """Insert a ``run_status='failed'`` ExtractionRun row and return."""
     run = ExtractionRun(
@@ -440,6 +441,7 @@ async def _persist_failed_run(
         ingestion_window_end=window_end,
         candidate_count=0,
         run_status="failed",
+        operator_user_id=operator_user_id,
     )
     session.add(run)
     await session.flush()
@@ -450,6 +452,7 @@ async def _persist_failed_run(
             "failure_reason": failure_reason,
             "window_start": window_start.isoformat(),
             "window_end": window_end.isoformat(),
+            "operator_user_id": operator_user_id,
         },
     )
     return ExtractionResult(
@@ -506,6 +509,7 @@ async def run_extraction_pass(
             ingestion_window_end=window_end,
             candidate_count=0,
             run_status="completed",
+            operator_user_id=operator_user_id,
         )
         session.add(run)
         await session.flush()
@@ -529,6 +533,7 @@ async def run_extraction_pass(
             window_start=window_start,
             window_end=window_end,
             failure_reason=reason or "governance_violation",
+            operator_user_id=operator_user_id,
         )
 
     if not rows:
@@ -537,6 +542,7 @@ async def run_extraction_pass(
             ingestion_window_end=window_end,
             candidate_count=0,
             run_status="completed",
+            operator_user_id=operator_user_id,
         )
         session.add(run)
         await session.flush()
@@ -564,6 +570,7 @@ async def run_extraction_pass(
         ingestion_window_end=window_end,
         candidate_count=0,
         run_status="running",
+        operator_user_id=operator_user_id,
     )
     session.add(run)
     await session.flush()

--- a/docs/memory-system/PHASE6_PLAN.md
+++ b/docs/memory-system/PHASE6_PLAN.md
@@ -528,6 +528,14 @@ Wave 3 (optional):     E
   - Calls `run_extraction_pass(session, window_start=..., window_end=...)` directly, bypassing the scheduler flag.
   - Records an `ExtractionRun` row with explicit operator `user_id` audit marker.
   - Returns a summary message to the admin (candidates emitted, `run_status`, `llm_usage_ledger` entry id).
+- Notes / known limitations:
+  - **Router registration deferred to T6-03** alongside concrete gateway DI. Both `admin_extract.router` and the scheduler tick wire concrete `ExtractCandidatesGateway` via DI middleware — neither is registered in `bot/__main__.py` from T6-02 alone (T6-02 ships only the Protocol seam + handlers).
+  - **`phase_6_enabled_at` is not monotonic** (Codex MED #1). The value is `FeatureFlag.updated_at`, which regresses if the flag is toggled OFF → ON. This is intentional for the operator-explicit backfill workflow (Q5): re-enabling treats the new timestamp as the new lower bound, and operators cover any OFF window using `/admin_extract --window` for the gap. A durable monotonic watermark may be added in a follow-up if append-only audit is later required.
+  - **Atomic 3-stage lifecycle (Codex HIGH #3)**: `run_extraction_pass` INSERTs `run_status='running'` BEFORE the gateway call, wraps the call in `session.begin_nested()` (SAVEPOINT), and transitions to `completed` or `failed` based on outcome. Gateway crashes leave a durable `failed` audit row.
+  - **Privacy invariant #4 (Codex CRITICAL #1)**: if the gateway returns `llm_usage_ledger_id=None` with candidates, the pass fails closed (`failure_reason='no_llm_ledger_entry'`). Empty-bundle short-circuit (no gateway call) is exempt.
+  - **SELECT→gateway race guard (Codex CRITICAL #3)**: `_bundle_is_clean` re-queries `forget_events` for fresh tombstones AFTER `_select_eligible_sources` and BEFORE the gateway call. Closes the same race-window class as H-Cdx-2.
+  - **Scheduler tick idempotency (Codex HIGH #4)**: `extraction_scheduler_tick` acquires `pg_try_advisory_xact_lock` on `_p6_scheduler_lock_id()` (constant `p6:extraction_scheduler` namespace, disjoint from `p6:mvid:`). Second concurrent tick returns `skipped=True, reason='locked'`.
+  - **Operator audit marker (Codex HIGH #5 + alembic 035)**: `extraction_runs.operator_user_id BIGINT NULLABLE` durably records the admin who triggered `/admin_extract`. NULL = scheduler-driven.
 - Dependencies: T6-00, T6-01.
 - Stream: Wave 1 / Stream B.
 
@@ -539,6 +547,8 @@ Wave 3 (optional):     E
   - Every call is associated with the Phase 5 LLM usage ledger.
   - Output schema includes candidate payload and source `message_version_id`s.
   - Forbidden source content cannot be passed to the gateway.
+  - **Router registration**: register `bot.handlers.admin_extract.router` in `bot/__main__.py` `dp.include_routers(...)` adjacent to `admin.router` (deferred from T6-02 alongside the concrete gateway DI).
+  - **Gateway DI wiring**: wire the concrete `ExtractCandidatesGateway` instance into BOTH the `admin_extract` handler call site AND the `extraction_scheduler_tick` call site. Use the existing aiogram DI middleware pattern (same as the Phase 5 LLM gateway wiring) so per-request session + gateway both reach handlers as kwargs. The Protocol decorator `@runtime_checkable` (added in T6-02) enables a defensive `isinstance(gw, ExtractCandidatesGateway)` validation at wire time if desired.
   - **Phase 11 leakage binding test green on the T6-03 PR head before merge** — critical sub-gate per §6. The sub-gate requires ALL cases L1, L2, L3a, L3b, L3c, L4, L5 in `tests/evals/test_leakage.py::test_leakage_invariants` green, plus R1, R2, R3, R4 refusal cases (`tests/evals/test_refusal.py`) green. The CI nightly `evals.yml` workflow result alone is NOT sufficient — a re-run must be triggered on the T6-03 PR head specifically.
 - Dependencies: Phase 5 gateway/ledger, T6-00, T6-02.
 - Stream: Wave 1 / Stream B.

--- a/tests/db/test_fts_schema.py
+++ b/tests/db/test_fts_schema.py
@@ -181,9 +181,9 @@ async def migrated_database_url(temp_database_url: str) -> AsyncIterator[str]:
 async def test_alembic_upgrade_head_on_clean_db_green(migrated_database_url: str) -> None:
     current = await _fetch_value(migrated_database_url, "SELECT version_num FROM alembic_version")
 
-    # T6-01 (alembic 030-034) advanced the head past 025. Assert the current
-    # head explicitly; revisit when future migrations land.
-    assert current == "034"
+    # T6-01 (030-034) + T6-02 (035 operator_user_id) advanced the head past 025.
+    # Assert the current head explicitly; revisit when future migrations land.
+    assert current == "035"
 
 
 async def test_insert_message_versions_generates_search_tsv_from_normalized_text(

--- a/tests/handlers/test_admin_extract.py
+++ b/tests/handlers/test_admin_extract.py
@@ -1,0 +1,353 @@
+"""T6-02 ``/admin/extract`` handler + window parser tests.
+
+PHASE6_PLAN.md §7 T6-02 acceptance criteria:
+
+* Admin-only Telegram handler ``/admin/extract --window <ISO8601>..<ISO8601>``.
+* Window parser validates ISO8601, non-empty range, ≤ 30 days length.
+* Calls ``run_extraction_pass`` directly, bypassing the scheduler flag.
+* Records ExtractionRun with operator user_id (logged audit marker).
+* Returns summary message: candidates emitted, run_status,
+  llm_usage_ledger entry id.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+pytestmark = pytest.mark.usefixtures("app_env")
+
+
+# ─── Window parser tests ─────────────────────────────────────────────────────
+
+
+def test_parse_extract_window_valid_iso8601_range() -> None:
+    """ISO8601 ``<start>..<end>`` parses to a (start, end) tuple of
+    timezone-aware datetimes."""
+    from bot.handlers.admin_extract import parse_extract_window
+
+    raw = "2026-05-12T00:00:00+00:00..2026-05-13T00:00:00+00:00"
+    start, end = parse_extract_window(raw)
+    assert start == datetime(2026, 5, 12, tzinfo=timezone.utc)
+    assert end == datetime(2026, 5, 13, tzinfo=timezone.utc)
+
+
+def test_parse_extract_window_iso8601_with_z_suffix() -> None:
+    """``Z`` suffix is normalized to ``+00:00`` UTC."""
+    from bot.handlers.admin_extract import parse_extract_window
+
+    raw = "2026-05-12T00:00:00Z..2026-05-13T00:00:00Z"
+    start, end = parse_extract_window(raw)
+    assert start.tzinfo is not None
+    assert end.tzinfo is not None
+
+
+def test_parse_extract_window_rejects_invalid_iso8601() -> None:
+    from bot.handlers.admin_extract import (
+        WindowParseError,
+        parse_extract_window,
+    )
+
+    with pytest.raises(WindowParseError):
+        parse_extract_window("not-a-date..2026-05-13T00:00:00Z")
+    with pytest.raises(WindowParseError):
+        parse_extract_window("2026-05-12T00:00:00Z..bad")
+    with pytest.raises(WindowParseError):
+        parse_extract_window("just-one-date")
+
+
+def test_parse_extract_window_rejects_empty_range() -> None:
+    """Window where ``end <= start`` is rejected."""
+    from bot.handlers.admin_extract import (
+        WindowParseError,
+        parse_extract_window,
+    )
+
+    # Exactly equal — empty range.
+    with pytest.raises(WindowParseError):
+        parse_extract_window(
+            "2026-05-12T00:00:00Z..2026-05-12T00:00:00Z"
+        )
+    # End < start — inverted.
+    with pytest.raises(WindowParseError):
+        parse_extract_window(
+            "2026-05-13T00:00:00Z..2026-05-12T00:00:00Z"
+        )
+
+
+def test_parse_extract_window_rejects_over_30_days() -> None:
+    """LLM budget guard: max window length is 30 days."""
+    from bot.handlers.admin_extract import (
+        WindowParseError,
+        parse_extract_window,
+    )
+
+    with pytest.raises(WindowParseError):
+        parse_extract_window(
+            "2026-01-01T00:00:00Z..2026-02-15T00:00:00Z"
+        )
+
+
+def test_parse_extract_window_accepts_exactly_30_days() -> None:
+    """Boundary case: exactly 30 days is accepted."""
+    from bot.handlers.admin_extract import parse_extract_window
+
+    start, end = parse_extract_window(
+        "2026-01-01T00:00:00Z..2026-01-31T00:00:00Z"
+    )
+    assert (end - start).days == 30
+
+
+# ─── /admin/extract handler tests ────────────────────────────────────────────
+
+
+@pytest.fixture
+def fake_admin_message() -> MagicMock:
+    """Construct a Telegram Message mock with admin sender + private chat."""
+    msg = MagicMock()
+    msg.from_user = MagicMock()
+    msg.from_user.id = 149820031  # match ADMIN_IDS from conftest.app_env
+    msg.from_user.username = "admin_user"
+    msg.from_user.first_name = "Admin"
+    msg.chat = MagicMock()
+    msg.chat.type = "private"
+    msg.chat.id = 149820031  # private chat = user id
+    msg.answer = AsyncMock()
+    msg.reply = AsyncMock()
+    return msg
+
+
+@pytest.fixture
+def fake_nonadmin_message() -> MagicMock:
+    msg = MagicMock()
+    msg.from_user = MagicMock()
+    msg.from_user.id = 99999  # NOT in ADMIN_IDS
+    msg.from_user.username = "regular_user"
+    msg.from_user.first_name = "Reg"
+    msg.chat = MagicMock()
+    msg.chat.type = "private"
+    msg.chat.id = 99999
+    msg.answer = AsyncMock()
+    msg.reply = AsyncMock()
+    return msg
+
+
+@pytest.fixture
+def fake_command_object_factory():
+    def _make(args: str | None) -> MagicMock:
+        cmd = MagicMock()
+        cmd.args = args
+        return cmd
+    return _make
+
+
+async def test_admin_extract_rejects_non_admin(
+    db_session,
+    fake_nonadmin_message,
+    fake_command_object_factory,
+) -> None:
+    """Non-admin senders MUST NOT trigger the pass; handler must return
+    without invoking ``run_extraction_pass``."""
+    import bot.handlers.admin_extract as h_module
+
+    called = {"count": 0}
+
+    async def fake_run_pass(*args, **kwargs):
+        called["count"] += 1
+        raise AssertionError("run_extraction_pass MUST NOT be called for non-admin")
+
+    h_module.run_extraction_pass = fake_run_pass  # type: ignore[attr-defined]
+    cmd = fake_command_object_factory(
+        "--window 2026-05-12T00:00:00Z..2026-05-13T00:00:00Z"
+    )
+
+    await h_module.cmd_admin_extract(
+        fake_nonadmin_message,
+        cmd,
+        session=db_session,
+        gateway=MagicMock(),
+    )
+
+    # Either no-op or explicit error — either way, no pass invocation.
+    assert called["count"] == 0
+
+
+async def test_admin_extract_calls_run_extraction_pass_with_window(
+    db_session,
+    fake_admin_message,
+    fake_command_object_factory,
+) -> None:
+    """Admin invocation parses the window and calls
+    ``run_extraction_pass`` directly (bypassing the scheduler flag)."""
+    import bot.handlers.admin_extract as h_module
+    from bot.services.extractor import ExtractionResult
+
+    captured: dict = {}
+
+    async def fake_run_pass(session, *, window_start, window_end, gateway, **kwargs):
+        captured["window_start"] = window_start
+        captured["window_end"] = window_end
+        captured["operator_user_id"] = kwargs.get("operator_user_id")
+        import uuid
+
+        return ExtractionResult(
+            extraction_run_id=uuid.uuid4(),
+            run_status="completed",
+            candidate_count=3,
+            llm_usage_ledger_id=42,
+        )
+
+    h_module.run_extraction_pass = fake_run_pass  # type: ignore[attr-defined]
+
+    cmd = fake_command_object_factory(
+        "--window 2026-05-12T00:00:00Z..2026-05-13T00:00:00Z"
+    )
+
+    await h_module.cmd_admin_extract(
+        fake_admin_message,
+        cmd,
+        session=db_session,
+        gateway=MagicMock(),
+    )
+
+    assert "window_start" in captured
+    assert captured["window_start"] == datetime(2026, 5, 12, tzinfo=timezone.utc)
+    assert captured["window_end"] == datetime(2026, 5, 13, tzinfo=timezone.utc)
+    # Operator user id is recorded as audit marker.
+    assert captured["operator_user_id"] == 149820031
+
+    # Admin received a summary reply mentioning candidate_count + run_status
+    # + llm_usage_ledger entry id.
+    assert fake_admin_message.answer.await_count + fake_admin_message.reply.await_count >= 1
+
+
+async def test_admin_extract_returns_summary_with_run_metadata(
+    db_session,
+    fake_admin_message,
+    fake_command_object_factory,
+) -> None:
+    """The admin reply must mention ``candidate_count``, ``run_status``, and
+    ``llm_usage_ledger_id`` from the ``ExtractionResult``."""
+    import bot.handlers.admin_extract as h_module
+    from bot.services.extractor import ExtractionResult
+
+    async def fake_run_pass(session, *, window_start, window_end, gateway, **kwargs):
+        import uuid
+
+        return ExtractionResult(
+            extraction_run_id=uuid.uuid4(),
+            run_status="completed",
+            candidate_count=7,
+            llm_usage_ledger_id=123,
+        )
+
+    h_module.run_extraction_pass = fake_run_pass  # type: ignore[attr-defined]
+    cmd = fake_command_object_factory(
+        "--window 2026-05-12T00:00:00Z..2026-05-13T00:00:00Z"
+    )
+
+    await h_module.cmd_admin_extract(
+        fake_admin_message,
+        cmd,
+        session=db_session,
+        gateway=MagicMock(),
+    )
+
+    # Inspect every call to .answer / .reply and confirm summary content.
+    call_texts: list[str] = []
+    for call in fake_admin_message.answer.await_args_list:
+        if call.args:
+            call_texts.append(str(call.args[0]))
+    for call in fake_admin_message.reply.await_args_list:
+        if call.args:
+            call_texts.append(str(call.args[0]))
+    summary = "\n".join(call_texts)
+    assert "7" in summary  # candidate_count
+    assert "completed" in summary  # run_status
+    assert "123" in summary  # llm_usage_ledger_id
+
+
+async def test_admin_extract_rejects_missing_window(
+    db_session,
+    fake_admin_message,
+    fake_command_object_factory,
+) -> None:
+    """``/admin/extract`` without ``--window`` must reject and NOT run."""
+    import bot.handlers.admin_extract as h_module
+
+    called = {"count": 0}
+
+    async def fake_run_pass(*args, **kwargs):
+        called["count"] += 1
+        return None
+
+    h_module.run_extraction_pass = fake_run_pass  # type: ignore[attr-defined]
+
+    cmd = fake_command_object_factory(None)  # no args
+    await h_module.cmd_admin_extract(
+        fake_admin_message,
+        cmd,
+        session=db_session,
+        gateway=MagicMock(),
+    )
+    assert called["count"] == 0
+
+
+async def test_admin_extract_rejects_invalid_window_format(
+    db_session,
+    fake_admin_message,
+    fake_command_object_factory,
+) -> None:
+    """Bad ISO8601 → admin receives an error message, pass NOT called."""
+    import bot.handlers.admin_extract as h_module
+
+    called = {"count": 0}
+
+    async def fake_run_pass(*args, **kwargs):
+        called["count"] += 1
+        return None
+
+    h_module.run_extraction_pass = fake_run_pass  # type: ignore[attr-defined]
+
+    cmd = fake_command_object_factory("--window not-a-date..also-not")
+    await h_module.cmd_admin_extract(
+        fake_admin_message,
+        cmd,
+        session=db_session,
+        gateway=MagicMock(),
+    )
+    assert called["count"] == 0
+    # Admin received an error reply.
+    assert (
+        fake_admin_message.answer.await_count + fake_admin_message.reply.await_count
+    ) >= 1
+
+
+async def test_admin_extract_rejects_window_over_30_days(
+    db_session,
+    fake_admin_message,
+    fake_command_object_factory,
+) -> None:
+    """LLM budget guard: > 30 day windows rejected."""
+    import bot.handlers.admin_extract as h_module
+
+    called = {"count": 0}
+
+    async def fake_run_pass(*args, **kwargs):
+        called["count"] += 1
+        return None
+
+    h_module.run_extraction_pass = fake_run_pass  # type: ignore[attr-defined]
+
+    cmd = fake_command_object_factory(
+        "--window 2026-01-01T00:00:00Z..2026-03-01T00:00:00Z"
+    )
+    await h_module.cmd_admin_extract(
+        fake_admin_message,
+        cmd,
+        session=db_session,
+        gateway=MagicMock(),
+    )
+    assert called["count"] == 0

--- a/tests/services/test_extractor.py
+++ b/tests/services/test_extractor.py
@@ -596,6 +596,71 @@ async def test_extraction_scheduler_tick_flag_false_skips(db_session) -> None:
 # ─── Test 8: scheduler flag — True runs the pass with phase_6_enabled_at ─────
 
 
+# ─── Codex HIGH #4: scheduler tick idempotency (advisory lock) ──────────────
+
+
+async def test_extraction_scheduler_tick_skips_when_locked(db_session) -> None:
+    """Two concurrent ``extraction_scheduler_tick`` calls would otherwise
+    process the same window twice. A ``pg_try_advisory_xact_lock`` on a
+    deterministic ``p6:scheduler`` namespace lock id MUST gate the tick:
+    if another tick already holds the lock, the second tick returns
+    ``skipped=True`` with reason ``locked``.
+
+    We simulate "another tick already holding" by monkeypatching
+    ``session.execute`` so the ``pg_try_advisory_xact_lock`` call returns
+    False on first invocation only.
+    """
+    from bot.db.repos.feature_flag import FeatureFlagRepo
+    from bot.services import extractor as ext_module
+    from bot.services.extractor import (
+        MEMORY_EXTRACTION_SCHEDULER_ENABLED_FLAG,
+        extraction_scheduler_tick,
+    )
+
+    await FeatureFlagRepo.set_enabled(
+        db_session, MEMORY_EXTRACTION_SCHEDULER_ENABLED_FLAG, True
+    )
+
+    # Patch the scheduler-lock acquisition to simulate contention.
+    original_try = ext_module._try_acquire_scheduler_lock
+
+    async def fake_try_acquire(session) -> bool:
+        return False  # always "another tick holds it"
+
+    ext_module._try_acquire_scheduler_lock = fake_try_acquire  # type: ignore[assignment]
+    try:
+        gw = FakeGateway(candidates_to_emit=[])
+        result = await extraction_scheduler_tick(db_session, gateway=gw)
+    finally:
+        ext_module._try_acquire_scheduler_lock = original_try  # type: ignore[assignment]
+
+    assert result.skipped is True
+    assert result.reason == "locked"
+    # Gateway must NOT have been called — the tick exited at the lock
+    # gate before any extraction work.
+    assert gw.calls == []
+
+
+def test_p6_scheduler_lock_id_is_deterministic_signed_int64() -> None:
+    """The advisory lock id MUST be deterministic, in the signed-int64
+    range expected by ``pg_advisory_xact_lock(bigint)``, and disjoint
+    from the ``p6:mvid:`` namespace used by /approve + cascade locks.
+    """
+    from bot.services.extractor import _p6_scheduler_lock_id
+    from bot.services.forget_cascade import _p6_mvid_advisory_lock_id
+
+    a = _p6_scheduler_lock_id()
+    b = _p6_scheduler_lock_id()
+    # Determinism.
+    assert a == b
+    # Signed int64 bounds.
+    assert -(2**63) <= a < 2**63
+    # Disjoint from p6:mvid namespace — picking arbitrary mvid values is
+    # enough since prefixes differ.
+    for mvid in (1, 42, 9999, 2**31):
+        assert a != _p6_mvid_advisory_lock_id(mvid)
+
+
 # ─── Codex HIGH #3: ExtractionRun atomic running → completed/failed lifecycle
 
 

--- a/tests/services/test_extractor.py
+++ b/tests/services/test_extractor.py
@@ -148,6 +148,28 @@ async def _make_pending_forget_event(
     return ev.id
 
 
+async def _make_llm_usage_ledger_row(db_session) -> int:
+    """Insert a synthetic ``llm_usage_ledger`` row so FK refs satisfy.
+
+    Used by extractor tests that need to assert the ExtractionRun's
+    ``llm_usage_ledger_id`` is correctly populated; the row is otherwise
+    unused.
+    """
+    from bot.db.models import LlmUsageLedger
+
+    led = LlmUsageLedger(
+        provider="test-fake",
+        model="test-model",
+        prompt_hash=None,
+        response_hash=None,
+        tokens_in=0,
+        tokens_out=0,
+    )
+    db_session.add(led)
+    await db_session.flush()
+    return led.id
+
+
 # ─── Fake gateway implementations (Protocol seam) ────────────────────────────
 
 
@@ -202,6 +224,12 @@ async def test_run_extraction_pass_writes_candidates_and_completed_run(
         db_session, when=when, text="alpha fact"
     )
 
+    # NOTE: Privacy invariant #4 — gateway-emitted candidates MUST be
+    # paired with an llm_usage_ledger_id (see PHASE6_PLAN §8 and the
+    # null-ledger regression test below). Synthesize a real ledger row
+    # to satisfy the FK + invariant guard.
+    ledger_id = await _make_llm_usage_ledger_row(db_session)
+
     gw = FakeGateway(
         candidates_to_emit=[
             {
@@ -209,7 +237,7 @@ async def test_run_extraction_pass_writes_candidates_and_completed_run(
                 "source_message_version_ids": [ver_id],
             }
         ],
-        llm_usage_ledger_id=None,
+        llm_usage_ledger_id=ledger_id,
     )
 
     result = await run_extraction_pass(
@@ -221,6 +249,7 @@ async def test_run_extraction_pass_writes_candidates_and_completed_run(
 
     assert result.run_status == "completed"
     assert result.candidate_count == 1
+    assert result.llm_usage_ledger_id == ledger_id
     # Gateway was called exactly once.
     assert len(gw.calls) == 1
     assert ver_id in [
@@ -418,6 +447,7 @@ async def test_run_extraction_pass_excludes_messages_with_forget_tombstone(
         tombstone_key=f"message:{chat_id_f}:{msg_id_f}",
     )
 
+    ledger_id = await _make_llm_usage_ledger_row(db_session)
     gw = FakeGateway(
         candidates_to_emit=[
             {
@@ -425,6 +455,7 @@ async def test_run_extraction_pass_excludes_messages_with_forget_tombstone(
                 "source_message_version_ids": [ver_normal],
             }
         ],
+        llm_usage_ledger_id=ledger_id,
     )
 
     result = await run_extraction_pass(
@@ -565,6 +596,103 @@ async def test_extraction_scheduler_tick_flag_false_skips(db_session) -> None:
 # ─── Test 8: scheduler flag — True runs the pass with phase_6_enabled_at ─────
 
 
+# ─── Codex CRITICAL #1: ledger_id=None enforcement ──────────────────────────
+
+
+async def test_run_extraction_pass_fails_when_gateway_returns_null_ledger_id(
+    db_session,
+) -> None:
+    """Privacy invariant #4 (PHASE6_PLAN §8): an extraction run that
+    actually invoked the gateway MUST be associated with an
+    llm_usage_ledger entry. If the gateway returns ``llm_usage_ledger_id
+    is None`` while emitting candidates (i.e. a real LLM call happened
+    but the audit linkage is missing), the pass MUST fail closed:
+    ``run_status='failed'`` with reason ``no_llm_ledger_entry`` and NO
+    candidates persisted.
+
+    The empty-bundle short-circuit path (no gateway call) is exempt — it
+    legitimately produces ``llm_usage_ledger_id=None`` because no LLM
+    call was made.
+    """
+    from bot.db.models import ExtractionCandidate, ExtractionRun
+    from bot.services.extractor import run_extraction_pass
+
+    window_start = datetime.now(timezone.utc) - timedelta(hours=1)
+    window_end = datetime.now(timezone.utc) + timedelta(hours=1)
+    when = window_start + timedelta(minutes=5)
+    _, ver_id, _, _ = await _make_chat_message(db_session, when=when, text="alpha")
+
+    # Gateway returns candidates but ZERO ledger linkage — represents a
+    # buggy/misconfigured gateway path that must NOT silently persist
+    # un-audited extractions.
+    gw = FakeGateway(
+        candidates_to_emit=[
+            {
+                "candidate_json": {"title": "fact", "body": "alpha"},
+                "source_message_version_ids": [ver_id],
+            }
+        ],
+        llm_usage_ledger_id=None,
+    )
+
+    result = await run_extraction_pass(
+        db_session,
+        window_start=window_start,
+        window_end=window_end,
+        gateway=gw,
+    )
+
+    assert result.run_status == "failed"
+    assert result.failure_reason == "no_llm_ledger_entry"
+    assert result.candidate_count == 0
+    # Run row recorded as failed.
+    run_row = await db_session.get(ExtractionRun, result.extraction_run_id)
+    assert run_row is not None
+    assert run_row.run_status == "failed"
+    # No candidates persisted — gateway output is discarded on audit
+    # invariant violation.
+    cands = (
+        await db_session.execute(
+            select(ExtractionCandidate).where(
+                ExtractionCandidate.extraction_run_id == result.extraction_run_id
+            )
+        )
+    ).scalars().all()
+    assert cands == []
+
+
+async def test_run_extraction_pass_empty_bundle_skips_ledger_check(
+    db_session,
+) -> None:
+    """The empty-bundle short-circuit (no rows in window) must NOT trip
+    the ledger_id=None invariant guard — it's a legitimate no-op."""
+    from bot.db.models import ExtractionRun
+    from bot.services.extractor import run_extraction_pass
+
+    # Far-past window — no eligible rows; gateway should NOT be invoked
+    # at all.
+    window_start = datetime(2000, 1, 1, tzinfo=timezone.utc)
+    window_end = datetime(2000, 1, 2, tzinfo=timezone.utc)
+
+    gw = FakeGateway(candidates_to_emit=[], llm_usage_ledger_id=None)
+    result = await run_extraction_pass(
+        db_session,
+        window_start=window_start,
+        window_end=window_end,
+        gateway=gw,
+    )
+    assert result.run_status == "completed"
+    assert gw.calls == []
+    # No "no_llm_ledger_entry" failure — empty bundle is exempt.
+    assert result.failure_reason is None
+    run_row = await db_session.get(ExtractionRun, result.extraction_run_id)
+    assert run_row is not None
+    assert run_row.run_status == "completed"
+
+
+# ─── Test 8: scheduler flag — True runs the pass with phase_6_enabled_at ─────
+
+
 async def test_extraction_scheduler_tick_flag_true_runs_pass(db_session) -> None:
     """When the scheduler flag is ON, the tick MUST run the pass with the
     flag row's ``updated_at`` as the forward-only lower bound (``window_start``).
@@ -587,6 +715,9 @@ async def test_extraction_scheduler_tick_flag_true_runs_pass(db_session) -> None
         db_session, when=when, text="post-enable msg"
     )
 
+    # Need a real ledger row to satisfy the privacy-invariant #4 guard
+    # (gateway-emitted candidates require an llm_usage_ledger_id).
+    ledger_id = await _make_llm_usage_ledger_row(db_session)
     gw = FakeGateway(
         candidates_to_emit=[
             {
@@ -594,6 +725,7 @@ async def test_extraction_scheduler_tick_flag_true_runs_pass(db_session) -> None
                 "source_message_version_ids": [ver_id],
             }
         ],
+        llm_usage_ledger_id=ledger_id,
     )
     # Pass an explicit ``now`` >> when to guarantee inclusion.
     result = await extraction_scheduler_tick(

--- a/tests/services/test_extractor.py
+++ b/tests/services/test_extractor.py
@@ -81,8 +81,18 @@ async def _make_chat_message(
     is_redacted: bool = False,
     text: str = "extraction source content",
     version_is_redacted: bool = False,
+    mv_content_hash: str | None = None,
 ) -> tuple[int, int, int, int]:
     """Insert chat_messages + v1 message_versions row.
+
+    ``mv_content_hash`` is the SHA-like value persisted on
+    ``message_versions.content_hash`` (NOT NULL in the schema). The live
+    persistence path (``bot/db/repos/message.py::MessageRepo.save``)
+    never populates ``chat_messages.content_hash``, so this helper
+    mirrors live behaviour: it leaves ``chat_messages.content_hash``
+    NULL and only sets ``message_versions.content_hash``. Tests asserting
+    ``message_hash:`` tombstone behaviour against a live row must pass
+    ``mv_content_hash`` explicitly.
 
     Returns ``(chat_message_id, message_version_id, chat_id, message_id)``.
     """
@@ -118,7 +128,11 @@ async def _make_chat_message(
         text=text,
         normalized_text=text,
         entities_json={},
-        content_hash=f"h{_uuid_module.uuid4().hex[:16]}",
+        content_hash=(
+            mv_content_hash
+            if mv_content_hash is not None
+            else f"h{_uuid_module.uuid4().hex[:16]}"
+        ),
         is_redacted=version_is_redacted,
     )
     db_session.add(v)
@@ -1058,3 +1072,80 @@ async def test_extraction_scheduler_tick_flag_true_runs_pass(db_session) -> None
     assert result.extraction_result.run_status == "completed"
     # Gateway was invoked.
     assert len(gw.calls) >= 1
+
+
+# ─── Round 3 regression: tombstone via mv.content_hash for live-path messages ─
+
+
+async def test_run_extraction_pass_excludes_live_message_via_mv_content_hash_tombstone(
+    db_session,
+) -> None:
+    """Regression for Codex round 3 CRITICAL.
+
+    Live ChatMessage persist (bot/db/repos/message.py::MessageRepo.save) leaves
+    chat_messages.content_hash NULL — only message_versions.content_hash is
+    populated. Therefore the extractor SELECT tombstone filter MUST check
+    mv.content_hash (joined), NOT c.content_hash, for 'message_hash:<hash>'
+    forget_events.
+    """
+    from bot.db.repos.forget_event import ForgetEventRepo
+    from bot.services.extractor import run_extraction_pass
+
+    window_start = datetime.now(timezone.utc) - timedelta(hours=1)
+    window_end = datetime.now(timezone.utc) + timedelta(hours=1)
+    when = window_start + timedelta(minutes=5)
+
+    # Normal message — included.
+    _, ver_normal, _, _ = await _make_chat_message(
+        db_session, when=when, text="alpha normal"
+    )
+
+    # Live-path message: chat_messages.content_hash is NULL, mv.content_hash="X".
+    mv_hash = "live_msg_sha_for_tombstone_test"
+    _, ver_live, _, _ = await _make_chat_message(
+        db_session,
+        when=when,
+        text="DO_NOT_LEAK_LIVE_HASH",
+        mv_content_hash=mv_hash,
+    )
+
+    # Insert forget_event keyed by message_hash matching the MV's content_hash.
+    # If the filter incorrectly uses chat_messages.content_hash (NULL) — the
+    # match fails and ver_live leaks. The fix uses mv.content_hash.
+    await ForgetEventRepo.create(
+        db_session,
+        target_type="message_hash",
+        target_id=mv_hash,
+        actor_user_id=None,
+        authorized_by="admin",
+        tombstone_key=f"message_hash:{mv_hash}",
+    )
+
+    ledger_id = await _make_llm_usage_ledger_row(db_session)
+    gw = FakeGateway(
+        candidates_to_emit=[
+            {
+                "candidate_json": {"title": "ok", "body": "alpha"},
+                "source_message_version_ids": [ver_normal],
+            }
+        ],
+        llm_usage_ledger_id=ledger_id,
+    )
+
+    result = await run_extraction_pass(
+        db_session,
+        window_start=window_start,
+        window_end=window_end,
+        gateway=gw,
+    )
+
+    assert result.run_status == "completed"
+    forwarded_ids = [
+        sv["message_version_id"]
+        for call in gw.calls
+        for sv in call["source_versions"]
+    ]
+    assert ver_live not in forwarded_ids
+    for call in gw.calls:
+        for sv in call["source_versions"]:
+            assert "DO_NOT_LEAK_LIVE_HASH" not in (sv.get("text") or "")

--- a/tests/services/test_extractor.py
+++ b/tests/services/test_extractor.py
@@ -445,17 +445,17 @@ async def test_run_extraction_pass_excludes_messages_with_forget_tombstone(
         db_session, when=when, text="alpha normal"
     )
     # Forgotten message — excluded.
-    cm_forgotten, ver_forgotten, chat_id_f, msg_id_f = await _make_chat_message(
-        db_session, when=when, text="DO_NOT_LEAK_FORGOTTEN"
+    cm_tombstoned, ver_tombstoned, chat_id_f, msg_id_f = await _make_chat_message(
+        db_session, when=when, text="DO_NOT_LEAK_TOMBSTONED"
     )
-    # Insert pending forget_event matching the forgotten message by
+    # Insert pending forget_event matching the tombstoned message by
     # tombstone_key = 'message:<chat_id>:<message_id>'.
     from bot.db.repos.forget_event import ForgetEventRepo
 
     await ForgetEventRepo.create(
         db_session,
         target_type="message",
-        target_id=str(cm_forgotten),
+        target_id=str(cm_tombstoned),
         actor_user_id=None,
         authorized_by="admin",
         tombstone_key=f"message:{chat_id_f}:{msg_id_f}",
@@ -485,10 +485,10 @@ async def test_run_extraction_pass_excludes_messages_with_forget_tombstone(
         for call in gw.calls
         for sv in call["source_versions"]
     ]
-    assert ver_forgotten not in forwarded_ids
+    assert ver_tombstoned not in forwarded_ids
     for call in gw.calls:
         for sv in call["source_versions"]:
-            assert "DO_NOT_LEAK_FORGOTTEN" not in (sv.get("text") or "")
+            assert "DO_NOT_LEAK_TOMBSTONED" not in (sv.get("text") or "")
 
 
 # ─── Test 4: empty window — zero candidates, completed run ───────────────────
@@ -868,7 +868,7 @@ async def test_run_extraction_pass_rejects_bundle_when_fresh_forget_event_arrive
     The materialized ``memory_policy`` / ``is_redacted`` fields in the
     bundle are point-in-time snapshots. Without a re-query of
     ``forget_events`` inside ``_bundle_is_clean``, a forget event that
-    lands in this gap would leak forgotten content to the LLM. Same
+    lands in this gap would leak tombstoned content to the LLM. Same
     class of race as H-Cdx-2.
 
     We simulate the race by inserting the forget_event AFTER
@@ -886,7 +886,7 @@ async def test_run_extraction_pass_rejects_bundle_when_fresh_forget_event_arrive
     window_end = datetime.now(timezone.utc) + timedelta(hours=1)
     when = window_start + timedelta(minutes=5)
     cm_id, _, chat_id_v, msg_id_v = await _make_chat_message(
-        db_session, when=when, text="will-be-forgotten-mid-pass"
+        db_session, when=when, text="will-be-tombstoned-mid-pass"
     )
 
     # Patch _select_eligible_sources to insert a forget_event AFTER the

--- a/tests/services/test_extractor.py
+++ b/tests/services/test_extractor.py
@@ -596,6 +596,79 @@ async def test_extraction_scheduler_tick_flag_false_skips(db_session) -> None:
 # ─── Test 8: scheduler flag — True runs the pass with phase_6_enabled_at ─────
 
 
+# ─── Codex CRITICAL #3: SELECT→gateway race window ──────────────────────────
+
+
+async def test_run_extraction_pass_rejects_bundle_when_fresh_forget_event_arrives(
+    db_session,
+) -> None:
+    """A ``forget_events`` row inserted AFTER ``_select_eligible_sources``
+    but BEFORE the gateway call MUST cause the bundle to be rejected.
+
+    The materialized ``memory_policy`` / ``is_redacted`` fields in the
+    bundle are point-in-time snapshots. Without a re-query of
+    ``forget_events`` inside ``_bundle_is_clean``, a forget event that
+    lands in this gap would leak forgotten content to the LLM. Same
+    class of race as H-Cdx-2.
+
+    We simulate the race by inserting the forget_event AFTER
+    ``_select_eligible_sources`` returns (the fake gateway is the seam
+    where the insert occurs — its first call is the proxy for "LLM
+    request about to start"). The bundle re-check inside
+    ``run_extraction_pass`` MUST see the fresh tombstone and refuse to
+    invoke the gateway, recording ``run_status='failed'``.
+    """
+    from bot.db.repos.forget_event import ForgetEventRepo
+    from bot.services import extractor as ext_module
+    from bot.services.extractor import run_extraction_pass
+
+    window_start = datetime.now(timezone.utc) - timedelta(hours=1)
+    window_end = datetime.now(timezone.utc) + timedelta(hours=1)
+    when = window_start + timedelta(minutes=5)
+    cm_id, _, chat_id_v, msg_id_v = await _make_chat_message(
+        db_session, when=when, text="will-be-forgotten-mid-pass"
+    )
+
+    # Patch _select_eligible_sources to insert a forget_event AFTER the
+    # SELECT returns its eligible rows — modelling the race window.
+    original_select = ext_module._select_eligible_sources
+    raced = {"inserted": False}
+
+    async def racing_select(session, **kwargs):
+        rows = await original_select(session, **kwargs)
+        if not raced["inserted"]:
+            await ForgetEventRepo.create(
+                session,
+                target_type="message",
+                target_id=str(cm_id),
+                actor_user_id=None,
+                authorized_by="admin",
+                tombstone_key=f"message:{chat_id_v}:{msg_id_v}",
+            )
+            await session.flush()
+            raced["inserted"] = True
+        return rows
+
+    ext_module._select_eligible_sources = racing_select  # type: ignore[assignment]
+    try:
+        gw = FakeGateway(candidates_to_emit=[])
+        result = await run_extraction_pass(
+            db_session,
+            window_start=window_start,
+            window_end=window_end,
+            gateway=gw,
+        )
+    finally:
+        ext_module._select_eligible_sources = original_select  # type: ignore[assignment]
+
+    assert result.run_status == "failed"
+    # Reason must clearly identify the race-window cause for ops triage.
+    assert result.failure_reason is not None
+    assert "fresh_forget_event" in result.failure_reason
+    # Gateway must NOT have been called — privacy guard fired pre-call.
+    assert gw.calls == []
+
+
 # ─── Codex CRITICAL #1: ledger_id=None enforcement ──────────────────────────
 
 

--- a/tests/services/test_extractor.py
+++ b/tests/services/test_extractor.py
@@ -596,6 +596,38 @@ async def test_extraction_scheduler_tick_flag_false_skips(db_session) -> None:
 # ─── Test 8: scheduler flag — True runs the pass with phase_6_enabled_at ─────
 
 
+# ─── Codex MED #2: ExtractCandidatesGateway runtime-checkable ──────────────
+
+
+def test_extract_candidates_gateway_protocol_is_runtime_checkable() -> None:
+    """The ``ExtractCandidatesGateway`` Protocol MUST carry the
+    ``@runtime_checkable`` decorator so T6-03 DI can validate gateway
+    instances with ``isinstance(gw, ExtractCandidatesGateway)``.
+
+    Without the decorator, ``isinstance(...)`` against a Protocol raises
+    ``TypeError``. We assert isinstance works against a duck-typed fake.
+    """
+    from bot.services.extractor import ExtractCandidatesGateway
+
+    class _DuckGateway:
+        async def extract_candidates(
+            self,
+            session: Any,
+            *,
+            source_versions: list[dict[str, Any]],
+            prompt_template_version: str = "v0.1.0",
+        ) -> dict[str, Any]:
+            return {"candidates": [], "llm_usage_ledger_id": None}
+
+    class _MissingMethod:
+        pass
+
+    # The bare isinstance call against the Protocol must NOT raise.
+    assert isinstance(_DuckGateway(), ExtractCandidatesGateway)
+    # And it must distinguish — missing extract_candidates → False.
+    assert not isinstance(_MissingMethod(), ExtractCandidatesGateway)
+
+
 # ─── Codex HIGH #5: operator_user_id persisted on ExtractionRun ─────────────
 
 

--- a/tests/services/test_extractor.py
+++ b/tests/services/test_extractor.py
@@ -596,6 +596,73 @@ async def test_extraction_scheduler_tick_flag_false_skips(db_session) -> None:
 # ─── Test 8: scheduler flag — True runs the pass with phase_6_enabled_at ─────
 
 
+# ─── Codex HIGH #3: ExtractionRun atomic running → completed/failed lifecycle
+
+
+async def test_run_extraction_pass_records_failed_state_on_gateway_exception(
+    db_session,
+) -> None:
+    """If the gateway raises mid-pass (network blip, timeout, bug), an
+    ``ExtractionRun`` row MUST still be persisted with
+    ``run_status='failed'`` — no orphan/half-written runs, no leak of a
+    silent ``running`` row.
+
+    The extractor wraps the gateway call in try/except so the failed
+    audit row lands regardless of how the LLM call dies.
+    """
+    from bot.db.models import ExtractionRun
+    from bot.services.extractor import run_extraction_pass
+
+    window_start = datetime.now(timezone.utc) - timedelta(hours=1)
+    window_end = datetime.now(timezone.utc) + timedelta(hours=1)
+    when = window_start + timedelta(minutes=5)
+    _, ver_id, _, _ = await _make_chat_message(db_session, when=when, text="alpha")
+
+    @dataclass
+    class CrashingGateway:
+        calls: list = None  # type: ignore[assignment]
+
+        def __post_init__(self) -> None:
+            if self.calls is None:
+                self.calls = []
+
+        async def extract_candidates(
+            self,
+            session: Any,
+            *,
+            source_versions: list[dict[str, Any]],
+            prompt_template_version: str = "v0.1.0",
+        ) -> dict[str, Any]:
+            self.calls.append({"source_versions": list(source_versions)})
+            raise RuntimeError("simulated provider blip")
+
+    gw = CrashingGateway()
+    with pytest.raises(RuntimeError, match="simulated provider blip"):
+        await run_extraction_pass(
+            db_session,
+            window_start=window_start,
+            window_end=window_end,
+            gateway=gw,
+        )
+
+    # After the raised exception, an ExtractionRun row exists in the
+    # current transaction with run_status='failed' — the gateway crash
+    # is captured durably. This requires SAVEPOINT-style isolation so
+    # the failed UPDATE survives the gateway call's rollback.
+    rows = (
+        await db_session.execute(
+            select(ExtractionRun).where(
+                ExtractionRun.ingestion_window_start == window_start,
+                ExtractionRun.ingestion_window_end == window_end,
+            )
+        )
+    ).scalars().all()
+    assert len(rows) >= 1
+    failed = [r for r in rows if r.run_status == "failed"]
+    assert len(failed) >= 1
+    assert gw.calls  # gateway WAS invoked before the raise.
+
+
 # ─── Codex CRITICAL #3: SELECT→gateway race window ──────────────────────────
 
 

--- a/tests/services/test_extractor.py
+++ b/tests/services/test_extractor.py
@@ -1,0 +1,609 @@
+"""T6-02 extractor service tests.
+
+PHASE6_PLAN.md §5.B + §7 T6-02 acceptance criteria.
+
+Tests cover:
+
+* ``run_extraction_pass`` happy path: candidates emitted, run_status='completed'.
+* Privacy refusal: any source row with ``memory_policy != 'normal'`` aborts the
+  pass and records ``run_status='failed'`` without invoking the gateway.
+* Tombstone exclusion: messages targeted by a ``forget_events`` row are skipped
+  from the bundle (no leakage).
+* Empty window: zero candidates, run_status='completed', candidate_count=0.
+* Window bounds: only ``chat_messages.created_at`` within ``[window_start,
+  window_end)`` are considered.
+* Scheduler flag gating: scheduler tick reads the
+  ``memory.extraction.scheduler.enabled`` flag and no-ops when off (default).
+* Forward-only forwarding: the scheduler tick passes ``phase_6_enabled_at`` as
+  ``window_start`` (read from the flag row's ``updated_at``).
+
+The gateway is injected via the ``ExtractCandidatesGateway`` Protocol seam —
+T6-02 ships a typed contract; T6-03 lands the concrete implementation under
+``bot/services/llm_gateway.py::extract_candidates``.
+"""
+
+from __future__ import annotations
+
+import itertools
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import pytest
+from sqlalchemy import select
+
+pytestmark = pytest.mark.usefixtures("app_env")
+
+
+_user_counter = itertools.count(start=8_700_000_000)
+_msg_counter = itertools.count(start=870_000)
+_chat_counter = itertools.count(start=1)
+_key_counter = itertools.count(start=1)
+
+
+def _next_user() -> int:
+    return next(_user_counter)
+
+
+def _next_msg_id() -> int:
+    return next(_msg_counter)
+
+
+def _next_chat_id() -> int:
+    return -1_000_000_000_000 - next(_chat_counter)
+
+
+def _next_key(prefix: str = "message") -> str:
+    return f"{prefix}:t6-02:test:{next(_key_counter)}"
+
+
+async def _make_user(db_session) -> int:
+    from bot.db.repos.user import UserRepo
+
+    uid = _next_user()
+    await UserRepo.upsert(
+        db_session,
+        telegram_id=uid,
+        username=f"u{uid}",
+        first_name="Test",
+        last_name=None,
+    )
+    return uid
+
+
+async def _make_chat_message(
+    db_session,
+    *,
+    chat_id: int | None = None,
+    user_id: int | None = None,
+    when: datetime | None = None,
+    memory_policy: str = "normal",
+    is_redacted: bool = False,
+    text: str = "extraction source content",
+    version_is_redacted: bool = False,
+) -> tuple[int, int, int, int]:
+    """Insert chat_messages + v1 message_versions row.
+
+    Returns ``(chat_message_id, message_version_id, chat_id, message_id)``.
+    """
+    import uuid as _uuid_module
+
+    from bot.db.models import ChatMessage, MessageVersion
+    from sqlalchemy import update as sa_update
+
+    if user_id is None:
+        user_id = await _make_user(db_session)
+    if chat_id is None:
+        chat_id = _next_chat_id()
+    if when is None:
+        when = datetime.now(timezone.utc)
+    message_id = _next_msg_id()
+
+    msg = ChatMessage(
+        message_id=message_id,
+        chat_id=chat_id,
+        user_id=user_id,
+        text=text,
+        date=when,
+        created_at=when,
+        memory_policy=memory_policy,
+        is_redacted=is_redacted,
+    )
+    db_session.add(msg)
+    await db_session.flush()
+
+    v = MessageVersion(
+        chat_message_id=msg.id,
+        version_seq=1,
+        text=text,
+        normalized_text=text,
+        entities_json={},
+        content_hash=f"h{_uuid_module.uuid4().hex[:16]}",
+        is_redacted=version_is_redacted,
+    )
+    db_session.add(v)
+    await db_session.flush()
+    await db_session.execute(
+        sa_update(ChatMessage)
+        .where(ChatMessage.id == msg.id)
+        .values(current_version_id=v.id)
+    )
+    await db_session.flush()
+    return msg.id, v.id, chat_id, message_id
+
+
+async def _make_pending_forget_event(
+    db_session, *, target_type: str, target_id: int | str
+) -> int:
+    from bot.db.repos.forget_event import ForgetEventRepo
+
+    ev = await ForgetEventRepo.create(
+        db_session,
+        target_type=target_type,
+        target_id=str(target_id),
+        actor_user_id=None,
+        authorized_by="admin",
+        tombstone_key=_next_key(target_type),
+    )
+    return ev.id
+
+
+# ─── Fake gateway implementations (Protocol seam) ────────────────────────────
+
+
+@dataclass
+class FakeGateway:
+    """Test double for ``ExtractCandidatesGateway`` Protocol.
+
+    Records every call and replays predetermined extraction candidates plus
+    a synthetic ``llm_usage_ledger_id`` from a queue.
+    """
+
+    candidates_to_emit: list[dict[str, Any]]
+    llm_usage_ledger_id: int | None = None
+    calls: list[dict[str, Any]] = None  # type: ignore[assignment]
+
+    def __post_init__(self) -> None:
+        if self.calls is None:
+            self.calls = []
+
+    async def extract_candidates(
+        self,
+        session: Any,
+        *,
+        source_versions: list[dict[str, Any]],
+        prompt_template_version: str = "v0.1.0",
+    ) -> dict[str, Any]:
+        self.calls.append(
+            {
+                "source_versions": list(source_versions),
+                "prompt_template_version": prompt_template_version,
+            }
+        )
+        return {
+            "candidates": list(self.candidates_to_emit),
+            "llm_usage_ledger_id": self.llm_usage_ledger_id,
+        }
+
+
+# ─── Test 1: happy path — candidates written, run_status='completed' ─────────
+
+
+async def test_run_extraction_pass_writes_candidates_and_completed_run(
+    db_session,
+) -> None:
+    from bot.db.models import ExtractionCandidate, ExtractionRun
+    from bot.services.extractor import run_extraction_pass
+
+    window_start = datetime.now(timezone.utc) - timedelta(hours=1)
+    window_end = datetime.now(timezone.utc) + timedelta(hours=1)
+    when = window_start + timedelta(minutes=5)
+    cm_id, ver_id, chat_id, _ = await _make_chat_message(
+        db_session, when=when, text="alpha fact"
+    )
+
+    gw = FakeGateway(
+        candidates_to_emit=[
+            {
+                "candidate_json": {"title": "fact a", "body": "alpha"},
+                "source_message_version_ids": [ver_id],
+            }
+        ],
+        llm_usage_ledger_id=None,
+    )
+
+    result = await run_extraction_pass(
+        db_session,
+        window_start=window_start,
+        window_end=window_end,
+        gateway=gw,
+    )
+
+    assert result.run_status == "completed"
+    assert result.candidate_count == 1
+    # Gateway was called exactly once.
+    assert len(gw.calls) == 1
+    assert ver_id in [
+        sv["message_version_id"] for sv in gw.calls[0]["source_versions"]
+    ]
+
+    # ExtractionRun row exists with completed status.
+    run_row = await db_session.get(ExtractionRun, result.extraction_run_id)
+    assert run_row is not None
+    assert run_row.run_status == "completed"
+    assert run_row.candidate_count == 1
+    assert run_row.ingestion_window_start is not None
+    assert run_row.ingestion_window_end is not None
+
+    # Candidate row exists, pending, with the staged source_message_version_id.
+    cands = (
+        await db_session.execute(
+            select(ExtractionCandidate).where(
+                ExtractionCandidate.extraction_run_id == result.extraction_run_id
+            )
+        )
+    ).scalars().all()
+    assert len(cands) == 1
+    assert cands[0].status == "pending"
+    assert cands[0].source_message_version_ids == [ver_id]
+
+
+# ─── Test 2: privacy refusal — offrecord source → run_status='failed' ────────
+
+
+async def test_run_extraction_pass_aborts_on_offrecord_source(db_session) -> None:
+    """If ANY source row in the eligible bundle has memory_policy != 'normal',
+    the gateway MUST NOT be called and the ExtractionRun must record failed.
+    """
+    from bot.db.models import ExtractionCandidate, ExtractionRun
+    from bot.services.extractor import run_extraction_pass
+
+    window_start = datetime.now(timezone.utc) - timedelta(hours=1)
+    window_end = datetime.now(timezone.utc) + timedelta(hours=1)
+    when = window_start + timedelta(minutes=5)
+    # One normal message + one offrecord message. The offrecord row must be
+    # excluded from the bundle entirely (governance pre-filter), and the
+    # remaining normal row is allowed. Privacy-positive: the run should
+    # succeed on the normal row, NOT fail open.
+    #
+    # But §5.B Stop Condition: "If any selected source row has
+    # `memory_policy!='normal'` ... the pass stops and records a failed
+    # `extraction_runs` row." This refers to defense-in-depth: if a row
+    # *somehow* slipped past the SELECT filter (e.g., a race or a buggy
+    # join), the bundle-assembly step double-checks and aborts.
+    #
+    # We exercise the defense-in-depth path by inserting a message with
+    # memory_policy='offrecord' that the test forces through a stub
+    # ``_select_eligible_sources`` override below.
+    await _make_chat_message(
+        db_session,
+        when=when,
+        text="legit normal",
+    )
+    # Insert a SECOND row but with offrecord; the production SELECT must
+    # exclude this. We verify via the gateway call inputs (must not contain
+    # offrecord text).
+    await _make_chat_message(
+        db_session,
+        when=when,
+        text="DO_NOT_LEAK_OFFRECORD",
+        memory_policy="offrecord",
+        is_redacted=True,
+    )
+
+    gw = FakeGateway(
+        candidates_to_emit=[
+            {
+                "candidate_json": {"title": "from legit", "body": "alpha"},
+                "source_message_version_ids": [],
+            }
+        ],
+    )
+
+    result = await run_extraction_pass(
+        db_session,
+        window_start=window_start,
+        window_end=window_end,
+        gateway=gw,
+    )
+
+    # Run completes (offrecord row never reached the bundle), and no
+    # forbidden content was forwarded to the gateway.
+    assert result.run_status in ("completed", "failed")
+    for call in gw.calls:
+        for sv in call["source_versions"]:
+            assert "DO_NOT_LEAK_OFFRECORD" not in (sv.get("text") or "")
+            assert "DO_NOT_LEAK_OFFRECORD" not in (sv.get("normalized_text") or "")
+
+    # If completed (typical) — Candidates may exist; if defense-in-depth
+    # aborted (atypical) — no candidates.
+    if result.run_status == "completed":
+        run_row = await db_session.get(ExtractionRun, result.extraction_run_id)
+        assert run_row is not None
+        assert run_row.run_status == "completed"
+    else:
+        cands = (
+            await db_session.execute(
+                select(ExtractionCandidate).where(
+                    ExtractionCandidate.extraction_run_id == result.extraction_run_id
+                )
+            )
+        ).scalars().all()
+        assert len(cands) == 0
+
+
+async def test_run_extraction_pass_defense_in_depth_aborts_when_bundle_has_offrecord(
+    db_session,
+) -> None:
+    """If callers (or future code paths) bypass the SELECT filter and pass a
+    bundle containing an offrecord row, ``run_extraction_pass`` MUST refuse to
+    call the gateway and MUST record run_status='failed'.
+
+    This pins the §5.B + §1 invariant guard at the function boundary, not
+    just in the SELECT query.
+    """
+    from bot.db.models import ExtractionRun
+    from bot.services.extractor import run_extraction_pass
+
+    window_start = datetime.now(timezone.utc) - timedelta(hours=1)
+    window_end = datetime.now(timezone.utc) + timedelta(hours=1)
+    when = window_start + timedelta(minutes=5)
+
+    # Force the offrecord row into the bundle via the SELECT bypass kwarg
+    # ``_force_include_message_ids`` (test-only seam — production callers
+    # never set it). The point is to confirm the pre-gateway invariant
+    # check fires.
+    _, _, _, _ = await _make_chat_message(db_session, when=when, text="normal-row")
+    bad_cm_id, _, _, _ = await _make_chat_message(
+        db_session,
+        when=when,
+        text="LEAK_GUARD_BODY",
+        memory_policy="offrecord",
+        is_redacted=True,
+    )
+
+    gw = FakeGateway(candidates_to_emit=[])
+    result = await run_extraction_pass(
+        db_session,
+        window_start=window_start,
+        window_end=window_end,
+        gateway=gw,
+        _force_include_chat_message_ids=[bad_cm_id],
+    )
+
+    assert result.run_status == "failed"
+    assert result.failure_reason is not None
+    # Gateway must NOT have been invoked.
+    assert gw.calls == []
+    # Failed ExtractionRun exists.
+    run_row = await db_session.get(ExtractionRun, result.extraction_run_id)
+    assert run_row is not None
+    assert run_row.run_status == "failed"
+
+
+# ─── Test 3: forget tombstone exclusion ──────────────────────────────────────
+
+
+async def test_run_extraction_pass_excludes_messages_with_forget_tombstone(
+    db_session,
+) -> None:
+    """A chat_messages row whose chat_id/message_id matches an existing
+    ``forget_events`` tombstone MUST NOT appear in the bundle and MUST NOT
+    reach the gateway.
+    """
+    from bot.services.extractor import run_extraction_pass
+
+    window_start = datetime.now(timezone.utc) - timedelta(hours=1)
+    window_end = datetime.now(timezone.utc) + timedelta(hours=1)
+    when = window_start + timedelta(minutes=5)
+
+    # Normal message — included.
+    _, ver_normal, _, _ = await _make_chat_message(
+        db_session, when=when, text="alpha normal"
+    )
+    # Forgotten message — excluded.
+    cm_forgotten, ver_forgotten, chat_id_f, msg_id_f = await _make_chat_message(
+        db_session, when=when, text="DO_NOT_LEAK_FORGOTTEN"
+    )
+    # Insert pending forget_event matching the forgotten message by
+    # tombstone_key = 'message:<chat_id>:<message_id>'.
+    from bot.db.repos.forget_event import ForgetEventRepo
+
+    await ForgetEventRepo.create(
+        db_session,
+        target_type="message",
+        target_id=str(cm_forgotten),
+        actor_user_id=None,
+        authorized_by="admin",
+        tombstone_key=f"message:{chat_id_f}:{msg_id_f}",
+    )
+
+    gw = FakeGateway(
+        candidates_to_emit=[
+            {
+                "candidate_json": {"title": "ok", "body": "alpha"},
+                "source_message_version_ids": [ver_normal],
+            }
+        ],
+    )
+
+    result = await run_extraction_pass(
+        db_session,
+        window_start=window_start,
+        window_end=window_end,
+        gateway=gw,
+    )
+
+    assert result.run_status == "completed"
+    forwarded_ids = [
+        sv["message_version_id"]
+        for call in gw.calls
+        for sv in call["source_versions"]
+    ]
+    assert ver_forgotten not in forwarded_ids
+    for call in gw.calls:
+        for sv in call["source_versions"]:
+            assert "DO_NOT_LEAK_FORGOTTEN" not in (sv.get("text") or "")
+
+
+# ─── Test 4: empty window — zero candidates, completed run ───────────────────
+
+
+async def test_run_extraction_pass_empty_window_records_completed_with_zero(
+    db_session,
+) -> None:
+    from bot.db.models import ExtractionRun
+    from bot.services.extractor import run_extraction_pass
+
+    # Window in the far past; no messages should match.
+    window_start = datetime(2000, 1, 1, tzinfo=timezone.utc)
+    window_end = datetime(2000, 1, 2, tzinfo=timezone.utc)
+
+    gw = FakeGateway(candidates_to_emit=[])
+
+    result = await run_extraction_pass(
+        db_session,
+        window_start=window_start,
+        window_end=window_end,
+        gateway=gw,
+    )
+
+    assert result.run_status == "completed"
+    assert result.candidate_count == 0
+    # Gateway is NOT called when bundle is empty.
+    assert gw.calls == []
+
+    run_row = await db_session.get(ExtractionRun, result.extraction_run_id)
+    assert run_row is not None
+    assert run_row.run_status == "completed"
+    assert run_row.candidate_count == 0
+
+
+# ─── Test 5: window bounds excluded outside [start, end) ─────────────────────
+
+
+async def test_run_extraction_pass_respects_window_bounds(db_session) -> None:
+    from bot.services.extractor import run_extraction_pass
+
+    window_start = datetime.now(timezone.utc) - timedelta(hours=1)
+    window_end = datetime.now(timezone.utc) + timedelta(hours=1)
+    # In-window message.
+    _, ver_in, _, _ = await _make_chat_message(
+        db_session, when=window_start + timedelta(minutes=10), text="in-window"
+    )
+    # Before window.
+    _, ver_before, _, _ = await _make_chat_message(
+        db_session, when=window_start - timedelta(hours=2), text="BEFORE_NOT_LEAK"
+    )
+    # After window (exclusive upper bound is window_end).
+    _, ver_after, _, _ = await _make_chat_message(
+        db_session, when=window_end + timedelta(hours=2), text="AFTER_NOT_LEAK"
+    )
+
+    gw = FakeGateway(candidates_to_emit=[])
+    await run_extraction_pass(
+        db_session,
+        window_start=window_start,
+        window_end=window_end,
+        gateway=gw,
+    )
+
+    forwarded_ids = [
+        sv["message_version_id"]
+        for call in gw.calls
+        for sv in call["source_versions"]
+    ]
+    assert ver_in in forwarded_ids
+    assert ver_before not in forwarded_ids
+    assert ver_after not in forwarded_ids
+    for call in gw.calls:
+        for sv in call["source_versions"]:
+            assert "NOT_LEAK" not in (sv.get("text") or "")
+
+
+# ─── Test 6: scheduler flag — default OFF skips pass ─────────────────────────
+
+
+async def test_extraction_scheduler_tick_default_skips(db_session) -> None:
+    """Without the flag set (default), the scheduler entry-point must NOT
+    invoke ``run_extraction_pass`` and must not call the gateway.
+    """
+    from bot.services.extractor import (
+        MEMORY_EXTRACTION_SCHEDULER_ENABLED_FLAG,
+        extraction_scheduler_tick,
+    )
+
+    assert MEMORY_EXTRACTION_SCHEDULER_ENABLED_FLAG == "memory.extraction.scheduler.enabled"
+
+    gw = FakeGateway(candidates_to_emit=[])
+    result = await extraction_scheduler_tick(db_session, gateway=gw)
+
+    assert result.skipped is True
+    assert gw.calls == []
+
+
+# ─── Test 7: scheduler flag — explicit False skips pass ──────────────────────
+
+
+async def test_extraction_scheduler_tick_flag_false_skips(db_session) -> None:
+    from bot.db.repos.feature_flag import FeatureFlagRepo
+    from bot.services.extractor import (
+        MEMORY_EXTRACTION_SCHEDULER_ENABLED_FLAG,
+        extraction_scheduler_tick,
+    )
+
+    await FeatureFlagRepo.set_enabled(
+        db_session, MEMORY_EXTRACTION_SCHEDULER_ENABLED_FLAG, False
+    )
+    gw = FakeGateway(candidates_to_emit=[])
+    result = await extraction_scheduler_tick(db_session, gateway=gw)
+
+    assert result.skipped is True
+    assert gw.calls == []
+
+
+# ─── Test 8: scheduler flag — True runs the pass with phase_6_enabled_at ─────
+
+
+async def test_extraction_scheduler_tick_flag_true_runs_pass(db_session) -> None:
+    """When the scheduler flag is ON, the tick MUST run the pass with the
+    flag row's ``updated_at`` as the forward-only lower bound (``window_start``).
+    """
+    from bot.db.repos.feature_flag import FeatureFlagRepo
+    from bot.services.extractor import (
+        MEMORY_EXTRACTION_SCHEDULER_ENABLED_FLAG,
+        extraction_scheduler_tick,
+    )
+
+    # Enable flag — its updated_at is now phase_6_enabled_at.
+    await FeatureFlagRepo.set_enabled(
+        db_session, MEMORY_EXTRACTION_SCHEDULER_ENABLED_FLAG, True
+    )
+
+    # Insert a message AFTER the flag was enabled (timestamp slightly past
+    # phase_6_enabled_at so window_start <= created_at < window_end holds).
+    when = datetime.now(timezone.utc)
+    _, ver_id, _, _ = await _make_chat_message(
+        db_session, when=when, text="post-enable msg"
+    )
+
+    gw = FakeGateway(
+        candidates_to_emit=[
+            {
+                "candidate_json": {"title": "t", "body": "b"},
+                "source_message_version_ids": [ver_id],
+            }
+        ],
+    )
+    # Pass an explicit ``now`` >> when to guarantee inclusion.
+    result = await extraction_scheduler_tick(
+        db_session,
+        gateway=gw,
+        now=when + timedelta(hours=1),
+    )
+
+    assert result.skipped is False
+    assert result.extraction_result is not None
+    assert result.extraction_result.run_status == "completed"
+    # Gateway was invoked.
+    assert len(gw.calls) >= 1

--- a/tests/services/test_extractor.py
+++ b/tests/services/test_extractor.py
@@ -596,6 +596,88 @@ async def test_extraction_scheduler_tick_flag_false_skips(db_session) -> None:
 # ─── Test 8: scheduler flag — True runs the pass with phase_6_enabled_at ─────
 
 
+# ─── Codex HIGH #5: operator_user_id persisted on ExtractionRun ─────────────
+
+
+async def test_run_extraction_pass_persists_operator_user_id(db_session) -> None:
+    """When an admin invokes ``/admin_extract``, the resulting ExtractionRun
+    MUST persist the operator's Telegram user id in the DB column
+    ``operator_user_id`` — not just in a structured log. PHASE6_PLAN §5.C
+    requires a durable audit marker so reviewers can attribute an
+    extraction back to the operator who triggered it.
+
+    Scheduler-driven ticks remain ``operator_user_id=NULL`` (no operator).
+    """
+    from bot.db.models import ExtractionRun
+    from bot.services.extractor import run_extraction_pass
+
+    window_start = datetime.now(timezone.utc) - timedelta(hours=1)
+    window_end = datetime.now(timezone.utc) + timedelta(hours=1)
+    when = window_start + timedelta(minutes=5)
+    _, ver_id, _, _ = await _make_chat_message(db_session, when=when, text="alpha")
+    ledger_id = await _make_llm_usage_ledger_row(db_session)
+
+    gw = FakeGateway(
+        candidates_to_emit=[
+            {
+                "candidate_json": {"title": "ok", "body": "alpha"},
+                "source_message_version_ids": [ver_id],
+            }
+        ],
+        llm_usage_ledger_id=ledger_id,
+    )
+
+    operator_id = 7700700700
+    result = await run_extraction_pass(
+        db_session,
+        window_start=window_start,
+        window_end=window_end,
+        gateway=gw,
+        operator_user_id=operator_id,
+    )
+    assert result.run_status == "completed"
+    run_row = await db_session.get(ExtractionRun, result.extraction_run_id)
+    assert run_row is not None
+    assert run_row.operator_user_id == operator_id
+
+
+async def test_run_extraction_pass_operator_user_id_null_for_scheduler(
+    db_session,
+) -> None:
+    """Without an explicit operator_user_id (scheduler-driven tick), the
+    ExtractionRun.operator_user_id column MUST be NULL — the operator
+    audit marker is opt-in and absent by default."""
+    from bot.db.models import ExtractionRun
+    from bot.services.extractor import run_extraction_pass
+
+    window_start = datetime.now(timezone.utc) - timedelta(hours=1)
+    window_end = datetime.now(timezone.utc) + timedelta(hours=1)
+    when = window_start + timedelta(minutes=5)
+    _, ver_id, _, _ = await _make_chat_message(db_session, when=when, text="alpha")
+    ledger_id = await _make_llm_usage_ledger_row(db_session)
+
+    gw = FakeGateway(
+        candidates_to_emit=[
+            {
+                "candidate_json": {"title": "ok", "body": "alpha"},
+                "source_message_version_ids": [ver_id],
+            }
+        ],
+        llm_usage_ledger_id=ledger_id,
+    )
+
+    result = await run_extraction_pass(
+        db_session,
+        window_start=window_start,
+        window_end=window_end,
+        gateway=gw,
+    )
+    assert result.run_status == "completed"
+    run_row = await db_session.get(ExtractionRun, result.extraction_run_id)
+    assert run_row is not None
+    assert run_row.operator_user_id is None
+
+
 # ─── Codex HIGH #4: scheduler tick idempotency (advisory lock) ──────────────
 
 


### PR DESCRIPTION
Phase 6 Wave 1 **Stream B** sprint 1 — ticket T6-02 (issue #234).

## Summary

- `bot/services/extractor.py` (new) — `run_extraction_pass`, `ExtractCandidatesGateway` Protocol seam (T6-03 lands concrete), `extraction_scheduler_tick` with pg_try_advisory_xact_lock idempotency, defense-in-depth `_bundle_is_clean` with fresh `forget_events` re-query
- `bot/handlers/admin_extract.py` (new) — `/admin_extract --window <ISO8601>..<ISO8601>` admin handler with operator_user_id persistence
- `alembic/versions/035_add_extraction_runs_operator_user_id.py` (new) — adds `operator_user_id` column to `extraction_runs` (audit marker per spec)
- 31 new tests + 4 spec patches in PHASE6_PLAN.md

## Privacy invariants enforced

1. **§8 #4** — Extraction run without LLM usage ledger entry blocks completion (CRITICAL guard, commit `8aa142c`)
2. **§8 #1** — `memory_policy != 'normal'` SELECT exclusion + defense-in-depth re-check
3. **SELECT→gateway race** closed via fresh `forget_events` re-query inside `_bundle_is_clean` (CRITICAL fix, commit `58469d2`)
4. **Live-path tombstone** — filter uses `mv.content_hash` not `c.content_hash` (CRITICAL fix round 3, commit `1ce196a`)
5. **Crash safety** — `run_status='running'` INSERT committed BEFORE gateway call (HIGH fix round 3, commit `2a27ba5`)

Note: terminology unified to `tombstoned` (was `forgotten`) post-merge in `7c11dde` to align with #247 narrow privacy allowlist.

## Deferred to T6-03

Per spec addendum in T6-04 acceptance:
- `admin_extract.router` registration in `bot/__main__.py`
- Concrete `ExtractCandidatesGateway` DI wiring

Per T6-04 acceptance (Wave 2):
- `pg_advisory_xact_lock(_p6_mvid_advisory_lock_id(mvid))` at `/approve` handler
- Same lock at forget-cascade orchestrator (`_process_one_event`)

## Review

- Claude product reviewer: **ACCEPTED** — 0 CRITICAL/HIGH, 1 MED (router defer T6-03 — judged spec-consistent), 3 LOW
- Codex tech reviewer (gpt-5.5 high) 3 rounds:
  - Round 1 REQUEST_CHANGES (3 CRITICAL + 5 HIGH + 4 MED + 4 LOW) → 6 fix commits: `8aa142c` (CRIT #1 ledger_id), `58469d2` (CRIT #3 race), `ed5bdc3` (HIGH #3 lifecycle), `66c523a` (HIGH #4 advisory lock), `d1e4f47` (HIGH #5 operator_user_id), `017de5b` (MED #2 @runtime_checkable). Remaining round-1 findings folded into initial impl commits `f139d20` / `ee5363e` or deferred LOW per acceptance.
  - Round 2 REQUEST_CHANGES (CRITICAL live-path tombstone + HIGH committed running) → 3 fix commits (`1ce196a`, `2a27ba5`, `1cf0ce1` regression test)
  - Round 3 **APPROVE** — all fixes verified verbatim with file:line citations

## Post-merge cleanup

- `06e0220` + `24bff07` — fts_schema test head bump to 035 + semgrep `nosemgrep` on `text()` with constant predicate
- `7c11dde` — terminology unification `forgotten` → `tombstoned` (post #247)

## Test plan

- [x] 31 service+handler tests pass (including 11 round 1+2+3 regression tests)
- [x] Phase 11 binding 21/21 green
- [x] alembic 035 round-trip clean
- [x] Ruff + privacy lint green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
