### PR TITLE
feat(bot): /healthz/db sub-endpoint follow-up (#270)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,7 @@ Vibe Gatekeeper is a Telegram + web gatekeeping system for managing community ap
 - Coolify is the target runtime manager for product apps.
 - Host-level operator services stay outside Coolify if they need direct VPS control.
 - Bot process exposes `/healthz` on `:3000` via aiohttp for Coolify health_check (added 2026-05-14, issue #168). Env var `HEALTHZ_PORT` overrides the port (default 3000). Post-merge operator step: enable Coolify health_check via `PATCH /api/v1/applications/<id>` with `{"health_check_enabled": true, "health_check_path": "/healthz", "health_check_port": 3000}` — safe to flip only AFTER this release is deployed.
+- `/healthz/db` is a DB-only sub-endpoint (faster, separates DB hiccups from app crashes; consumed by `ops/healing/healthcheck.py` after #270).
 
 ## Environments
 

--- a/bot/__main__.py
+++ b/bot/__main__.py
@@ -9,7 +9,7 @@ from aiogram.enums import ParseMode
 from aiohttp import web
 
 from bot.config import settings
-from bot.services.health import report
+from bot.services.health import check_db, report
 from bot.handlers import (
     admin,
     admin_cards,
@@ -67,6 +67,22 @@ async def _healthz_handler(request: web.Request) -> web.Response:
     return web.json_response(h.to_dict(), status=status_code)
 
 
+async def _healthz_db_handler(request: web.Request) -> web.Response:
+    """GET /healthz/db — DB-only roundtrip check. Fast, no other checks.
+
+    Returns 200 + {"db": "ok"} when the DB is reachable.
+    Returns 503 + {"db": "fail", "reason": "<exc class>"} when not.
+
+    No secrets are included: check_db() returns only the exception class name,
+    never the full connection string or credentials.
+    Consumed by ops/healing/healthcheck.py after issue #270.
+    """
+    result = await check_db()
+    if result.ok:
+        return web.json_response({"db": "ok"}, status=200)
+    return web.json_response({"db": "fail", "reason": result.reason}, status=503)
+
+
 async def start_healthz_runner(
     host: str = "0.0.0.0",
     port: int = 3000,
@@ -78,6 +94,7 @@ async def start_healthz_runner(
     """
     app = web.Application()
     app.router.add_get("/healthz", _healthz_handler)
+    app.router.add_get("/healthz/db", _healthz_db_handler)
     runner = web.AppRunner(app)
     await runner.setup()
     site = web.TCPSite(runner, host, port)

--- a/tests/test_healthz_bot.py
+++ b/tests/test_healthz_bot.py
@@ -147,3 +147,78 @@ async def test_healthz_concurrent_with_polling_stub(app_env, monkeypatch) -> Non
         assert response.status_code == 200
     finally:
         await runner.cleanup()
+
+
+# ─── /healthz/db tests ───────────────────────────────────────────────────────
+
+
+async def _start_server_for_db(
+    monkeypatch, db_ok: bool
+) -> tuple[str, "web.AppRunner"]:
+    """Start the healthz server with check_db patched. Returns (base_url, runner)."""
+    from bot.services import health as health_module
+
+    async def _fake_check_db():
+        if db_ok:
+            return health_module.CheckResult(ok=True)
+        return health_module.CheckResult(ok=False, reason="OperationalError")
+
+    monkeypatch.setattr("bot.services.health.check_db", _fake_check_db)
+    bot_main = import_module("bot.__main__")
+    monkeypatch.setattr(bot_main, "check_db", _fake_check_db)
+
+    runner, port = await bot_main.start_healthz_runner(host="127.0.0.1", port=0)
+    base_url = f"http://127.0.0.1:{port}"
+    return base_url, runner
+
+
+@pytest.mark.asyncio
+async def test_healthz_db_returns_200_when_db_healthy(app_env, monkeypatch) -> None:
+    """GET /healthz/db → 200 + {db: ok} when check_db is green."""
+    base_url, runner = await _start_server_for_db(monkeypatch, db_ok=True)
+    try:
+        async with httpx.AsyncClient() as client:
+            response = await client.get(f"{base_url}/healthz/db")
+        assert response.status_code == 200
+        body = response.json()
+        assert body.get("db") == "ok"
+    finally:
+        await runner.cleanup()
+
+
+@pytest.mark.asyncio
+async def test_healthz_db_returns_503_when_db_down(app_env, monkeypatch) -> None:
+    """GET /healthz/db → 503 + {db: fail, reason: ...} when check_db fails."""
+    base_url, runner = await _start_server_for_db(monkeypatch, db_ok=False)
+    try:
+        async with httpx.AsyncClient() as client:
+            response = await client.get(f"{base_url}/healthz/db")
+        assert response.status_code == 503
+        body = response.json()
+        assert body.get("db") == "fail"
+        assert "reason" in body
+    finally:
+        await runner.cleanup()
+
+
+@pytest.mark.asyncio
+async def test_healthz_db_does_not_leak_secrets(app_env, monkeypatch) -> None:
+    """Response body of /healthz/db must contain no BOT_TOKEN, WEB_PASSWORD, or DB password."""
+    base_url, runner = await _start_server_for_db(monkeypatch, db_ok=True)
+    try:
+        async with httpx.AsyncClient() as client:
+            response = await client.get(f"{base_url}/healthz/db")
+        body_str = json.dumps(response.json())
+        forbidden = [
+            "123456:test-token",    # BOT_TOKEN
+            "test-pass",            # WEB_PASSWORD
+            "test-session-secret",  # WEB_SESSION_SECRET
+            "changeme",             # DB password
+            "149820031",            # ADMIN_IDS member
+        ]
+        for needle in forbidden:
+            assert needle not in body_str, (
+                f"/healthz/db endpoint leaked secret-shaped string: {needle!r}"
+            )
+    finally:
+        await runner.cleanup()


### PR DESCRIPTION
## Summary

- Adds `GET /healthz/db` to the aiohttp healthz server on `:3000` (same port as `/healthz` from PR #286).
- Handler calls `check_db()` directly — the existing granular async function in `bot/services/health.py` — without running the full `HealthReport`. This keeps the endpoint fast and scoped.
- Returns `200 + {"db": "ok"}` when the DB roundtrip succeeds; `503 + {"db": "fail", "reason": "<exc class>"}` when not.
- No secrets in the response body: `check_db()` already returns only the exception class name, never the full connection string or credentials.
- Route registered alongside `/healthz` in `start_healthz_runner`.
- `CLAUDE.md` updated with a one-line note about the new sub-endpoint.

Closes #270 follow-up for the bot side; re-enabling `check_db_roundtrip` in `ops/healing/healthcheck.py` (the TODO at line ~48) is owned separately by the healing orchestrator — that TODO comment is intentionally left in place.

## Test plan

- [x] `test_healthz_db_returns_200_when_db_healthy` — monkeypatches `check_db` to ok; asserts 200 + `{"db": "ok"}`
- [x] `test_healthz_db_returns_503_when_db_down` — monkeypatches `check_db` to fail; asserts 503 + `{"db": "fail", "reason": ...}`
- [x] `test_healthz_db_does_not_leak_secrets` — asserts response body contains no BOT_TOKEN, WEB_PASSWORD, WEB_SESSION_SECRET, DB password, or ADMIN_IDS values
- [x] All 4 existing `/healthz` tests still pass (7/7 total in `test_healthz_bot.py`)
- [x] `ruff check` clean
- [x] `scripts/lint_privacy_check.sh` exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)