### PR TITLE
feat(p7-t7-01): add digests + digest_runs schema (migration 037)

### DIFF
--- a/alembic/versions/037_add_digests.py
+++ b/alembic/versions/037_add_digests.py
@@ -1,0 +1,192 @@
+"""add_digests
+
+T7-01 / Phase 7: daily digest tables — ``digests`` and ``digest_runs``.
+
+``digests`` is the primary record for one generated digest window. Each row
+is keyed by ``(type, window_start, window_end)`` for idempotent re-runs.
+``body_markdown`` is NULL while ``status='running'`` and NOT NULL in
+all user-visible states (draft, posting, posted, redacted, redacted_edit_failed).
+``citations`` is a JSONB array of ``{kind, id, position}`` objects — never raw
+message text. ``llm_usage_ledger_id`` ties the cost entry to the row; FK is
+ON DELETE SET NULL so ledger pruning does not cascade-delete digests.
+
+``digest_runs`` is an append-only audit log of invocations, one row per
+``run_digest()`` call. ``digest_id`` is FK ON DELETE SET NULL so it survives
+if the parent digest is ever manually removed in a future admin path.
+
+Status enums:
+- digests.status: running | draft | posting | posted | failed | skipped |
+                  cost_exceeded | skipped_no_destination | redacted |
+                  redacted_edit_failed
+- digest_runs.status: running | finished | failed | skipped | cost_exceeded |
+                      skipped_no_destination
+
+Constraints:
+- UNIQUE (type, window_start, window_end) — idempotency key.
+- body_markdown NOT NULL enforced for status IN
+  ('draft','posting','posted','redacted','redacted_edit_failed').
+- posted_chat_id, posted_message_id, posted_at NOT NULL enforced for
+  status='posted'.
+
+Indexes:
+- ix_digests_status_draft: partial WHERE status='draft' — publisher scan.
+- ix_digests_citations_gin: GIN jsonb_path_ops — forget cascade containment.
+- ix_digests_posting_started_at: partial WHERE status='posting' — stale reaper.
+
+Rollback drops only digest_runs then digests; no other tables touched.
+
+Revision ID: 037
+Revises: 036
+Create Date: 2026-05-13
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
+
+revision: str = "037"
+down_revision: Union[str, Sequence[str], None] = "036"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "digests",
+        sa.Column("id", sa.BigInteger(), nullable=False, autoincrement=True),
+        sa.Column("type", sa.Text(), nullable=False),
+        sa.Column("window_start", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("window_end", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("body_markdown", sa.Text(), nullable=True),
+        sa.Column(
+            "citations",
+            JSONB(),
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+        sa.Column("status", sa.Text(), nullable=False),
+        sa.Column("llm_usage_ledger_id", sa.BigInteger(), nullable=True),
+        sa.Column("posted_chat_id", sa.BigInteger(), nullable=True),
+        sa.Column("posted_message_id", sa.BigInteger(), nullable=True),
+        sa.Column("posted_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("posting_started_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("error_text", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "type",
+            "window_start",
+            "window_end",
+            name="uq_digests_type_window",
+        ),
+        sa.CheckConstraint(
+            "type IN ('daily','weekly')",
+            name="ck_digests_type",
+        ),
+        sa.CheckConstraint(
+            "status IN ('running','draft','posting','posted','failed','skipped',"
+            "'cost_exceeded','skipped_no_destination','redacted','redacted_edit_failed')",
+            name="ck_digests_status",
+        ),
+        # body_markdown must NOT be NULL in all user-visible states.
+        sa.CheckConstraint(
+            "status NOT IN ('draft','posting','posted','redacted','redacted_edit_failed')"
+            " OR body_markdown IS NOT NULL",
+            name="ck_digests_body_markdown_not_null_for_visible_statuses",
+        ),
+        # posted fields required when status='posted'.
+        sa.CheckConstraint(
+            "status <> 'posted'"
+            " OR (posted_chat_id IS NOT NULL"
+            " AND posted_message_id IS NOT NULL"
+            " AND posted_at IS NOT NULL)",
+            name="ck_digests_posted_fields_required",
+        ),
+        sa.ForeignKeyConstraint(
+            ["llm_usage_ledger_id"],
+            ["llm_usage_ledger.id"],
+            name="fk_digests_llm_usage_ledger_id",
+            ondelete="SET NULL",
+        ),
+    )
+
+    # Publisher scan: find draft digests ready to publish.
+    op.create_index(
+        "ix_digests_status_draft",
+        "digests",
+        ["status"],
+        postgresql_where=sa.text("status = 'draft'"),
+    )
+
+    # Forget cascade: GIN index for jsonb_path_ops containment checks on citations.
+    op.create_index(
+        "ix_digests_citations_gin",
+        "digests",
+        ["citations"],
+        postgresql_using="gin",
+        postgresql_ops={"citations": "jsonb_path_ops"},
+    )
+
+    # Stale-posting reaper: partial index for orphan posting rows.
+    op.create_index(
+        "ix_digests_posting_started_at",
+        "digests",
+        ["posting_started_at"],
+        postgresql_where=sa.text("status = 'posting'"),
+    )
+
+    op.create_table(
+        "digest_runs",
+        sa.Column("id", sa.BigInteger(), nullable=False, autoincrement=True),
+        sa.Column("digest_id", sa.BigInteger(), nullable=True),
+        sa.Column("status", sa.Text(), nullable=False),
+        sa.Column(
+            "started_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column("finished_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("error_text", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.CheckConstraint(
+            "status IN ('running','finished','failed','skipped',"
+            "'cost_exceeded','skipped_no_destination')",
+            name="ck_digest_runs_status",
+        ),
+        sa.ForeignKeyConstraint(
+            ["digest_id"],
+            ["digests.id"],
+            name="fk_digest_runs_digest_id",
+            ondelete="SET NULL",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("digest_runs")
+    op.drop_index("ix_digests_posting_started_at", table_name="digests")
+    op.drop_index("ix_digests_citations_gin", table_name="digests")
+    op.drop_index("ix_digests_status_draft", table_name="digests")
+    op.drop_table("digests")

--- a/bot/db/models.py
+++ b/bot/db/models.py
@@ -1293,3 +1293,151 @@ class ExtractionDecision(Base):
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=func.now()
     )
+
+
+class Digest(Base):
+    """One generated digest window (T7-01 / alembic 037).
+
+    Keyed by ``(type, window_start, window_end)`` for idempotent re-runs.
+    ``body_markdown`` is NULL while ``status='running'`` and NOT NULL in all
+    user-visible states (draft, posting, posted, redacted, redacted_edit_failed).
+    ``citations`` is a JSONB array of ``{kind, id, position}`` objects per
+    PHASE7_PLAN.md §5.A — never raw message text.
+
+    Status lifecycle:
+      running → draft → posting → posted
+                     ↘ failed / skipped / cost_exceeded / skipped_no_destination
+    Terminal redaction states: redacted, redacted_edit_failed.
+
+    Constraints (DB-level, see migration 037):
+
+    * ``type IN ('daily','weekly')`` — 'weekly' schema-ready, daily-only runtime.
+    * ``status`` enum — full set including transient 'posting'.
+    * ``status IN (draft,posting,posted,redacted,redacted_edit_failed)``
+      implies ``body_markdown IS NOT NULL``.
+    * ``status='posted'`` implies ``posted_chat_id``, ``posted_message_id``,
+      ``posted_at`` all NOT NULL.
+    """
+
+    __tablename__ = "digests"
+    __table_args__ = (
+        UniqueConstraint(
+            "type",
+            "window_start",
+            "window_end",
+            name="uq_digests_type_window",
+        ),
+        CheckConstraint(
+            "type IN ('daily','weekly')",
+            name="ck_digests_type",
+        ),
+        CheckConstraint(
+            "status IN ('running','draft','posting','posted','failed','skipped',"
+            "'cost_exceeded','skipped_no_destination','redacted','redacted_edit_failed')",
+            name="ck_digests_status",
+        ),
+        CheckConstraint(
+            "status NOT IN ('draft','posting','posted','redacted','redacted_edit_failed')"
+            " OR body_markdown IS NOT NULL",
+            name="ck_digests_body_markdown_not_null_for_visible_statuses",
+        ),
+        CheckConstraint(
+            "status <> 'posted'"
+            " OR (posted_chat_id IS NOT NULL"
+            " AND posted_message_id IS NOT NULL"
+            " AND posted_at IS NOT NULL)",
+            name="ck_digests_posted_fields_required",
+        ),
+        Index(
+            "ix_digests_status_draft",
+            "status",
+            postgresql_where=text("status = 'draft'"),
+        ),
+        Index(
+            "ix_digests_citations_gin",
+            "citations",
+            postgresql_using="gin",
+            postgresql_ops={"citations": "jsonb_path_ops"},
+        ),
+        Index(
+            "ix_digests_posting_started_at",
+            "posting_started_at",
+            postgresql_where=text("status = 'posting'"),
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    type: Mapped[str] = mapped_column(Text, nullable=False)
+    window_start: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    window_end: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    body_markdown: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # JSONB on postgres (enables GIN jsonb_path_ops containment for forget cascade);
+    # JSON elsewhere for sqlite test compat.
+    citations: Mapped[list] = mapped_column(
+        JSON().with_variant(JSONB(), "postgresql"),
+        nullable=False,
+        server_default="'[]'",  # align ORM with migration (PG migration uses ::jsonb cast)
+    )
+    status: Mapped[str] = mapped_column(Text, nullable=False)
+    llm_usage_ledger_id: Mapped[int | None] = mapped_column(
+        BigInteger,
+        ForeignKey(
+            "llm_usage_ledger.id",
+            name="fk_digests_llm_usage_ledger_id",
+            ondelete="SET NULL",
+        ),
+        nullable=True,
+    )
+    posted_chat_id: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+    posted_message_id: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+    posted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    posting_started_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    error_text: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+
+
+class DigestRun(Base):
+    """Append-only audit log of one ``run_digest()`` invocation (T7-01 / alembic 037).
+
+    One row per scheduler tick or admin ``/digest_now`` call. ``digest_id`` FK is
+    ON DELETE SET NULL so audit rows survive if the parent digest is manually removed.
+
+    Status lifecycle: running → finished | failed | skipped | cost_exceeded |
+                                skipped_no_destination.
+    """
+
+    __tablename__ = "digest_runs"
+    __table_args__ = (
+        CheckConstraint(
+            "status IN ('running','finished','failed','skipped',"
+            "'cost_exceeded','skipped_no_destination')",
+            name="ck_digest_runs_status",
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    digest_id: Mapped[int | None] = mapped_column(
+        BigInteger,
+        ForeignKey(
+            "digests.id",
+            name="fk_digest_runs_digest_id",
+            ondelete="SET NULL",
+        ),
+        nullable=True,
+    )
+    status: Mapped[str] = mapped_column(Text, nullable=False)
+    started_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    finished_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    error_text: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )

--- a/tests/db/test_digests_schema.py
+++ b/tests/db/test_digests_schema.py
@@ -1,0 +1,469 @@
+"""T7-01 acceptance tests — digests + digest_runs schema (migration 037).
+
+These tests use the same pattern as test_fts_schema.py and
+test_llm_usage_ledger_schema.py: a temporary isolated database is created,
+Alembic upgrade head is run, then schema-shape and constraint assertions are
+executed via asyncpg. The temporary database is dropped after each test.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import uuid
+from collections.abc import AsyncIterator
+from pathlib import Path
+
+import asyncpg
+import pytest
+import pytest_asyncio
+from sqlalchemy.engine.url import URL, make_url
+
+from tests.conftest import DEFAULT_LOCAL_POSTGRES_URL
+
+pytestmark = pytest.mark.usefixtures("app_env")
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _base_test_url() -> URL:
+    raw_url = (
+        os.environ.get("TEST_DATABASE_URL")
+        or os.environ.get("DATABASE_URL")
+        or DEFAULT_LOCAL_POSTGRES_URL
+    )
+    return make_url(raw_url)
+
+
+def _asyncpg_kwargs(url: URL, *, database: str | None = None) -> dict[str, object]:
+    return {
+        "user": url.username,
+        "password": url.password,
+        "host": url.host or "127.0.0.1",
+        "port": url.port or 5432,
+        "database": database or url.database,
+    }
+
+
+def _quote_identifier(identifier: str) -> str:
+    return '"' + identifier.replace('"', '""') + '"'
+
+
+async def _create_database(admin_url: URL, database_name: str) -> None:
+    conn = await asyncpg.connect(**_asyncpg_kwargs(admin_url, database="postgres"))
+    try:
+        await conn.execute(f"CREATE DATABASE {_quote_identifier(database_name)}")
+    finally:
+        await conn.close()
+
+
+async def _drop_database(admin_url: URL, database_name: str) -> None:
+    conn = await asyncpg.connect(**_asyncpg_kwargs(admin_url, database="postgres"))
+    try:
+        await conn.execute(
+            """
+            SELECT pg_terminate_backend(pid)
+            FROM pg_stat_activity
+            WHERE datname = $1 AND pid <> pg_backend_pid()
+            """,
+            database_name,
+        )
+        await conn.execute(f"DROP DATABASE IF EXISTS {_quote_identifier(database_name)}")
+    finally:
+        await conn.close()
+
+
+def _run_alembic(database_url: str, *args: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["DATABASE_URL"] = database_url
+    return subprocess.run(
+        [sys.executable, "-m", "alembic", *args],
+        cwd=PROJECT_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=120,
+        check=True,
+    )
+
+
+async def _fetch_value(database_url: str, query: str, *args: object) -> object:
+    conn = await asyncpg.connect(**_asyncpg_kwargs(make_url(database_url)))
+    try:
+        return await conn.fetchval(query, *args)
+    finally:
+        await conn.close()
+
+
+async def _fetch_row(database_url: str, query: str, *args: object) -> asyncpg.Record | None:
+    conn = await asyncpg.connect(**_asyncpg_kwargs(make_url(database_url)))
+    try:
+        return await conn.fetchrow(query, *args)
+    finally:
+        await conn.close()
+
+
+@pytest_asyncio.fixture()
+async def temp_database_url() -> AsyncIterator[str]:
+    base_url = _base_test_url()
+    database_name = f"shkoder_digests_schema_{uuid.uuid4().hex[:12]}"
+    try:
+        await _create_database(base_url, database_name)
+    except Exception as exc:  # pragma: no cover - environment guard
+        pytest.skip(f"cannot create temporary postgres database: {exc!s}")
+
+    try:
+        yield base_url.set(database=database_name).render_as_string(hide_password=False)
+    finally:
+        await _drop_database(base_url, database_name)
+
+
+@pytest_asyncio.fixture()
+async def migrated_database_url(temp_database_url: str) -> AsyncIterator[str]:
+    _run_alembic(temp_database_url, "upgrade", "head")
+    yield temp_database_url
+
+
+# ─── Test 1: head is now 037 ─────────────────────────────────────────────────
+
+
+async def test_alembic_head_is_037(migrated_database_url: str) -> None:
+    """After upgrade head, alembic_version reports 037."""
+    current = await _fetch_value(
+        migrated_database_url, "SELECT version_num FROM alembic_version"
+    )
+    assert current == "037"
+
+
+# ─── Test 2: unique constraint on (type, window_start, window_end) ────────────
+
+
+async def test_digests_unique_type_window_start_window_end(migrated_database_url: str) -> None:
+    """INSERT same (type, window_start, window_end) twice → unique violation."""
+    conn = await asyncpg.connect(**_asyncpg_kwargs(make_url(migrated_database_url)))
+    try:
+        await conn.execute(
+            """
+            INSERT INTO digests (type, window_start, window_end, status, citations)
+            VALUES (
+                'daily',
+                '2026-05-13 00:00:00+00',
+                '2026-05-14 00:00:00+00',
+                'running',
+                '[]'::jsonb
+            )
+            """
+        )
+        with pytest.raises(asyncpg.exceptions.UniqueViolationError):
+            await conn.execute(
+                """
+                INSERT INTO digests (type, window_start, window_end, status, citations)
+                VALUES (
+                    'daily',
+                    '2026-05-13 00:00:00+00',
+                    '2026-05-14 00:00:00+00',
+                    'running',
+                    '[]'::jsonb
+                )
+                """
+            )
+    finally:
+        await conn.close()
+
+
+# ─── Test 3: body_markdown NOT NULL when status='draft' ─────────────────────
+
+
+async def test_digests_status_draft_requires_body_markdown(migrated_database_url: str) -> None:
+    """INSERT status='draft' with body_markdown=NULL → check constraint violation."""
+    conn = await asyncpg.connect(**_asyncpg_kwargs(make_url(migrated_database_url)))
+    try:
+        with pytest.raises(asyncpg.exceptions.CheckViolationError):
+            await conn.execute(
+                """
+                INSERT INTO digests (type, window_start, window_end, status, citations, body_markdown)
+                VALUES (
+                    'daily',
+                    '2026-05-13 01:00:00+00',
+                    '2026-05-14 01:00:00+00',
+                    'draft',
+                    '[]'::jsonb,
+                    NULL
+                )
+                """
+            )
+    finally:
+        await conn.close()
+
+
+# ─── Test 4: status='running' with body_markdown=NULL succeeds ───────────────
+
+
+async def test_digests_status_running_body_markdown_null_ok(migrated_database_url: str) -> None:
+    """INSERT status='running' with body_markdown=NULL → succeeds."""
+    conn = await asyncpg.connect(**_asyncpg_kwargs(make_url(migrated_database_url)))
+    try:
+        row_id = await conn.fetchval(
+            """
+            INSERT INTO digests (type, window_start, window_end, status, citations, body_markdown)
+            VALUES (
+                'daily',
+                '2026-05-13 02:00:00+00',
+                '2026-05-14 02:00:00+00',
+                'running',
+                '[]'::jsonb,
+                NULL
+            )
+            RETURNING id
+            """
+        )
+        assert row_id is not None
+    finally:
+        await conn.close()
+
+
+# ─── Test 5: status='posted' requires posted_message_id NOT NULL ─────────────
+
+
+async def test_digests_status_posted_requires_posted_fields(migrated_database_url: str) -> None:
+    """INSERT status='posted' with posted_message_id=NULL → check constraint violation."""
+    conn = await asyncpg.connect(**_asyncpg_kwargs(make_url(migrated_database_url)))
+    try:
+        with pytest.raises(asyncpg.exceptions.CheckViolationError):
+            await conn.execute(
+                """
+                INSERT INTO digests (
+                    type, window_start, window_end, status, citations,
+                    body_markdown, posted_chat_id, posted_message_id, posted_at
+                )
+                VALUES (
+                    'daily',
+                    '2026-05-13 03:00:00+00',
+                    '2026-05-14 03:00:00+00',
+                    'posted',
+                    '[]'::jsonb,
+                    'body',
+                    -1001234567890,
+                    NULL,
+                    now()
+                )
+                """
+            )
+    finally:
+        await conn.close()
+
+
+# ─── Test 6: citations default is '[]'::jsonb ─────────────────────────────────
+
+
+async def test_digests_citations_default_empty_array(migrated_database_url: str) -> None:
+    """Omitting citations on INSERT → row has '[]'::jsonb default."""
+    conn = await asyncpg.connect(**_asyncpg_kwargs(make_url(migrated_database_url)))
+    try:
+        row_id = await conn.fetchval(
+            """
+            INSERT INTO digests (type, window_start, window_end, status)
+            VALUES (
+                'daily',
+                '2026-05-13 04:00:00+00',
+                '2026-05-14 04:00:00+00',
+                'running'
+            )
+            RETURNING id
+            """
+        )
+        assert row_id is not None
+
+        citations = await conn.fetchval(
+            "SELECT citations FROM digests WHERE id = $1",
+            row_id,
+        )
+        # asyncpg returns JSONB as a Python list; normalise both representations.
+        import json as _json
+
+        if isinstance(citations, str):
+            citations = _json.loads(citations)
+        assert citations == []
+    finally:
+        await conn.close()
+
+
+# ─── Test 7: partial index ix_digests_status_draft exists ────────────────────
+
+
+async def test_ix_digests_status_draft_partial_index_exists(migrated_database_url: str) -> None:
+    """ix_digests_status_draft partial index exists on digests table."""
+    indexdef = await _fetch_value(
+        migrated_database_url,
+        """
+        SELECT indexdef
+        FROM pg_indexes
+        WHERE schemaname = 'public'
+          AND tablename = 'digests'
+          AND indexname = 'ix_digests_status_draft'
+        """,
+    )
+    assert indexdef is not None, "ix_digests_status_draft not found"
+    lowered = str(indexdef).lower()
+    assert "where" in lowered
+    assert "draft" in lowered
+
+
+# ─── Test 8: GIN index ix_digests_citations_gin exists ───────────────────────
+
+
+async def test_ix_digests_citations_gin_exists(migrated_database_url: str) -> None:
+    """ix_digests_citations_gin GIN index exists on digests.citations."""
+    indexdef = await _fetch_value(
+        migrated_database_url,
+        """
+        SELECT indexdef
+        FROM pg_indexes
+        WHERE schemaname = 'public'
+          AND tablename = 'digests'
+          AND indexname = 'ix_digests_citations_gin'
+        """,
+    )
+    assert indexdef is not None, "ix_digests_citations_gin not found"
+    lowered = str(indexdef).lower()
+    assert "using gin" in lowered
+
+
+# ─── Test 9: partial index ix_digests_posting_started_at exists ──────────────
+
+
+async def test_ix_digests_posting_started_at_partial_index_exists(
+    migrated_database_url: str,
+) -> None:
+    """ix_digests_posting_started_at partial index exists on digests table."""
+    indexdef = await _fetch_value(
+        migrated_database_url,
+        """
+        SELECT indexdef
+        FROM pg_indexes
+        WHERE schemaname = 'public'
+          AND tablename = 'digests'
+          AND indexname = 'ix_digests_posting_started_at'
+        """,
+    )
+    assert indexdef is not None, "ix_digests_posting_started_at not found"
+    lowered = str(indexdef).lower()
+    assert "where" in lowered
+    assert "posting" in lowered
+
+
+# ─── Test 10: downgrade -1 drops digest_runs then digests ────────────────────
+
+
+async def test_alembic_downgrade_drops_digest_tables(temp_database_url: str) -> None:
+    """alembic downgrade -1 from 037 drops digest_runs and digests, returns to 036."""
+    _run_alembic(temp_database_url, "upgrade", "head")
+
+    # Verify both tables exist before downgrade
+    for table_name in ("digests", "digest_runs"):
+        exists = await _fetch_value(
+            temp_database_url,
+            """
+            SELECT EXISTS (
+                SELECT 1 FROM information_schema.tables
+                WHERE table_schema = 'public' AND table_name = $1
+            )
+            """,
+            table_name,
+        )
+        assert exists is True, f"Expected '{table_name}' to exist before downgrade"
+
+    _run_alembic(temp_database_url, "downgrade", "-1")
+
+    # Both tables must be gone
+    for table_name in ("digests", "digest_runs"):
+        exists = await _fetch_value(
+            temp_database_url,
+            """
+            SELECT EXISTS (
+                SELECT 1 FROM information_schema.tables
+                WHERE table_schema = 'public' AND table_name = $1
+            )
+            """,
+            table_name,
+        )
+        assert exists is False, f"Expected '{table_name}' to be absent after downgrade"
+
+    current = await _fetch_value(temp_database_url, "SELECT version_num FROM alembic_version")
+    assert current == "036"
+
+
+# ─── Test 11: upgrade → downgrade → upgrade roundtrip ────────────────────────
+
+
+async def test_alembic_037_upgrade_downgrade_upgrade_roundtrip(temp_database_url: str) -> None:
+    """Full roundtrip: upgrade head → downgrade -1 → upgrade head."""
+    _run_alembic(temp_database_url, "upgrade", "head")
+    _run_alembic(temp_database_url, "downgrade", "-1")
+    _run_alembic(temp_database_url, "upgrade", "head")
+
+    current = await _fetch_value(temp_database_url, "SELECT version_num FROM alembic_version")
+    assert current == "037"
+
+    # Verify tables re-appeared
+    for table_name in ("digests", "digest_runs"):
+        exists = await _fetch_value(
+            temp_database_url,
+            """
+            SELECT EXISTS (
+                SELECT 1 FROM information_schema.tables
+                WHERE table_schema = 'public' AND table_name = $1
+            )
+            """,
+            table_name,
+        )
+        assert exists is True, f"Expected '{table_name}' to exist after re-upgrade"
+
+
+# ─── Test 12: ORM metadata smoke ─────────────────────────────────────────────
+
+
+def test_digest_orm_classes_registered(app_env) -> None:
+    """Digest and DigestRun ORM classes are registered in Base.metadata."""
+    from tests.conftest import import_module
+
+    models = import_module("bot.db.models")
+    assert models.Digest.__tablename__ == "digests"
+    assert models.DigestRun.__tablename__ == "digest_runs"
+    assert "digests" in models.Base.metadata.tables
+    assert "digest_runs" in models.Base.metadata.tables
+
+
+# ─── Test 13: digest_runs FK ON DELETE SET NULL ───────────────────────────────
+
+
+async def test_digest_runs_fk_digest_id_set_null_on_digest_delete(
+    migrated_database_url: str,
+) -> None:
+    """DELETE digests row → digest_runs.digest_id becomes NULL (ON DELETE SET NULL)."""
+    conn = await asyncpg.connect(**_asyncpg_kwargs(make_url(migrated_database_url)))
+    try:
+        digest_id = await conn.fetchval(
+            """
+            INSERT INTO digests (type, window_start, window_end, status, citations)
+            VALUES ('daily', '2026-05-13 05:00:00+00', '2026-05-14 05:00:00+00', 'running', '[]')
+            RETURNING id
+            """
+        )
+        run_id = await conn.fetchval(
+            """
+            INSERT INTO digest_runs (digest_id, status)
+            VALUES ($1, 'running')
+            RETURNING id
+            """,
+            digest_id,
+        )
+        await conn.execute("DELETE FROM digests WHERE id = $1", digest_id)
+        row = await conn.fetchrow(
+            "SELECT digest_id FROM digest_runs WHERE id = $1", run_id
+        )
+        assert row is not None
+        assert row["digest_id"] is None
+    finally:
+        await conn.close()

--- a/tests/db/test_fts_schema.py
+++ b/tests/db/test_fts_schema.py
@@ -182,9 +182,9 @@ async def test_alembic_upgrade_head_on_clean_db_green(migrated_database_url: str
     current = await _fetch_value(migrated_database_url, "SELECT version_num FROM alembic_version")
 
     # T6-01 (030-034) + T6-02 (035 operator_user_id) + Phase 6.5 M-2 (036
-    # gateway_error) advanced the head past 025.
+    # gateway_error) + T7-01 (037 digests) advanced the head past 025.
     # Assert the current head explicitly; revisit when future migrations land.
-    assert current == "036"
+    assert current == "037"
 
 
 async def test_insert_message_versions_generates_search_tsv_from_normalized_text(


### PR DESCRIPTION
## Summary

Phase 7 Wave 1A — first code PR after T7-S0 ratification (#285). Lands the schema for daily-digest persistence per `docs/memory-system/PHASE7_PLAN.md` §5.A.

- 2 new tables: `digests` (16 cols, 4 CHECK constraints, 3 indexes), `digest_runs` (7 cols, FK, 1 CHECK).
- 2 new ORM classes: `Digest`, `DigestRun`.
- 13 new schema tests in `tests/db/test_digests_schema.py`.
- `test_fts_schema.py` head expectation bumped 036 → 037.

**Migration:** `037_add_digests.py`, `down_revision = "036"` (Phase 6.5 carryover head, PR #281 merged 2026-05-13).

**Diff:** 811 lines added across 4 files.

## Test plan

- [x] `alembic upgrade head` succeeds (implementer-run)
- [x] `alembic downgrade -1` returns to 036, `upgrade head` again to 037
- [x] `pytest tests/db/` — **199 passed, 0 regressions**
- [x] `pytest tests/db/test_digests_schema.py -v` — 13 new tests green
- [x] No code outside scope (no service files, no handlers, no LLM)
- [ ] CI green
- [ ] Codex + Claude code review PASS

## Schema highlights

| Element | Value | Purpose |
|---|---|---|
| `digests.status` | CHECK 10 values | `running`/`draft`/`posting`/`posted`/`failed`/`skipped`/`cost_exceeded`/`skipped_no_destination`/`redacted`/`redacted_edit_failed` |
| `digests.citations` | `JSONB NOT NULL DEFAULT '[]'` | array of `{kind, id, position}` — ids only, no raw text |
| `UNIQUE(type, window_start, window_end)` | idempotency key |
| `posting_started_at` | nullable, cleared on terminal | stale-posting reaper (§5.K) target |
| `error_text` | nullable | mirrors `digest_runs.error_text` for self-contained inspection |
| `ix_digests_status_draft` | partial WHERE status='draft' | publisher scan |
| `ix_digests_citations_gin` | GIN jsonb_path_ops | forget cascade scan |
| `ix_digests_posting_started_at` | partial WHERE status='posting' | reaper scan |

## What's NOT in this PR

No service code (`bot/services/digests.py`, `digest_context.py`, etc.) — that's T7-02 / T7-03. This is pure schema.

## Tracks

Part of epic #111.

🤖 Generated with [Claude Code](https://claude.com/claude-code)