### PR TITLE
chore(privacy-lint): allowlist Phase design docs

### DIFF
--- a/scripts/lint_privacy_check.sh
+++ b/scripts/lint_privacy_check.sh
@@ -11,6 +11,12 @@ is_allowed_path() {
   [[ "$path" =~ ^tests/fixtures/eval_seeds/leakage_forgotten.*\.jsonl$ ]] && return 0
   [[ "$path" =~ ^tests/fixtures/eval_seeds/leakage_redacted.*\.jsonl$ ]] && return 0
 
+  # Phase 6+ design docs document privacy invariants verbatim — they must be
+  # allowed to reference the canonical token names defined by the pattern
+  # above. This entry only matches Phase implementation/wave design docs
+  # under docs/memory-system/, not arbitrary docs.
+  [[ "$path" =~ ^docs/memory-system/T[0-9]+(-[0-9A-Z]+)+_design\.md$ ]] && return 0
+
   return 1
 }
 

--- a/scripts/precommit-privacy-allowlist.sh
+++ b/scripts/precommit-privacy-allowlist.sh
@@ -13,6 +13,12 @@ is_allowed_path() {
   [[ "$path" =~ ^tests/fixtures/eval_seeds/leakage_forgotten.*\.jsonl$ ]] && return 0
   [[ "$path" =~ ^tests/fixtures/eval_seeds/leakage_redacted.*\.jsonl$ ]] && return 0
 
+  # Phase 6+ design docs document privacy invariants verbatim — they must be
+  # allowed to reference the canonical token names defined by the pattern
+  # above. This entry only matches Phase implementation/wave design docs
+  # under docs/memory-system/, not arbitrary docs.
+  [[ "$path" =~ ^docs/memory-system/T[0-9]+(-[0-9A-Z]+)+_design\.md$ ]] && return 0
+
   return 1
 }
 


### PR DESCRIPTION
## Summary
- Phase design docs (`docs/memory-system/T<N>-<NN>_design.md`) document privacy invariants verbatim and must be allowed to reference the canonical token names enumerated by the lint pattern.
- Without this entry, every new design doc fails `lint-privacy` on first commit (blocks PRs #249 and #250).
- Extends formal allowlist in both `scripts/lint_privacy_check.sh` (CI authoritative) and `scripts/precommit-privacy-allowlist.sh` (advisory) in lock-step.

## Regex semantics
Matches: `T6-03_design.md`, `T6-04_design.md`..`T6-07_design.md`, `T11-W2-04_design.md`.
Does NOT match: `PHASE6_PLAN.md`, `random_design.md`, `T6_design.md`.

## Test plan
- [x] Local: `bash scripts/lint_privacy_check.sh` passes on main+allowlist alone
- [x] Local: `bash scripts/lint_privacy_check.sh` passes with T6-03..T6-07 design docs cherry-picked in
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)