### PR TITLE
fix(healing): exclude db_roundtrip from is_red until #168 lands

### DIFF
--- a/ops/healing/healthcheck.py
+++ b/ops/healing/healthcheck.py
@@ -39,9 +39,18 @@ class CheckReport:
 
     @property
     def is_red(self) -> bool:
+        # db_roundtrip is excluded from is_red calculation: the GitHub Actions
+        # self-hosted runner has no route to Coolify's internal Docker bridge
+        # (172.24.x.x) where Postgres lives, so the check has been continuously
+        # RED since 2026-04-30 without ever reflecting actual DB health. The
+        # check still runs and its result is emitted in the JSON payload for
+        # diagnostic visibility, but it does not trigger healing dispatch.
+        # TODO: re-include once #168 (`/healthz/db` endpoint on bot) lands,
+        # which will provide app-boundary DB observability reachable from the
+        # runner via Tailscale.
         return any(
             result.is_red
-            for result in (self.coolify_status, self.telegram_pending, self.db_roundtrip)
+            for result in (self.coolify_status, self.telegram_pending)
         )
 
     def to_dict(self) -> dict[str, Any]:

--- a/tests/healing/test_healthcheck.py
+++ b/tests/healing/test_healthcheck.py
@@ -148,6 +148,41 @@ def test_check_db_roundtrip_red_on_exception(monkeypatch: Any) -> None:
     assert "database timeout" in result.reason
 
 
+def test_check_report_is_red_excludes_db_roundtrip_when_only_db_red() -> None:
+    """Sprint 1C: db_roundtrip RED alone must not trigger is_red.
+
+    Runner has no route to Coolify-internal Postgres bridge; until #168
+    ('/healthz/db') lands, this check is informational only.
+    """
+    from ops.healing.healthcheck import CheckReport, CheckResult
+
+    green = CheckResult("x", "green", "", {}, 0)
+    red = CheckResult("x", "red", "stale", {}, 0)
+    report = CheckReport(
+        generated_at="2026-05-13T00:00:00+00:00",
+        coolify_status=green,
+        telegram_pending=green,
+        db_roundtrip=red,
+    )
+    assert report.is_red is False, "is_red must not be triggered by db_roundtrip alone"
+
+
+def test_check_report_is_red_triggers_on_coolify_or_telegram_red() -> None:
+    """Sprint 1C: coolify_status or telegram_pending RED still triggers is_red."""
+    from ops.healing.healthcheck import CheckReport, CheckResult
+
+    green = CheckResult("x", "green", "", {}, 0)
+    red = CheckResult("x", "red", "down", {}, 0)
+    for coolify, telegram in [(red, green), (green, red), (red, red)]:
+        report = CheckReport(
+            generated_at="2026-05-13T00:00:00+00:00",
+            coolify_status=coolify,
+            telegram_pending=telegram,
+            db_roundtrip=green,
+        )
+        assert report.is_red is True, "real signals must still trigger is_red"
+
+
 def test_run_all_writes_state_file(monkeypatch: Any, tmp_path: Path) -> None:
     _set_env(monkeypatch)
     monkeypatch.setattr(

--- a/tests/healing/test_healthcheck.py
+++ b/tests/healing/test_healthcheck.py
@@ -168,19 +168,31 @@ def test_check_report_is_red_excludes_db_roundtrip_when_only_db_red() -> None:
 
 
 def test_check_report_is_red_triggers_on_coolify_or_telegram_red() -> None:
-    """Sprint 1C: coolify_status or telegram_pending RED still triggers is_red."""
+    """Sprint 1C: coolify_status or telegram_pending RED still triggers is_red.
+
+    db_roundtrip state is irrelevant — it's been removed from the is_red gate.
+    """
     from ops.healing.healthcheck import CheckReport, CheckResult
 
     green = CheckResult("x", "green", "", {}, 0)
     red = CheckResult("x", "red", "down", {}, 0)
-    for coolify, telegram in [(red, green), (green, red), (red, red)]:
+    cases = [
+        # (coolify, telegram, db_roundtrip)
+        (red, green, green),
+        (green, red, green),
+        (red, red, green),
+        (red, green, red),
+        (green, red, red),
+        (red, red, red),
+    ]
+    for coolify, telegram, db in cases:
         report = CheckReport(
             generated_at="2026-05-13T00:00:00+00:00",
             coolify_status=coolify,
             telegram_pending=telegram,
-            db_roundtrip=green,
+            db_roundtrip=db,
         )
-        assert report.is_red is True, "real signals must still trigger is_red"
+        assert report.is_red is True, f"real signals must still trigger is_red; case (c,t,d)=({coolify.status},{telegram.status},{db.status})"
 
 
 def test_run_all_writes_state_file(monkeypatch: Any, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

`check_db_roundtrip` has been continuously RED on every Autonomous Healing run since 2026-04-30 — the GitHub Actions self-hosted runner sits on the Hostinger VPS host network, while Coolify Postgres lives in an internal Docker bridge (`172.24.x.x`) unreachable from the host. The check has never observed a green datapoint and provides no actual signal.

Sprint 1A (PR #268) surfaced this in logs. Sprint 1B (PR #269) made `context_bundle` survive Coolify-API 404 so we could observe the cascade. This PR is the final piece: stop the broken sensor from triggering false healing dispatches and admin escalations.

- `check_db_roundtrip` **still runs** and is emitted in the JSON payload for diagnostic visibility.
- It is **excluded from `is_red`** so healthcheck workflow exits 0 if only db_roundtrip is RED.
- A code comment links to #168 (`/healthz/db` endpoint, the proper replacement).
- Follow-up issue #270 documents explicit re-enable criterion when #168 lands.

## Caveat (per Codex review)

`coolify_status` is the only current proxy for "DB issues that matter to the bot", and it only catches `restart_delta > 2`. A DB outage that manifests as connection-pool exhaustion **without** bot crash would not currently trigger healing. This is the acceptable trade-off until #168 provides an app-boundary `/healthz/db` reachable from the runner via Tailscale.

## Test plan

- [x] `pytest tests/healing/test_healthcheck.py -v` — 10 tests passed (includes 2 new for the is_red contract).
- [x] Broader healing suite — 29 passed, no regression.
- [ ] After merge, manual `gh workflow run healing.yml` with a fake all-green-except-db payload → workflow exits 0 (no dispatch).
- [ ] After merge, observe next 24h: scheduled `Healing Healthcheck` should no longer dispatch `Autonomous Healing` unless coolify_status or telegram_pending genuinely flips RED.

## Reviewers

- Codex (gpt-5.5, high reasoning): APPROVE_WITH_NOTES on initial commit. Notes addressed:
  - Added test case varying `db_roundtrip` in is-red TRUE paths (commit `f974ee3`).
  - Opened follow-up #270 with explicit re-enable criterion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)