### PR TITLE
fix(healing): graceful Coolify /deployments 404 in context_bundle

### DIFF
--- a/ops/healing/context_bundle.py
+++ b/ops/healing/context_bundle.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import os
 import subprocess
+import sys
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -121,7 +122,17 @@ def _coolify_state(app_uuid: str) -> dict[str, Any]:
 
 
 def _last_deployments(app_uuid: str, config: ChunkingConfig) -> Any:
-    payload = _coolify_json(f"/api/v1/applications/{app_uuid}/deployments")
+    try:
+        payload = _coolify_json(f"/api/v1/applications/{app_uuid}/deployments")
+    except httpx.HTTPStatusError as exc:
+        if exc.response.status_code == 404:
+            sys.stderr.write(
+                "[ops.healing.context_bundle] Coolify deployments endpoint 404 "
+                f"(app {app_uuid}); emitting empty deployments list and continuing.\n"
+            )
+            sys.stderr.flush()
+            return []
+        raise
     if isinstance(payload, dict) and isinstance(payload.get("data"), list):
         return payload["data"][: config.deployments]
     if isinstance(payload, list):

--- a/tests/healing/test_context_bundle.py
+++ b/tests/healing/test_context_bundle.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Any
 
 import httpx
+import pytest
 
 from ops.healing import context_bundle
 
@@ -78,3 +79,33 @@ def test_assemble_contains_all_sections(monkeypatch: Any, tmp_path: Path) -> Non
     assert "## Snapshot reference" in bundle
     assert "BOT_TOKEN" in bundle
     assert "hidden" not in bundle
+
+
+def test_last_deployments_returns_empty_on_404(capsys: pytest.CaptureFixture[str], monkeypatch: Any) -> None:
+    """Sprint 1B: Coolify /deployments endpoint may not exist in current Coolify version.
+
+    Degrade to empty list + stderr marker rather than crashing context_bundle.
+    """
+    def fake_coolify_json(path: str) -> Any:
+        request = httpx.Request("GET", f"http://example/{path}")
+        response = httpx.Response(404, request=request)
+        raise httpx.HTTPStatusError("404", request=request, response=response)
+
+    monkeypatch.setattr(context_bundle, "_coolify_json", fake_coolify_json)
+    result = context_bundle._last_deployments("abc-uuid", context_bundle.ChunkingConfig())
+    assert result == []
+    err = capsys.readouterr().err
+    assert "Coolify deployments endpoint 404" in err
+    assert "abc-uuid" in err
+
+
+def test_last_deployments_propagates_non_404(monkeypatch: Any) -> None:
+    """Non-404 HTTP errors must still propagate — we only mask the missing endpoint."""
+    def fake_coolify_json(path: str) -> Any:
+        request = httpx.Request("GET", f"http://example/{path}")
+        response = httpx.Response(500, request=request)
+        raise httpx.HTTPStatusError("500", request=request, response=response)
+
+    monkeypatch.setattr(context_bundle, "_coolify_json", fake_coolify_json)
+    with pytest.raises(httpx.HTTPStatusError):
+        context_bundle._last_deployments("abc-uuid", context_bundle.ChunkingConfig())


### PR DESCRIPTION
## Summary

Once Sprint 1A (PR #268) surfaced the real child stderr in healing logs, the actual cause of every Autonomous Healing failure since 2026-04-30 was revealed: `httpx.HTTPStatusError: 404 Not Found for url 'http://100.101.196.21:8100/api/v1/applications/<uuid>/deployments'`.

Coolify API surface varies by version — `/applications/{uuid}/deployments` returns 404 here while `/applications/{uuid}` works (`_coolify_state` succeeds in the same workflow with same auth and UUID).

This PR makes `ops/healing/context_bundle.py::_last_deployments` degrade gracefully on 404 — return `[]` with a stderr marker — so the rest of the bundle assembles. Non-404 errors still propagate.

This is Sprint 1B of the healing pipeline fix. Sprint 1C (`check_db_roundtrip` drop-vs-probe-container decision) is next.

## Test plan

- [x] `pytest tests/healing/test_context_bundle.py -v` — 3 passed (1 existing + 2 new)
- [x] Broader healing suite — 29 passed, no regression
- [ ] After merge, manual `gh workflow run healing.yml` with a fake red signal payload → workflow exits 0 (no longer crashes on Coolify 404)

## Reviewers

- Codex (gpt-5.5, high reasoning): APPROVE_WITH_NOTES. Notes are medium-priority observability suggestions (visible-warning in bundle text), no Critical/High. Accepted option (a): empty deployments section is implicit signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)