### PR TITLE
fix(p4-fu): message branch tombstone uses mv.content_hash (closes #255)

### DIFF
--- a/bot/services/search.py
+++ b/bot/services/search.py
@@ -116,8 +116,14 @@ WHERE c.chat_id = :chat_id
         WHERE (
             fe.tombstone_key = 'message:' || c.chat_id::text || ':' || c.message_id::text
             OR (
-                c.content_hash IS NOT NULL
-                AND fe.tombstone_key = 'message_hash:' || c.content_hash
+                -- #255 + T6-02 round 3 lesson: ``message_hash:`` tombstone MUST
+                -- match against ``message_versions.content_hash`` (NOT NULL by
+                -- schema), NOT ``chat_messages.content_hash`` (nullable — live
+                -- ingestion via ``MessageRepo.save`` never populates it; only
+                -- import path does). Filtering on ``c.content_hash`` silently
+                -- leaks live messages whose hash IS tombstoned.
+                mv.content_hash IS NOT NULL
+                AND fe.tombstone_key = 'message_hash:' || mv.content_hash
             )
             OR (
                 c.user_id IS NOT NULL
@@ -198,8 +204,10 @@ message_hits AS (
             WHERE (
                 fe.tombstone_key = 'message:' || c.chat_id::text || ':' || c.message_id::text
                 OR (
-                    c.content_hash IS NOT NULL
-                    AND fe.tombstone_key = 'message_hash:' || c.content_hash
+                    -- #255: see ``_PHASE4_SQL`` comment — same fix here for the
+                    -- Phase 6 ``message_hits`` branch.
+                    mv.content_hash IS NOT NULL
+                    AND fe.tombstone_key = 'message_hash:' || mv.content_hash
                 )
                 OR (
                     c.user_id IS NOT NULL

--- a/tests/services/test_search.py
+++ b/tests/services/test_search.py
@@ -320,6 +320,47 @@ async def test_search_empty_message_hash_tombstone_does_not_match_null_hash(
     assert [hit.message_version_id for hit in hits] == [created.version_id]
 
 
+async def test_message_hash_tombstone_filters_live_only_content_hash(
+    db_session,
+) -> None:
+    """Regression #255: message_hash tombstone must block live messages where
+    chat_messages.content_hash IS NULL but message_versions.content_hash is set.
+
+    Live message ingestion via ``MessageRepo.save`` does NOT populate
+    ``chat_messages.content_hash``. Only ``message_versions.content_hash`` is
+    populated (NOT NULL by schema). Filtering on ``c.content_hash`` silently
+    no-ops every ``message_hash:<hash>`` tombstone for live messages.
+
+    The fix must use ``mv.content_hash`` instead.
+    """
+    from bot.db.models import ChatMessage
+    from bot.services.search import search_messages
+
+    chat_id = -100_422
+    created = await _create_versioned_message(
+        db_session,
+        chat_id=chat_id,
+        text="live message hash питон",
+    )
+    # Simulate live ingestion: c.content_hash is NULL, mv.content_hash is set.
+    chat_message = await db_session.get(ChatMessage, created.chat_message_id)
+    assert chat_message is not None
+    chat_message.content_hash = None
+    await db_session.flush()
+
+    # Tombstone keyed on the message_versions.content_hash (the only one populated).
+    await _create_forget_event(
+        db_session,
+        tombstone_key=f"message_hash:{created.content_hash}",
+        target_type="message_hash",
+        status="pending",
+    )
+
+    hits = await search_messages(db_session, "питон", chat_id=chat_id)
+
+    assert hits == []
+
+
 async def test_search_chat_isolation(db_session) -> None:
     from bot.services.search import search_messages
 


### PR DESCRIPTION
Closes #255 — pre-existing privacy leak on main.

## Bug

`bot/services/search.py` message branch (`_PHASE4_SQL` + `_PHASE6_SQL.message_hits`) used `c.content_hash` для `message_hash:` tombstone match. `MessageRepo.save` НЕ populates `chat_messages.content_hash` для live messages — только `message_versions.content_hash` (NOT NULL by schema). Forget_events keyed `message_hash:<hash>` тихо НЕ блокировали live messages.

## Fix

Mirror Stream D card branch + T6-02 round 3 extractor pattern: use `mv.content_hash` in both message-branch tombstone subqueries.

Adds regression test `test_message_hash_tombstone_filters_live_only_content_hash` exercising exact bug class.

## Test plan

- [x] Regression test red→green (verified manually)
- [x] All 21 test_search.py cases green
- [x] Phase 11 binding 28+/28+ green
- [x] Ruff + privacy lint green

🤖 Generated with [Claude Code](https://claude.com/claude-code)