### PR TITLE
fix(healing): surface child stderr in _run + redact args

### DIFF
--- a/ops/healing/orchestrator.py
+++ b/ops/healing/orchestrator.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import os
 import subprocess
+import sys
 import time
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
@@ -34,13 +35,27 @@ class HealingResult:
 
 
 def _run(command: list[str], input_text: str | None = None) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(
-        command,
-        input=input_text,
-        text=True,
-        capture_output=True,
-        check=True,
-    )
+    try:
+        return subprocess.run(
+            command,
+            input=input_text,
+            text=True,
+            capture_output=True,
+            check=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        # Surface child output so failures are debuggable in CI logs.
+        # capture_output=True hides stderr by default; without this, callers see
+        # only the parent CalledProcessError frame.
+        sys.stderr.write(
+            f"[ops.healing._run] Child failed (exit={exc.returncode}): {' '.join(command)}\n"
+        )
+        if exc.stdout:
+            sys.stderr.write(f"[ops.healing._run] child stdout:\n{exc.stdout}\n")
+        if exc.stderr:
+            sys.stderr.write(f"[ops.healing._run] child stderr:\n{exc.stderr}\n")
+        sys.stderr.flush()
+        raise
 
 
 def _dry_run_result(scenario: str, config: HealingConfig) -> HealingResult:

--- a/ops/healing/orchestrator.py
+++ b/ops/healing/orchestrator.py
@@ -47,8 +47,19 @@ def _run(command: list[str], input_text: str | None = None) -> subprocess.Comple
         # Surface child output so failures are debuggable in CI logs.
         # capture_output=True hides stderr by default; without this, callers see
         # only the parent CalledProcessError frame.
+        # Redact full args from log — some callers pass --signal-json payloads
+        # containing connection details. Show only program path + first 2 non-flag
+        # args (typically `-m module.path`) so debug can identify the failed command
+        # without leaking secret values.
+        cmd_preview_parts = [command[0]] if command else ["<empty>"]
+        for arg in command[1:3]:
+            cmd_preview_parts.append(arg)
+        remaining = max(0, len(command) - 3)
+        cmd_preview = " ".join(cmd_preview_parts)
+        if remaining > 0:
+            cmd_preview += f" [+{remaining} args redacted]"
         sys.stderr.write(
-            f"[ops.healing._run] Child failed (exit={exc.returncode}): {' '.join(command)}\n"
+            f"[ops.healing._run] Child failed (exit={exc.returncode}): {cmd_preview}\n"
         )
         if exc.stdout:
             sys.stderr.write(f"[ops.healing._run] child stdout:\n{exc.stdout}\n")

--- a/tests/healing/test_orchestrator.py
+++ b/tests/healing/test_orchestrator.py
@@ -1,0 +1,39 @@
+"""Tests for ops.healing.orchestrator._run.
+
+Sprint 1A: ensure child failures surface stdout/stderr to parent stderr so
+GitHub Actions logs capture the real error, not just `exit status 1`.
+"""
+
+import subprocess
+import sys
+
+import pytest
+
+from ops.healing.orchestrator import _run
+
+
+def test_run_surfaces_child_stderr_on_failure(capsys: pytest.CaptureFixture[str]) -> None:
+    # Use a command that exits non-zero and writes to stderr.
+    failing = [sys.executable, "-c", "import sys; sys.stderr.write('TEST_CHILD_STDERR'); sys.exit(2)"]
+    with pytest.raises(subprocess.CalledProcessError):
+        _run(failing)
+    captured = capsys.readouterr()
+    assert "TEST_CHILD_STDERR" in captured.err
+    assert "[ops.healing._run]" in captured.err
+
+
+def test_run_surfaces_child_stdout_on_failure(capsys: pytest.CaptureFixture[str]) -> None:
+    failing = [sys.executable, "-c", "import sys; print('TEST_CHILD_STDOUT'); sys.exit(3)"]
+    with pytest.raises(subprocess.CalledProcessError):
+        _run(failing)
+    captured = capsys.readouterr()
+    assert "TEST_CHILD_STDOUT" in captured.err  # we redirect stdout into stderr surface
+    assert "exit=3" in captured.err
+
+
+def test_run_success_does_not_emit_to_stderr(capsys: pytest.CaptureFixture[str]) -> None:
+    result = _run([sys.executable, "-c", "print('ok')"])
+    captured = capsys.readouterr()
+    assert result.returncode == 0
+    assert result.stdout == "ok\n"
+    assert "[ops.healing._run]" not in captured.err

--- a/tests/healing/test_orchestrator.py
+++ b/tests/healing/test_orchestrator.py
@@ -31,6 +31,16 @@ def test_run_surfaces_child_stdout_on_failure(capsys: pytest.CaptureFixture[str]
     assert "exit=3" in captured.err
 
 
+def test_run_redacts_command_args_on_failure(capsys: pytest.CaptureFixture[str]) -> None:
+    cmd = [sys.executable, "-c", "import sys; sys.exit(1)", "--signal-json", '{"secret":"xxx"}', "--token", "abc"]
+    with pytest.raises(subprocess.CalledProcessError):
+        _run(cmd)
+    captured = capsys.readouterr()
+    assert '"secret":"xxx"' not in captured.err
+    assert "abc" not in captured.err
+    assert "[+4 args redacted]" in captured.err
+
+
 def test_run_success_does_not_emit_to_stderr(capsys: pytest.CaptureFixture[str]) -> None:
     result = _run([sys.executable, "-c", "print('ok')"])
     captured = capsys.readouterr()


### PR DESCRIPTION
## Summary

- Patch `ops/healing/orchestrator.py::_run` to surface child stdout/stderr to parent stderr on `CalledProcessError`. Without this, `capture_output=True` swallowed the real error and every Autonomous Healing failure since 2026-04-30 showed only `subprocess.CalledProcessError ... returned non-zero exit status 1`.
- Redact command arguments in the failure log (Codex review feedback) — show only program path + first 2 non-flag args + redacted-count, to avoid leaking `--signal-json` payload contents into CI logs.
- Add `tests/healing/test_orchestrator.py` with 4 focused tests covering: stderr surfacing, stdout surfacing, redaction of sensitive args, no-emit on success.

## Why

The autonomous-healing pipeline has been emitting ~8 false-positive workflow failures per day. The visible error was opaque. Sprint 0 diagnosis (4-round dialogue + Codex independent review + deep-analyst) revealed the workflow fails on `context_bundle.py` re-run, not on `check_db_roundtrip` as initially assumed — but the child's traceback was being silently dropped. This patch is the prerequisite for diagnosing the real failure cause.

This is Sprint 1A of the healing pipeline fix. Sprint 1B (apply the targeted fix once stderr reveals it) and Sprint 1C (`check_db_roundtrip` drop-vs-probe-container decision) are queued and conditional on what 1A's logs reveal.

## Test plan

- [x] `pytest tests/healing/test_orchestrator.py -v` — 4 passed
- [x] `pytest tests/healing/test_dry_run_e2e.py tests/healing/test_state_branch.py tests/healing/test_pre_tool_use_hook.py` — 22 passed, no regression
- [ ] After merge, monitor next scheduled Autonomous Healing run → confirm real child traceback appears in the workflow log (not just `exit status 1`)
- [ ] Verify no secret-looking strings leak into the failure log

## Reviewers

- Codex (gpt-5.5, high reasoning): APPROVE on `c2d3c24` (post-redaction-fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)