### PR TITLE
feat(p6-w2-stream-d): T6-06 search include_cards + T6-07 EvidenceItem source_type

### DIFF
--- a/bot/handlers/qa.py
+++ b/bot/handlers/qa.py
@@ -20,7 +20,7 @@ from bot.db.repos.llm_synthesis_cache import SynthesisCacheRepo
 from bot.db.repos.llm_usage_ledger import LedgerRepo
 from bot.db.repos.qa_trace import QaTraceRepo
 from bot.db.repos.user import UserRepo
-from bot.services.evidence import EvidenceBundle
+from bot.services.evidence import EvidenceBundle, EvidenceItem
 from bot.services.governance import detect_policy
 from bot.services.llm_gateway import (
     AnswerWithCitations,
@@ -80,23 +80,84 @@ def _author_name(user: object | None) -> str:
     return "—"
 
 
+def _format_message_item(
+    item: EvidenceItem,
+    short_chat_id: str,
+    users_by_id: dict[int, object],
+) -> str:
+    """T6-07: message-hit renderer used in the mixed-bundle branch only.
+
+    The pure-message bundle keeps its rendering INLINED in ``_format_response``
+    for byte-for-byte Phase 4 preservation (see comment at the Phase 4 fast
+    path below; tests/handlers/test_qa_recall_phase4_preserved.py is the
+    regression guard).
+    """
+    author_name = _author_name(users_by_id.get(item.user_id) if item.user_id else None)
+    date_text = _format_date(item.message_date)
+    snippet = _safe_headline(item.snippet)
+    link = f"https://t.me/c/{short_chat_id}/{item.message_id}"
+    return (
+        f"<blockquote>{snippet}</blockquote>\n"
+        f"<i>— {author_name}, {date_text}</i> · "
+        f"<a href=\"{html.escape(link, quote=True)}\">сообщение</a> · "
+        f"<code>message_version_id:{item.message_version_id}</code>"
+    )
+
+
+def _format_card_item(item: EvidenceItem, short_chat_id: str) -> str:
+    """T6-07 card-hit rendering with back-citation trace.
+
+    Per PHASE6_PLAN.md §1 invariant #4 every card citation MUST surface the
+    source ``message_version_id`` set so the rendered output traces back to
+    the underlying messages. The anchor source's Telegram message is also
+    linked so admins can jump to the primary source.
+    """
+    date_text = _format_date(item.message_date)  # T6-06 substitutes approved_at here
+    snippet = _safe_headline(item.snippet)
+    anchor_link = f"https://t.me/c/{short_chat_id}/{item.message_id}"
+    mvid_list = ", ".join(str(m) for m in item.card_source_message_version_ids)
+    return (
+        f"<blockquote>{snippet}</blockquote>\n"
+        f"<i>\U0001f4cb Карточка, {date_text}</i> · "
+        f"<a href=\"{html.escape(anchor_link, quote=True)}\">первоисточник</a> · "
+        f"<code>card_id:{item.card_id}</code> · "
+        f"<code>sources:[{mvid_list}]</code>"
+    )
+
+
 def _format_response(bundle: EvidenceBundle, users_by_id: dict[int, object]) -> str:
     if bundle.abstained:
         return "Не нашёл подходящих свидетельств в истории чата."
 
+    # T6-07: detect mixed-bundle (any card hit) vs pure-message bundle. The
+    # pure-message path stays INLINED below for byte-for-byte Phase 4 preservation
+    # (tests/handlers/test_qa_recall_phase4_preserved.py is the regression guard).
+    has_card = any(item.source_type == "card" for item in bundle.items)
+    if not has_card:
+        # Phase 4 path — preserved byte-for-byte from the original implementation.
+        parts = ["<b>Найденные свидетельства:</b>"]
+        short_chat_id = _short_chat_id(bundle.chat_id)
+        for item in bundle.items:
+            author_name = _author_name(users_by_id.get(item.user_id) if item.user_id else None)
+            date_text = _format_date(item.message_date)
+            snippet = _safe_headline(item.snippet)
+            link = f"https://t.me/c/{short_chat_id}/{item.message_id}"
+            parts.append(
+                f"<blockquote>{snippet}</blockquote>\n"
+                f"<i>— {author_name}, {date_text}</i> · "
+                f"<a href=\"{html.escape(link, quote=True)}\">сообщение</a> · "
+                f"<code>message_version_id:{item.message_version_id}</code>"
+            )
+        return "\n\n".join(parts)
+
+    # T6-07 mixed/card path — uses the helper renderers above.
     parts = ["<b>Найденные свидетельства:</b>"]
     short_chat_id = _short_chat_id(bundle.chat_id)
     for item in bundle.items:
-        author_name = _author_name(users_by_id.get(item.user_id) if item.user_id else None)
-        date_text = _format_date(item.message_date)
-        snippet = _safe_headline(item.snippet)
-        link = f"https://t.me/c/{short_chat_id}/{item.message_id}"
-        parts.append(
-            f"<blockquote>{snippet}</blockquote>\n"
-            f"<i>— {author_name}, {date_text}</i> · "
-            f"<a href=\"{html.escape(link, quote=True)}\">сообщение</a> · "
-            f"<code>message_version_id:{item.message_version_id}</code>"
-        )
+        if item.source_type == "card":
+            parts.append(_format_card_item(item, short_chat_id))
+        else:
+            parts.append(_format_message_item(item, short_chat_id, users_by_id))
     return "\n\n".join(parts)
 
 
@@ -171,16 +232,46 @@ def _format_synthesized_response(
     surviving evidence so the cascade can invalidate them, but the
     user-facing layout reuses the Phase 4 evidence list verbatim.
     """
+    # T6-07: detect mixed-bundle. Pure-message bundles keep the Phase 5 footer
+    # byte-for-byte (tests/handlers/test_qa_llm_synthesis.py is the guard).
+    has_card = any(item.source_type == "card" for item in bundle.items)
     answer_text = html.escape(answer.answer_text, quote=False)
     parts = [answer_text, "", "<b>Источники:</b>"]
+    if not has_card:
+        # Phase 5 path — preserved byte-for-byte.
+        for idx, item in enumerate(bundle.items, start=1):
+            author_name = _author_name(
+                users_by_id.get(item.user_id) if item.user_id else None
+            )
+            date_text = _format_date(item.message_date)
+            snippet = _safe_headline(item.snippet)
+            parts.append(f"[{idx}] {date_text} — {author_name}: {snippet}")
+        return "\n".join(parts)
+
+    # T6-07 mixed/card path.
     for idx, item in enumerate(bundle.items, start=1):
-        author_name = _author_name(
-            users_by_id.get(item.user_id) if item.user_id else None
-        )
-        date_text = _format_date(item.message_date)
-        snippet = _safe_headline(item.snippet)
-        parts.append(f"[{idx}] {date_text} — {author_name}: {snippet}")
+        if item.source_type == "card":
+            parts.append(_format_synth_card_footer(idx, item))
+        else:
+            author_name = _author_name(
+                users_by_id.get(item.user_id) if item.user_id else None
+            )
+            date_text = _format_date(item.message_date)
+            snippet = _safe_headline(item.snippet)
+            parts.append(f"[{idx}] {date_text} — {author_name}: {snippet}")
     return "\n".join(parts)
+
+
+def _format_synth_card_footer(idx: int, item: EvidenceItem) -> str:
+    """T6-07 Phase 5 synthesis-mode card footer entry."""
+    date_text = _format_date(item.message_date)  # T6-06 substitutes approved_at
+    snippet = _safe_headline(item.snippet)
+    source_count = len(item.card_source_message_version_ids)
+    return (
+        f"[{idx}] {date_text} — \U0001f4cb Card "
+        f"<code>{item.card_id}</code> "
+        f"(sources: {source_count}): {snippet}"
+    )
 
 
 async def _write_trace(

--- a/bot/services/evidence.py
+++ b/bot/services/evidence.py
@@ -1,11 +1,22 @@
-"""Frozen evidence bundle contract for Phase 4 retrieval consumers."""
+"""Frozen evidence bundle contract for Phase 4 retrieval consumers.
+
+Phase 6 (T6-07) extension: ``EvidenceItem`` carries a ``source_type`` field
+discriminating message-version hits from approved-knowledge-card hits. Card
+hits additionally expose ``card_id`` and ``card_source_message_version_ids``
+so the consumer (``bot/handlers/qa.py`` rendering, the LLM gateway citation
+filter) can render a back-citation trace per ``PHASE6_PLAN.md §1`` invariant #4.
+
+The new fields default to message-shape values so every Phase 4 caller (search
+hits, tests, fakes) constructs an ``EvidenceItem`` unchanged.
+"""
 
 from __future__ import annotations
 
+import uuid
 from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Protocol
+from typing import Literal, Protocol
 
 
 class SearchHitLike(Protocol):
@@ -31,6 +42,14 @@ class EvidenceItem:
     ts_rank: float
     captured_at: datetime
     message_date: datetime
+    # T6-07: source-type discriminator. Defaults trip for Phase 4 callers so
+    # existing construction sites (search hits, test fakes) are unchanged.
+    # For card hits, ``message_version_id`` is the anchor source's mvid
+    # (lowest-position ``card_sources`` row); the FULL source-mvid set is
+    # surfaced via ``card_source_message_version_ids`` for the renderer.
+    source_type: Literal["message", "card"] = "message"
+    card_id: uuid.UUID | None = None
+    card_source_message_version_ids: tuple[int, ...] = ()
 
     def to_dict(self) -> dict[str, object]:
         return {
@@ -43,6 +62,11 @@ class EvidenceItem:
             "ts_rank": self.ts_rank,
             "captured_at": self.captured_at.isoformat(),
             "message_date": self.message_date.isoformat(),
+            "source_type": self.source_type,
+            "card_id": str(self.card_id) if self.card_id is not None else None,
+            "card_source_message_version_ids": list(
+                self.card_source_message_version_ids
+            ),
         }
 
 
@@ -72,6 +96,15 @@ class EvidenceBundle:
                 ts_rank=hit.ts_rank,
                 captured_at=hit.captured_at,
                 message_date=hit.message_date,
+                # T6-07 cross-stream contract: T6-06 ``SearchHit`` exposes
+                # ``source_type`` / ``card_id`` / ``card_source_message_version_ids``;
+                # pre-T6-06 fakes don't have them — ``getattr`` defaults trip
+                # to message-shape values.
+                source_type=getattr(hit, "source_type", "message"),
+                card_id=getattr(hit, "card_id", None),
+                card_source_message_version_ids=tuple(
+                    getattr(hit, "card_source_message_version_ids", ())
+                ),
             )
             for hit in hits
         )

--- a/bot/services/search.py
+++ b/bot/services/search.py
@@ -1,10 +1,40 @@
-"""Governance-filtered full-text search for Phase 4 memory retrieval."""
+"""Governance-filtered full-text search for Phase 4 memory retrieval.
+
+Phase 6 (T6-06) extension: ``include_cards`` parameter routes the SQL through
+a UNION ALL of the Phase 4 message branch + an approved-knowledge-cards
+branch. The card branch enforces:
+
+1. ``card_status='approved'`` (governance gate per PHASE6_PLAN.md §1 #4).
+2. NO source has been forgotten (defense-in-depth NOT EXISTS over
+   ``card_sources`` → ``message_versions`` → ``chat_messages`` →
+   ``forget_events`` with the canonical 3-status tombstone-key construction).
+3. NO source has ``memory_policy != 'normal'`` OR ``is_redacted=TRUE``
+   (catches manual redaction without a ``forget_event``).
+
+The cascade rule (``_cascade_card_sources_on_forget``) demotes a card to
+``archived`` only when ALL sources are forgotten; T6-06 enforces stricter
+exclusion at the search boundary so ``/recall include_cards=True`` cannot
+return a card paraphrasing now-forgotten content before admin re-review.
+
+The default is ``include_cards=True`` per PHASE6_PLAN.md §5.D; passing
+``include_cards=False`` preserves Phase 4 behaviour byte-for-byte (literal
+copy of the Phase 4 SQL, no UNION).
+
+``SearchHit`` gains three defaulted fields (``source_type`` /
+``card_id`` / ``card_source_message_version_ids``) so existing callers
+treating hits as message-shape see no breaking change. For card hits the
+``message_version_id`` / ``chat_message_id`` / ``chat_id`` / ``message_id``
+columns point at the anchor source (lowest-position ``card_sources`` row)
+so the downstream renderer (T6-07) can link to a Telegram message.
+"""
 
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass
+import uuid
+from dataclasses import dataclass, field
 from datetime import datetime
+from typing import Literal
 
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -12,6 +42,12 @@ from sqlalchemy.ext.asyncio import AsyncSession
 logger = logging.getLogger(__name__)
 
 MAX_QUERY_LENGTH = 256
+
+# T6-06: multiplicative boost applied to ``ts_rank_cd`` of card hits so they
+# rank slightly above equivalent raw message hits. Tunable; chosen empirically
+# per T6-06_design.md §3 (Rank boost). A strong message match still beats a
+# weak card match — the boost lifts cards above message hits of similar rank.
+CARD_RANK_BOOST = 1.15
 
 
 @dataclass(frozen=True)
@@ -25,6 +61,257 @@ class SearchHit:
     ts_rank: float
     captured_at: datetime
     message_date: datetime
+    # T6-06: card-hit discriminator. Defaults trip for message hits so every
+    # Phase 4 caller (incl. fakes) sees the same dataclass shape it had.
+    # For card hits: ``source_type='card'``, ``card_id`` is the UUID of the
+    # ``knowledge_cards`` row, and ``card_source_message_version_ids`` is
+    # the full ordered tuple of mvids attached via ``card_sources``.
+    source_type: Literal["message", "card"] = "message"
+    card_id: uuid.UUID | None = None
+    card_source_message_version_ids: tuple[int, ...] = field(default_factory=tuple)
+
+
+# ─── Phase 4 SQL — preserved verbatim for ``include_cards=False`` callers ────
+#
+# This is the literal Phase 4 statement that shipped in PR #151 + #156. It is
+# kept as a string constant so the ``include_cards=False`` path executes the
+# exact same SQL (modulo whitespace identical to the original) — the
+# byte-for-byte guarantee in PHASE6_PLAN.md §5.D / T6-06_design.md §2 holds
+# at the result-set level.
+_PHASE4_SQL = """
+WITH q AS (
+    SELECT plainto_tsquery('russian', :query) AS tsq
+)
+SELECT
+    mv.id AS message_version_id,
+    mv.chat_message_id AS chat_message_id,
+    c.chat_id AS chat_id,
+    c.message_id AS message_id,
+    c.user_id AS user_id,
+    COALESCE(
+        ts_headline(
+            'russian',
+            concat_ws(' ', mv.normalized_text, mv.caption),
+            q.tsq,
+            :headline_options
+        ),
+        ''
+    ) AS snippet,
+    ts_rank_cd(mv.search_tsv, q.tsq) AS rank,
+    mv.captured_at AS captured_at,
+    c.date AS message_date
+FROM message_versions AS mv
+JOIN chat_messages AS c
+    ON c.id = mv.chat_message_id
+    AND c.current_version_id = mv.id
+CROSS JOIN q
+WHERE c.chat_id = :chat_id
+    AND c.memory_policy = 'normal'
+    AND c.is_redacted = FALSE
+    AND mv.is_redacted = FALSE
+    AND mv.search_tsv @@ q.tsq
+    AND NOT EXISTS (
+        SELECT 1
+        FROM forget_events AS fe
+        WHERE (
+            fe.tombstone_key = 'message:' || c.chat_id::text || ':' || c.message_id::text
+            OR (
+                c.content_hash IS NOT NULL
+                AND fe.tombstone_key = 'message_hash:' || c.content_hash
+            )
+            OR (
+                c.user_id IS NOT NULL
+                AND fe.tombstone_key = 'user:' || c.user_id::text
+            )
+        )
+        AND fe.status IN ('pending', 'processing', 'completed')
+    )
+ORDER BY rank DESC, mv.captured_at DESC, mv.id DESC
+LIMIT :limit
+"""
+
+
+# ─── Phase 6 SQL — UNION ALL of message + card branches ──────────────────────
+#
+# The message branch is a literal mirror of ``_PHASE4_SQL`` body minus the
+# outer ORDER BY / LIMIT (the wrapping query owns those). It emits NULL
+# placeholders for ``card_id`` and ``card_source_message_version_ids`` so
+# column counts match the card branch.
+#
+# The card branch:
+#   - Filters approved cards FTS-matched on ``body_tsv`` (GIN index from
+#     migration 032).
+#   - Enforces defense-in-depth source-state via TWO ``NOT EXISTS``:
+#     * one for forget-event tombstones (mirroring the Phase 4 3-key
+#       construction across message:/message_hash:/user:);
+#     * one for governance state (``memory_policy != 'normal'`` OR
+#       ``is_redacted=TRUE`` on either ``chat_messages`` or
+#       ``message_versions``).
+#   - Resolves the anchor source (lowest-position ``card_sources`` row) so
+#     the hit carries a citable Telegram message_id / chat_id.
+#   - Aggregates ALL source mvids into ``card_source_message_version_ids``
+#     so the renderer (T6-07) can list the full back-citation trace.
+#
+# Card hits are NOT filtered by ``:chat_id``: cards are admin-curated
+# canonical knowledge potentially bridging chats. Phase 6 ingestion only
+# touches a single community chat today, so this is a no-op; left permissive
+# for the multi-chat future per T6-06_design.md §3 (Chat scope for card hits).
+_PHASE6_SQL = """
+WITH q AS (
+    SELECT plainto_tsquery('russian', :query) AS tsq
+),
+message_hits AS (
+    SELECT
+        mv.id AS message_version_id,
+        mv.chat_message_id AS chat_message_id,
+        c.chat_id AS chat_id,
+        c.message_id AS message_id,
+        c.user_id AS user_id,
+        COALESCE(
+            ts_headline(
+                'russian',
+                concat_ws(' ', mv.normalized_text, mv.caption),
+                q.tsq,
+                :headline_options
+            ),
+            ''
+        ) AS snippet,
+        ts_rank_cd(mv.search_tsv, q.tsq) AS rank,
+        mv.captured_at AS captured_at,
+        c.date AS message_date,
+        'message'::text AS source_type,
+        NULL::uuid AS card_id,
+        ARRAY[]::int[] AS card_source_message_version_ids
+    FROM message_versions AS mv
+    JOIN chat_messages AS c
+        ON c.id = mv.chat_message_id
+        AND c.current_version_id = mv.id
+    CROSS JOIN q
+    WHERE c.chat_id = :chat_id
+        AND c.memory_policy = 'normal'
+        AND c.is_redacted = FALSE
+        AND mv.is_redacted = FALSE
+        AND mv.search_tsv @@ q.tsq
+        AND NOT EXISTS (
+            SELECT 1
+            FROM forget_events AS fe
+            WHERE (
+                fe.tombstone_key = 'message:' || c.chat_id::text || ':' || c.message_id::text
+                OR (
+                    c.content_hash IS NOT NULL
+                    AND fe.tombstone_key = 'message_hash:' || c.content_hash
+                )
+                OR (
+                    c.user_id IS NOT NULL
+                    AND fe.tombstone_key = 'user:' || c.user_id::text
+                )
+            )
+            AND fe.status IN ('pending', 'processing', 'completed')
+        )
+),
+approved_card_hits AS (
+    SELECT
+        kc.id AS card_id,
+        ts_rank_cd(kc.body_tsv, q.tsq) AS rank,
+        COALESCE(
+            ts_headline(
+                'russian',
+                kc.body_markdown,
+                q.tsq,
+                :headline_options
+            ),
+            ''
+        ) AS snippet,
+        kc.approved_at AS approved_at
+    FROM knowledge_cards AS kc
+    CROSS JOIN q
+    WHERE kc.card_status = 'approved'
+        AND kc.body_tsv @@ q.tsq
+        AND NOT EXISTS (
+            -- Defense-in-depth #1: exclude card if ANY source is tombstoned
+            -- (forget_event open in pending|processing|completed status).
+            SELECT 1
+            FROM card_sources cs2
+            JOIN message_versions mv2 ON mv2.id = cs2.message_version_id
+            JOIN chat_messages c2 ON c2.id = mv2.chat_message_id
+            JOIN forget_events fe2 ON (
+                fe2.tombstone_key
+                    = 'message:' || c2.chat_id::text || ':' || c2.message_id::text
+                OR (
+                    c2.content_hash IS NOT NULL
+                    AND fe2.tombstone_key = 'message_hash:' || c2.content_hash
+                )
+                OR (
+                    c2.user_id IS NOT NULL
+                    AND fe2.tombstone_key = 'user:' || c2.user_id::text
+                )
+            )
+            WHERE cs2.card_id = kc.id
+                AND fe2.status IN ('pending', 'processing', 'completed')
+        )
+        AND NOT EXISTS (
+            -- Defense-in-depth #2: exclude card if ANY source has
+            -- memory_policy != 'normal' OR is_redacted=TRUE.
+            SELECT 1
+            FROM card_sources cs3
+            JOIN message_versions mv3 ON mv3.id = cs3.message_version_id
+            JOIN chat_messages c3 ON c3.id = mv3.chat_message_id
+            WHERE cs3.card_id = kc.id
+                AND (
+                    c3.memory_policy <> 'normal'
+                    OR c3.is_redacted = TRUE
+                    OR mv3.is_redacted = TRUE
+                )
+        )
+),
+card_anchors AS (
+    SELECT DISTINCT ON (cs.card_id)
+        cs.card_id,
+        mv.id AS message_version_id,
+        c.id AS chat_message_id,
+        c.chat_id AS chat_id,
+        c.message_id AS message_id,
+        c.date AS source_message_date
+    FROM card_sources cs
+    JOIN message_versions mv ON mv.id = cs.message_version_id
+    JOIN chat_messages c ON c.id = mv.chat_message_id
+    WHERE cs.card_id IN (SELECT card_id FROM approved_card_hits)
+    ORDER BY cs.card_id, cs.position ASC, cs.id ASC
+),
+card_source_lists AS (
+    SELECT cs.card_id,
+           ARRAY_AGG(cs.message_version_id ORDER BY cs.position ASC, cs.id ASC) AS mvids
+    FROM card_sources cs
+    WHERE cs.card_id IN (SELECT card_id FROM approved_card_hits)
+    GROUP BY cs.card_id
+),
+card_hits AS (
+    SELECT
+        ca.message_version_id AS message_version_id,
+        ca.chat_message_id AS chat_message_id,
+        ca.chat_id AS chat_id,
+        ca.message_id AS message_id,
+        NULL::bigint AS user_id,
+        ach.snippet AS snippet,
+        ach.rank * :card_rank_boost AS rank,
+        ach.approved_at AS captured_at,
+        COALESCE(ach.approved_at, ca.source_message_date) AS message_date,
+        'card'::text AS source_type,
+        ach.card_id AS card_id,
+        csl.mvids AS card_source_message_version_ids
+    FROM approved_card_hits ach
+    JOIN card_anchors ca ON ca.card_id = ach.card_id
+    JOIN card_source_lists csl ON csl.card_id = ach.card_id
+)
+SELECT *
+FROM (
+    SELECT * FROM message_hits
+    UNION ALL
+    SELECT * FROM card_hits
+) AS all_hits
+ORDER BY rank DESC, captured_at DESC, message_version_id DESC
+LIMIT :limit
+"""
 
 
 async def search_messages(
@@ -34,11 +321,23 @@ async def search_messages(
     chat_id: int,
     limit: int = 3,
     headline_max_words: int = 35,
+    include_cards: bool = True,
 ) -> list[SearchHit]:
-    """Search visible message versions in one chat.
+    """Search visible message versions (+ optionally approved cards) in one chat.
 
-    The governance filter is intentionally repeated here instead of depending on
-    index shape for privacy.
+    When ``include_cards=False`` returns Phase 4 results byte-for-byte (uses
+    the literal Phase 4 SQL, no card branch). Default ``True`` per
+    ``PHASE6_PLAN.md §5.D``: card hits surface alongside message hits with a
+    multiplicative rank boost (``CARD_RANK_BOOST``) so admin-curated content
+    ranks slightly above equivalent raw message hits.
+
+    The governance filter is intentionally repeated here instead of depending
+    on index shape for privacy.
+
+    SQLite dialect: ``to_tsvector`` / ``ts_rank_cd`` / ``ts_headline`` are
+    Postgres-only. For SQLite-bound sessions the card branch is silently
+    skipped via dialect detection — the function returns only message hits
+    (or an empty list if even the Phase 4 SQL isn't Postgres-compatible).
     """
     normalized_query = query.strip()
     if not normalized_query:
@@ -59,59 +358,41 @@ async def search_messages(
         f"MaxWords={headline_max_words},MinWords=10,ShortWord=2,HighlightAll=false"
     )
 
-    stmt = text(
-        """
-        WITH q AS (
-            SELECT plainto_tsquery('russian', :query) AS tsq
+    # T6-06 dialect guard: SQLite has no Russian tsvector functions. Strip the
+    # card branch on SQLite even if the caller asked for it (returns only the
+    # Phase 4 result set, possibly empty). Production runs on Postgres; this
+    # branch keeps ORM-only SQLite tests from breaking.
+    dialect_name = session.bind.dialect.name if session.bind is not None else "postgresql"
+    if dialect_name != "postgresql":
+        include_cards = False
+
+    if not include_cards:
+        stmt = text(_PHASE4_SQL)
+        result = await session.execute(
+            stmt,
+            {
+                "query": normalized_query,
+                "chat_id": chat_id,
+                "limit": limit,
+                "headline_options": headline_options,
+            },
         )
-        SELECT
-            mv.id AS message_version_id,
-            mv.chat_message_id AS chat_message_id,
-            c.chat_id AS chat_id,
-            c.message_id AS message_id,
-            c.user_id AS user_id,
-            COALESCE(
-                ts_headline(
-                    'russian',
-                    concat_ws(' ', mv.normalized_text, mv.caption),
-                    q.tsq,
-                    :headline_options
-                ),
-                ''
-            ) AS snippet,
-            ts_rank_cd(mv.search_tsv, q.tsq) AS rank,
-            mv.captured_at AS captured_at,
-            c.date AS message_date
-        FROM message_versions AS mv
-        JOIN chat_messages AS c
-            ON c.id = mv.chat_message_id
-            AND c.current_version_id = mv.id
-        CROSS JOIN q
-        WHERE c.chat_id = :chat_id
-            AND c.memory_policy = 'normal'
-            AND c.is_redacted = FALSE
-            AND mv.is_redacted = FALSE
-            AND mv.search_tsv @@ q.tsq
-            AND NOT EXISTS (
-                SELECT 1
-                FROM forget_events AS fe
-                WHERE (
-                    fe.tombstone_key = 'message:' || c.chat_id::text || ':' || c.message_id::text
-                    OR (
-                        c.content_hash IS NOT NULL
-                        AND fe.tombstone_key = 'message_hash:' || c.content_hash
-                    )
-                    OR (
-                        c.user_id IS NOT NULL
-                        AND fe.tombstone_key = 'user:' || c.user_id::text
-                    )
-                )
-                AND fe.status IN ('pending', 'processing', 'completed')
+        return [
+            SearchHit(
+                message_version_id=row["message_version_id"],
+                chat_message_id=row["chat_message_id"],
+                chat_id=row["chat_id"],
+                message_id=row["message_id"],
+                user_id=row["user_id"],
+                snippet=row["snippet"],
+                ts_rank=float(row["rank"]),
+                captured_at=row["captured_at"],
+                message_date=row["message_date"],
             )
-        ORDER BY rank DESC, mv.captured_at DESC, mv.id DESC
-        LIMIT :limit
-        """
-    )
+            for row in result.mappings().all()
+        ]
+
+    stmt = text(_PHASE6_SQL)
     result = await session.execute(
         stmt,
         {
@@ -119,20 +400,28 @@ async def search_messages(
             "chat_id": chat_id,
             "limit": limit,
             "headline_options": headline_options,
+            "card_rank_boost": CARD_RANK_BOOST,
         },
     )
 
-    return [
-        SearchHit(
-            message_version_id=row["message_version_id"],
-            chat_message_id=row["chat_message_id"],
-            chat_id=row["chat_id"],
-            message_id=row["message_id"],
-            user_id=row["user_id"],
-            snippet=row["snippet"],
-            ts_rank=float(row["rank"]),
-            captured_at=row["captured_at"],
-            message_date=row["message_date"],
+    hits: list[SearchHit] = []
+    for row in result.mappings().all():
+        raw_mvids = row.get("card_source_message_version_ids") or ()
+        mvids_tuple = tuple(int(m) for m in raw_mvids)
+        hits.append(
+            SearchHit(
+                message_version_id=row["message_version_id"],
+                chat_message_id=row["chat_message_id"],
+                chat_id=row["chat_id"],
+                message_id=row["message_id"],
+                user_id=row["user_id"],
+                snippet=row["snippet"],
+                ts_rank=float(row["rank"]),
+                captured_at=row["captured_at"],
+                message_date=row["message_date"],
+                source_type=row["source_type"],
+                card_id=row["card_id"],
+                card_source_message_version_ids=mvids_tuple,
+            )
         )
-        for row in result.mappings().all()
-    ]
+    return hits

--- a/bot/services/search.py
+++ b/bot/services/search.py
@@ -383,10 +383,21 @@ async def search_messages(
     The governance filter is intentionally repeated here instead of depending
     on index shape for privacy.
 
-    SQLite dialect: ``to_tsvector`` / ``ts_rank_cd`` / ``ts_headline`` are
-    Postgres-only. For SQLite-bound sessions the card branch is silently
-    skipped via dialect detection — the function returns only message hits
-    (or an empty list if even the Phase 4 SQL isn't Postgres-compatible).
+    SQLite dialect: this function is **Postgres-only** at the contract
+    level. Both ``_PHASE4_SQL`` and ``_PHASE6_SQL`` rely on
+    ``plainto_tsquery`` / ``ts_rank_cd`` / ``ts_headline`` and the
+    ``message_versions.search_tsv`` (and, for cards, ``knowledge_cards.body_tsv``)
+    GIN-indexed ``tsvector`` columns. None of those exist in SQLite.
+
+    The dialect guard below flips ``include_cards=False`` on non-Postgres
+    sessions to remove the **card branch** from the SQL — that branch alone
+    references tables and indexes (``knowledge_cards``, ``card_sources``,
+    ``body_tsv``) that ORM-only SQLite tests do not create. The guard does
+    **not** make the Phase 4 SQL itself SQLite-safe. ORM-only SQLite tests
+    that call this function will fail at the database layer; the guard's
+    only contract is "the card-extension does not make Phase 4 callers any
+    less SQLite-compatible than they already were." Production runs on
+    Postgres.
     """
     normalized_query = query.strip()
     if not normalized_query:
@@ -407,10 +418,15 @@ async def search_messages(
         f"MaxWords={headline_max_words},MinWords=10,ShortWord=2,HighlightAll=false"
     )
 
-    # T6-06 dialect guard: SQLite has no Russian tsvector functions. Strip the
-    # card branch on SQLite even if the caller asked for it (returns only the
-    # Phase 4 result set, possibly empty). Production runs on Postgres; this
-    # branch keeps ORM-only SQLite tests from breaking.
+    # T6-06 dialect guard — SCOPE: card-branch removal only, NOT full
+    # SQLite safety. The Phase 4 SQL underneath still uses
+    # ``plainto_tsquery`` / ``ts_rank_cd`` / ``ts_headline`` which are
+    # Postgres-only; running this on SQLite will fail in the message
+    # branch regardless. The guard's sole purpose is to avoid widening
+    # the SQLite-incompatibility surface by referencing card tables that
+    # ORM-only SQLite tests do not create (``knowledge_cards`` /
+    # ``card_sources`` / ``body_tsv``). Production runs on Postgres.
+    # See the docstring above for the full contract.
     dialect_name = session.bind.dialect.name if session.bind is not None else "postgresql"
     if dialect_name != "postgresql":
         include_cards = False

--- a/bot/services/search.py
+++ b/bot/services/search.py
@@ -230,6 +230,15 @@ approved_card_hits AS (
         AND NOT EXISTS (
             -- Defense-in-depth #1: exclude card if ANY source is tombstoned
             -- (forget_event open in pending|processing|completed status).
+            --
+            -- The ``message_hash:`` branch MUST filter on ``mv2.content_hash``
+            -- (NOT NULL by schema), NOT on ``c2.content_hash`` (nullable; live
+            -- persistence in ``bot/db/repos/message.py::MessageRepo.save``
+            -- leaves it NULL). Filtering on ``c2.content_hash`` silently
+            -- no-op's every ``message_hash:`` tombstone for live messages,
+            -- letting tombstoned content leak via cards. Same class as the
+            -- T6-02 round 3 fix in ``bot/services/extractor.py`` — keep the
+            -- two query bodies in lock-step.
             SELECT 1
             FROM card_sources cs2
             JOIN message_versions mv2 ON mv2.id = cs2.message_version_id
@@ -238,8 +247,8 @@ approved_card_hits AS (
                 fe2.tombstone_key
                     = 'message:' || c2.chat_id::text || ':' || c2.message_id::text
                 OR (
-                    c2.content_hash IS NOT NULL
-                    AND fe2.tombstone_key = 'message_hash:' || c2.content_hash
+                    mv2.content_hash IS NOT NULL
+                    AND fe2.tombstone_key = 'message_hash:' || mv2.content_hash
                 )
                 OR (
                     c2.user_id IS NOT NULL

--- a/bot/services/search.py
+++ b/bot/services/search.py
@@ -274,13 +274,13 @@ approved_card_hits AS (
         )
 ),
 -- Per-source tombstone re-check. ``approved_card_hits`` excludes a card
--- when ANY source is tombstoned, so in normal flow no forgotten source
+-- when ANY source is tombstoned, so in normal flow no tombstoned source
 -- reaches the anchor or the mvid array. This CTE re-applies the same
 -- 3-key tombstone check per individual source as belt-and-suspenders
 -- against:
 --   1. A future refactor of ``approved_card_hits`` that loosens the
 --      exclusion condition.
---   2. A race window where the cascade has not yet deleted forgotten
+--   2. A race window where the cascade has not yet deleted tombstoned
 --      ``card_sources`` rows but the forget_event is already visible.
 -- This guarantees no tombstoned mvid can appear in the anchor row or
 -- the ``card_source_message_version_ids`` array. Per-source re-check

--- a/bot/services/search.py
+++ b/bot/services/search.py
@@ -273,26 +273,66 @@ approved_card_hits AS (
                 )
         )
 ),
+-- Per-source tombstone re-check. ``approved_card_hits`` excludes a card
+-- when ANY source is tombstoned, so in normal flow no forgotten source
+-- reaches the anchor or the mvid array. This CTE re-applies the same
+-- 3-key tombstone check per individual source as belt-and-suspenders
+-- against:
+--   1. A future refactor of ``approved_card_hits`` that loosens the
+--      exclusion condition.
+--   2. A race window where the cascade has not yet deleted forgotten
+--      ``card_sources`` rows but the forget_event is already visible.
+-- This guarantees no tombstoned mvid can appear in the anchor row or
+-- the ``card_source_message_version_ids`` array. Per-source re-check
+-- requested by Codex round-2 review (CRITICAL #2).
+unforgotten_card_sources AS (
+    SELECT cs.id AS card_source_id,
+           cs.card_id,
+           cs.message_version_id,
+           cs.position
+    FROM card_sources cs
+    JOIN message_versions mv ON mv.id = cs.message_version_id
+    JOIN chat_messages c ON c.id = mv.chat_message_id
+    WHERE cs.card_id IN (SELECT card_id FROM approved_card_hits)
+        AND NOT EXISTS (
+            SELECT 1
+            FROM forget_events AS fe
+            WHERE (
+                fe.tombstone_key
+                    = 'message:' || c.chat_id::text || ':' || c.message_id::text
+                OR (
+                    mv.content_hash IS NOT NULL
+                    AND fe.tombstone_key = 'message_hash:' || mv.content_hash
+                )
+                OR (
+                    c.user_id IS NOT NULL
+                    AND fe.tombstone_key = 'user:' || c.user_id::text
+                )
+            )
+            AND fe.status IN ('pending', 'processing', 'completed')
+        )
+),
 card_anchors AS (
-    SELECT DISTINCT ON (cs.card_id)
-        cs.card_id,
+    SELECT DISTINCT ON (ucs.card_id)
+        ucs.card_id,
         mv.id AS message_version_id,
         c.id AS chat_message_id,
         c.chat_id AS chat_id,
         c.message_id AS message_id,
         c.date AS source_message_date
-    FROM card_sources cs
-    JOIN message_versions mv ON mv.id = cs.message_version_id
+    FROM unforgotten_card_sources ucs
+    JOIN message_versions mv ON mv.id = ucs.message_version_id
     JOIN chat_messages c ON c.id = mv.chat_message_id
-    WHERE cs.card_id IN (SELECT card_id FROM approved_card_hits)
-    ORDER BY cs.card_id, cs.position ASC, cs.id ASC
+    ORDER BY ucs.card_id, ucs.position ASC, ucs.card_source_id ASC
 ),
 card_source_lists AS (
-    SELECT cs.card_id,
-           ARRAY_AGG(cs.message_version_id ORDER BY cs.position ASC, cs.id ASC) AS mvids
-    FROM card_sources cs
-    WHERE cs.card_id IN (SELECT card_id FROM approved_card_hits)
-    GROUP BY cs.card_id
+    SELECT ucs.card_id,
+           ARRAY_AGG(
+               ucs.message_version_id
+               ORDER BY ucs.position ASC, ucs.card_source_id ASC
+           ) AS mvids
+    FROM unforgotten_card_sources ucs
+    GROUP BY ucs.card_id
 ),
 card_hits AS (
     SELECT

--- a/bot/services/search.py
+++ b/bot/services/search.py
@@ -5,16 +5,16 @@ a UNION ALL of the Phase 4 message branch + an approved-knowledge-cards
 branch. The card branch enforces:
 
 1. ``card_status='approved'`` (governance gate per PHASE6_PLAN.md §1 #4).
-2. NO source has been forgotten (defense-in-depth NOT EXISTS over
+2. NO source has been tombstoned (defense-in-depth NOT EXISTS over
    ``card_sources`` → ``message_versions`` → ``chat_messages`` →
    ``forget_events`` with the canonical 3-status tombstone-key construction).
 3. NO source has ``memory_policy != 'normal'`` OR ``is_redacted=TRUE``
    (catches manual redaction without a ``forget_event``).
 
 The cascade rule (``_cascade_card_sources_on_forget``) demotes a card to
-``archived`` only when ALL sources are forgotten; T6-06 enforces stricter
+``archived`` only when ALL sources are tombstoned; T6-06 enforces stricter
 exclusion at the search boundary so ``/recall include_cards=True`` cannot
-return a card paraphrasing now-forgotten content before admin re-review.
+return a card paraphrasing now-tombstoned content before admin re-review.
 
 The default is ``include_cards=True`` per PHASE6_PLAN.md §5.D; passing
 ``include_cards=False`` preserves Phase 4 behaviour byte-for-byte (literal

--- a/tests/evals/test_citations.py
+++ b/tests/evals/test_citations.py
@@ -26,7 +26,7 @@ from typing import Any
 
 import pytest
 import pytest_asyncio
-from sqlalchemy import select, text
+from sqlalchemy import select
 
 from bot.db.models import (
     CardSource,

--- a/tests/evals/test_citations.py
+++ b/tests/evals/test_citations.py
@@ -1,6 +1,6 @@
-"""Citation invariant tests for the Phase 4 recall / evidence pipeline (T11-W2-02).
+"""Citation invariant tests for the Phase 4 / Phase 6 recall pipeline.
 
-Four sub-cases verified against a live seeded database:
+Phase 4 cases (T11-W2-02, message-only bundles):
 
   C1 every-item-has-id    — each EvidenceItem.message_version_id is a positive int
                             that resolves to an existing message_versions row.
@@ -8,16 +8,34 @@ Four sub-cases verified against a live seeded database:
                             memory_policy='normal' AND is_redacted=FALSE.
   C3 cited-not-tombstoned — no forget_events tombstone covers any cited message.
   C4 audit-trace-matches  — evidence_ids written to qa_traces match the bundle.
+
+Phase 6 cases (T6-06 / T6-07, card-discriminator bundles):
+
+  C5 card-citation-trace  — every card EvidenceItem carries card_id != None AND
+                            a non-empty card_source_message_version_ids tuple; the
+                            anchor mvid (EvidenceItem.message_version_id) appears
+                            in the source list; every source mvid resolves to a
+                            non-redacted message_versions row whose parent
+                            chat_messages row has memory_policy='normal' and
+                            is_redacted=FALSE.
 """
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from typing import Any
 
 import pytest
 import pytest_asyncio
-from sqlalchemy import select
+from sqlalchemy import select, text
 
-from bot.db.models import ChatMessage, ForgetEvent, MessageVersion, QaTrace
+from bot.db.models import (
+    CardSource,
+    ChatMessage,
+    ForgetEvent,
+    KnowledgeCard,
+    MessageVersion,
+    QaTrace,
+)
 from bot.services.eval_runner import run_eval_recall
 from tests.evals.conftest import SEED_CHAT_ID, Seed
 
@@ -187,3 +205,214 @@ class TestCitationInvariants:
             f"qa_traces.evidence_ids={persisted.evidence_ids!r} does not match "
             f"bundle.evidence_ids={mv_ids!r}"
         )
+
+
+# ---------------------------------------------------------------------------
+# T6-06 / T6-07 card citation invariant — C5.
+#
+# Phase 11 binding sub-gate: when a card is returned by /recall, the back-
+# citation trace must point at non-redacted, governance-clean messages. The
+# anchor mvid (EvidenceItem.message_version_id) must be a member of the
+# card_source_message_version_ids tuple. Every mvid in that tuple must
+# resolve to a non-redacted message_versions row.
+# ---------------------------------------------------------------------------
+
+# Function-scoped (so cleanup runs per test) — C5 owns its own card so we
+# don't have to coordinate with the class-scope golden_recall_seed fixture.
+_C5_QUERY = "карточка-cyrus уникальное диковина15"
+_C5_TOPIC = "карточка-cyrus уникальное диковина15 для теста"
+
+
+@pytest.mark.asyncio(loop_scope="class")
+@pytest.mark.usefixtures("eval_app_env")
+class TestPhase6CardCitationInvariants:
+    """C5: approved-card hits must surface a complete, intact source trace.
+
+    A single approved card + 3 governance-clean source messages is seeded
+    once at class-scope via the ``c5_seed`` fixture (mirrors the C1-C4
+    class-scoped pattern). All four sub-cases (C5a/b/c/d) share the seed.
+    Cleanup happens implicitly when ``eval_db_session`` rolls back its
+    outer transaction at class teardown.
+    """
+
+    @pytest_asyncio.fixture(scope="class")
+    async def c5_seed(
+        self,
+        eval_db_session: Any,
+        golden_recall_seed: Seed,
+    ) -> tuple[Any, list[int]]:
+        """Seed: 3 governance-clean messages + 1 approved knowledge_card
+        wiring them as card_sources in position order.
+
+        The ``golden_recall_seed`` dependency is intentional: it primes the
+        DB to the same state the message-only suite expects (so the C5
+        cleanup at the start doesn't strip the C1-C4 seed). We rely on
+        message_id collision avoidance — C5 uses 12_400+ while seed_v1
+        uses lower ranges (see seed_v1/chat_history.jsonl).
+        """
+        _ = golden_recall_seed  # ensure C1-C4 seed loaded first
+        from bot.db.repos.user import UserRepo
+
+        admin_id = 950_000_001
+        await UserRepo.upsert(
+            eval_db_session,
+            telegram_id=admin_id,
+            username=f"c5_admin_{admin_id}",
+            first_name="C5Admin",
+            last_name=None,
+        )
+
+        mvids: list[int] = []
+        for idx in range(3):
+            user_id = 951_000_000 + idx
+            await UserRepo.upsert(
+                eval_db_session,
+                telegram_id=user_id,
+                username=f"c5_user_{idx}",
+                first_name="C5",
+                last_name=None,
+            )
+            cm = ChatMessage(
+                message_id=12_400 + idx,
+                chat_id=SEED_CHAT_ID,
+                user_id=user_id,
+                text=f"источник-{idx} {_C5_TOPIC}",
+                caption=None,
+                date=datetime.now(timezone.utc),
+                memory_policy="normal",
+                is_redacted=False,
+                content_hash=f"c5-hash-{idx}",
+            )
+            eval_db_session.add(cm)
+            await eval_db_session.flush()
+            mv = MessageVersion(
+                chat_message_id=cm.id,
+                version_seq=1,
+                text=cm.text,
+                caption=None,
+                normalized_text=cm.text,
+                content_hash=cm.content_hash,
+                is_redacted=False,
+            )
+            eval_db_session.add(mv)
+            await eval_db_session.flush()
+            cm.current_version_id = mv.id
+            await eval_db_session.flush()
+            mvids.append(mv.id)
+
+        card = KnowledgeCard(
+            title="C5 Card",
+            body_markdown=_C5_TOPIC,
+            card_status="approved",
+            approved_by_user_id=admin_id,
+            approved_at=datetime.now(timezone.utc),
+        )
+        eval_db_session.add(card)
+        await eval_db_session.flush()
+        for position, mvid in enumerate(mvids):
+            eval_db_session.add(
+                CardSource(card_id=card.id, message_version_id=mvid, position=position)
+            )
+        await eval_db_session.flush()
+
+        return card.id, mvids
+
+    @pytest_asyncio.fixture(scope="class")
+    async def c5_bundle(
+        self,
+        eval_db_session: Any,
+        c5_seed: tuple[Any, list[int]],
+    ) -> Any:
+        """Run /recall once at class-scope and expose the bundle."""
+        _ = c5_seed
+        bundle, _trace = await run_eval_recall(
+            eval_db_session, query=_C5_QUERY, chat_id=SEED_CHAT_ID
+        )
+        assert not bundle.abstained, "C5 seed must yield at least one card hit"
+        return bundle
+
+    async def test_c5a_card_item_has_card_id(
+        self,
+        c5_bundle: Any,
+        c5_seed: tuple[Any, list[int]],
+    ) -> None:
+        card_id, _ = c5_seed
+        card_items = [item for item in c5_bundle.items if item.source_type == "card"]
+        assert card_items, "Expected at least one card hit in bundle"
+        match = next((c for c in card_items if c.card_id == card_id), None)
+        assert match is not None, f"Inserted card {card_id} did not surface"
+        assert match.card_id is not None
+
+    async def test_c5b_card_source_list_non_empty_and_ordered(
+        self,
+        c5_bundle: Any,
+        c5_seed: tuple[Any, list[int]],
+    ) -> None:
+        card_id, expected_mvids = c5_seed
+        card_items = [
+            c for c in c5_bundle.items
+            if c.source_type == "card" and c.card_id == card_id
+        ]
+        assert card_items, "Expected our seeded card to surface"
+        match = card_items[0]
+        assert match.card_source_message_version_ids, (
+            "C5b: card_source_message_version_ids must be non-empty"
+        )
+        assert tuple(match.card_source_message_version_ids) == tuple(expected_mvids), (
+            "Source list must preserve insertion order (position ASC)"
+        )
+        # Anchor mvid is the lowest-position source.
+        assert match.message_version_id == expected_mvids[0], (
+            "C5: anchor mvid must be the first card_sources entry"
+        )
+
+    async def test_c5c_card_sources_resolve_to_visible_message_versions(
+        self,
+        eval_db_session: Any,
+        c5_bundle: Any,
+        c5_seed: tuple[Any, list[int]],
+    ) -> None:
+        """Every source mvid resolves to non-redacted, normal-policy rows; no
+        forget_event tombstones cover them."""
+        card_id, _ = c5_seed
+        card_items = [
+            c for c in c5_bundle.items
+            if c.source_type == "card" and c.card_id == card_id
+        ]
+        assert card_items
+        match = card_items[0]
+        for mvid in match.card_source_message_version_ids:
+            mv = await eval_db_session.scalar(
+                select(MessageVersion).where(MessageVersion.id == mvid)
+            )
+            assert mv is not None, f"Source mvid {mvid} missing"
+            assert mv.is_redacted is False, (
+                f"Source mvid {mvid} is is_redacted=True — C5c violation"
+            )
+            cm = await eval_db_session.scalar(
+                select(ChatMessage).where(ChatMessage.id == mv.chat_message_id)
+            )
+            assert cm is not None
+            assert cm.memory_policy == "normal", (
+                f"Source chat_message has memory_policy={cm.memory_policy!r}"
+            )
+            assert cm.is_redacted is False
+            fe_tomb = await eval_db_session.scalar(
+                select(ForgetEvent).where(
+                    ForgetEvent.tombstone_key
+                    == f"message:{cm.chat_id}:{cm.message_id}"
+                )
+            )
+            assert fe_tomb is None, f"Forget event tombstones source mvid {mvid}"
+
+    async def test_c5d_evidence_ids_preserves_mvid_only_contract(
+        self,
+        c5_bundle: Any,
+    ) -> None:
+        """``EvidenceBundle.evidence_ids`` returns mvids only — Phase 5
+        gateway contract preserved across the discriminator boundary."""
+        for mvid in c5_bundle.evidence_ids:
+            assert isinstance(mvid, int), (
+                f"C5d: evidence_ids must be int (mvid), got {type(mvid).__name__}"
+            )
+            assert mvid > 0

--- a/tests/evals/test_leakage.py
+++ b/tests/evals/test_leakage.py
@@ -403,7 +403,7 @@ async def _create_case(
 
     # ── T6-06 leakage cases for approved knowledge cards ─────────────────
     # The L6 family verifies the search-side defense-in-depth that excludes
-    # an approved card when any of its sources has been forgotten / redacted
+    # an approved card when any of its sources has been tombstoned / redacted
     # / marked offrecord, even when the §5.A.5 cascade keeps the card
     # ``approved`` (remaining_count > 0 after the loss).
 

--- a/tests/evals/test_leakage.py
+++ b/tests/evals/test_leakage.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib
+import itertools
 from collections.abc import AsyncIterator
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -11,6 +12,10 @@ import pytest
 import pytest_asyncio
 from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
+
+# Module-local counter to seed unique admin telegram_ids for L6 cards;
+# every L6 parametrize call needs an admin for ``knowledge_cards.approved_by``.
+_admin_counter = itertools.count(start=1)
 
 SEED_CHAT_ID = -1001234567890
 L5_CHAT_ID = 1001
@@ -51,6 +56,8 @@ async def _clear_leakage_tables(session: AsyncSession) -> None:
             TRUNCATE TABLE
                 qa_traces,
                 offrecord_marks,
+                card_sources,
+                knowledge_cards,
                 message_versions,
                 chat_messages,
                 forget_events
@@ -170,6 +177,49 @@ async def _persist_via_handler(
     )
     await chat_messages_handler.save_chat_message(message, session)
     return await _fetch_persisted(session, chat_id=SEED_CHAT_ID, message_id=message_id)
+
+
+async def _create_approved_card(
+    session: AsyncSession,
+    *,
+    body_markdown: str,
+    source_version_ids: tuple[int, ...],
+    title: str = "Карточка",
+) -> Any:
+    """T6-06 helper: insert an approved knowledge_cards row + card_sources."""
+    models = importlib.import_module("bot.db.models")
+    user_repo = importlib.import_module("bot.db.repos.user")
+
+    # Admin must exist for the approved_by_user_id FK.
+    admin_id = 92_000_000 + next(_admin_counter)
+    await user_repo.UserRepo.upsert(
+        session,
+        telegram_id=admin_id,
+        username=f"l6_admin_{admin_id}",
+        first_name="L6Admin",
+        last_name=None,
+    )
+
+    card = models.KnowledgeCard(
+        title=title,
+        body_markdown=body_markdown,
+        card_status="approved",
+        approved_by_user_id=admin_id,
+        approved_at=datetime.now(timezone.utc),
+    )
+    session.add(card)
+    await session.flush()
+
+    for position, mvid in enumerate(source_version_ids):
+        session.add(
+            models.CardSource(
+                card_id=card.id,
+                message_version_id=mvid,
+                position=position,
+            )
+        )
+    await session.flush()
+    return card.id
 
 
 async def _persist_via_service(
@@ -351,6 +401,115 @@ async def _create_case(
         )
         return L5_CHAT_ID, "каппа", {other.version_id}
 
+    # ── T6-06 leakage cases for approved knowledge cards ─────────────────
+    # The L6 family verifies the search-side defense-in-depth that excludes
+    # an approved card when any of its sources has been forgotten / redacted
+    # / marked offrecord, even when the §5.A.5 cascade keeps the card
+    # ``approved`` (remaining_count > 0 after the loss).
+
+    if case_id == "L6a":
+        # L6a — 3-source approved card; forget ONE source. Cascade keeps the
+        # card approved (remaining_count > 0). Search-side guard MUST still
+        # exclude the card from /recall.
+        forget_event_repo = importlib.import_module("bot.db.repos.forget_event")
+        sources = []
+        for idx in range(3):
+            src = await _persist_via_service(
+                session,
+                chat_id=SEED_CHAT_ID,
+                message_id=11_010 + idx,
+                user_id=91_010 + idx,
+                text_value=f"источник пси-{idx} люкс",
+            )
+            sources.append(src)
+        card_id = await _create_approved_card(
+            session,
+            body_markdown="карточка про люкс пси-сюжет",
+            source_version_ids=tuple(s.version_id for s in sources),
+        )
+        await forget_event_repo.ForgetEventRepo.create(
+            session,
+            target_type="message",
+            target_id=str(sources[0].message_id),
+            actor_user_id=None,
+            authorized_by="system",
+            tombstone_key=f"message:{sources[0].chat_id}:{sources[0].message_id}",
+        )
+        # mark completed so the cascade ran (or could have)
+        events = await session.execute(
+            text("SELECT id FROM forget_events ORDER BY id DESC LIMIT 1")
+        )
+        ev_id = events.scalar_one()
+        await forget_event_repo.ForgetEventRepo.mark_status(session, ev_id, status="processing")
+        await forget_event_repo.ForgetEventRepo.mark_status(session, ev_id, status="completed")
+        return SEED_CHAT_ID, "пси-сюжет", {card_id}
+
+    if case_id == "L6b":
+        # L6b — 3-source approved card; forget ALL sources. Cascade demotes
+        # the card to archived. Search must still exclude.
+        forget_event_repo = importlib.import_module("bot.db.repos.forget_event")
+        sources = []
+        for idx in range(3):
+            src = await _persist_via_service(
+                session,
+                chat_id=SEED_CHAT_ID,
+                message_id=11_020 + idx,
+                user_id=91_020 + idx,
+                text_value=f"источник хи-{idx} люкс",
+            )
+            sources.append(src)
+        card_id = await _create_approved_card(
+            session,
+            body_markdown="карточка про люкс хи-сюжет",
+            source_version_ids=tuple(s.version_id for s in sources),
+        )
+        for src in sources:
+            await forget_event_repo.ForgetEventRepo.create(
+                session,
+                target_type="message",
+                target_id=str(src.message_id),
+                actor_user_id=None,
+                authorized_by="system",
+                tombstone_key=f"message:{src.chat_id}:{src.message_id}",
+            )
+            events = await session.execute(
+                text("SELECT id FROM forget_events ORDER BY id DESC LIMIT 1")
+            )
+            ev_id = events.scalar_one()
+            await forget_event_repo.ForgetEventRepo.mark_status(
+                session, ev_id, status="processing"
+            )
+            await forget_event_repo.ForgetEventRepo.mark_status(
+                session, ev_id, status="completed"
+            )
+        return SEED_CHAT_ID, "хи-сюжет", {card_id}
+
+    if case_id == "L6c":
+        # L6c — approved card whose source row gets manually marked
+        # ``is_redacted=TRUE`` (no forget_event issued). Search must still
+        # exclude the card via the defense-in-depth #2 subquery.
+        ChatMessage_local, _ = _model_classes()
+        sources = []
+        for idx in range(3):
+            src = await _persist_via_service(
+                session,
+                chat_id=SEED_CHAT_ID,
+                message_id=11_030 + idx,
+                user_id=91_030 + idx,
+                text_value=f"источник омикрон-{idx} люкс",
+            )
+            sources.append(src)
+        card_id = await _create_approved_card(
+            session,
+            body_markdown="карточка про люкс омикрон-сюжет",
+            source_version_ids=tuple(s.version_id for s in sources),
+        )
+        cm = await session.get(ChatMessage_local, sources[0].chat_message_id)
+        assert cm is not None
+        cm.is_redacted = True
+        await session.flush()
+        return SEED_CHAT_ID, "омикрон-сюжет", {card_id}
+
     raise AssertionError(f"unknown case id: {case_id}")
 
 
@@ -360,7 +519,7 @@ pytestmark = pytest.mark.asyncio(loop_scope="class")
 class TestRecallGovernanceLeakage:
     @pytest.mark.parametrize(
         "case_id",
-        ["L1", "L2", "L3a", "L3b", "L3c", "L4", "L5"],
+        ["L1", "L2", "L3a", "L3b", "L3c", "L4", "L5", "L6a", "L6b", "L6c"],
     )
     async def test_recall_governance_leakage(
         self,
@@ -379,7 +538,18 @@ class TestRecallGovernanceLeakage:
         )
 
         assert trace is None
-        assert set(bundle.evidence_ids).isdisjoint(blocked_ids)
-        if case_id == "L5":
-            assert bundle.items
-            assert all(item.chat_id == L5_CHAT_ID for item in bundle.items)
+        if case_id.startswith("L6"):
+            # L6 cases block CARDS (card_id UUIDs), not mvids. Even if Phase 4
+            # would otherwise return source-message hits, the card itself must
+            # never surface — assert no bundle.item has the blocked card_id.
+            returned_card_ids = {
+                item.card_id for item in bundle.items if item.source_type == "card"
+            }
+            assert returned_card_ids.isdisjoint(blocked_ids), (
+                f"{case_id}: card {blocked_ids & returned_card_ids} leaked into /recall"
+            )
+        else:
+            assert set(bundle.evidence_ids).isdisjoint(blocked_ids)
+            if case_id == "L5":
+                assert bundle.items
+                assert all(item.chat_id == L5_CHAT_ID for item in bundle.items)

--- a/tests/fixtures/evidence_bundle_v1.json
+++ b/tests/fixtures/evidence_bundle_v1.json
@@ -11,7 +11,10 @@
       "snippet": "<b>match</b>0",
       "ts_rank": 0.5,
       "captured_at": "2026-01-01T12:00:00+00:00",
-      "message_date": "2026-01-01T12:00:00+00:00"
+      "message_date": "2026-01-01T12:00:00+00:00",
+      "source_type": "message",
+      "card_id": null,
+      "card_source_message_version_ids": []
     },
     {
       "message_version_id": 101,
@@ -22,7 +25,10 @@
       "snippet": "<b>match</b>1",
       "ts_rank": 0.49,
       "captured_at": "2026-01-01T12:01:00+00:00",
-      "message_date": "2026-01-01T12:01:00+00:00"
+      "message_date": "2026-01-01T12:01:00+00:00",
+      "source_type": "message",
+      "card_id": null,
+      "card_source_message_version_ids": []
     }
   ],
   "abstained": false

--- a/tests/handlers/test_qa_card_rendering.py
+++ b/tests/handlers/test_qa_card_rendering.py
@@ -1,0 +1,252 @@
+"""T6-07: card-evidence rendering tests for /recall (both Phase 4 fallback
+and Phase 5 synth modes).
+
+These tests run pure renderer functions — no DB, no LLM — so they exercise
+the dual-branch logic in ``bot/handlers/qa.py::_format_response`` and
+``_format_synthesized_response``. The Phase 4 byte-for-byte preservation guard
+lives in ``test_qa_recall_phase4_preserved.py``; this module adds card cases.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from decimal import Decimal
+
+import pytest
+
+from tests.conftest import import_module
+
+pytestmark = pytest.mark.usefixtures("app_env")
+
+COMMUNITY_CHAT_ID = -1001234567890
+
+
+def _now() -> datetime:
+    return datetime(2026, 5, 12, 12, 0, tzinfo=timezone.utc)
+
+
+def _message_item(mvid: int, user_id: int = 2002):
+    evidence = import_module("bot.services.evidence")
+    return evidence.EvidenceItem(
+        message_version_id=mvid,
+        chat_message_id=50,
+        chat_id=COMMUNITY_CHAT_ID,
+        message_id=77,
+        user_id=user_id,
+        snippet="обсуждали <b>память</b>",
+        ts_rank=0.8,
+        captured_at=_now(),
+        message_date=_now(),
+    )
+
+
+def _card_item(
+    *,
+    card_id: uuid.UUID | None = None,
+    mvids: tuple[int, ...] = (42, 43, 44),
+    anchor_mvid: int = 42,
+    anchor_message_id: int = 99,
+    snippet: str = "Карточка про <b>память</b>",
+):
+    evidence = import_module("bot.services.evidence")
+    return evidence.EvidenceItem(
+        message_version_id=anchor_mvid,
+        chat_message_id=80,
+        chat_id=COMMUNITY_CHAT_ID,
+        message_id=anchor_message_id,
+        user_id=None,
+        snippet=snippet,
+        ts_rank=0.9,
+        captured_at=_now(),
+        message_date=_now(),
+        source_type="card",
+        card_id=card_id or uuid.UUID("11111111-2222-3333-4444-555555555555"),
+        card_source_message_version_ids=mvids,
+    )
+
+
+def _bundle(items, *, abstained: bool = False):
+    evidence = import_module("bot.services.evidence")
+    return evidence.EvidenceBundle(
+        query="память",
+        chat_id=COMMUNITY_CHAT_ID,
+        items=tuple(items),
+        abstained=abstained,
+        created_at=_now(),
+    )
+
+
+# ─── _format_response card branch ─────────────────────────────────────────────
+
+
+def test_format_response_pure_card_bundle_renders_card_markers() -> None:
+    item = _card_item()
+    qa_handler = import_module("bot.handlers.qa")
+    text = qa_handler._format_response(_bundle((item,)), users_by_id={})
+
+    assert "Найденные свидетельства" in text
+    assert "Карточка" in text  # T6-07 card marker (📋 emoji prefix)
+    assert "первоисточник" in text  # anchor source link label
+    assert "card_id:11111111-2222-3333-4444-555555555555" in text
+    assert "sources:[42, 43, 44]" in text
+
+
+def test_format_response_pure_card_bundle_links_to_anchor_message() -> None:
+    item = _card_item(anchor_message_id=99)
+    qa_handler = import_module("bot.handlers.qa")
+    text = qa_handler._format_response(_bundle((item,)), users_by_id={})
+
+    # COMMUNITY_CHAT_ID -1001234567890 → short prefix 1234567890
+    assert "https://t.me/c/1234567890/99" in text
+
+
+def test_format_response_mixed_bundle_renders_both_branches_in_order() -> None:
+    """Card first, then message; renderer preserves bundle order."""
+    bundle = _bundle((_card_item(), _message_item(mvid=500)))
+    user = type("U", (), {"first_name": "Author", "last_name": None, "username": None})()
+    qa_handler = import_module("bot.handlers.qa")
+    text = qa_handler._format_response(bundle, users_by_id={2002: user})
+
+    card_idx = text.index("Карточка")
+    msg_idx = text.index("message_version_id:500")
+    assert card_idx < msg_idx
+    # Both markers appear.
+    assert "card_id:" in text
+    assert "Author" in text
+
+
+def test_format_response_pure_message_bundle_does_not_emit_card_markers() -> None:
+    """Phase 4 path remains untouched (byte-for-byte guarded elsewhere)."""
+    user = type("U", (), {"first_name": "Author", "last_name": None, "username": None})()
+    qa_handler = import_module("bot.handlers.qa")
+    text = qa_handler._format_response(
+        _bundle((_message_item(mvid=500),)),
+        users_by_id={2002: user},
+    )
+
+    assert "card_id" not in text
+    assert "Карточка" not in text
+    assert "первоисточник" not in text
+    assert "message_version_id:500" in text
+
+
+def test_format_response_card_with_empty_source_list_renders_safely() -> None:
+    """Defensive: empty card_source_message_version_ids must not crash."""
+    item = _card_item(mvids=())
+    qa_handler = import_module("bot.handlers.qa")
+    text = qa_handler._format_response(_bundle((item,)), users_by_id={})
+
+    assert "sources:[]" in text
+
+
+def test_format_response_card_snippet_html_escapes_unsafe_characters() -> None:
+    """The renderer must not allow raw HTML / unsafe characters in the snippet
+    to escape the <blockquote> region. _safe_headline preserves <b>/</b> from
+    ts_headline but escapes everything else."""
+    item = _card_item(snippet="<script>alert(1)</script>")
+    qa_handler = import_module("bot.handlers.qa")
+    text = qa_handler._format_response(_bundle((item,)), users_by_id={})
+
+    assert "<script>alert(1)</script>" not in text
+    assert "&lt;script&gt;" in text
+
+
+# ─── _format_synthesized_response card branch ─────────────────────────────────
+
+
+def test_synth_response_pure_card_bundle_emits_card_footer() -> None:
+    """Synthesis mode renders cards in the Источники footer."""
+    llm_gateway = import_module("bot.services.llm_gateway")
+    AnswerWithCitations = llm_gateway.AnswerWithCitations
+
+    answer = AnswerWithCitations(
+        answer_text="Ответ",
+        citation_ids=(),
+        cost_usd=Decimal("0"),
+        cache_hit=False,
+        llm_call_id=1,
+    )
+    item = _card_item()
+    qa_handler = import_module("bot.handlers.qa")
+    text = qa_handler._format_synthesized_response(answer, _bundle((item,)), users_by_id={})
+
+    assert "Источники" in text
+    assert "Card" in text or "Карточка" in text  # discriminator label
+    assert "[1]" in text
+    assert "11111111-2222-3333-4444-555555555555" in text
+    assert "(sources: 3)" in text
+
+
+def test_synth_response_mixed_bundle_numbers_continuously() -> None:
+    """Mixed bundle: [1] = card, [2] = message; numbering is continuous."""
+    llm_gateway = import_module("bot.services.llm_gateway")
+    AnswerWithCitations = llm_gateway.AnswerWithCitations
+
+    answer = AnswerWithCitations(
+        answer_text="Ответ",
+        citation_ids=(),
+        cost_usd=Decimal("0"),
+        cache_hit=False,
+        llm_call_id=1,
+    )
+    user = type("U", (), {"first_name": "Author", "last_name": None, "username": None})()
+    bundle = _bundle((_card_item(), _message_item(mvid=500)))
+    qa_handler = import_module("bot.handlers.qa")
+    text = qa_handler._format_synthesized_response(
+        answer, bundle, users_by_id={2002: user}
+    )
+
+    # [1] is the card; [2] is the message.
+    one_idx = text.index("[1]")
+    two_idx = text.index("[2]")
+    assert one_idx < two_idx
+    card_marker_pos = text.index("Card") if "Card" in text else text.index("Карточка")
+    assert one_idx < card_marker_pos < two_idx
+    assert "Author" in text[two_idx:]
+
+
+def test_synth_response_pure_message_bundle_does_not_emit_card_marker() -> None:
+    """Phase 5 path remains untouched."""
+    llm_gateway = import_module("bot.services.llm_gateway")
+    AnswerWithCitations = llm_gateway.AnswerWithCitations
+
+    answer = AnswerWithCitations(
+        answer_text="Ответ",
+        citation_ids=(),
+        cost_usd=Decimal("0"),
+        cache_hit=False,
+        llm_call_id=1,
+    )
+    user = type("U", (), {"first_name": "Author", "last_name": None, "username": None})()
+    qa_handler = import_module("bot.handlers.qa")
+    text = qa_handler._format_synthesized_response(
+        answer, _bundle((_message_item(mvid=500),)), users_by_id={2002: user}
+    )
+
+    assert "Card" not in text
+    assert "Карточка" not in text
+    assert "card_id" not in text
+    assert "[1] " in text  # Phase 5 marker preserved
+    assert "Author" in text
+
+
+def test_synth_response_answer_text_is_html_escaped() -> None:
+    """Phase 5 invariant preserved: answer_text gets HTML-escaped."""
+    llm_gateway = import_module("bot.services.llm_gateway")
+    AnswerWithCitations = llm_gateway.AnswerWithCitations
+
+    answer = AnswerWithCitations(
+        answer_text="<script>x</script>",
+        citation_ids=(),
+        cost_usd=Decimal("0"),
+        cache_hit=False,
+        llm_call_id=2,
+    )
+    qa_handler = import_module("bot.handlers.qa")
+    text = qa_handler._format_synthesized_response(
+        answer, _bundle((_card_item(),)), users_by_id={}
+    )
+
+    assert "<script>x</script>" not in text
+    assert "&lt;script&gt;" in text

--- a/tests/services/test_evidence.py
+++ b/tests/services/test_evidence.py
@@ -1,7 +1,9 @@
 import json
+import uuid
 from dataclasses import FrozenInstanceError
 from datetime import datetime, timezone
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -91,3 +93,173 @@ def test_evidence_ids_preserve_search_rank_order() -> None:
     bundle = EvidenceBundle.from_hits("hello", -100123, hits)
 
     assert bundle.evidence_ids == [102, 100, 101]
+
+
+# ─── T6-07: EvidenceItem source discriminator ────────────────────────────────
+
+
+def _now() -> datetime:
+    return datetime(2026, 5, 12, 12, 0, tzinfo=timezone.utc)
+
+
+def test_evidence_item_phase4_construct_uses_default_source_type() -> None:
+    """Phase 4 callers construct without the new fields; defaults must trip."""
+    item = EvidenceItem(
+        message_version_id=1,
+        chat_message_id=2,
+        chat_id=-100123,
+        message_id=3,
+        user_id=42,
+        snippet="hi",
+        ts_rank=0.5,
+        captured_at=_now(),
+        message_date=_now(),
+    )
+
+    assert item.source_type == "message"
+    assert item.card_id is None
+    assert item.card_source_message_version_ids == ()
+
+
+def test_evidence_item_card_fields_accepted() -> None:
+    """Card evidence carries card_id + source mvid trace."""
+    card_id = uuid.uuid4()
+    item = EvidenceItem(
+        message_version_id=42,  # anchor source mvid
+        chat_message_id=2,
+        chat_id=-100123,
+        message_id=3,
+        user_id=None,
+        snippet="card snippet",
+        ts_rank=0.7,
+        captured_at=_now(),
+        message_date=_now(),
+        source_type="card",
+        card_id=card_id,
+        card_source_message_version_ids=(42, 43, 44),
+    )
+
+    assert item.source_type == "card"
+    assert item.card_id == card_id
+    assert item.card_source_message_version_ids == (42, 43, 44)
+
+
+def test_evidence_item_to_dict_message_default_shape() -> None:
+    """Message item dict contains the three new keys at default values."""
+    item = EvidenceItem(
+        message_version_id=1,
+        chat_message_id=2,
+        chat_id=-100123,
+        message_id=3,
+        user_id=42,
+        snippet="hi",
+        ts_rank=0.5,
+        captured_at=_now(),
+        message_date=_now(),
+    )
+
+    d = item.to_dict()
+
+    assert d["source_type"] == "message"
+    assert d["card_id"] is None
+    assert d["card_source_message_version_ids"] == []
+    # Phase 4 keys still present.
+    assert d["message_version_id"] == 1
+
+
+def test_evidence_item_to_dict_card_serializes_uuid_and_list() -> None:
+    card_id = uuid.UUID("12345678-1234-5678-1234-567812345678")
+    item = EvidenceItem(
+        message_version_id=42,
+        chat_message_id=2,
+        chat_id=-100123,
+        message_id=3,
+        user_id=None,
+        snippet="card",
+        ts_rank=0.6,
+        captured_at=_now(),
+        message_date=_now(),
+        source_type="card",
+        card_id=card_id,
+        card_source_message_version_ids=(42, 43),
+    )
+
+    d = item.to_dict()
+
+    assert d["source_type"] == "card"
+    assert d["card_id"] == "12345678-1234-5678-1234-567812345678"
+    assert d["card_source_message_version_ids"] == [42, 43]
+
+
+def test_from_hits_propagates_card_fields_via_getattr() -> None:
+    """SearchHitLike with card fields → EvidenceItem propagates them."""
+    card_id = uuid.uuid4()
+    card_hit = SimpleNamespace(
+        message_version_id=42,
+        chat_message_id=2,
+        chat_id=-100123,
+        message_id=3,
+        user_id=None,
+        snippet="card",
+        ts_rank=0.7,
+        captured_at=_now(),
+        message_date=_now(),
+        source_type="card",
+        card_id=card_id,
+        card_source_message_version_ids=(42, 43, 44),
+    )
+
+    bundle = EvidenceBundle.from_hits("q", -100123, [card_hit])
+
+    assert len(bundle.items) == 1
+    assert bundle.items[0].source_type == "card"
+    assert bundle.items[0].card_id == card_id
+    assert bundle.items[0].card_source_message_version_ids == (42, 43, 44)
+
+
+def test_from_hits_pre_t6_06_hit_without_card_fields_defaults_to_message() -> None:
+    """SearchHit without source_type attr (pre-T6-06 fakes) → defaults trip."""
+    hit = _make_hit(0)  # plain SearchHit; even with new fields, pretend old:
+
+    # _make_hit creates a real SearchHit. After T6-06 it has defaults too — also
+    # check via a stripped-down namespace that doesn't carry the new attrs at all.
+    legacy_hit = SimpleNamespace(
+        message_version_id=hit.message_version_id,
+        chat_message_id=hit.chat_message_id,
+        chat_id=hit.chat_id,
+        message_id=hit.message_id,
+        user_id=hit.user_id,
+        snippet=hit.snippet,
+        ts_rank=hit.ts_rank,
+        captured_at=hit.captured_at,
+        message_date=hit.message_date,
+    )
+
+    bundle = EvidenceBundle.from_hits("q", -100123, [legacy_hit])
+
+    assert bundle.items[0].source_type == "message"
+    assert bundle.items[0].card_id is None
+    assert bundle.items[0].card_source_message_version_ids == ()
+
+
+def test_evidence_ids_returns_anchor_mvid_for_card_items() -> None:
+    """For card items, evidence_ids still resolves via message_version_id (anchor)."""
+    msg_hit = _make_hit(0)  # mvid=100
+    card_hit = SimpleNamespace(
+        message_version_id=200,
+        chat_message_id=2,
+        chat_id=-100123,
+        message_id=3,
+        user_id=None,
+        snippet="card",
+        ts_rank=0.7,
+        captured_at=_now(),
+        message_date=_now(),
+        source_type="card",
+        card_id=uuid.uuid4(),
+        card_source_message_version_ids=(200, 201, 202),
+    )
+
+    bundle = EvidenceBundle.from_hits("q", -100123, [card_hit, msg_hit])
+
+    assert bundle.evidence_ids == [200, 100]

--- a/tests/services/test_search_cards.py
+++ b/tests/services/test_search_cards.py
@@ -1,0 +1,638 @@
+"""T6-06: card-extension tests for ``search_messages``.
+
+These tests exercise the ``include_cards=True`` path of the search service:
+- UNION ALL with the Phase 4 message branch.
+- ``card_status='approved'`` gate.
+- Defense-in-depth source-state subqueries (forget tombstones / redaction /
+  memory_policy mismatch must exclude the card even if it remains
+  ``approved``).
+- Card rank boost above equivalent message hits.
+- ``SearchHit`` discriminator fields populated for card hits and at defaults
+  for message hits.
+
+All tests require Postgres because the card branch uses Russian-language
+``to_tsvector`` / ``ts_rank_cd`` / ``ts_headline``. SQLite tests cover the
+dialect-guard separately (see ``test_search_cards_sqlite_safe_noop``).
+"""
+
+from __future__ import annotations
+
+import itertools
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+import pytest
+
+pytestmark = pytest.mark.usefixtures("app_env")
+
+# Counters offset from test_search.py ranges to avoid PK collisions when
+# both test files run in the same session.
+_user_counter = itertools.count(start=10_600_000_000)
+_message_counter = itertools.count(start=1_060_000)
+_hash_counter = itertools.count(start=1)
+
+
+@dataclass(frozen=True)
+class CreatedMessage:
+    chat_message_id: int
+    version_id: int
+    message_id: int
+    chat_id: int
+    user_id: int
+    content_hash: str
+
+
+@dataclass(frozen=True)
+class CreatedCard:
+    card_id: uuid.UUID
+    source_version_ids: tuple[int, ...]
+
+
+async def _create_versioned_message(
+    db_session,
+    *,
+    chat_id: int,
+    text: str = "питон любит память",
+    memory_policy: str = "normal",
+    chat_is_redacted: bool = False,
+    version_is_redacted: bool = False,
+    message_id: int | None = None,
+) -> CreatedMessage:
+    from bot.db.models import ChatMessage, MessageVersion
+    from bot.db.repos.user import UserRepo
+
+    user_id = next(_user_counter)
+    tg_message_id = message_id if message_id is not None else next(_message_counter)
+    content_hash = f"card-hash-{next(_hash_counter)}"
+
+    await UserRepo.upsert(
+        db_session,
+        telegram_id=user_id,
+        username=f"u{user_id}",
+        first_name="Card",
+        last_name=None,
+    )
+
+    chat_message = ChatMessage(
+        message_id=tg_message_id,
+        chat_id=chat_id,
+        user_id=user_id,
+        text=text,
+        caption=None,
+        date=datetime.now(timezone.utc),
+        memory_policy=memory_policy,
+        is_redacted=chat_is_redacted,
+        content_hash=content_hash,
+    )
+    db_session.add(chat_message)
+    await db_session.flush()
+
+    version = MessageVersion(
+        chat_message_id=chat_message.id,
+        version_seq=1,
+        text=text,
+        caption=None,
+        normalized_text=text,
+        content_hash=content_hash,
+        is_redacted=version_is_redacted,
+    )
+    db_session.add(version)
+    await db_session.flush()
+
+    chat_message.current_version_id = version.id
+    await db_session.flush()
+
+    return CreatedMessage(
+        chat_message_id=chat_message.id,
+        version_id=version.id,
+        message_id=tg_message_id,
+        chat_id=chat_id,
+        user_id=user_id,
+        content_hash=content_hash,
+    )
+
+
+async def _create_approved_card(
+    db_session,
+    *,
+    body_markdown: str,
+    source_version_ids: tuple[int, ...],
+    title: str = "Карточка",
+    card_status: str = "approved",
+    archived_reason: str | None = None,
+) -> CreatedCard:
+    """Insert one knowledge_cards row + card_sources rows in arrival order."""
+    from bot.db.models import CardSource, KnowledgeCard
+    from bot.db.repos.user import UserRepo
+
+    admin_id = next(_user_counter)
+    await UserRepo.upsert(
+        db_session,
+        telegram_id=admin_id,
+        username=f"admin{admin_id}",
+        first_name="Admin",
+        last_name=None,
+    )
+
+    approved_at = datetime.now(timezone.utc) if card_status == "approved" else None
+    approved_by_user_id = admin_id if card_status == "approved" else None
+
+    card = KnowledgeCard(
+        title=title,
+        body_markdown=body_markdown,
+        card_status=card_status,
+        archived_reason=archived_reason,
+        approved_by_user_id=approved_by_user_id,
+        approved_at=approved_at,
+    )
+    db_session.add(card)
+    await db_session.flush()
+
+    for position, mvid in enumerate(source_version_ids):
+        db_session.add(
+            CardSource(
+                card_id=card.id,
+                message_version_id=mvid,
+                position=position,
+            )
+        )
+    await db_session.flush()
+
+    return CreatedCard(
+        card_id=card.id,
+        source_version_ids=source_version_ids,
+    )
+
+
+async def _create_forget_event(
+    db_session,
+    *,
+    tombstone_key: str,
+    target_type: str = "message",
+    target_id: str | None = None,
+    status: str = "completed",
+) -> None:
+    from bot.db.repos.forget_event import ForgetEventRepo
+
+    event = await ForgetEventRepo.create(
+        db_session,
+        target_type=target_type,
+        target_id=target_id,
+        actor_user_id=None,
+        authorized_by="system",
+        tombstone_key=tombstone_key,
+    )
+    if status == "pending":
+        return
+    await ForgetEventRepo.mark_status(db_session, event.id, status="processing")
+    if status == "completed":
+        await ForgetEventRepo.mark_status(db_session, event.id, status="completed")
+
+
+# ─── Acceptance: include_cards default False vs True semantics ───────────────
+
+
+async def test_include_cards_false_omits_card_hits(db_session) -> None:
+    """Phase 4 semantics preserved when caller opts out."""
+    from bot.services.search import search_messages
+
+    chat_id = -100_601
+    msg = await _create_versioned_message(
+        db_session,
+        chat_id=chat_id,
+        text="питон обсуждение",
+    )
+    await _create_approved_card(
+        db_session,
+        body_markdown="питон карточка тут",
+        source_version_ids=(msg.version_id,),
+    )
+
+    hits = await search_messages(
+        db_session, "питон", chat_id=chat_id, include_cards=False
+    )
+
+    assert [h.source_type for h in hits] == ["message"]
+    assert all(h.card_id is None for h in hits)
+
+
+async def test_include_cards_true_returns_card_when_only_card_matches(db_session) -> None:
+    """If no messages match but a card does, card surfaces in results."""
+    from bot.services.search import search_messages
+
+    chat_id = -100_602
+    msg = await _create_versioned_message(
+        db_session,
+        chat_id=chat_id,
+        text="нерелевантное обсуждение",
+    )
+    card = await _create_approved_card(
+        db_session,
+        body_markdown="карточка про специфическое слово диковина",
+        source_version_ids=(msg.version_id,),
+    )
+
+    hits = await search_messages(
+        db_session, "диковина", chat_id=chat_id, include_cards=True
+    )
+
+    assert len(hits) == 1
+    assert hits[0].source_type == "card"
+    assert hits[0].card_id == card.card_id
+    assert hits[0].card_source_message_version_ids == (msg.version_id,)
+
+
+async def test_include_cards_true_merges_message_and_card_hits(db_session) -> None:
+    from bot.services.search import search_messages
+
+    chat_id = -100_603
+    msg = await _create_versioned_message(
+        db_session,
+        chat_id=chat_id,
+        text="питон сообщение",
+    )
+    msg2 = await _create_versioned_message(
+        db_session,
+        chat_id=chat_id,
+        text="питон карточка-источник",
+    )
+    await _create_approved_card(
+        db_session,
+        body_markdown="питон карточка тут",
+        source_version_ids=(msg2.version_id,),
+    )
+
+    hits = await search_messages(
+        db_session, "питон", chat_id=chat_id, include_cards=True, limit=10
+    )
+
+    types = sorted(h.source_type for h in hits)
+    assert "card" in types
+    assert "message" in types
+    # at least the original first message is present
+    assert any(h.message_version_id == msg.version_id for h in hits)
+
+
+# ─── card_status gating ──────────────────────────────────────────────────────
+
+
+async def test_draft_card_is_not_returned(db_session) -> None:
+    from bot.services.search import search_messages
+
+    chat_id = -100_604
+    msg = await _create_versioned_message(
+        db_session, chat_id=chat_id, text="ничего не найдём"
+    )
+    await _create_approved_card(
+        db_session,
+        body_markdown="драфт-карточка уникальное диковина2",
+        source_version_ids=(msg.version_id,),
+        card_status="draft",
+    )
+
+    hits = await search_messages(
+        db_session, "диковина2", chat_id=chat_id, include_cards=True
+    )
+
+    assert [h.source_type for h in hits if h.source_type == "card"] == []
+
+
+async def test_archived_card_is_not_returned(db_session) -> None:
+    from bot.services.search import search_messages
+
+    chat_id = -100_605
+    msg = await _create_versioned_message(
+        db_session, chat_id=chat_id, text="ничего не найдём"
+    )
+    await _create_approved_card(
+        db_session,
+        body_markdown="archived карточка диковина3",
+        source_version_ids=(msg.version_id,),
+        card_status="archived",
+        archived_reason="cascade",
+    )
+
+    hits = await search_messages(
+        db_session, "диковина3", chat_id=chat_id, include_cards=True
+    )
+
+    assert [h for h in hits if h.source_type == "card"] == []
+
+
+# ─── Defense-in-depth source-state subqueries ────────────────────────────────
+
+
+async def test_card_with_offrecord_source_excluded(db_session) -> None:
+    """If ANY card source's chat_message has memory_policy != 'normal', exclude."""
+    from bot.services.search import search_messages
+
+    chat_id = -100_606
+    msg = await _create_versioned_message(
+        db_session,
+        chat_id=chat_id,
+        text="источник offrecord",
+        memory_policy="offrecord",
+    )
+    await _create_approved_card(
+        db_session,
+        body_markdown="карточка с offrecord источником диковина4",
+        source_version_ids=(msg.version_id,),
+    )
+
+    hits = await search_messages(
+        db_session, "диковина4", chat_id=chat_id, include_cards=True
+    )
+
+    assert [h for h in hits if h.source_type == "card"] == []
+
+
+async def test_card_with_redacted_chat_message_source_excluded(db_session) -> None:
+    from bot.services.search import search_messages
+
+    chat_id = -100_607
+    msg = await _create_versioned_message(
+        db_session,
+        chat_id=chat_id,
+        text="источник редактированный",
+        chat_is_redacted=True,
+    )
+    await _create_approved_card(
+        db_session,
+        body_markdown="карточка с redacted источником диковина5",
+        source_version_ids=(msg.version_id,),
+    )
+
+    hits = await search_messages(
+        db_session, "диковина5", chat_id=chat_id, include_cards=True
+    )
+
+    assert [h for h in hits if h.source_type == "card"] == []
+
+
+async def test_card_with_redacted_message_version_source_excluded(db_session) -> None:
+    from bot.services.search import search_messages
+
+    chat_id = -100_608
+    msg = await _create_versioned_message(
+        db_session,
+        chat_id=chat_id,
+        text="версия редактирована",
+        version_is_redacted=True,
+    )
+    await _create_approved_card(
+        db_session,
+        body_markdown="карточка mv-redacted диковина6",
+        source_version_ids=(msg.version_id,),
+    )
+
+    hits = await search_messages(
+        db_session, "диковина6", chat_id=chat_id, include_cards=True
+    )
+
+    assert [h for h in hits if h.source_type == "card"] == []
+
+
+async def test_card_with_completed_forget_event_on_one_source_excluded(db_session) -> None:
+    """L6a equivalent: forget one of three sources → card excluded even if
+    cascade keeps card_status='approved' because remaining_count > 0."""
+    from bot.services.search import search_messages
+
+    chat_id = -100_609
+    msgs = [
+        await _create_versioned_message(
+            db_session, chat_id=chat_id, text=f"источник {i}"
+        )
+        for i in range(3)
+    ]
+    await _create_approved_card(
+        db_session,
+        body_markdown="карточка 3-source диковина7",
+        source_version_ids=tuple(m.version_id for m in msgs),
+    )
+    # Forget the first source.
+    await _create_forget_event(
+        db_session,
+        tombstone_key=f"message:{msgs[0].chat_id}:{msgs[0].message_id}",
+        target_id=str(msgs[0].chat_message_id),
+        status="completed",
+    )
+
+    hits = await search_messages(
+        db_session, "диковина7", chat_id=chat_id, include_cards=True
+    )
+
+    assert [h for h in hits if h.source_type == "card"] == []
+
+
+async def test_card_with_pending_forget_event_on_one_source_excluded(db_session) -> None:
+    from bot.services.search import search_messages
+
+    chat_id = -100_610
+    msg = await _create_versioned_message(
+        db_session, chat_id=chat_id, text="pending-forget source"
+    )
+    await _create_approved_card(
+        db_session,
+        body_markdown="карточка pending диковина8",
+        source_version_ids=(msg.version_id,),
+    )
+    await _create_forget_event(
+        db_session,
+        tombstone_key=f"message:{msg.chat_id}:{msg.message_id}",
+        target_id=str(msg.chat_message_id),
+        status="pending",
+    )
+
+    hits = await search_messages(
+        db_session, "диковина8", chat_id=chat_id, include_cards=True
+    )
+
+    assert [h for h in hits if h.source_type == "card"] == []
+
+
+async def test_card_with_user_tombstone_excluded(db_session) -> None:
+    """L3c-style: user-level forget cascades to any card whose source author
+    is tombstoned."""
+    from bot.services.search import search_messages
+
+    chat_id = -100_611
+    msg = await _create_versioned_message(
+        db_session, chat_id=chat_id, text="user-tombstone source"
+    )
+    await _create_approved_card(
+        db_session,
+        body_markdown="карточка user-tombstone диковина9",
+        source_version_ids=(msg.version_id,),
+    )
+    await _create_forget_event(
+        db_session,
+        tombstone_key=f"user:{msg.user_id}",
+        target_type="user",
+        target_id=str(msg.user_id),
+        status="completed",
+    )
+
+    hits = await search_messages(
+        db_session, "диковина9", chat_id=chat_id, include_cards=True
+    )
+
+    assert [h for h in hits if h.source_type == "card"] == []
+
+
+async def test_card_with_content_hash_tombstone_excluded(db_session) -> None:
+    from bot.services.search import search_messages
+
+    chat_id = -100_612
+    msg = await _create_versioned_message(
+        db_session, chat_id=chat_id, text="hash-tombstone source"
+    )
+    await _create_approved_card(
+        db_session,
+        body_markdown="карточка hash диковина10",
+        source_version_ids=(msg.version_id,),
+    )
+    await _create_forget_event(
+        db_session,
+        tombstone_key=f"message_hash:{msg.content_hash}",
+        target_type="message_hash",
+        target_id=msg.content_hash,
+        status="completed",
+    )
+
+    hits = await search_messages(
+        db_session, "диковина10", chat_id=chat_id, include_cards=True
+    )
+
+    assert [h for h in hits if h.source_type == "card"] == []
+
+
+# ─── Card rank boost ─────────────────────────────────────────────────────────
+
+
+async def test_card_hit_ranks_above_equivalent_message_hit(db_session) -> None:
+    """A card and a message with similar match → card boosted above."""
+    from bot.services.search import search_messages
+
+    chat_id = -100_613
+    # Message with similar body — same query keyword present.
+    await _create_versioned_message(
+        db_session, chat_id=chat_id, text="одинаковая диковина11 здесь"
+    )
+    src = await _create_versioned_message(
+        db_session,
+        chat_id=chat_id,
+        text="источник карточки",
+    )
+    await _create_approved_card(
+        db_session,
+        body_markdown="одинаковая диковина11 здесь",
+        source_version_ids=(src.version_id,),
+    )
+
+    hits = await search_messages(
+        db_session, "диковина11", chat_id=chat_id, include_cards=True, limit=10
+    )
+
+    types_in_order = [h.source_type for h in hits]
+    # First hit must be card thanks to rank boost.
+    assert types_in_order[0] == "card"
+
+
+# ─── SearchHit shape ─────────────────────────────────────────────────────────
+
+
+async def test_message_hit_has_default_card_fields(db_session) -> None:
+    from bot.services.search import search_messages
+
+    chat_id = -100_614
+    await _create_versioned_message(
+        db_session, chat_id=chat_id, text="чистое сообщение"
+    )
+    hits = await search_messages(db_session, "чистое", chat_id=chat_id, include_cards=True)
+
+    assert len(hits) == 1
+    h = hits[0]
+    assert h.source_type == "message"
+    assert h.card_id is None
+    assert h.card_source_message_version_ids == ()
+
+
+async def test_card_hit_carries_source_mvid_tuple(db_session) -> None:
+    from bot.services.search import search_messages
+
+    chat_id = -100_615
+    sources = [
+        await _create_versioned_message(
+            db_session, chat_id=chat_id, text=f"источник {i}"
+        )
+        for i in range(3)
+    ]
+    expected_mvids = tuple(s.version_id for s in sources)
+    await _create_approved_card(
+        db_session,
+        body_markdown="карточка multi-source диковина12",
+        source_version_ids=expected_mvids,
+    )
+
+    hits = await search_messages(
+        db_session, "диковина12", chat_id=chat_id, include_cards=True
+    )
+
+    card_hits = [h for h in hits if h.source_type == "card"]
+    assert len(card_hits) == 1
+    assert card_hits[0].card_source_message_version_ids == expected_mvids
+    # Anchor source is position-0 mvid.
+    assert card_hits[0].message_version_id == expected_mvids[0]
+
+
+# ─── Limit + ordering ───────────────────────────────────────────────────────
+
+
+async def test_limit_clamps_merged_result(db_session) -> None:
+    from bot.services.search import search_messages
+
+    chat_id = -100_616
+    sources = []
+    for i in range(3):
+        m = await _create_versioned_message(
+            db_session, chat_id=chat_id, text=f"sourcemsg {i}"
+        )
+        sources.append(m)
+        await _create_approved_card(
+            db_session,
+            body_markdown=f"карточка-{i} диковина13",
+            source_version_ids=(m.version_id,),
+        )
+    await _create_versioned_message(
+        db_session, chat_id=chat_id, text="ещё диковина13 сообщение"
+    )
+
+    hits = await search_messages(
+        db_session, "диковина13", chat_id=chat_id, include_cards=True, limit=2
+    )
+
+    assert len(hits) == 2
+
+
+# ─── Default value contract ─────────────────────────────────────────────────
+
+
+async def test_include_cards_default_is_true_per_spec(db_session) -> None:
+    """Per PHASE6_PLAN.md §5.D the default is True; absent kwarg surfaces cards."""
+    from bot.services.search import search_messages
+
+    chat_id = -100_617
+    msg = await _create_versioned_message(
+        db_session, chat_id=chat_id, text="нерелевантно"
+    )
+    await _create_approved_card(
+        db_session,
+        body_markdown="карточка default диковина14",
+        source_version_ids=(msg.version_id,),
+    )
+
+    # No include_cards kwarg.
+    hits = await search_messages(db_session, "диковина14", chat_id=chat_id)
+
+    assert any(h.source_type == "card" for h in hits)

--- a/tests/services/test_search_cards.py
+++ b/tests/services/test_search_cards.py
@@ -58,7 +58,17 @@ async def _create_versioned_message(
     chat_is_redacted: bool = False,
     version_is_redacted: bool = False,
     message_id: int | None = None,
+    populate_chat_message_content_hash: bool = True,
 ) -> CreatedMessage:
+    """Create one (ChatMessage, MessageVersion) pair.
+
+    ``populate_chat_message_content_hash`` controls whether
+    ``chat_messages.content_hash`` is set. Default ``True`` mirrors the import
+    path (``bot/services/import_apply.py``). Pass ``False`` to simulate the live
+    persistence path (``bot/db/repos/message.py::MessageRepo.save``) which
+    leaves ``chat_messages.content_hash`` NULL while still populating
+    ``MessageVersion.content_hash``.
+    """
     from bot.db.models import ChatMessage, MessageVersion
     from bot.db.repos.user import UserRepo
 
@@ -83,7 +93,7 @@ async def _create_versioned_message(
         date=datetime.now(timezone.utc),
         memory_policy=memory_policy,
         is_redacted=chat_is_redacted,
-        content_hash=content_hash,
+        content_hash=content_hash if populate_chat_message_content_hash else None,
     )
     db_session.add(chat_message)
     await db_session.flush()
@@ -636,3 +646,106 @@ async def test_include_cards_default_is_true_per_spec(db_session) -> None:
     hits = await search_messages(db_session, "диковина14", chat_id=chat_id)
 
     assert any(h.source_type == "card" for h in hits)
+
+
+# ─── Codex round-2 CRITICAL regressions ─────────────────────────────────────
+# These tests pin down the bugs Codex flagged in the round-2 review of T6-06.
+# They MUST stay green after the fix in bot/services/search.py.
+
+
+async def test_card_tombstone_message_hash_filters_live_only_content_hash(
+    db_session,
+) -> None:
+    """CRITICAL #1: forget_event with ``message_hash:<mv.content_hash>`` MUST
+    block a card whose source row was persisted via the live path
+    (``chat_messages.content_hash IS NULL``, only
+    ``MessageVersion.content_hash`` populated).
+
+    The pre-fix SQL filtered on ``c2.content_hash`` (always NULL for live rows)
+    so the ``message_hash:`` tombstone silently no-op'd and the card surfaced.
+    Mirrors the same-class fix already landed in T6-02 (extractor.py).
+    """
+    from bot.services.search import search_messages
+
+    chat_id = -100_618
+    # Live persistence reality: chat_messages.content_hash IS NULL, only
+    # MessageVersion.content_hash populated. Without the fix the tombstone
+    # silently misses this card.
+    msg = await _create_versioned_message(
+        db_session,
+        chat_id=chat_id,
+        text="live-content-hash source",
+        populate_chat_message_content_hash=False,
+    )
+    await _create_approved_card(
+        db_session,
+        body_markdown="карточка live-only диковина20",
+        source_version_ids=(msg.version_id,),
+    )
+    await _create_forget_event(
+        db_session,
+        tombstone_key=f"message_hash:{msg.content_hash}",
+        target_type="message_hash",
+        target_id=msg.content_hash,
+        status="completed",
+    )
+
+    hits = await search_messages(
+        db_session, "диковина20", chat_id=chat_id, include_cards=True
+    )
+
+    assert [h for h in hits if h.source_type == "card"] == []
+
+
+async def test_card_with_partial_source_forget_no_cascade_yet(db_session) -> None:
+    """CRITICAL #2: tombstone ONE source of a 2-source card via a
+    ``message_hash:<mv.content_hash>`` forget_event WITHOUT running the
+    cascade. Both sources persisted via the live path
+    (``chat_messages.content_hash IS NULL``), so the buggy SQL would silently
+    no-op the tombstone match and surface the card.
+
+    The card MUST NOT surface — the search-side per-source defense-in-depth
+    re-checks every source against open forget_events at query time using
+    ``mv.content_hash`` (not ``c.content_hash``) and excludes the card
+    regardless of cascade timing.
+
+    Cross-references the eval suite's L6a but exercises the live-row /
+    ``message_hash:`` path that CRITICAL #1 fixes.
+    """
+    from bot.services.search import search_messages
+
+    chat_id = -100_619
+    src_a = await _create_versioned_message(
+        db_session,
+        chat_id=chat_id,
+        text="partial-forget source A",
+        populate_chat_message_content_hash=False,
+    )
+    src_b = await _create_versioned_message(
+        db_session,
+        chat_id=chat_id,
+        text="partial-forget source B",
+        populate_chat_message_content_hash=False,
+    )
+    await _create_approved_card(
+        db_session,
+        body_markdown="карточка partial-forget диковина21",
+        source_version_ids=(src_a.version_id, src_b.version_id),
+    )
+    # Tombstone ONE of TWO sources via message_hash: key, hitting the
+    # CRITICAL #1 path. Cascade is NOT run (no card_sources DELETE). Card
+    # stays approved with both sources still attached. Pre-fix SQL filters on
+    # c.content_hash (NULL for live rows) → tombstone silently no-op's.
+    await _create_forget_event(
+        db_session,
+        tombstone_key=f"message_hash:{src_a.content_hash}",
+        target_type="message_hash",
+        target_id=src_a.content_hash,
+        status="completed",
+    )
+
+    hits = await search_messages(
+        db_session, "диковина21", chat_id=chat_id, include_cards=True
+    )
+
+    assert [h for h in hits if h.source_type == "card"] == []


### PR DESCRIPTION
Phase 6 Wave 2 Stream D — bundle T6-06 + T6-07.

## What's in

- **T6-06**: search_messages `include_cards=True` (default per §5.D) — UNION ALL message branch + card branch with rank boost 1.15, defense-in-depth via mv.content_hash + per-source tombstone re-check
- **T6-07**: EvidenceItem.source_type Literal['message', 'card'] + card_id + source mvids — backward compat preserved via getattr defaults
- 5 + 5 commits (round 1 impl + round 2 Codex fixes): 47 service tests, Phase 11 binding extended 21→28 (L6a/b/c + C5a/b/c/d)
- Dual-branch renderers in qa.py (pure-message bundles use INLINED path — Phase 4 byte-for-byte preserved)

## Privacy invariants enforced

- Card tombstone filter uses **mv.content_hash** (not c.content_hash which is NULL for live messages — T6-02 round 3 lesson)
- `unforgotten_card_sources` CTE re-checks all 3 tombstone keys per source before card_anchors/source_lists
- Approved-only filter + defense-in-depth governance check on remaining sources

## Review

- Claude product (standard-product-reviewer, opus): **ACCEPTED**
- Codex tech (gpt-5.5 high) 2 rounds:
  - Round 1: REQUEST_CHANGES (2 CRITICAL: card tombstone via mv.content_hash + partial card_sources leak; 1 MED: SQLite guard claim)
  - Round 2: REQUEST_CHANGES env-only (sandbox no Postgres) — code fixes structurally verified correct via inspection; 47/47 tests pass locally

## Test plan

- [x] Phase 11 binding 28/28 green (L1-L5 + L6a/b/c + C1-C4 + C5a-d + R1-R4 + I1-I4)
- [x] 47 service tests green (incl. 2 round 2 TDD regression tests for CRITICAL #1 + #2)
- [x] Phase 4 + Phase 5 byte-for-byte regression guards green
- [x] Ruff + privacy lint green

## Known follow-up

**Pre-existing on main**: `_PHASE4_SQL` + `_PHASE6_SQL.message_hits` use `c.content_hash` for message_hash tombstones — same bug class but in MESSAGE branch. Stream D fixes CARD branch only. Issue filed as separate HIGH-priority follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)