### PR TITLE
chore(p6): Codex H2 fail-loud + H3 chat-scope invariant (closes #278 + #279)

### DIFF
--- a/bot/services/search.py
+++ b/bot/services/search.py
@@ -320,6 +320,11 @@ unforgotten_card_sources AS (
             AND fe.status IN ('pending', 'processing', 'completed')
         )
 ),
+-- T6-06 chat-scope assumption: card hits are NOT filtered by :chat_id.
+-- Phase 6 ingestion is single-chat (gatekeeper handler enforces
+-- COMMUNITY_CHAT_ID at the boundary). Multi-chat support requires
+-- adding EXISTS card_sources -> chat_messages WHERE chat_id=:chat_id.
+-- See issue #279.
 card_anchors AS (
     SELECT DISTINCT ON (ucs.card_id)
         ucs.card_id,
@@ -397,15 +402,16 @@ async def search_messages(
     ``message_versions.search_tsv`` (and, for cards, ``knowledge_cards.body_tsv``)
     GIN-indexed ``tsvector`` columns. None of those exist in SQLite.
 
-    The dialect guard below flips ``include_cards=False`` on non-Postgres
-    sessions to remove the **card branch** from the SQL — that branch alone
-    references tables and indexes (``knowledge_cards``, ``card_sources``,
-    ``body_tsv``) that ORM-only SQLite tests do not create. The guard does
-    **not** make the Phase 4 SQL itself SQLite-safe. ORM-only SQLite tests
-    that call this function will fail at the database layer; the guard's
-    only contract is "the card-extension does not make Phase 4 callers any
-    less SQLite-compatible than they already were." Production runs on
-    Postgres.
+    Calling ``search_messages(include_cards=True)`` on a non-Postgres
+    session raises ``ValueError`` immediately (H2 / #278 fail-loud guard).
+    Phase 4 SQL itself also requires Postgres, so there is no meaningful
+    SQLite execution path for this function. Tests that call this function
+    on a SQLite session MUST pass ``include_cards=False`` explicitly —
+    which still fails at the database layer on Phase 4 SQL, but at least
+    makes the Postgres requirement visible instead of hiding it behind a
+    silent flip.
+
+    Production always runs on Postgres.
     """
     normalized_query = query.strip()
     if not normalized_query:
@@ -426,18 +432,28 @@ async def search_messages(
         f"MaxWords={headline_max_words},MinWords=10,ShortWord=2,HighlightAll=false"
     )
 
-    # T6-06 dialect guard — SCOPE: card-branch removal only, NOT full
-    # SQLite safety. The Phase 4 SQL underneath still uses
-    # ``plainto_tsquery`` / ``ts_rank_cd`` / ``ts_headline`` which are
-    # Postgres-only; running this on SQLite will fail in the message
-    # branch regardless. The guard's sole purpose is to avoid widening
-    # the SQLite-incompatibility surface by referencing card tables that
-    # ORM-only SQLite tests do not create (``knowledge_cards`` /
-    # ``card_sources`` / ``body_tsv``). Production runs on Postgres.
-    # See the docstring above for the full contract.
+    # H2 (#278): fail-loud on non-Postgres dialects when include_cards=True.
+    #
+    # Phase 4 SQL (_PHASE4_SQL) itself requires Postgres FTS
+    # (plainto_tsquery / ts_rank_cd / ts_headline / tsvector GIN indexes).
+    # Silently flipping include_cards=False on SQLite was misleading: it
+    # implied graceful degradation while the Phase 4 message branch ALSO
+    # fails on SQLite, so there is no meaningful SQLite execution path for
+    # search_messages.
+    #
+    # Callers that need to exercise card API shape on a SQLite test session
+    # MUST pass include_cards=False explicitly — which still fails at the
+    # database layer on Phase 4 SQL, but at least makes the Postgres
+    # requirement visible instead of hiding it behind a silent flip.
+    #
+    # See T6-06_design.md §3 "SQLite test path" (updated 2026-05-13).
     dialect_name = session.bind.dialect.name if session.bind is not None else "postgresql"
-    if dialect_name != "postgresql":
-        include_cards = False
+    if dialect_name != "postgresql" and include_cards:
+        raise ValueError(
+            "search_messages(include_cards=True) requires PostgreSQL; "
+            "SQLite is not supported. "
+            "Pass include_cards=False explicitly for SQLite test paths."
+        )
 
     if not include_cards:
         stmt = text(_PHASE4_SQL)

--- a/docs/memory-system/T6-06_design.md
+++ b/docs/memory-system/T6-06_design.md
@@ -307,17 +307,18 @@ Question: do card hits filter by `chat_id`?
 
 Cards are content distilled from messages in the community chat (Phase 6 ingests only `chat_messages.memory_policy='normal'`, which today is COMMUNITY_CHAT_ID). For multi-chat futures, cards may span multiple chats. T6-06 design choice:
 
-- **Recommended:** card hits are NOT filtered by `:chat_id`. Cards are admin-curated canonical knowledge; they may legitimately bridge sources from different chats (future). At T6-06 ship, Phase 6 only ingests from COMMUNITY_CHAT_ID, so all card sources will be in one chat anyway.
-- The anchor source's `chat_id` is reported on the hit; renderers can decide how to display the link.
+**Shipped behaviour:** card hits are NOT filtered by `:chat_id`. Cards are admin-curated canonical knowledge potentially bridging chats. The anchor source's `chat_id` is reported on the hit; renderers can decide how to display the link.
 
-If review wants strict chat scoping (mirror message branch's `c.chat_id = :chat_id`), add a JOIN on `card_sources` → `chat_messages` filtered by `c.chat_id = :chat_id` AT LEAST ONE source (EXISTS subquery). Defer to review.
+**Single-chat assumption (H3 / issue #279, 2026-05-13):** The card branch trusts an upstream invariant: Phase 6 ingestion is single-chat at the application boundary. `bot/handlers/chat_messages.py` only forwards `COMMUNITY_CHAT_ID` messages to the extractor; `_select_eligible_sources` in `bot/services/extractor.py` does NOT accept a `chat_id` parameter and does not filter by it. All card sources therefore share `COMMUNITY_CHAT_ID` in Phase 6, making the missing `:chat_id` filter a no-op.
 
-> **L-2 (multi-chat future, issue #262):** The current T6-06 design intentionally does NOT
-> chat-scope card hits — `_PHASE6_SQL` has no `card_id → card_sources → chat_messages WHERE chat_id=:chat_id`
-> filter on the card branch. This is correct for Phase 6 (single-chat community, all card sources
-> share COMMUNITY_CHAT_ID). If multi-chat is added later, the card branch MUST add an
-> `EXISTS (SELECT 1 FROM card_sources cs_scope JOIN chat_messages cm_scope ON ... WHERE cm_scope.chat_id=:chat_id)`
-> subquery so a query against chat A cannot surface cards whose sources are exclusively in chat B.
+This invariant is documented by an automated test (`test_extractor_eligible_sources_does_not_filter_by_chat_id_invariant` in `tests/services/test_search_cards.py`) that will **intentionally fail** if multi-chat ingestion is added — reminding the implementer to also add chat-scope to the card branch.
+
+**Multi-chat future options (issue #279):**
+
+- **(a)** Add an EXISTS subquery on the card branch: `EXISTS (SELECT 1 FROM card_sources cs_scope JOIN chat_messages cm_scope ON cs_scope.message_version_id = mv_scope.id JOIN message_versions mv_scope ON mv_scope.chat_message_id = cm_scope.id WHERE cs_scope.card_id = kc.id AND cm_scope.chat_id = :chat_id)` — so a query against chat A cannot surface cards whose sources are exclusively in chat B.
+- **(b)** Per-chat card tables — a more complete architectural change.
+
+The decision is deferred to issue #279. Do NOT implement either option without updating the invariant test.
 
 ### UNION ALL + final ranking
 
@@ -368,12 +369,15 @@ No new indexes needed.
 
 ### SQLite test path
 
-`tsvector` / `to_tsvector` / `ts_rank_cd` are Postgres-only. SQLite tests must use a fallback. Two options:
+`tsvector` / `to_tsvector` / `ts_rank_cd` are Postgres-only. Phase 4 SQL (`_PHASE4_SQL`) itself also uses these operators — there is no meaningful SQLite execution path for `search_messages`.
 
-1. **Skip SQLite test path entirely for include_cards=True.** The Phase 4 search itself already mandates Postgres for FTS tests; SQLite tests cover ORM-only paths. Acceptable.
-2. **Dialect-guard the entire card branch.** If `session.bind.dialect.name != 'postgresql'`, return only the message branch (with empty card results). Useful for SQLite-path callers that just want to exercise the `include_cards=True` API without expecting Postgres semantics.
+**Shipped behaviour (H2 / issue #278, 2026-05-13):** `search_messages(include_cards=True)` on a non-Postgres session raises `ValueError` immediately with message:
 
-Recommendation: option 2. The function still returns a coherent result; tests requiring real card FTS run on Postgres. The conditional is a small Python branch before SQL execution.
+> `search_messages(include_cards=True) requires PostgreSQL; SQLite is not supported. Pass include_cards=False explicitly for SQLite test paths.`
+
+This replaces the previous "option 2" design (silently flip `include_cards=False`). The silent flip was misleading: it implied graceful SQLite degradation while the Phase 4 message branch ALSO fails on SQLite. Failing loudly surfaces the Postgres requirement instead of hiding it.
+
+Tests that call `search_messages` on SQLite MUST pass `include_cards=False` explicitly — which still fails at the database layer on Phase 4 SQL, but at least makes the requirement explicit. Production always runs on Postgres.
 
 ---
 

--- a/tests/services/test_search_cards.py
+++ b/tests/services/test_search_cards.py
@@ -11,8 +11,9 @@ These tests exercise the ``include_cards=True`` path of the search service:
   for message hits.
 
 All tests require Postgres because the card branch uses Russian-language
-``to_tsvector`` / ``ts_rank_cd`` / ``ts_headline``. SQLite tests cover the
-dialect-guard separately (see ``test_search_cards_sqlite_safe_noop``).
+``to_tsvector`` / ``ts_rank_cd`` / ``ts_headline``. SQLite dialect behaviour
+is tested via ``test_search_messages_sqlite_dialect_raises_when_include_cards_true``
+below (H2: fail-loud guard, closes #278).
 """
 
 from __future__ import annotations
@@ -749,3 +750,86 @@ async def test_card_with_partial_source_forget_no_cascade_yet(db_session) -> Non
     )
 
     assert [h for h in hits if h.source_type == "card"] == []
+
+
+# ─── H2: SQLite fail-loud guard (closes #278) ───────────────────────────────
+
+
+def test_search_messages_sqlite_dialect_raises_when_include_cards_true() -> None:
+    """H2 (#278): search_messages(include_cards=True) on a non-Postgres session
+    MUST raise ValueError immediately instead of silently falling back to the
+    Phase 4 message-only path.
+
+    Rationale: Phase 4 SQL itself requires Postgres FTS (plainto_tsquery /
+    ts_rank_cd / ts_headline). Silently flipping include_cards=False on SQLite
+    was misleading — it implied SQLite was *supported* via graceful degradation
+    when the Phase 4 branch itself will fail on SQLite.  Callers that need to
+    exercise card API shape on a SQLite test session MUST pass
+    include_cards=False explicitly, making the Postgres requirement visible.
+    See T6-06_design.md §3 SQLite test path (updated).
+    """
+    import asyncio
+    from unittest.mock import MagicMock
+
+    from bot.services.search import search_messages
+
+    # Build a fake session whose dialect reports "sqlite".
+    fake_dialect = MagicMock()
+    fake_dialect.name = "sqlite"
+    fake_bind = MagicMock()
+    fake_bind.dialect = fake_dialect
+    fake_session = MagicMock()
+    fake_session.bind = fake_bind
+
+    with pytest.raises(ValueError, match="include_cards=True.*PostgreSQL"):
+        asyncio.run(
+            search_messages(fake_session, "query", chat_id=-1, include_cards=True)
+        )
+
+
+# ─── H3: single-chat ingestion invariant (closes #279) ──────────────────────
+
+
+def test_extractor_eligible_sources_does_not_filter_by_chat_id_invariant() -> None:
+    """H3 (#279): documents the single-chat ingestion assumption.
+
+    ``_select_eligible_sources`` in ``bot/services/extractor.py`` does NOT
+    accept a ``chat_id`` parameter — all card sources can originate from ANY
+    chat with ``memory_policy='normal'``.  The search-side card branch in
+    ``_PHASE6_SQL`` trusts this upstream invariant: Phase 6 ingestion is
+    single-chat at the application boundary (``bot/handlers/chat_messages.py``
+    only forwards COMMUNITY_CHAT_ID to extraction).
+
+    This test asserts via source inspection that:
+    1. ``_select_eligible_sources`` signature has NO ``chat_id`` parameter.
+    2. The ``base_predicate`` SQL literal inside the function does NOT contain
+       a ``c.chat_id = :chat_id`` equality filter (only uses ``c.chat_id`` in
+       the tombstone key construction, not as a row filter).
+
+    If multi-chat ingestion is added later, this test will intentionally fail,
+    reminding the implementer to also add chat-scope to the card branch SQL.
+    See issue #279 for the two future-proofing options:
+      (a) EXISTS subquery on card_sources → chat_messages WHERE chat_id=:chat_id
+      (b) per-chat card tables.
+    """
+    import inspect
+    import re
+
+    from bot.services import extractor
+
+    sig = inspect.signature(extractor._select_eligible_sources)
+    assert "chat_id" not in sig.parameters, (
+        "_select_eligible_sources gained a chat_id parameter — "
+        "if multi-chat ingestion landed, also update the card branch in "
+        "_PHASE6_SQL (see issue #279)."
+    )
+
+    src = inspect.getsource(extractor._select_eligible_sources)
+    # The tombstone key construction uses c.chat_id::text — that is allowed.
+    # What must NOT appear is a WHERE equality filter like "c.chat_id = :chat_id"
+    # or "c.chat_id = :param_chat_id" (whitespace-insensitive).
+    assert not re.search(r"c\.chat_id\s*=\s*:", src), (
+        "_select_eligible_sources now filters by c.chat_id = :param — "
+        "multi-chat ingestion has landed. Update _PHASE6_SQL card branch "
+        "to add EXISTS chat-scope filter (see issue #279)."
+    )


### PR DESCRIPTION
## Summary

- **H2 (#278):** Replace the silent `include_cards=False` flip on non-Postgres dialects with a `ValueError` raise in `search_messages`. Phase 4 SQL itself requires Postgres FTS — the silent flip falsely implied SQLite degradation where none existed. Callers that need SQLite must pass `include_cards=False` explicitly.
- **H3 (#279):** Document the single-chat ingestion assumption with an invariant test that uses source inspection (`inspect.getsource` + regex) to assert `_select_eligible_sources` has no `chat_id` filter. The test will intentionally fail when multi-chat ingestion lands, prompting the implementer to also add chat-scope to `_PHASE6_SQL`. Add inline SQL comment at `card_anchors` CTE.
- **Design doc:** Update `T6-06_design.md` §3 for both SQLite path (fail-loud) and chat scope (single-chat invariant + two future-proofing options).
- **Dead reference removed:** Stale reference to non-existent `test_search_cards_sqlite_safe_noop` in module docstring (Codex M3).

## Commits

1. `fix(p6-search): fail-loud on SQLite with include_cards=True (closes #278 H2)`
2. `test(p6-search): SQLite-raises + single-chat invariant assertions (closes #278 H2 + #279 H3)`
3. `chore(p6): document single-chat invariant + SQLite fail-loud + multi-chat future (closes #279 H3)`

## Test plan

- [ ] `pytest -q tests/services/test_search_cards.py` — 21 passed (19 existing + 2 new)
- [ ] `pytest -q --ignore=tests/healing/test_healthcheck.py` — 1074 passed, 1 pre-existing env failure (BOT_TOKEN missing in `test_llm_gateway_extract_candidates`)
- [ ] `ruff check bot/services/search.py tests/services/test_search_cards.py` — all checks passed
- [ ] `bash scripts/lint_privacy_check.sh` — exit code 0

## No-change guarantees

- No migrations, no schema changes.
- No production behaviour change beyond the new fail-loud guard (which only fires on non-Postgres sessions calling `include_cards=True` — production is always Postgres).
- No extractor changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)