### PR TITLE
fix(p65): bundle B — /approve deadlock sort + LLM source-mvid dedupe (#262 M-1+M-4)

### DIFF
--- a/bot/handlers/admin_cards.py
+++ b/bot/handlers/admin_cards.py
@@ -326,13 +326,18 @@ async def cmd_approve(
         return
 
     # Step 1d: if the canonical mvid set picked up any rows that step 1a
-    # missed, acquire advisory locks for the new mvids too. Sorted across
-    # the union to maintain deadlock-avoidance ordering. The candidate's
-    # source set is normally immutable after creation, so this is a
-    # defence-in-depth path.
-    new_mvids = [m for m in mvids if m not in set(initial_mvids)]
-    if new_mvids:
-        await _acquire_mvid_locks(session, new_mvids)
+    # missed, acquire advisory locks for ALL mvids in the full union (sorted).
+    # Passing only the new delta would produce a different global ordering
+    # from two concurrent /approve callers whose mvid sets overlap — that is
+    # the lock-order inversion that causes deadlock. Passing the full union to
+    # _acquire_mvid_locks (which sorts internally) keeps the acquisition order
+    # identical to the cascade orchestrator's protocol for any subset of mvids.
+    # pg_advisory_xact_lock re-entry is safe: PostgreSQL ignores duplicate
+    # xact-lock requests for a key already held within the same transaction.
+    full_union_mvids = list(set(initial_mvids) | set(mvids))
+    if set(full_union_mvids) != set(initial_mvids):
+        # Only re-acquire when the union differs from what was locked in 1b.
+        await _acquire_mvid_locks(session, full_union_mvids)
 
     # Step 3+4: deterministic governance re-validation (NO LLM re-prompt).
     status, payload = await revalidate_sources(session, mvids)

--- a/bot/services/llm_gateway.py
+++ b/bot/services/llm_gateway.py
@@ -1231,13 +1231,19 @@ async def extract_candidates(
         if not isinstance(source_ids_raw, list):
             continue
         # Drop hallucinated mvids; keep only those present in input set.
+        # Deduplicate while preserving first-occurrence order — the LLM may
+        # return the same mvid multiple times; downstream CardSourceRepo has
+        # UNIQUE(card_id, message_version_id) and would raise IntegrityError
+        # on duplicates (#262 M-4).
         source_ids: list[int] = []
+        _seen_ids: set[int] = set()
         for x in source_ids_raw:
             try:
                 xid = int(x)
             except (TypeError, ValueError):
                 continue
-            if xid in valid_mvid_set:
+            if xid in valid_mvid_set and xid not in _seen_ids:
+                _seen_ids.add(xid)
                 source_ids.append(xid)
         if not source_ids:
             # Invariant: no card without source.

--- a/tests/handlers/test_admin_cards.py
+++ b/tests/handlers/test_admin_cards.py
@@ -1167,3 +1167,89 @@ async def test_card_detail_returns_not_found_for_archived(
     assert "archived" not in reply.lower()
     # And positive assertion: the handler explicitly says "not found".
     assert "Card not found" in reply
+
+
+# ─── /approve step 1d — full-union sort regression (M-1 deadlock fix) ─────────
+
+
+def test_acquire_mvid_locks_called_with_full_union_in_step_1d() -> None:
+    """Regression guard for #262 M-1: step 1d MUST pass the full union of
+    mvids (initial ∪ new) to ``_acquire_mvid_locks``, not just the delta.
+
+    Rationale: if two concurrent /approve invocations share a subset of mvids,
+    each calling _acquire_mvid_locks with only their own partial set produces
+    different global orderings and can deadlock. Sorting the FULL union before
+    any second-round acquisition matches the cascade orchestrator's protocol.
+
+    This test patches ``_acquire_mvid_locks`` and verifies the call args
+    include every mvid from both the initial read and the FOR UPDATE read.
+    """
+    import asyncio
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    # Simulate: step 1a sees [10, 30], step 1c sees [10, 20, 30] (20 was added).
+    initial_mvids = [10, 30]
+    final_mvids = [10, 20, 30]
+
+    # Build a minimal candidate mock.
+    initial_cand = MagicMock()
+    initial_cand.source_message_version_ids = initial_mvids
+    locked_cand = MagicMock()
+    locked_cand.source_message_version_ids = final_mvids
+    locked_cand.status = "pending"
+
+    lock_calls: list[list[int]] = []
+
+    async def _capture_lock_calls(session, mvids):
+        lock_calls.append(list(mvids))
+
+    async def _run():
+        with (
+            patch(
+                "bot.handlers.admin_cards.ExtractionCandidateRepo.get_by_id",
+                new=AsyncMock(return_value=initial_cand),
+            ),
+            patch(
+                "bot.handlers.admin_cards.ExtractionCandidateRepo.get_by_id_for_update",
+                new=AsyncMock(return_value=locked_cand),
+            ),
+            patch(
+                "bot.handlers.admin_cards._acquire_mvid_locks",
+                side_effect=_capture_lock_calls,
+            ),
+            patch(
+                "bot.handlers.admin_cards.revalidate_sources",
+                new=AsyncMock(return_value=("blocked", {"reason": "test_sentinel"})),
+            ),
+        ):
+            from bot.handlers.admin_cards import cmd_approve
+
+            msg = MagicMock()
+            msg.from_user = MagicMock()
+            msg.from_user.id = 149820031
+            msg.from_user.username = "admin_user"
+            msg.answer = AsyncMock()
+            msg.reply = AsyncMock()
+
+            cmd_obj = MagicMock()
+            cmd_obj.args = str(_uuid_module.uuid4())
+
+            session = MagicMock()
+            await cmd_approve(msg, cmd_obj, session=session)
+
+        return lock_calls
+
+    calls = asyncio.run(_run())
+
+    # Step 1b: initial_mvids were locked first.
+    assert len(calls) >= 2, (
+        f"expected at least 2 _acquire_mvid_locks calls (1b + 1d); got {calls}"
+    )
+
+    # The LAST call (step 1d) MUST include ALL mvids from the full union —
+    # specifically mvid 20 which only appeared in the FOR UPDATE read.
+    last_call = calls[-1]
+    assert set(last_call) == set(initial_mvids + final_mvids), (
+        f"step 1d must pass full union to _acquire_mvid_locks; got {last_call}, "
+        f"expected superset of {initial_mvids + final_mvids}"
+    )

--- a/tests/services/test_llm_gateway_extract_candidates.py
+++ b/tests/services/test_llm_gateway_extract_candidates.py
@@ -410,3 +410,74 @@ async def test_live_gateway_adapter_satisfies_protocol_and_delegates() -> None:
     assert len(result["candidates"]) == 1
     assert result["llm_usage_ledger_id"] is not None
     assert len(provider.calls) == 1
+
+
+# ─── Tests: M-4 — LLM-returned duplicate source_message_version_ids ──────────
+
+
+@pytest.mark.asyncio
+async def test_duplicate_source_mvids_in_llm_response_are_deduped() -> None:
+    """Regression guard for #262 M-4: the gateway MUST dedupe
+    source_message_version_ids returned by the LLM before surfacing them to
+    callers, preserving first-occurrence order.
+
+    Without the fix, a response like [100, 100, 101] produces a downstream
+    CardSourceRepo.bulk_create that violates the UNIQUE(card_id,
+    message_version_id) constraint and raises an IntegrityError.
+
+    With the fix, [100, 100, 101] → [100, 101] (first-occurrence order).
+    """
+    ledger = FakeLedgerRepo()
+    # Provider returns mvid 100 twice — simulates the LLM-duplication bug.
+    provider = FakeExtractionProvider(
+        candidates_json=(
+            '[{"candidate_json": {"title": "dedup test"}, '
+            '"source_message_version_ids": [100, 100, 101]}]'
+        )
+    )
+    session = FakeSession(query_results=[[{"sum": 0}], [{"sum": 0}]])
+
+    result = await extract_candidates(
+        session,  # type: ignore[arg-type]
+        source_versions=_make_source_versions((100, 101)),
+        prompt_template_version="v0.1.0",
+        ledger_repo=ledger,
+        provider=provider,
+        config=_config(),
+    )
+
+    assert len(result["candidates"]) == 1
+    source_ids = result["candidates"][0]["source_message_version_ids"]
+    # Duplicates removed, first-occurrence order preserved.
+    assert source_ids == [100, 101], (
+        f"expected deduplicated [100, 101] but got {source_ids}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_all_duplicate_source_mvids_keeps_one_entry() -> None:
+    """A candidate whose entire mvid list is duplicate [100, 100] MUST be
+    kept (not dropped) with a single deduplicated entry [100]."""
+    ledger = FakeLedgerRepo()
+    provider = FakeExtractionProvider(
+        candidates_json=(
+            '[{"candidate_json": {"title": "all dups"}, '
+            '"source_message_version_ids": [100, 100]}]'
+        )
+    )
+    session = FakeSession(query_results=[[{"sum": 0}], [{"sum": 0}]])
+
+    result = await extract_candidates(
+        session,  # type: ignore[arg-type]
+        source_versions=_make_source_versions((100,)),
+        prompt_template_version="v0.1.0",
+        ledger_repo=ledger,
+        provider=provider,
+        config=_config(),
+    )
+
+    assert len(result["candidates"]) == 1
+    source_ids = result["candidates"][0]["source_message_version_ids"]
+    assert source_ids == [100], (
+        f"all-duplicate list [100, 100] must reduce to [100]; got {source_ids}"
+    )


### PR DESCRIPTION
## Summary

Phase 6.5 carryover bundle B — closes 2 of 3 deferred MED items from issue #262 (M-2 gateway_error column deferred — needs schema migration).

Reopened scope from closed PR #274 (branch deleted before merge in cleanup race).

**M-1 — `/approve` step 1d latent deadlock**

`bot/handlers/admin_cards.py` step 1d was passing only the delta `new_mvids = [m for m in mvids if m not in initial_mvids]` to `_acquire_mvid_locks`. Two concurrent `/approve` callers with overlapping mvid sets would each sort their own partial delta differently → lock-order inversion deadlock.

Fix: pass `full_union_mvids = list(set(initial_mvids) | set(mvids))` so `_acquire_mvid_locks` (which sorts internally via `sorted(_p6_mvid_advisory_lock_id(m) for m in mvids)`) produces a globally deterministic order matching the cascade orchestrator's protocol (`bot/services/forget_cascade.py:969`). `pg_advisory_xact_lock` re-entry is safe within the same transaction (auto-released on commit/rollback).

**M-4 — LLM gateway dedupe of `source_message_version_ids`**

`bot/services/llm_gateway.py:extract_candidates` parsed mvids into `source_ids` without dedup. LLM returning `[100, 100, 101]` produced an `IntegrityError` downstream via `CardSourceRepo.bulk_create` (UNIQUE on `(card_id, message_version_id)`).

Fix: per-candidate `_seen_ids: set[int]` guard inside the parsing loop, preserving first-occurrence order, applied AFTER the `valid_mvid_set` hallucination filter.

## Test plan
- [x] `test_acquire_mvid_locks_called_with_full_union_in_step_1d` — M-1 regression (red→green)
- [x] `test_duplicate_source_mvids_in_llm_response_are_deduped` — M-4 regression
- [x] `test_all_duplicate_source_mvids_keeps_one_entry` — M-4 boundary case
- [x] Full suite: 1030 passed, 1 skipped (pre-existing BOT_TOKEN env failure unrelated)
- [x] Ruff clean
- [x] Privacy lint exit 0

## Self-review (Codex companion auth expired — Codex audit unavailable)
- `_acquire_mvid_locks` in `bot/handlers/admin_cards.py:181` sorts via `sorted(_p6_mvid_advisory_lock_id(m) for m in mvids)`.
- Cascade in `bot/services/forget_cascade.py:969` sorts via identical pattern. ✅ Cross-protocol consistency confirmed.
- `pg_advisory_xact_lock` re-entry is safe: count-based, auto-released on tx end.

## Deferred
- #262 M-2 — `llm_usage_ledger`/`gateway_error` column addition: needs schema migration + design.
- Codex H2 (SQLite fallback policy) — product decision.
- Codex H3 (card chat scope) — product decision.

## Closes
- Closes #274 (replaced)
- Partially addresses #262 (M-2 still open)

🤖 Generated with [Claude Code](https://claude.com/claude-code)