### PR TITLE
feat(p6-t6-03): gateway extract_candidates + router + DI (Wave 1 close)

### DIFF
--- a/bot/__main__.py
+++ b/bot/__main__.py
@@ -10,6 +10,7 @@ from aiogram.enums import ParseMode
 from bot.config import settings
 from bot.handlers import (
     admin,
+    admin_extract,
     chat_events,
     chat_messages,
     edited_message,
@@ -108,6 +109,7 @@ async def main() -> None:
         questionnaire.router,
         vouch.router,
         admin.router,
+        admin_extract.router,  # T6-03: /admin_extract — Phase 6 backfill (private chat + admin gated)
         chat_events.router,
         edited_message.router,  # T1-14: edited_message handler (before chat_messages catch-all)
         forget_me.router,  # T3-03: /forget_me command (DM or in-chat)

--- a/bot/handlers/admin_extract.py
+++ b/bot/handlers/admin_extract.py
@@ -28,10 +28,13 @@ from aiogram.types import Message
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from bot.config import settings
+from bot.db.repos.llm_usage_ledger import LedgerRepo
 from bot.filters.chat_type import PrivateChatFilter
-from bot.services.extractor import (
-    ExtractCandidatesGateway,
-    run_extraction_pass,
+from bot.services.extractor import run_extraction_pass
+from bot.services.llm_gateway import (
+    LiveExtractCandidatesGateway,
+    load_gateway_config,
+    resolve_provider,
 )
 
 logger = logging.getLogger(__name__)
@@ -117,7 +120,6 @@ async def cmd_admin_extract(
     message: Message,
     command: CommandObject,
     session: AsyncSession,
-    gateway: ExtractCandidatesGateway,
 ) -> None:
     """Admin-only ``/admin_extract --window <start>..<end>`` handler.
 
@@ -136,6 +138,11 @@ async def cmd_admin_extract(
     * Window parser → ``run_extraction_pass`` direct invocation
       (scheduler flag is NOT checked here — operator-explicit backfill
       per PHASE6_PLAN.md Q5).
+    * **Gateway DI (T6-03)**: the handler constructs
+      ``LiveExtractCandidatesGateway`` locally from env-derived config,
+      mirroring the Phase 5 QA precedent (``bot/handlers/qa.py:332-343``).
+      No aiogram middleware DI is used; the Protocol seam from T6-02
+      keeps tests injectable via ``monkeypatch``.
     * Returns summary text with ``candidate_count`` + ``run_status`` +
       ``llm_usage_ledger_id``.
     """
@@ -193,6 +200,13 @@ async def cmd_admin_extract(
             "window_start": window_start.isoformat(),
             "window_end": window_end.isoformat(),
         },
+    )
+
+    # T6-03 design §3: build the gateway locally (Phase 5 precedent).
+    cfg = load_gateway_config()
+    provider = resolve_provider(cfg.provider)
+    gateway = LiveExtractCandidatesGateway(
+        ledger_repo=LedgerRepo(), provider=provider, config=cfg
     )
 
     result = await run_extraction_pass(

--- a/bot/services/llm_gateway.py
+++ b/bot/services/llm_gateway.py
@@ -897,6 +897,78 @@ def _estimate_cost(
         return Decimal("0")
 
 
+# ─── Shared config loader (T6-03 R-7 / design §3) ────────────────────────────
+
+
+# Default prompt template version pinned for the Phase 5 ``synthesize_answer``
+# call site (matches the v1.0.0 baseline introduced with T5-04b — see
+# contracts.md §12.5). Re-exported here so both the QA handler and the
+# Phase 6 admin/scheduler call sites share a single source of truth.
+DEFAULT_PROMPT_TEMPLATE_VERSION = "v1.0.0"
+
+
+def load_gateway_config(
+    *, prompt_template_version: str = DEFAULT_PROMPT_TEMPLATE_VERSION
+) -> "LLMGatewayConfig":
+    """Resolve ``LLMGatewayConfig`` from env vars with sane defaults.
+
+    Reads (per global rule — NEVER rename existing env var keys):
+
+    * ``LLM_PROVIDER`` (default ``"anthropic"``).
+    * ``LLM_MODEL`` (provider-specific default).
+    * ``LLM_DAILY_USD_CEILING`` (default ``Decimal("5.00")``).
+    * ``LLM_MONTHLY_USD_CEILING`` (default ``Decimal("50.00")``).
+
+    Shared by Phase 5 QA synthesis (``bot/handlers/qa.py::recall_handler``)
+    and Phase 6 extraction (``bot/handlers/admin_extract.py`` + scheduler
+    tick wrapper). Budget ceilings are SHARED across synthesis and
+    extraction (single ledger, simpler accounting — T6-03 design open
+    question #2 resolution).
+    """
+    # Lazy import — provider modules import the SDK lazily inside ``call``,
+    # but importing the class at module load creates an unwanted dep from
+    # every call site. Lazy here keeps this file SDK-import-free.
+    import os
+
+    from bot.services.llm_providers.anthropic import DEFAULT_ANTHROPIC_MODEL
+    from bot.services.llm_providers.openai import DEFAULT_OPENAI_MODEL
+
+    provider = os.environ.get("LLM_PROVIDER", "anthropic")
+    if provider not in ("anthropic", "openai"):
+        raise ValueError(f"unknown provider: {provider}")
+
+    default_model = (
+        DEFAULT_OPENAI_MODEL if provider == "openai" else DEFAULT_ANTHROPIC_MODEL
+    )
+    model = os.environ.get("LLM_MODEL", default_model)
+    daily = Decimal(os.environ.get("LLM_DAILY_USD_CEILING", "5.00"))
+    monthly = Decimal(os.environ.get("LLM_MONTHLY_USD_CEILING", "50.00"))
+    return LLMGatewayConfig(
+        provider=provider,  # type: ignore[arg-type]  # validated above
+        model=model,
+        daily_ceiling_usd=daily,
+        monthly_ceiling_usd=monthly,
+        prompt_template_version=prompt_template_version,
+    )
+
+
+def resolve_provider(provider_name: str) -> LLMProvider:
+    """Instantiate Anthropic or OpenAI provider per config.
+
+    Raises ``ValueError`` on unknown ``provider_name``. Lazy import keeps
+    the gateway module SDK-import-free at top level.
+    """
+    if provider_name == "anthropic":
+        from bot.services.llm_providers.anthropic import AnthropicProvider
+
+        return AnthropicProvider()
+    if provider_name == "openai":
+        from bot.services.llm_providers.openai import OpenAIProvider
+
+        return OpenAIProvider()
+    raise ValueError(f"unknown provider: {provider_name}")
+
+
 # ─── Phase 6 / T6-03 — extract_candidates gateway entry point ───────────────
 
 
@@ -1221,6 +1293,7 @@ __all__ = [
     "Abstention",
     "AbstentionReason",
     "AnswerWithCitations",
+    "DEFAULT_PROMPT_TEMPLATE_VERSION",
     "LLM_BUDGET_LOCK_ID",
     "LLMGatewayConfig",
     "LedgerRepoProtocol",
@@ -1231,5 +1304,7 @@ __all__ = [
     "_cache_input_hash",
     "_normalize_query",
     "extract_candidates",
+    "load_gateway_config",
+    "resolve_provider",
     "synthesize_answer",
 ]

--- a/bot/services/llm_gateway.py
+++ b/bot/services/llm_gateway.py
@@ -45,6 +45,7 @@ Privacy-critical design notes
 from __future__ import annotations
 
 import hashlib
+import json
 import logging
 import time
 from dataclasses import dataclass
@@ -896,6 +897,326 @@ def _estimate_cost(
         return Decimal("0")
 
 
+# ─── Phase 6 / T6-03 — extract_candidates gateway entry point ───────────────
+
+
+# Prompt template v0.1.0 — deliberately simple JSON-array envelope.
+# Note: this is the canonical instruction-text only. The wire prompt
+# includes the source mvid set so the model can cite them deterministically.
+# Real prompt-engineering work belongs to later prompt-template versions.
+_EXTRACT_PROMPT_TEMPLATE_V0_1_0 = (
+    "Extract knowledge-card candidates from the following Telegram chat "
+    "messages. Return a JSON array of objects with exact shape:\n"
+    '  [{"candidate_json": {"title": str, "summary": str, "tags": [str]}, '
+    '"source_message_version_ids": [int, ...]}, ...]\n'
+    "Each source_message_version_ids entry MUST be drawn from the input "
+    "message_version_id values. Return [] if no candidates. JSON only — "
+    "no prose, no markdown fences.\n\n"
+    "MESSAGES:\n"
+)
+
+
+def _build_extraction_prompt(
+    source_versions: list[dict[str, Any]],
+    prompt_template_version: str,
+) -> str:
+    """Render a deterministic prompt for extraction.
+
+    Order is preserved (caller passes already-sorted bundle from the
+    extractor). ``prompt_template_version`` is appended so ``_prompt_hash``
+    distinguishes future template revisions. Source bodies are concatenated
+    plainly (no markdown) — the gateway treats the bodies as already-
+    governance-cleared input from ``_bundle_is_clean`` upstream.
+    """
+    body_parts: list[str] = []
+    for sv in source_versions:
+        mvid = sv.get("message_version_id")
+        text = sv.get("text") or sv.get("caption") or sv.get("normalized_text") or ""
+        body_parts.append(f"[mvid={mvid}] {text}")
+    return (
+        f"# template_version={prompt_template_version}\n"
+        + _EXTRACT_PROMPT_TEMPLATE_V0_1_0
+        + "\n".join(body_parts)
+    )
+
+
+def _parse_extraction_response(answer_text: str) -> list[dict[str, Any]]:
+    """Parse the provider response into a list of candidate dicts.
+
+    Returns ``[]`` for unparseable output. The gateway downgrades parse
+    failures to abstention (no candidates) rather than raising — this
+    keeps the SAVEPOINT in ``run_extraction_pass`` clean and lets the
+    audit layer record ``error="no_valid_candidates"`` on the ledger row.
+    """
+    try:
+        parsed = json.loads(answer_text)
+    except (json.JSONDecodeError, ValueError):
+        return []
+    if not isinstance(parsed, list):
+        return []
+    out: list[dict[str, Any]] = []
+    for item in parsed:
+        if not isinstance(item, dict):
+            continue
+        out.append(item)
+    return out
+
+
+async def extract_candidates(
+    session: AsyncSession,
+    *,
+    source_versions: list[dict[str, Any]],
+    prompt_template_version: str = "v0.1.0",
+    ledger_repo: LedgerRepoProtocol,
+    provider: LLMProvider,
+    config: LLMGatewayConfig,
+) -> dict[str, Any]:
+    """Single Phase 6 LLM extraction entry point — see T6-03_design.md §1.
+
+    Returns ``{"candidates": [...], "llm_usage_ledger_id": int | None}``
+    matching the ``ExtractCandidatesGateway`` Protocol surface
+    (``bot/services/extractor.py``).
+
+    The gateway is the ONLY allowed LLM call site for extraction (HANDOFF
+    invariant #2). Privacy is gatekept upstream by ``run_extraction_pass``
+    via ``_select_eligible_sources`` + ``_bundle_is_clean`` — the gateway
+    trusts ``source_versions`` as authoritative validated input and does
+    NOT re-filter (re-filtering would create drift risk with the
+    extractor's authoritative governance check).
+
+    Privacy discipline:
+
+    * MUST NOT log raw ``text`` / ``caption`` / ``normalized_text`` —
+      use ``prompt_hash`` + ``message_version_id`` for traceability.
+    * MUST NOT include source content in error messages or ledger fields.
+
+    Failure semantics (alignment with T6-02 invariant #4):
+
+    * Empty input → SHORT-CIRCUIT: no provider call, no ledger row,
+      returns ``llm_usage_ledger_id=None``. This is the asymmetry T6-02
+      handles — "only runs that actually invoked the gateway need a
+      ledger row".
+    * All other paths write at least a placeholder ledger row that the
+      extractor's invariant guard sees as non-None.
+    """
+    # Invariant 1 — empty input short-circuit (no provider, no ledger).
+    if not source_versions:
+        return {"candidates": [], "llm_usage_ledger_id": None}
+
+    # Build deterministic prompt + prompt_hash. The prompt body itself is
+    # used by the provider; ``prompt_hash`` is the stable sentinel stored
+    # in the ledger row for audit/dedup. NO raw source content goes into
+    # the hash beyond what the prompt itself contains (privacy invariant
+    # holds because the gateway is downstream of ``_bundle_is_clean``).
+    prompt = _build_extraction_prompt(source_versions, prompt_template_version)
+    prompt_hash = _prompt_hash(prompt)
+
+    # Authoritative input mvid set — used to drop hallucinated citations
+    # from the provider response (defense-in-depth; the extractor's
+    # ``_bundle_is_clean`` already cleared the input set upstream).
+    valid_mvid_set: frozenset[int] = frozenset(
+        int(sv["message_version_id"]) for sv in source_versions
+    )
+
+    # Invariant 5 — budget guard + placeholder ledger row. Mirrors the
+    # Phase 5 ``synthesize_answer`` pattern: acquire budget advisory
+    # lock, read cost totals, either abort (``budget_exceeded``) or
+    # write a placeholder ledger row, then release the lock BEFORE
+    # provider dispatch. Lock release is in a ``finally`` so any early
+    # return still unlocks.
+    placeholder_row: Any
+    try:
+        await session.execute(
+            _BUDGET_LOCK_SESSION_SQL, {"lock_id": LLM_BUDGET_LOCK_ID}
+        )
+        over_budget = await _budget_check(session, config, ledger_repo)
+        if over_budget:
+            row = await ledger_repo.record(
+                session,
+                qa_trace_id=None,
+                provider=config.provider,
+                model=config.model,
+                prompt_hash=prompt_hash,
+                response_hash=None,
+                tokens_in=0,
+                tokens_out=0,
+                cost_usd=Decimal("0"),
+                latency_ms=0,
+                request_id=None,
+                cache_hit=False,
+                error="budget_exceeded",
+            )
+            return {"candidates": [], "llm_usage_ledger_id": row.id}
+
+        placeholder_row = await ledger_repo.record(
+            session,
+            qa_trace_id=None,
+            provider=config.provider,
+            model=config.model,
+            prompt_hash=prompt_hash,
+            response_hash=None,
+            tokens_in=0,
+            tokens_out=0,
+            cost_usd=Decimal("0"),
+            latency_ms=0,
+            request_id=None,
+            cache_hit=False,
+            error=None,
+        )
+    finally:
+        await session.execute(
+            _BUDGET_UNLOCK_SESSION_SQL, {"lock_id": LLM_BUDGET_LOCK_ID}
+        )
+
+    # Invariant 6 — provider dispatch with categorised error handling.
+    # ALL exceptions are caught + translated into ledger error fields so
+    # the SAVEPOINT in ``run_extraction_pass`` stays clean and the
+    # extractor's invariant #4 (non-None ledger_id) holds.
+    started = time.monotonic()
+    try:
+        provider_result = await provider.call(prompt=prompt, model=config.model)
+    except ProviderTransientError as exc:
+        latency = int((time.monotonic() - started) * 1000)
+        await ledger_repo.update_placeholder(
+            session,
+            llm_call_id=placeholder_row.id,
+            cost_usd=Decimal("0"),
+            response_hash=None,
+            tokens_in=0,
+            tokens_out=0,
+            request_id=None,
+            latency_ms=latency,
+            error=f"provider_transient:{exc.subtype}",
+        )
+        return {"candidates": [], "llm_usage_ledger_id": placeholder_row.id}
+    except ProviderStructuralError as exc:
+        logger.error(
+            "llm_gateway: extraction structural provider failure subtype=%s",
+            exc.subtype,
+            exc_info=True,
+        )
+        from bot.services import observability
+
+        observability.emit_stop_signal("llm_provider_structural")
+        latency = int((time.monotonic() - started) * 1000)
+        await ledger_repo.update_placeholder(
+            session,
+            llm_call_id=placeholder_row.id,
+            cost_usd=Decimal("0"),
+            response_hash=None,
+            tokens_in=0,
+            tokens_out=0,
+            request_id=None,
+            latency_ms=latency,
+            error=f"provider_structural:{exc.subtype}",
+        )
+        return {"candidates": [], "llm_usage_ledger_id": placeholder_row.id}
+    except Exception as exc:
+        logger.error(
+            "llm_gateway: extraction unknown provider failure class=%s",
+            type(exc).__name__,
+            exc_info=True,
+        )
+        latency = int((time.monotonic() - started) * 1000)
+        await ledger_repo.update_placeholder(
+            session,
+            llm_call_id=placeholder_row.id,
+            cost_usd=Decimal("0"),
+            response_hash=None,
+            tokens_in=0,
+            tokens_out=0,
+            request_id=None,
+            latency_ms=latency,
+            error=f"provider_unknown:{type(exc).__name__}",
+        )
+        return {"candidates": [], "llm_usage_ledger_id": placeholder_row.id}
+
+    # Parse JSON envelope + filter for citation conformance.
+    candidates_raw = _parse_extraction_response(provider_result.answer_text)
+    valid_candidates: list[dict[str, Any]] = []
+    for c in candidates_raw:
+        source_ids_raw = c.get("source_message_version_ids") or []
+        if not isinstance(source_ids_raw, list):
+            continue
+        # Drop hallucinated mvids; keep only those present in input set.
+        source_ids: list[int] = []
+        for x in source_ids_raw:
+            try:
+                xid = int(x)
+            except (TypeError, ValueError):
+                continue
+            if xid in valid_mvid_set:
+                source_ids.append(xid)
+        if not source_ids:
+            # Invariant: no card without source.
+            continue
+        cand_json = c.get("candidate_json")
+        if not isinstance(cand_json, dict):
+            continue
+        valid_candidates.append(
+            {
+                "candidate_json": dict(cand_json),
+                "source_message_version_ids": source_ids,
+            }
+        )
+
+    cost_usd = _estimate_cost(
+        config=config,
+        tokens_in=provider_result.tokens_in,
+        tokens_out=provider_result.tokens_out,
+    )
+    latency = int((time.monotonic() - started) * 1000)
+    await ledger_repo.update_placeholder(
+        session,
+        llm_call_id=placeholder_row.id,
+        cost_usd=cost_usd,
+        response_hash=_response_hash(provider_result.answer_text),
+        tokens_in=provider_result.tokens_in,
+        tokens_out=provider_result.tokens_out,
+        request_id=provider_result.request_id,
+        latency_ms=latency,
+        error=None if valid_candidates else "no_valid_candidates",
+    )
+    return {
+        "candidates": valid_candidates,
+        "llm_usage_ledger_id": placeholder_row.id,
+    }
+
+
+class LiveExtractCandidatesGateway:
+    """Concrete impl of T6-02 ``ExtractCandidatesGateway`` Protocol.
+
+    Stub for TDD RED phase; real implementation lands as the next commit.
+    """
+
+    def __init__(
+        self,
+        *,
+        ledger_repo: LedgerRepoProtocol,
+        provider: LLMProvider,
+        config: LLMGatewayConfig,
+    ) -> None:
+        self._ledger_repo = ledger_repo
+        self._provider = provider
+        self._config = config
+
+    async def extract_candidates(
+        self,
+        session: Any,
+        *,
+        source_versions: list[dict[str, Any]],
+        prompt_template_version: str = "v0.1.0",
+    ) -> dict[str, Any]:
+        return await extract_candidates(
+            session,
+            source_versions=source_versions,
+            prompt_template_version=prompt_template_version,
+            ledger_repo=self._ledger_repo,
+            provider=self._provider,
+            config=self._config,
+        )
+
+
 __all__ = [
     "Abstention",
     "AbstentionReason",
@@ -903,10 +1224,12 @@ __all__ = [
     "LLM_BUDGET_LOCK_ID",
     "LLMGatewayConfig",
     "LedgerRepoProtocol",
+    "LiveExtractCandidatesGateway",
     "MAX_QUERY_LENGTH",
     "SynthesisCacheRepoProtocol",
     "SynthesisResult",
     "_cache_input_hash",
     "_normalize_query",
+    "extract_candidates",
     "synthesize_answer",
 ]

--- a/bot/services/scheduler.py
+++ b/bot/services/scheduler.py
@@ -12,10 +12,17 @@ from bot.db.engine import async_session
 from bot.db.models import IntroRefreshTracking
 from bot.db.repos.application import ApplicationRepo
 from bot.db.repos.intro import IntroRepo
+from bot.db.repos.llm_usage_ledger import LedgerRepo
 from bot.db.repos.user import UserRepo
 from bot.html_escape import html_escape
+from bot.services.extractor import extraction_scheduler_tick
 from bot.services.forget_cascade import cascade_worker_tick
 from bot.services.invite_worker import process_invite_outbox
+from bot.services.llm_gateway import (
+    LiveExtractCandidatesGateway,
+    load_gateway_config,
+    resolve_provider,
+)
 from bot.texts import (
     ADMIN_NUDGE_MSG,
     NUDGE_MSG,
@@ -226,6 +233,49 @@ async def sync_google_sheets() -> None:
         logger.exception("Google Sheets sync failed")
 
 
+async def run_extraction_scheduler_tick() -> None:
+    """T6-03 wrapper — wires the Phase 6 extraction tick into apscheduler.
+
+    PHASE6_PLAN.md §5.B + T6-03 design §3-§4:
+
+    * Opens a fresh ``async_session()``.
+    * Builds ``LiveExtractCandidatesGateway`` locally via env-derived config
+      (same pattern as the QA handler at ``bot/handlers/qa.py:332-343``).
+    * Calls ``extraction_scheduler_tick`` from ``bot.services.extractor``,
+      which short-circuits when the feature flag is OFF (default).
+    * Commits on success; logs + ignores any exception so the scheduler
+      keeps running (per Phase 5 invite-outbox precedent).
+
+    The flag default is OFF so this job is a strict no-op until an operator
+    flips ``memory.extraction.scheduler.enabled`` in the ``feature_flags``
+    table. The 15-min interval mirrors ``check_vouch_deadlines``; the
+    actual tick runtime is dominated by gateway HTTP latency (~5-15s) when
+    the flag is on.
+    """
+    try:
+        async with async_session() as session:
+            try:
+                cfg = load_gateway_config()
+                provider = resolve_provider(cfg.provider)
+                gateway = LiveExtractCandidatesGateway(
+                    ledger_repo=LedgerRepo(), provider=provider, config=cfg
+                )
+                await extraction_scheduler_tick(session, gateway=gateway)
+                await session.commit()
+            except Exception:
+                # Rollback the per-tick transaction so the scheduler can
+                # retry on the next fire without poisoning the session.
+                try:
+                    await session.rollback()
+                except Exception:
+                    logger.exception("extraction_scheduler_tick rollback failed")
+                logger.exception("extraction_scheduler_tick crashed")
+    except Exception:
+        # Catch-all — the wrapper must NEVER let an exception propagate to
+        # apscheduler, which would mark the job as failed and stop firing.
+        logger.exception("extraction_scheduler_tick session setup failed")
+
+
 def start_scheduler(bot: Bot) -> None:
     """Configure and start the scheduler."""
     scheduler.add_job(
@@ -273,6 +323,21 @@ def start_scheduler(bot: Bot) -> None:
         "interval",
         seconds=30,
         id="forget_cascade_worker",
+        replace_existing=True,
+        max_instances=1,
+        coalesce=True,
+        misfire_grace_time=60,
+    )
+    # T6-03: Phase 6 extraction scheduler. Default OFF via flag
+    # ``memory.extraction.scheduler.enabled`` (see bot/services/extractor.py).
+    # 15-min interval mirrors ``check_vouch_deadlines`` — operator-explicit
+    # ``/admin_extract --window`` remains the primary entry point until the
+    # flag is enabled. Strict no-op when flag is OFF.
+    scheduler.add_job(
+        run_extraction_scheduler_tick,
+        "interval",
+        minutes=15,
+        id="extraction_scheduler_tick",
         replace_existing=True,
         max_instances=1,
         coalesce=True,

--- a/scripts/lint_privacy_check.sh
+++ b/scripts/lint_privacy_check.sh
@@ -10,6 +10,8 @@ is_allowed_path() {
   [[ "$path" =~ ^tests/fixtures/eval_seeds/leakage_nomem.*\.jsonl$ ]] && return 0
   [[ "$path" =~ ^tests/fixtures/eval_seeds/leakage_forgotten.*\.jsonl$ ]] && return 0
   [[ "$path" =~ ^tests/fixtures/eval_seeds/leakage_redacted.*\.jsonl$ ]] && return 0
+  # T6-03 design doc — describes privacy invariants by name; baseline-stable.
+  [[ "$path" == "docs/memory-system/T6-03_design.md" ]] && return 0
 
   # Phase 6+ design docs document privacy invariants verbatim — they must be
   # allowed to reference the canonical token names defined by the pattern

--- a/tests/handlers/test_admin_extract.py
+++ b/tests/handlers/test_admin_extract.py
@@ -167,7 +167,6 @@ async def test_admin_extract_rejects_non_admin(
         fake_nonadmin_message,
         cmd,
         session=db_session,
-        gateway=MagicMock(),
     )
 
     # Either no-op or explicit error — either way, no pass invocation.
@@ -209,7 +208,6 @@ async def test_admin_extract_calls_run_extraction_pass_with_window(
         fake_admin_message,
         cmd,
         session=db_session,
-        gateway=MagicMock(),
     )
 
     assert "window_start" in captured
@@ -252,7 +250,6 @@ async def test_admin_extract_returns_summary_with_run_metadata(
         fake_admin_message,
         cmd,
         session=db_session,
-        gateway=MagicMock(),
     )
 
     # Inspect every call to .answer / .reply and confirm summary content.
@@ -290,7 +287,6 @@ async def test_admin_extract_rejects_missing_window(
         fake_admin_message,
         cmd,
         session=db_session,
-        gateway=MagicMock(),
     )
     assert called["count"] == 0
 
@@ -316,7 +312,6 @@ async def test_admin_extract_rejects_invalid_window_format(
         fake_admin_message,
         cmd,
         session=db_session,
-        gateway=MagicMock(),
     )
     assert called["count"] == 0
     # Admin received an error reply.
@@ -348,6 +343,80 @@ async def test_admin_extract_rejects_window_over_30_days(
         fake_admin_message,
         cmd,
         session=db_session,
-        gateway=MagicMock(),
     )
     assert called["count"] == 0
+
+
+# ─── T6-03: DI refactor — handler builds gateway locally ─────────────────────
+
+
+async def test_admin_extract_builds_gateway_locally_t6_03(
+    db_session,
+    fake_admin_message,
+    fake_command_object_factory,
+) -> None:
+    """T6-03 design §3: handler MUST build LiveExtractCandidatesGateway locally
+    rather than accept a gateway kwarg from aiogram DI middleware.
+
+    The handler signature should expose ONLY ``message``, ``command``,
+    ``session`` (matches the Phase 5 ``qa.recall_handler`` precedent at
+    bot/handlers/qa.py:332-343 — local instantiation, not aiogram DI).
+    """
+    import inspect
+
+    import bot.handlers.admin_extract as h_module
+
+    sig = inspect.signature(h_module.cmd_admin_extract)
+    # T6-03 contract: ``gateway`` MUST NOT appear in the public signature.
+    assert "gateway" not in sig.parameters, (
+        "T6-03: handler should not declare ``gateway`` kwarg — gateway is "
+        "constructed locally inside the handler body, matching the Phase 5 "
+        "QA precedent (bot/handlers/qa.py)."
+    )
+
+    # The handler should accept (message, command, session) at minimum.
+    assert "message" in sig.parameters
+    assert "command" in sig.parameters
+    assert "session" in sig.parameters
+
+
+async def test_admin_extract_invokes_run_extraction_pass_without_gateway_kwarg(
+    db_session,
+    fake_admin_message,
+    fake_command_object_factory,
+    monkeypatch,
+) -> None:
+    """Handler must construct gateway internally and pass it to
+    ``run_extraction_pass``. Verifies the wired local LiveExtractCandidatesGateway.
+    """
+    import uuid
+
+    import bot.handlers.admin_extract as h_module
+    from bot.services.extractor import ExtractionResult
+    from bot.services.llm_gateway import LiveExtractCandidatesGateway
+
+    captured: dict = {}
+
+    async def fake_run_pass(session, *, window_start, window_end, gateway, **kwargs):
+        captured["gateway"] = gateway
+        return ExtractionResult(
+            extraction_run_id=uuid.uuid4(),
+            run_status="completed",
+            candidate_count=0,
+            llm_usage_ledger_id=1,
+        )
+
+    monkeypatch.setattr(h_module, "run_extraction_pass", fake_run_pass)
+
+    cmd = fake_command_object_factory(
+        "--window 2026-05-12T00:00:00Z..2026-05-13T00:00:00Z"
+    )
+    # NOTE: NO ``gateway=`` kwarg passed — handler builds it locally.
+    await h_module.cmd_admin_extract(
+        fake_admin_message,
+        cmd,
+        session=db_session,
+    )
+
+    assert "gateway" in captured
+    assert isinstance(captured["gateway"], LiveExtractCandidatesGateway)

--- a/tests/services/test_llm_gateway_extract_candidates.py
+++ b/tests/services/test_llm_gateway_extract_candidates.py
@@ -32,7 +32,6 @@ from bot.services.llm_providers import (
 )
 from tests.services.test_llm_gateway import (
     FakeLedgerRepo,
-    FakeProvider,
     FakeSession,
     _config,
 )

--- a/tests/services/test_llm_gateway_extract_candidates.py
+++ b/tests/services/test_llm_gateway_extract_candidates.py
@@ -1,0 +1,413 @@
+"""Behaviour tests for `bot.services.llm_gateway.extract_candidates` (T6-03).
+
+PHASE6_PLAN.md §7 T6-03 acceptance criteria:
+
+* No provider SDK call exists outside ``llm_gateway`` (verified by AST test).
+* Every call is associated with the Phase 5 LLM usage ledger.
+* Output schema includes candidate payload + source ``message_version_id``s.
+* Forbidden source content cannot be passed to the gateway.
+
+These unit tests inject fakes that satisfy the §5.C
+``LedgerRepoProtocol`` and the ``LLMProvider`` Protocol. Reuses the
+fakes shape from ``tests/services/test_llm_gateway.py`` so the gateway
+behaviour mirrors Phase 5 placeholder-row + budget-guard patterns.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from decimal import Decimal
+from typing import Any
+
+import pytest
+
+from bot.services.llm_gateway import (
+    LiveExtractCandidatesGateway,
+    extract_candidates,
+)
+from bot.services.llm_providers import (
+    ProviderResult,
+    ProviderStructuralError,
+    ProviderTransientError,
+)
+from tests.services.test_llm_gateway import (
+    FakeLedgerRepo,
+    FakeProvider,
+    FakeSession,
+    _config,
+)
+
+
+def _make_source_versions(ids: tuple[int, ...] = (100, 101)) -> list[dict[str, Any]]:
+    """Build a minimal source_versions payload matching the extractor's contract."""
+    return [
+        {
+            "chat_message_id": 200 + idx,
+            "message_version_id": vid,
+            "chat_id": -1001,
+            "message_id": 300 + idx,
+            "user_id": 42,
+            "text": f"source body {idx}",
+            "caption": None,
+            "normalized_text": f"source body {idx}",
+        }
+        for idx, vid in enumerate(ids)
+    ]
+
+
+# ─── Provider stub returning candidates ──────────────────────────────────────
+
+
+@dataclass
+class FakeExtractionProvider:
+    """LLMProvider stub returning a JSON candidates envelope in answer_text."""
+
+    candidates_json: str = (
+        '[{"candidate_json": {"title": "t1", "summary": "s1"}, '
+        '"source_message_version_ids": [100]}]'
+    )
+    tokens_in: int = 100
+    tokens_out: int = 50
+    request_id: str = "req-extract"
+    raise_exc: BaseException | None = None
+    calls: list[dict[str, Any]] = field(default_factory=list)
+
+    async def call(self, *, prompt: str, model: str) -> ProviderResult:
+        self.calls.append({"prompt": prompt, "model": model})
+        if self.raise_exc is not None:
+            raise self.raise_exc
+        return ProviderResult(
+            answer_text=self.candidates_json,
+            citation_ids=tuple(),
+            tokens_in=self.tokens_in,
+            tokens_out=self.tokens_out,
+            request_id=self.request_id,
+            raw_latency_ms=12,
+        )
+
+
+# ─── Tests: invariant — empty input short-circuit ────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_empty_source_versions_short_circuits_without_provider_or_ledger() -> None:
+    """Empty input → returns immediately; no provider call, no ledger row.
+
+    PHASE6_PLAN.md §5.B + design §1: short-circuit MUST NOT write a
+    ledger row so the extractor's invariant #4 ("ledger_id non-null
+    when gateway was invoked") matches "ledger_id is None when gateway
+    short-circuited on empty input".
+    """
+    ledger = FakeLedgerRepo()
+    provider = FakeExtractionProvider()
+    session = FakeSession()
+
+    result = await extract_candidates(
+        session,  # type: ignore[arg-type]
+        source_versions=[],
+        prompt_template_version="v0.1.0",
+        ledger_repo=ledger,
+        provider=provider,
+        config=_config(),
+    )
+
+    assert result == {"candidates": [], "llm_usage_ledger_id": None}
+    assert provider.calls == []
+    assert ledger.rows == []
+
+
+# ─── Tests: happy path — provider returns valid candidates ───────────────────
+
+
+@pytest.mark.asyncio
+async def test_happy_path_returns_candidates_and_ledger_id() -> None:
+    """Valid candidates → returned, ledger row written with non-zero cost.
+
+    Provider returns JSON envelope containing one candidate citing mvid 100.
+    The gateway parses, validates citations against input mvid set, and
+    writes a placeholder ledger row (cost=0 pre-dispatch) updated to the
+    real cost post-dispatch via ``update_placeholder``.
+    """
+    ledger = FakeLedgerRepo()
+    provider = FakeExtractionProvider()
+    session = FakeSession(query_results=[[{"sum": 0}], [{"sum": 0}]])
+
+    result = await extract_candidates(
+        session,  # type: ignore[arg-type]
+        source_versions=_make_source_versions((100,)),
+        prompt_template_version="v0.1.0",
+        ledger_repo=ledger,
+        provider=provider,
+        config=_config(),
+    )
+
+    # One provider dispatch occurred.
+    assert len(provider.calls) == 1
+    # Output schema matches §1: list of {"candidate_json": ..., "source_message_version_ids": [...]}.
+    assert len(result["candidates"]) == 1
+    cand = result["candidates"][0]
+    assert cand["candidate_json"] == {"title": "t1", "summary": "s1"}
+    assert cand["source_message_version_ids"] == [100]
+    # Ledger row was written and id is surfaced.
+    assert result["llm_usage_ledger_id"] is not None
+    assert len(ledger.rows) == 1
+    row = ledger.rows[0]
+    assert result["llm_usage_ledger_id"] == row.id
+    # Final ledger row carries no error (success path).
+    assert row.error is None
+    assert row.tokens_in == 100
+    assert row.tokens_out == 50
+    assert row.request_id == "req-extract"
+    # qa_trace_id is None for extraction (no QA trace).
+    assert row.qa_trace_id is None
+
+
+# ─── Tests: citation hallucination is dropped ────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_hallucinated_mvid_is_dropped_other_candidates_pass_through() -> None:
+    """Provider cites mvid 999 (not in input) → that candidate is dropped.
+
+    Two candidates returned: one with valid mvid 100, one with hallucinated
+    999. The hallucinated one is filtered; the valid one is returned.
+    """
+    ledger = FakeLedgerRepo()
+    provider = FakeExtractionProvider(
+        candidates_json=(
+            '[{"candidate_json": {"title": "good"}, '
+            '"source_message_version_ids": [100]}, '
+            '{"candidate_json": {"title": "bad"}, '
+            '"source_message_version_ids": [999]}]'
+        )
+    )
+    session = FakeSession(query_results=[[{"sum": 0}], [{"sum": 0}]])
+
+    result = await extract_candidates(
+        session,  # type: ignore[arg-type]
+        source_versions=_make_source_versions((100,)),
+        prompt_template_version="v0.1.0",
+        ledger_repo=ledger,
+        provider=provider,
+        config=_config(),
+    )
+
+    assert len(result["candidates"]) == 1
+    assert result["candidates"][0]["candidate_json"] == {"title": "good"}
+    assert result["candidates"][0]["source_message_version_ids"] == [100]
+    # Ledger row carries no error — there was at least one valid candidate.
+    assert ledger.rows[-1].error is None
+
+
+# ─── Tests: provider returns empty candidate list ────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_empty_candidates_response_marks_ledger_no_valid_candidates() -> None:
+    """Provider returns ``[]`` → empty candidates, ledger error sentinel."""
+    ledger = FakeLedgerRepo()
+    provider = FakeExtractionProvider(candidates_json="[]")
+    session = FakeSession(query_results=[[{"sum": 0}], [{"sum": 0}]])
+
+    result = await extract_candidates(
+        session,  # type: ignore[arg-type]
+        source_versions=_make_source_versions((100,)),
+        prompt_template_version="v0.1.0",
+        ledger_repo=ledger,
+        provider=provider,
+        config=_config(),
+    )
+
+    assert result["candidates"] == []
+    assert result["llm_usage_ledger_id"] is not None
+    assert ledger.rows[-1].error == "no_valid_candidates"
+
+
+# ─── Tests: malformed JSON response → abstain ────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_malformed_json_response_abstains_with_no_valid_candidates() -> None:
+    """Provider returns non-JSON garbage → no crash; abstain with ledger marker."""
+    ledger = FakeLedgerRepo()
+    provider = FakeExtractionProvider(candidates_json="this is not json")
+    session = FakeSession(query_results=[[{"sum": 0}], [{"sum": 0}]])
+
+    result = await extract_candidates(
+        session,  # type: ignore[arg-type]
+        source_versions=_make_source_versions((100,)),
+        prompt_template_version="v0.1.0",
+        ledger_repo=ledger,
+        provider=provider,
+        config=_config(),
+    )
+
+    assert result["candidates"] == []
+    assert result["llm_usage_ledger_id"] is not None
+    assert ledger.rows[-1].error == "no_valid_candidates"
+
+
+# ─── Tests: provider transient error ─────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_provider_transient_error_returns_empty_with_ledger_marker() -> None:
+    """ProviderTransientError → empty candidates, ledger row updated.
+
+    Crucially, ledger_id IS NOT None — the extractor's invariant #4
+    requires non-None ledger_id whenever the gateway was invoked.
+    """
+    ledger = FakeLedgerRepo()
+    provider = FakeExtractionProvider(
+        raise_exc=ProviderTransientError("rate_limit", message="rate limit"),
+    )
+    session = FakeSession(query_results=[[{"sum": 0}], [{"sum": 0}]])
+
+    result = await extract_candidates(
+        session,  # type: ignore[arg-type]
+        source_versions=_make_source_versions((100,)),
+        prompt_template_version="v0.1.0",
+        ledger_repo=ledger,
+        provider=provider,
+        config=_config(),
+    )
+
+    assert result["candidates"] == []
+    assert result["llm_usage_ledger_id"] is not None
+    assert ledger.rows[-1].error == "provider_transient:rate_limit"
+
+
+# ─── Tests: provider structural error ────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_provider_structural_error_returns_empty_with_ledger_marker() -> None:
+    """ProviderStructuralError → empty candidates, ledger row updated + stop signal."""
+    ledger = FakeLedgerRepo()
+    provider = FakeExtractionProvider(
+        raise_exc=ProviderStructuralError("auth", message="auth failed"),
+    )
+    session = FakeSession(query_results=[[{"sum": 0}], [{"sum": 0}]])
+
+    result = await extract_candidates(
+        session,  # type: ignore[arg-type]
+        source_versions=_make_source_versions((100,)),
+        prompt_template_version="v0.1.0",
+        ledger_repo=ledger,
+        provider=provider,
+        config=_config(),
+    )
+
+    assert result["candidates"] == []
+    assert result["llm_usage_ledger_id"] is not None
+    assert ledger.rows[-1].error == "provider_structural:auth"
+
+
+# ─── Tests: provider unknown error ───────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_provider_unknown_error_returns_empty_with_ledger_marker() -> None:
+    """Generic exception → empty candidates, ledger row updated; no raise."""
+    ledger = FakeLedgerRepo()
+    provider = FakeExtractionProvider(raise_exc=RuntimeError("boom"))
+    session = FakeSession(query_results=[[{"sum": 0}], [{"sum": 0}]])
+
+    result = await extract_candidates(
+        session,  # type: ignore[arg-type]
+        source_versions=_make_source_versions((100,)),
+        prompt_template_version="v0.1.0",
+        ledger_repo=ledger,
+        provider=provider,
+        config=_config(),
+    )
+
+    assert result["candidates"] == []
+    assert result["llm_usage_ledger_id"] is not None
+    assert ledger.rows[-1].error == "provider_unknown:RuntimeError"
+
+
+# ─── Tests: budget exceeded ──────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_budget_exceeded_writes_ledger_row_and_abstains() -> None:
+    """Daily ceiling reached → no provider call, ledger row with sentinel."""
+    ledger = FakeLedgerRepo(daily_cost=Decimal("10.00"))
+    provider = FakeExtractionProvider()
+    session = FakeSession()
+
+    result = await extract_candidates(
+        session,  # type: ignore[arg-type]
+        source_versions=_make_source_versions((100,)),
+        prompt_template_version="v0.1.0",
+        ledger_repo=ledger,
+        provider=provider,
+        config=_config(daily=Decimal("5.00")),
+    )
+
+    assert result["candidates"] == []
+    assert result["llm_usage_ledger_id"] is not None
+    assert provider.calls == []
+    assert len(ledger.rows) == 1
+    assert ledger.rows[0].error == "budget_exceeded"
+
+
+# ─── Tests: all candidates hallucinated → empty result + ledger marker ──────
+
+
+@pytest.mark.asyncio
+async def test_all_candidates_hallucinated_returns_empty_with_marker() -> None:
+    """Every candidate cites unknown mvid → empty result, ``no_valid_candidates``."""
+    ledger = FakeLedgerRepo()
+    provider = FakeExtractionProvider(
+        candidates_json=(
+            '[{"candidate_json": {"title": "bad"}, '
+            '"source_message_version_ids": [9001, 9002]}]'
+        )
+    )
+    session = FakeSession(query_results=[[{"sum": 0}], [{"sum": 0}]])
+
+    result = await extract_candidates(
+        session,  # type: ignore[arg-type]
+        source_versions=_make_source_versions((100,)),
+        prompt_template_version="v0.1.0",
+        ledger_repo=ledger,
+        provider=provider,
+        config=_config(),
+    )
+
+    assert result["candidates"] == []
+    assert result["llm_usage_ledger_id"] is not None
+    assert ledger.rows[-1].error == "no_valid_candidates"
+
+
+# ─── Tests: LiveExtractCandidatesGateway adapter ─────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_live_gateway_adapter_satisfies_protocol_and_delegates() -> None:
+    """LiveExtractCandidatesGateway delegates to extract_candidates with DI deps."""
+    from bot.services.extractor import ExtractCandidatesGateway
+
+    ledger = FakeLedgerRepo()
+    provider = FakeExtractionProvider()
+    config = _config()
+    gw = LiveExtractCandidatesGateway(
+        ledger_repo=ledger, provider=provider, config=config
+    )
+
+    # Protocol membership check — T6-02 ships @runtime_checkable, so
+    # isinstance works for attribute presence (not signature shape).
+    assert isinstance(gw, ExtractCandidatesGateway)
+
+    session = FakeSession(query_results=[[{"sum": 0}], [{"sum": 0}]])
+    result = await gw.extract_candidates(
+        session,  # type: ignore[arg-type]
+        source_versions=_make_source_versions((100,)),
+        prompt_template_version="v0.1.0",
+    )
+
+    assert len(result["candidates"]) == 1
+    assert result["llm_usage_ledger_id"] is not None
+    assert len(provider.calls) == 1

--- a/tests/test_extraction_scheduler_wrapper.py
+++ b/tests/test_extraction_scheduler_wrapper.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 import ast
 import inspect
 from pathlib import Path
-from unittest.mock import AsyncMock
 
 import pytest
 

--- a/tests/test_extraction_scheduler_wrapper.py
+++ b/tests/test_extraction_scheduler_wrapper.py
@@ -1,0 +1,142 @@
+"""T6-03 — apscheduler wrapper for the Phase 6 extraction scheduler tick.
+
+T6-03 design §3 + §4: a thin ``run_extraction_scheduler_tick`` wrapper in
+``bot/services/scheduler.py`` opens a fresh session, builds the live gateway
+locally, calls ``extraction_scheduler_tick`` from ``bot.services.extractor``,
+and commits — or logs + ignores on exception so the scheduler keeps running.
+
+Coverage:
+
+* Wrapper exists and is callable.
+* Wrapper builds ``LiveExtractCandidatesGateway`` via local DI.
+* Wrapper handles exceptions without raising (scheduler isolation).
+* ``start_scheduler`` registers the wrapper as an apscheduler job.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+pytestmark = pytest.mark.usefixtures("app_env")
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_run_extraction_scheduler_tick_wrapper_exists() -> None:
+    """The wrapper coroutine must be importable from bot.services.scheduler."""
+    from bot.services import scheduler
+
+    assert hasattr(scheduler, "run_extraction_scheduler_tick"), (
+        "T6-03: ``run_extraction_scheduler_tick`` MUST be defined in "
+        "bot/services/scheduler.py"
+    )
+    fn = scheduler.run_extraction_scheduler_tick
+    assert inspect.iscoroutinefunction(fn), (
+        "T6-03: ``run_extraction_scheduler_tick`` must be ``async def``"
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_extraction_scheduler_tick_constructs_live_gateway(monkeypatch) -> None:
+    """The wrapper must build LiveExtractCandidatesGateway and pass it to
+    ``extraction_scheduler_tick``.
+    """
+    from bot.services import scheduler as scheduler_module
+    from bot.services.extractor import SchedulerTickResult
+    from bot.services.llm_gateway import LiveExtractCandidatesGateway
+
+    captured: dict = {}
+
+    class _FakeSession:
+        async def commit(self) -> None: ...
+        async def rollback(self) -> None: ...
+
+    class _FakeSessionCtx:
+        async def __aenter__(self):
+            return _FakeSession()
+
+        async def __aexit__(self, *args):
+            return None
+
+    monkeypatch.setattr(
+        scheduler_module, "async_session", lambda: _FakeSessionCtx()
+    )
+
+    async def fake_tick(session, *, gateway, **kwargs):
+        captured["gateway"] = gateway
+        return SchedulerTickResult(skipped=True, reason="flag_disabled")
+
+    monkeypatch.setattr(
+        scheduler_module, "extraction_scheduler_tick", fake_tick
+    )
+
+    await scheduler_module.run_extraction_scheduler_tick()
+
+    assert "gateway" in captured
+    assert isinstance(captured["gateway"], LiveExtractCandidatesGateway)
+
+
+@pytest.mark.asyncio
+async def test_run_extraction_scheduler_tick_swallows_exceptions(monkeypatch) -> None:
+    """Tick crashes must NOT propagate — scheduler keeps running."""
+    from bot.services import scheduler as scheduler_module
+
+    class _FakeSession:
+        async def commit(self) -> None: ...
+        async def rollback(self) -> None: ...
+
+    class _FakeSessionCtx:
+        async def __aenter__(self):
+            return _FakeSession()
+
+        async def __aexit__(self, *args):
+            return None
+
+    monkeypatch.setattr(
+        scheduler_module, "async_session", lambda: _FakeSessionCtx()
+    )
+
+    async def fake_tick(session, *, gateway, **kwargs):
+        raise RuntimeError("simulated tick crash")
+
+    monkeypatch.setattr(
+        scheduler_module, "extraction_scheduler_tick", fake_tick
+    )
+
+    # Should not raise.
+    await scheduler_module.run_extraction_scheduler_tick()
+
+
+def test_extraction_scheduler_tick_registered_in_start_scheduler() -> None:
+    """``start_scheduler`` must register the extraction tick as an apscheduler job.
+
+    AST-level check (the live scheduler.add_job is a complex apscheduler obj
+    not trivial to introspect at runtime).
+    """
+    src = (REPO_ROOT / "bot" / "services" / "scheduler.py").read_text(
+        encoding="utf-8"
+    )
+    tree = ast.parse(src)
+    found_call = False
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not isinstance(func, ast.Attribute) or func.attr != "add_job":
+            continue
+        # First positional arg must be ``run_extraction_scheduler_tick``.
+        if not node.args:
+            continue
+        first = node.args[0]
+        if isinstance(first, ast.Name) and first.id == "run_extraction_scheduler_tick":
+            found_call = True
+            break
+    assert found_call, (
+        "T6-03: ``scheduler.add_job(run_extraction_scheduler_tick, ...)`` "
+        "must appear inside ``start_scheduler`` in bot/services/scheduler.py"
+    )

--- a/tests/test_main_routers.py
+++ b/tests/test_main_routers.py
@@ -1,0 +1,64 @@
+"""T6-03 — verify ``bot/__main__.py`` registers the Phase 6 admin_extract router.
+
+PHASE6_PLAN.md §7 T6-03 + T6-02 addendum: ``admin_extract.router`` MUST be
+included via ``dp.include_routers(...)`` adjacent to ``admin.router``.
+
+The check is AST-level (rather than importing ``bot.__main__`` and running
+its async ``main()``) so it works without the asyncio event-loop boot.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MAIN_PATH = REPO_ROOT / "bot" / "__main__.py"
+
+
+def _parse_main_module() -> ast.Module:
+    return ast.parse(MAIN_PATH.read_text(encoding="utf-8"))
+
+
+def test_admin_extract_imported_from_bot_handlers() -> None:
+    """``admin_extract`` MUST appear in the ``from bot.handlers import ...`` block."""
+    tree = _parse_main_module()
+    imported_handler_names: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module == "bot.handlers":
+            for alias in node.names:
+                imported_handler_names.append(alias.name)
+    assert "admin_extract" in imported_handler_names, (
+        "T6-03: ``admin_extract`` must be imported from ``bot.handlers`` in "
+        f"bot/__main__.py — currently imported handlers: {imported_handler_names}"
+    )
+
+
+def test_admin_extract_router_included_in_dispatcher() -> None:
+    """``admin_extract.router`` MUST be passed to ``dp.include_routers(...)``."""
+    tree = _parse_main_module()
+    found = False
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        # Match ``dp.include_routers(...)`` or ``dp.include_router(...)``.
+        if not isinstance(func, ast.Attribute):
+            continue
+        if func.attr not in ("include_routers", "include_router"):
+            continue
+        for arg in node.args:
+            if (
+                isinstance(arg, ast.Attribute)
+                and isinstance(arg.value, ast.Name)
+                and arg.value.id == "admin_extract"
+                and arg.attr == "router"
+            ):
+                found = True
+                break
+        if found:
+            break
+    assert found, (
+        "T6-03: ``admin_extract.router`` must appear as an argument to "
+        "``dp.include_routers(...)`` in bot/__main__.py"
+    )


### PR DESCRIPTION
Phase 6 **Wave 1 Stream B sprint 2** — closes Wave 1 functionally end-to-end.

## What's in

- `extract_candidates` method on `LLMGateway` — empty-input short-circuit, JSON envelope parser, citation hallucination filter, full provider error taxonomy, ledger write
- `LiveExtractCandidatesGateway` adapter — concrete impl of T6-02 Protocol seam
- Shared helpers `load_gateway_config` + `resolve_provider` + `DEFAULT_PROMPT_TEMPLATE_VERSION` in `llm_gateway.py`
- Router registration in `bot/__main__.py` (`admin_extract.router` adjacent to `admin.router`)
- DI refactor: `cmd_admin_extract` builds gateway locally (Phase 5 QA precedent)
- Scheduler wrapper `run_extraction_scheduler_tick` in `bot/services/scheduler.py` + 15-min apscheduler job, flag-gated default OFF
- 17 new tests (11 gateway + 3 router + 3 scheduler) + 14 admin handler regression tests

## Wave 1 closure flow verified

1. Admin sends `/admin_extract --window <ISO8601>..<ISO8601>` (private chat, ADMIN_IDS guard)
2. Handler parses window → builds `LiveExtractCandidatesGateway` from env config → calls `run_extraction_pass`
3. `run_extraction_pass`: INSERT ExtractionRun(running) + commit → SELECT eligible sources → `_bundle_is_clean` defense-in-depth re-query → gateway call inside SAVEPOINT → INSERT candidates → UPDATE run to `completed`
4. Gateway: budget lock → ledger row reservation → provider HTTP → JSON parse + hallucinated-mvid drop → ledger UPDATE with real cost
5. Admin sees summary: run_status, candidate_count, llm_usage_ledger_id, extraction_run_id

Scheduler tick enabled by FeatureFlag `memory.extraction.scheduler.enabled=True`; 15-min apscheduler job; short-circuits when flag OFF.

## Review

- Claude product (standard-product-reviewer, opus): **ACCEPTED** — all §7 T6-03 bullets met; Wave 1 closure ready
- Codex tech (gpt-5.5 high): **APPROVE** — 17/17 checklist PASS, 1 MED (cosmetic error name), 2 LOW deferred

## Test plan

- [x] Phase 11 binding 21/21 green on PR head (T6-03 sub-gate per §6 + §7)
- [x] Full pytest suite 892 passed, 1 skipped (pre-existing healing test psycopg gap)
- [x] Ruff + privacy lint green
- [x] All §7 T6-03 acceptance items verified

## Deferred to follow-up

- qa.py refactor → use shared `load_gateway_config` / `resolve_provider`
- Anthropic SDK declaration in `pyproject.toml` (pre-existing Phase 5 carryover)
- `test_extract_candidates_binding.py` (optional per design)

🤖 Generated with [Claude Code](https://claude.com/claude-code)