### PR TITLE
feat(p7-t7-05): publisher + renderer + redactor + cascade digests layer

### DIFF
--- a/bot/services/digest_admin_notify.py
+++ b/bot/services/digest_admin_notify.py
@@ -1,0 +1,67 @@
+"""Admin notification helper for Phase 7 / T7-05.
+
+Sends a DM to the first admin in ``settings.ADMIN_IDS`` on actionable
+failure modes. NOT triggered on transient / expected failure modes
+(empty window, unset destination) — those are operator-routine.
+
+Per PHASE7_PLAN.md §5.J: admin-notify fires on
+- ``cost_exceeded``
+- ``redacted_edit_failed``
+- markdown render errors / TelegramBadRequest
+- ``publish_lock_timeout``
+- ``bot_kicked_from_posted_chat_id`` (privacy gap)
+
+Silent on:
+- ``skipped`` (empty window)
+- ``skipped_no_destination``
+- transient LLM errors that get retried (Phase 7 does no auto-retry; but
+  the notify-on-failure path covers actionable subset only).
+"""
+
+from __future__ import annotations
+
+import logging
+
+from aiogram import Bot
+from aiogram.exceptions import TelegramBadRequest, TelegramForbiddenError
+
+from bot.config import settings
+from bot.html_escape import html_escape
+
+logger = logging.getLogger(__name__)
+
+
+async def notify_admins_digest_failure(
+    bot: Bot,
+    *,
+    digest_id: int | None,
+    status: str,
+    error_text: str,
+) -> None:
+    """Send DM to first admin in ``settings.ADMIN_IDS``.
+
+    Silent on send failures (admin DM is informational; no retry).
+    """
+    admins = list(settings.ADMIN_IDS) if settings.ADMIN_IDS else []
+    if not admins:
+        logger.warning("notify_admins_digest_failure: no ADMIN_IDS configured")
+        return
+    target = admins[0]
+    body = (
+        "<b>⚠️ Phase 7 digest alert</b>\n\n"
+        f"digest_id: <code>{html_escape(str(digest_id))}</code>\n"
+        f"status: <code>{html_escape(status)}</code>\n"
+        f"error_text: <code>{html_escape(error_text[:500])}</code>\n\n"
+        "<i>Check /digest_history for the full audit trail.</i>"
+    )
+    try:
+        await bot.send_message(chat_id=target, text=body, parse_mode="HTML")
+    except (TelegramBadRequest, TelegramForbiddenError) as exc:
+        logger.error(
+            "notify_admins_digest_failure: failed to DM admin %s: %s",
+            target,
+            exc,
+        )
+
+
+__all__ = ["notify_admins_digest_failure"]

--- a/bot/services/digest_publisher.py
+++ b/bot/services/digest_publisher.py
@@ -1,0 +1,305 @@
+"""Telegram digest publisher — T7-05 / Phase 7.
+
+Holds the digest row lock ACROSS ``bot.send_message`` in a single
+transaction (PHASE7_PLAN.md §5.F). This eliminates the race window where
+a forget cascade could see the row unlocked while Telegram is in-flight.
+
+Status state machine:
+    draft → posting → posted     (success)
+    draft → posting → failed     (TelegramBadRequest / format error)
+    draft → posting → failed     (TelegramForbiddenError / bot kicked)
+    draft → skipped_no_destination  (destination not configured)
+    draft → failed (publish_lock_timeout)  (3 NOWAIT retries exhausted)
+
+The publisher never re-publishes a row that's already terminal. The admin
+``/digest_now`` handler may invoke this on an existing draft (orphan
+recovery path, see PHASE7_PLAN.md §5.I).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime, timezone
+
+from aiogram import Bot
+from aiogram.exceptions import TelegramBadRequest, TelegramForbiddenError
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from bot.db.models import Digest, DigestRun
+from bot.services.digest_admin_notify import notify_admins_digest_failure
+from bot.services.digest_renderer import render_digest_html
+from bot.services.digests import DigestConfig
+
+logger = logging.getLogger(__name__)
+
+
+class DigestPublisherInvalidState(Exception):
+    """Row was not in ``draft`` state when the publisher acquired the lock."""
+
+
+async def _digest_revalidate_citations(
+    session: AsyncSession, *, digest: Digest
+) -> bool:
+    """Defense-in-depth: re-check every citation source id is still visible.
+
+    Returns True if all cited sources are clean, False if any failed
+    revalidation (caller should mark digest 'failed' and skip publish).
+    """
+    citations = digest.citations or []
+    mv_ids = [int(c["id"]) for c in citations if c.get("kind") == "message_version"]
+    cs_ids = [str(c["id"]) for c in citations if c.get("kind") == "card_source"]
+
+    if mv_ids:
+        result = await session.execute(
+            text(
+                "SELECT mv.id FROM message_versions mv "
+                "JOIN chat_messages cm ON cm.id = mv.chat_message_id "
+                "WHERE mv.id = ANY(:mv_ids) "
+                "  AND cm.memory_policy = 'normal' "
+                "  AND mv.is_redacted = FALSE "
+                "  AND NOT EXISTS ("
+                "      SELECT 1 FROM forget_events fe "
+                "      WHERE fe.status IN ('pending','processing','completed') "
+                "        AND ( "
+                "            (fe.target_type = 'message' AND fe.target_id = cm.id::text) "
+                "            OR (fe.target_type = 'user' AND fe.target_id = cm.user_id::text) "
+                "            OR (fe.target_type = 'message_hash' AND fe.target_id = mv.content_hash) "
+                "        ) "
+                "  )"
+            ),
+            {"mv_ids": mv_ids},
+        )
+        visible = {r[0] for r in result.all()}
+        if set(mv_ids) - visible:
+            return False
+    if cs_ids:
+        result = await session.execute(
+            text(
+                "SELECT cs.id::text FROM card_sources cs "
+                "JOIN knowledge_cards kc ON kc.id = cs.card_id "
+                "JOIN message_versions mv ON mv.id = cs.message_version_id "
+                "JOIN chat_messages cm ON cm.id = mv.chat_message_id "
+                "WHERE cs.id::text = ANY(:cs_ids) "
+                "  AND kc.card_status = 'approved' "
+                "  AND cm.memory_policy = 'normal' "
+                "  AND mv.is_redacted = FALSE "
+                "  AND NOT EXISTS ("
+                "      SELECT 1 FROM forget_events fe "
+                "      WHERE fe.status IN ('pending','processing','completed') "
+                "        AND ( "
+                "            (fe.target_type = 'message' AND fe.target_id = cm.id::text) "
+                "            OR (fe.target_type = 'user' AND fe.target_id = cm.user_id::text) "
+                "            OR (fe.target_type = 'message_hash' AND fe.target_id = mv.content_hash) "
+                "        ) "
+                "  )"
+            ),
+            {"cs_ids": cs_ids},
+        )
+        visible = {r[0] for r in result.all()}
+        if set(cs_ids) - visible:
+            return False
+    return True
+
+
+async def publish_digest(
+    session: AsyncSession,
+    *,
+    bot: Bot,
+    digest: Digest,
+    digest_config: DigestConfig,
+) -> Digest:
+    """Publish a digest to its destination chat.
+
+    Single long-lived transaction holding the row lock across send_message.
+    Caller MUST commit the session after this returns OR roll back on raise.
+    """
+    if digest.status != "draft":
+        raise DigestPublisherInvalidState(
+            f"expected status='draft', got {digest.status!r}"
+        )
+
+    # If no destination, skip publication cleanly.
+    if digest_config.destination_chat_id is None:
+        digest.status = "skipped_no_destination"
+        digest.updated_at = datetime.now(timezone.utc)
+        session.add(
+            DigestRun(
+                digest_id=digest.id,
+                status="skipped_no_destination",
+                finished_at=datetime.now(timezone.utc),
+            )
+        )
+        await session.flush()
+        return digest
+
+    # Set transaction-local timeout (covers 5s lock wait + ~20s Telegram + buffer).
+    await session.execute(
+        text("SELECT set_config('statement_timeout', '30s', true)")
+    )
+
+    # Try FOR UPDATE NOWAIT with up to 3 backoff retries.
+    locked = False
+    last_exc: Exception | None = None
+    for attempt in range(3):
+        try:
+            await session.execute(
+                text("SELECT id FROM digests WHERE id = :id FOR UPDATE NOWAIT"),
+                {"id": digest.id},
+            )
+            locked = True
+            break
+        except Exception as exc:
+            last_exc = exc
+            await asyncio.sleep(0.1 * (2**attempt))
+    if not locked:
+        # Fresh transaction guard: only update if still 'draft' (race-safe).
+        # Note: we're still inside the same session — for true fresh-tx,
+        # caller would need a separate session. For this implementation we
+        # update + log + raise; the scheduler wrapper rolls back outer tx.
+        logger.warning(
+            "publish_digest: lock acquisition exhausted (3 retries) digest_id=%s",
+            digest.id,
+        )
+        digest.status = "failed"
+        digest.error_text = "publish_lock_timeout"
+        session.add(
+            DigestRun(
+                digest_id=digest.id,
+                status="failed",
+                error_text="publish_lock_timeout",
+                finished_at=datetime.now(timezone.utc),
+            )
+        )
+        await session.flush()
+        await notify_admins_digest_failure(
+            bot,
+            digest_id=digest.id,
+            status="failed",
+            error_text=f"publish_lock_timeout (last={last_exc!r})",
+        )
+        return digest
+
+    # Transition draft → posting (in same transaction). Row remains locked.
+    digest.status = "posting"
+    digest.posting_started_at = datetime.now(timezone.utc)
+    digest.updated_at = datetime.now(timezone.utc)
+    await session.flush()
+
+    # Defense-in-depth revalidation — block forgotten-source publish even
+    # if it slipped past gateway-side check.
+    if not await _digest_revalidate_citations(session, digest=digest):
+        digest.status = "failed"
+        digest.error_text = "citations_stale_at_publish"
+        digest.posting_started_at = None
+        session.add(
+            DigestRun(
+                digest_id=digest.id,
+                status="failed",
+                error_text="citations_stale_at_publish",
+                finished_at=datetime.now(timezone.utc),
+            )
+        )
+        await session.flush()
+        await notify_admins_digest_failure(
+            bot,
+            digest_id=digest.id,
+            status="failed",
+            error_text="citations_stale_at_publish",
+        )
+        return digest
+
+    # Render + send.
+    body_html = render_digest_html(
+        digest.body_markdown or "",
+        window_start_utc=digest.window_start,
+    )
+    try:
+        sent = await bot.send_message(
+            chat_id=digest_config.destination_chat_id,
+            text=body_html,
+            parse_mode="HTML",
+            disable_web_page_preview=True,
+        )
+    except TelegramBadRequest as exc:
+        digest.status = "failed"
+        digest.error_text = str(exc)[:500]
+        digest.posting_started_at = None
+        session.add(
+            DigestRun(
+                digest_id=digest.id,
+                status="failed",
+                error_text=str(exc)[:2000],
+                finished_at=datetime.now(timezone.utc),
+            )
+        )
+        await session.flush()
+        await notify_admins_digest_failure(
+            bot, digest_id=digest.id, status="failed", error_text=str(exc)
+        )
+        return digest
+    except TelegramForbiddenError:
+        digest.status = "failed"
+        digest.error_text = "bot_not_in_destination"
+        digest.posting_started_at = None
+        session.add(
+            DigestRun(
+                digest_id=digest.id,
+                status="failed",
+                error_text="bot_not_in_destination",
+                finished_at=datetime.now(timezone.utc),
+            )
+        )
+        await session.flush()
+        await notify_admins_digest_failure(
+            bot,
+            digest_id=digest.id,
+            status="failed",
+            error_text="bot_not_in_destination",
+        )
+        return digest
+
+    # Success: posting → posted (guarded by status='posting' to prevent
+    # racing with reaper).
+    update_result = await session.execute(
+        text(
+            "UPDATE digests "
+            "SET status='posted', posted_chat_id=:cid, posted_message_id=:mid, "
+            "    posted_at=now(), posting_started_at=NULL, updated_at=now() "
+            "WHERE id = :id AND status='posting' "
+            "RETURNING id"
+        ),
+        {
+            "id": digest.id,
+            "cid": digest_config.destination_chat_id,
+            "mid": sent.message_id,
+        },
+    )
+    if update_result.rowcount == 0:
+        logger.warning(
+            "publish_digest: posted-transition rowcount=0 digest_id=%s "
+            "(reaper or another worker moved the row)",
+            digest.id,
+        )
+        # The Telegram message is posted but DB rejected — admin must investigate.
+        await notify_admins_digest_failure(
+            bot,
+            digest_id=digest.id,
+            status="failed",
+            error_text="posted_transition_rowcount_zero_after_send",
+        )
+        return digest
+    session.add(
+        DigestRun(
+            digest_id=digest.id,
+            status="finished",
+            finished_at=datetime.now(timezone.utc),
+        )
+    )
+    await session.flush()
+    await session.refresh(digest)
+    return digest
+
+
+__all__ = ["publish_digest", "DigestPublisherInvalidState"]

--- a/bot/services/digest_publisher.py
+++ b/bot/services/digest_publisher.py
@@ -187,7 +187,7 @@ async def publish_digest(
     digest.updated_at = datetime.now(timezone.utc)
     await session.flush()
 
-    # Defense-in-depth revalidation — block forgotten-source publish even
+    # Defense-in-depth revalidation — block tombstoned-source publish even
     # if it slipped past gateway-side check.
     if not await _digest_revalidate_citations(session, digest=digest):
         digest.status = "failed"

--- a/bot/services/digest_redactor.py
+++ b/bot/services/digest_redactor.py
@@ -1,0 +1,227 @@
+"""Forget-cascade digest redactor — T7-05 / Phase 7.
+
+Called from ``forget_cascade._cascade_digests`` (extension landed in
+this same PR). Masks affected bullets, persists DB redaction unconditionally,
+then attempts ``bot.edit_message_text`` for posted rows. Erratum follow-up
+on TelegramBadRequest; admin-notify on TelegramForbiddenError (no erratum
+because bot can't post — privacy stop signal per PHASE7_PLAN.md §8).
+
+Bullet identification uses the ``citations[i].position`` bullet index that
+``_parse_digest_citations`` now writes (Phase 7.5 fix #295).
+"""
+
+from __future__ import annotations
+
+import logging
+
+from aiogram import Bot
+from aiogram.exceptions import TelegramBadRequest, TelegramForbiddenError
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from bot.services.digest_admin_notify import notify_admins_digest_failure
+from bot.services.digest_renderer import render_digest_html
+
+logger = logging.getLogger(__name__)
+
+REDACTED_BULLET_TEMPLATE = "- [REDACTED — забыто]"
+
+
+def _mask_bullets_in_body(body_markdown: str, *, bullet_indices: set[int]) -> str:
+    """Replace bullets at the given 0-based indices with REDACTED template.
+
+    A bullet starts at a line beginning with ``- `` or ``• `` and extends
+    until the next bullet or end of body. The TL;DR header (text before
+    the first bullet) is preserved verbatim.
+    """
+    if not bullet_indices:
+        return body_markdown
+    lines = body_markdown.splitlines()
+    out: list[str] = []
+    current_bullet_idx = -1
+    skip_until_next_bullet = False
+    for line in lines:
+        is_bullet_start = line.startswith("- ") or line.startswith("• ")
+        if is_bullet_start:
+            current_bullet_idx += 1
+            if current_bullet_idx in bullet_indices:
+                out.append(REDACTED_BULLET_TEMPLATE)
+                skip_until_next_bullet = True
+                continue
+            else:
+                skip_until_next_bullet = False
+        if skip_until_next_bullet:
+            continue
+        out.append(line)
+    return "\n".join(out)
+
+
+async def redact_digest_for_forget(
+    session: AsyncSession,
+    *,
+    digest_id: int,
+    affected_mvids: set[int],
+    affected_card_source_ids: set[str],
+    bot: Bot | None,
+) -> None:
+    """Mask affected bullets in a digest. Always persists DB redaction; the
+    Telegram side-effect is best-effort.
+
+    Steps:
+    1. SELECT FOR UPDATE with statement_timeout 5s.
+    2. Resolve bullet indices from citations matching affected ids.
+    3. Mask bullets + filter citations.
+    4. UPDATE digests SET body / citations / status='redacted'.
+    5. If posted_message_id and bot is not None, try edit_message_text
+       unconditionally (bot-posted messages have no time limit).
+    6. On TelegramBadRequest → post erratum follow-up. Status →
+       redacted_edit_failed.
+    7. On TelegramForbiddenError → admin notify, no erratum.
+    """
+    await session.execute(
+        text("SELECT set_config('statement_timeout', '5s', true)")
+    )
+
+    try:
+        digest_row = (
+            await session.execute(
+                text("SELECT * FROM digests WHERE id = :id FOR UPDATE"),
+                {"id": digest_id},
+            )
+        ).mappings().one_or_none()
+    except Exception:
+        # statement_timeout fires here on stuck `posting` row. Per Codex
+        # round-3 fix: log + skip without raise (per-event isolation).
+        logger.warning(
+            "redact_digest_for_forget: FOR UPDATE timed out digest_id=%s",
+            digest_id,
+        )
+        return
+
+    if digest_row is None:
+        return
+
+    current_status = digest_row["status"]
+    if current_status not in ("draft", "posted", "redacted", "redacted_edit_failed"):
+        # Terminal states (skipped, failed, cost_exceeded, etc.) — nothing to redact.
+        return
+
+    citations = digest_row["citations"] or []
+    bullet_indices_to_mask: set[int] = set()
+    surviving_citations: list[dict] = []
+    for cit in citations:
+        kind = cit.get("kind")
+        cid = cit.get("id")
+        position = cit.get("position", -1)
+        affected = False
+        if kind == "message_version":
+            try:
+                affected = int(cid) in affected_mvids
+            except (TypeError, ValueError):
+                affected = False
+        elif kind == "card_source":
+            affected = str(cid) in affected_card_source_ids
+        if affected:
+            if isinstance(position, int) and position >= 0:
+                bullet_indices_to_mask.add(position)
+        else:
+            surviving_citations.append(cit)
+
+    if not bullet_indices_to_mask:
+        # Edge case: cited but position == -1 (TL;DR), or no citations matched.
+        # Still mark redacted to record event.
+        await session.execute(
+            text(
+                "UPDATE digests SET status='redacted', updated_at=now() "
+                "WHERE id = :id AND status IN "
+                "('draft','posted','redacted','redacted_edit_failed')"
+            ),
+            {"id": digest_id},
+        )
+        return
+
+    masked = _mask_bullets_in_body(
+        digest_row["body_markdown"] or "",
+        bullet_indices=bullet_indices_to_mask,
+    )
+
+    await session.execute(
+        text(
+            "UPDATE digests "
+            "SET body_markdown = :body, "
+            "    citations = CAST(:cits AS jsonb), "
+            "    status = 'redacted', "
+            "    updated_at = now() "
+            "WHERE id = :id"
+        ),
+        {
+            "id": digest_id,
+            "body": masked,
+            "cits": __import__("json").dumps(surviving_citations),
+        },
+    )
+
+    # Telegram side-effect — best effort.
+    posted_message_id = digest_row.get("posted_message_id")
+    posted_chat_id = digest_row.get("posted_chat_id")
+    if posted_message_id and bot is not None:
+        body_html = render_digest_html(
+            masked, window_start_utc=digest_row["window_start"]
+        )
+        try:
+            await bot.edit_message_text(
+                chat_id=posted_chat_id,
+                message_id=posted_message_id,
+                text=body_html,
+                parse_mode="HTML",
+                disable_web_page_preview=True,
+            )
+        except TelegramBadRequest as exc:
+            # Edit refused (bot still in chat) — post erratum.
+            await session.execute(
+                text(
+                    "UPDATE digests SET status='redacted_edit_failed' "
+                    "WHERE id = :id"
+                ),
+                {"id": digest_id},
+            )
+            erratum = (
+                f"Дайджест за {digest_row['window_start'].strftime('%d.%m.%Y')} "
+                "обновлён: цитата по запросу автора удалена. "
+                "Полный текст в /digest_history."
+            )
+            try:
+                await bot.send_message(
+                    chat_id=posted_chat_id,
+                    text=erratum,
+                    parse_mode="HTML",
+                )
+            except Exception:
+                logger.exception(
+                    "digest_redactor: erratum follow-up failed digest_id=%s",
+                    digest_id,
+                )
+            await notify_admins_digest_failure(
+                bot,
+                digest_id=digest_id,
+                status="redacted_edit_failed",
+                error_text=f"telegram_bad_request:{exc}",
+            )
+        except TelegramForbiddenError:
+            # Bot kicked — no erratum possible. Privacy stop signal.
+            await session.execute(
+                text(
+                    "UPDATE digests SET status='redacted_edit_failed' "
+                    "WHERE id = :id"
+                ),
+                {"id": digest_id},
+            )
+            await notify_admins_digest_failure(
+                bot,
+                digest_id=digest_id,
+                status="redacted_edit_failed",
+                error_text="bot_kicked_from_posted_chat_id",
+            )
+
+
+__all__ = ["redact_digest_for_forget", "_mask_bullets_in_body"]

--- a/bot/services/digest_renderer.py
+++ b/bot/services/digest_renderer.py
@@ -1,0 +1,135 @@
+"""HTML rendering for daily digests — T7-05.
+
+Converts the LLM-produced Markdown body (with `[[cs:UUID]]` / `[[mv:INT]]`
+citation tokens) into Telegram HTML for the publisher. Citation tokens are
+STRIPPED from the public output per ratified decision Q6 — operators see
+citation audit details via `/digest_preview` admin handler instead.
+
+Key invariants (per PHASE7_PLAN.md §5.G):
+- Truncate plain Markdown BEFORE escape+convert (avoid mid-tag cuts).
+- Strip citation tokens early.
+- Escape via stdlib `html.escape` (defense vs LLM-emitted angle-brackets).
+- Convert minimal Markdown (`**bold**`, `*italic*`, bullet prefixes).
+- Append footer with date + admin breadcrumb.
+- Tag-balance assertion: if `<b>` / `<i>` open/close counts diverge after
+  conversion, strip ALL formatting and fall back to plain-escaped text
+  (better dumb-but-valid than malformed-and-silently-dropped).
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+from bot.html_escape import html_escape
+
+_CITATION_TOKEN_RE = re.compile(r"\[\[(?:cs|mv|card):[^\]]+\]\]")
+_MAX_BODY_CHARS_BEFORE_HTML = 3800  # leaves 296 chars for HTML overhead + footer
+_TELEGRAM_HARD_LIMIT = 4096
+_BOLD_RE = re.compile(r"\*\*([^*\n]+)\*\*")
+_ITALIC_RE = re.compile(r"(?<!\*)\*([^*\n]+)\*(?!\*)")
+
+
+def _strip_citation_tokens(body: str) -> str:
+    """Remove all citation tokens from the body."""
+    return _CITATION_TOKEN_RE.sub("", body)
+
+
+def _truncate_plain_markdown(body: str, *, max_chars: int) -> str:
+    """Truncate ``body`` at the last paragraph boundary before ``max_chars``.
+
+    Operates on plain Markdown BEFORE escape+convert so we never cut inside
+    an open `<b>` / `<i>` tag.
+    """
+    if len(body) <= max_chars:
+        return body
+    cut = body.rfind("\n\n", 0, max_chars)
+    if cut <= 0:
+        cut = body.rfind("\n", 0, max_chars)
+    if cut <= 0:
+        cut = max_chars
+    return body[:cut].rstrip() + "\n\n..."
+
+
+def _convert_minimal_markdown(escaped: str) -> str:
+    """Convert escaped text into Telegram HTML.
+
+    Only handles `**bold**` → `<b>...</b>`, `*italic*` → `<i>...</i>`,
+    and `- ` / `• ` bullet prefixes (already-present `•` is preserved).
+    """
+    # Bold first so `*` doesn't get swallowed by italic.
+    out = _BOLD_RE.sub(r"<b>\1</b>", escaped)
+    out = _ITALIC_RE.sub(r"<i>\1</i>", out)
+
+    # Normalize bullet prefix at line start (Markdown `- ` → bullet character).
+    out_lines = []
+    for line in out.splitlines():
+        if line.startswith("- "):
+            out_lines.append("• " + line[2:])
+        else:
+            out_lines.append(line)
+    return "\n".join(out_lines)
+
+
+def _tag_balance_ok(html: str) -> bool:
+    open_b = html.count("<b>")
+    close_b = html.count("</b>")
+    open_i = html.count("<i>")
+    close_i = html.count("</i>")
+    return open_b == close_b and open_i == close_i
+
+
+def _strip_all_formatting(html: str) -> str:
+    """Last-resort: strip ALL <b>/<i> tags. Returns valid plain-HTML."""
+    html = html.replace("<b>", "").replace("</b>", "")
+    html = html.replace("<i>", "").replace("</i>", "")
+    return html
+
+
+def render_digest_html(
+    body_markdown: str,
+    *,
+    window_start_utc: datetime,
+    timezone_name: str = "Europe/Moscow",
+) -> str:
+    """Render a digest body for Telegram HTML output.
+
+    Steps:
+    1. Strip citation tokens.
+    2. Truncate plain Markdown.
+    3. html_escape (covers LLM-emitted `<`, `>`, `&`).
+    4. Convert minimal MD to HTML.
+    5. Append footer with date + admin breadcrumb.
+    6. Tag-balance assertion; strip formatting on imbalance.
+    7. Hard-cap to Telegram limit.
+
+    The output is a single string ready for `bot.send_message(parse_mode='HTML')`.
+    """
+    stripped = _strip_citation_tokens(body_markdown).strip()
+    truncated = _truncate_plain_markdown(stripped, max_chars=_MAX_BODY_CHARS_BEFORE_HTML)
+    escaped = html_escape(truncated)
+    converted = _convert_minimal_markdown(escaped)
+
+    # Footer in target timezone.
+    tz = ZoneInfo(timezone_name)
+    window_local = window_start_utc.astimezone(tz)
+    footer = (
+        "\n\n<i>Дайджест за "
+        f"{window_local.strftime('%d.%m.%Y')}. "
+        "Полный список источников: /digest_history</i>"
+    )
+
+    body_with_footer = converted + footer
+
+    if not _tag_balance_ok(body_with_footer):
+        body_with_footer = _strip_all_formatting(body_with_footer)
+        body_with_footer = body_with_footer + "\n\n[!] tag-balance fallback applied"
+
+    if len(body_with_footer) > _TELEGRAM_HARD_LIMIT:
+        body_with_footer = body_with_footer[: _TELEGRAM_HARD_LIMIT - 3] + "..."
+
+    return body_with_footer
+
+
+__all__ = ["render_digest_html"]

--- a/bot/services/forget_cascade.py
+++ b/bot/services/forget_cascade.py
@@ -141,6 +141,12 @@ CASCADE_LAYER_ORDER: tuple[str, ...] = (
     "llm_synthesis_cache",
     "qa_traces_llm",
     "llm_usage_ledger",
+    # Phase 7 / T7-05 layer — PHASE7_PLAN.md §5.H:
+    # ``digests`` MUST run BEFORE ``card_sources`` so card_source ids are
+    # still queryable when the JSONB scan resolves which digests cite each
+    # source. Otherwise the card_sources DELETE that follows would orphan
+    # the references and the redactor wouldn't know which bullets to mask.
+    "digests",
     # Phase 6 / T6-01 layer — PHASE6_PLAN.md §5.A.5 invariant:
     # ``card_sources`` MUST run AFTER ``qa_traces_llm`` so qa_trace summaries
     # are NULL'd before the card_source rows that the citation_ids referenced
@@ -794,6 +800,85 @@ async def _cascade_card_sources_on_forget(session: AsyncSession, event) -> int:
     return deleted_count
 
 
+async def _cascade_digests(session: AsyncSession, event) -> int:
+    """T7-05 / Phase 7 — single merged digests layer.
+
+    Detect digests citing the tombstoned source and redact them in one
+    transaction. Handles both ``kind='message_version'`` and
+    ``kind='card_source'`` citations. Runs BEFORE ``_cascade_card_sources``
+    so the card_source rows still exist when the JSONB scan runs.
+
+    Per-event isolation: on any failure inside redact_digest_for_forget,
+    log + continue (forget event proceeds to next layer). The
+    statement_timeout guard inside the redactor handles the publisher-race
+    case (5s blocking wait then log-and-skip).
+    """
+    from sqlalchemy import bindparam
+    from sqlalchemy.dialects.postgresql import ARRAY as PG_ARRAY
+    from sqlalchemy.types import BigInteger, String
+
+    mvids = await _resolve_affected_mvids(session, event)
+    if not mvids:
+        return 0
+
+    # Resolve card_source ids whose message_version is in the affected set.
+    # This MUST happen BEFORE the card_sources cascade layer DELETEs the rows.
+    cs_rows = await session.execute(
+        text(
+            "SELECT id::text FROM card_sources WHERE message_version_id = ANY(:mvids)"
+        ).bindparams(bindparam("mvids", type_=PG_ARRAY(BigInteger))),
+        {"mvids": list(mvids)},
+    )
+    affected_cs_ids = {r[0] for r in cs_rows}
+
+    # JSONB scan for digests citing either kind.
+    digest_rows = await session.execute(
+        text(
+            "SELECT d.id FROM digests d "
+            "WHERE d.status IN "
+            "('draft','posting','posted','redacted','redacted_edit_failed') "
+            "  AND EXISTS ("
+            "      SELECT 1 FROM jsonb_array_elements(d.citations) AS elem "
+            "      WHERE ("
+            "          (elem->>'kind') = 'message_version' "
+            "          AND (elem->>'id')::bigint = ANY(:mvids) "
+            "      ) OR ("
+            "          (elem->>'kind') = 'card_source' "
+            "          AND (elem->>'id') = ANY(:cs_ids) "
+            "      ) "
+            "  ) "
+            "ORDER BY d.id"
+        ).bindparams(
+            bindparam("mvids", type_=PG_ARRAY(BigInteger)),
+            bindparam("cs_ids", type_=PG_ARRAY(String)),
+        ),
+        {"mvids": list(mvids), "cs_ids": list(affected_cs_ids)},
+    )
+    affected_digest_ids = [r[0] for r in digest_rows]
+    if not affected_digest_ids:
+        return 0
+
+    from bot.services.digest_redactor import redact_digest_for_forget
+
+    runtime_bot = getattr(event, "_runtime_bot", None)
+    count = 0
+    for digest_id in affected_digest_ids:
+        try:
+            await redact_digest_for_forget(
+                session,
+                digest_id=digest_id,
+                affected_mvids=set(mvids),
+                affected_card_source_ids=affected_cs_ids,
+                bot=runtime_bot,
+            )
+            count += 1
+        except Exception:
+            logger.exception(
+                "_cascade_digests: redact failed for digest_id=%s", digest_id
+            )
+    return count
+
+
 # Map layer name → cascade function. Layers absent from this map are recorded as
 # skipped. When a future phase adds a layer's table, add its function here.
 _LAYER_FUNCS: dict[str, Any] = {
@@ -804,6 +889,8 @@ _LAYER_FUNCS: dict[str, Any] = {
     "llm_synthesis_cache": _cascade_llm_synthesis_cache,
     "qa_traces_llm": _cascade_qa_traces_llm,
     "llm_usage_ledger": _cascade_llm_usage_ledger,
+    # T7-05 Phase 7 layer — PHASE7_PLAN.md §5.H. Runs BEFORE card_sources.
+    "digests": _cascade_digests,
     # T6-01 Phase 6 layer — PHASE6_PLAN.md §5.A.5.
     "card_sources": _cascade_card_sources_on_forget,
 }

--- a/bot/services/llm_gateway.py
+++ b/bot/services/llm_gateway.py
@@ -1412,6 +1412,26 @@ class SynthesizeDigestResult:
 _CITATION_TOKEN_RE = re.compile(r"\[\[(cs|mv|card):([^\]]+)\]\]")
 
 
+def _bullet_index_at_offset(body_markdown: str, char_offset: int) -> int:
+    """Return the 0-based index of the bullet that contains ``char_offset``.
+
+    A bullet starts at a line beginning with ``- `` or ``• ``. Text before
+    the first bullet (TL;DR) is indexed as -1. Used by digest renderer +
+    redactor to align citations to bullets (Phase 7.5 issue #295 fix).
+    """
+    idx = -1
+    pos = 0
+    for line in body_markdown.splitlines(keepends=True):
+        line_start = pos
+        line_end = pos + len(line)
+        if line.startswith("- ") or line.startswith("• "):
+            idx += 1
+        if line_start <= char_offset < line_end:
+            return idx
+        pos = line_end
+    return idx
+
+
 def _parse_digest_citations(
     body_markdown: str,
     *,
@@ -1420,15 +1440,20 @@ def _parse_digest_citations(
 ) -> tuple[list[dict[str, Any]], list[str]]:
     """Parse citation tokens; return (valid_citations, dropped_tokens).
 
+    Each citation's ``position`` is the 0-based BULLET INDEX where the
+    token appears (Phase 7.5 fix per issue #295). The redactor needs this
+    to mask the correct bullet on forget cascade.
+
     Reject ``[[card:UUID]]`` as malformed (cards must be cited via
     card_source ids per plan §5.D). Drop hallucinated ids.
     """
     citations: list[dict[str, Any]] = []
     dropped: list[str] = []
     seen_keys: set[tuple[str, str]] = set()
-    for position, match in enumerate(_CITATION_TOKEN_RE.finditer(body_markdown)):
+    for match in _CITATION_TOKEN_RE.finditer(body_markdown):
         kind_raw, id_raw = match.group(1), match.group(2)
         token = match.group(0)
+        bullet_idx = _bullet_index_at_offset(body_markdown, match.start())
         if kind_raw == "card":
             dropped.append(token)
             continue
@@ -1441,7 +1466,7 @@ def _parse_digest_citations(
                 continue
             seen_keys.add(key)
             citations.append(
-                {"kind": "card_source", "id": id_raw, "position": position}
+                {"kind": "card_source", "id": id_raw, "position": bullet_idx}
             )
         elif kind_raw == "mv":
             try:
@@ -1457,7 +1482,7 @@ def _parse_digest_citations(
                 continue
             seen_keys.add(key)
             citations.append(
-                {"kind": "message_version", "id": mv_int, "position": position}
+                {"kind": "message_version", "id": mv_int, "position": bullet_idx}
             )
     return citations, dropped
 

--- a/scripts/lint_privacy_check.sh
+++ b/scripts/lint_privacy_check.sh
@@ -26,13 +26,16 @@ is_allowed_path() {
   # a baseline regen step.
   [[ "$path" =~ ^docs/memory-system/PHASE[0-9]+_PLAN\.md$ ]] && return 0
 
-  # Phase 7 digest context module + tests reference the canonical
+  # Phase 7 digest modules + tests reference the canonical
   # privacy literals in docstrings and test inputs because their job
   # is to ENFORCE the policy — they must name the literals to filter
   # against them. Same rationale as the design docs and phase plans
-  # above; new file added in PR #290 (T7-03).
+  # above; files added across PRs #290 (T7-03), #293 (T7-02), #296 (T7-05).
   [[ "$path" == "bot/services/digest_context.py" ]] && return 0
+  [[ "$path" == "bot/services/digest_publisher.py" ]] && return 0
+  [[ "$path" == "bot/services/digest_redactor.py" ]] && return 0
   [[ "$path" == "tests/services/test_digest_context.py" ]] && return 0
+  [[ "$path" == "tests/services/test_digest_publisher.py" ]] && return 0
 
   return 1
 }

--- a/tests/services/test_digest_publisher.py
+++ b/tests/services/test_digest_publisher.py
@@ -7,9 +7,7 @@ rendering), §5.H (forget cascade redactor + bullet masking).
 from __future__ import annotations
 
 import itertools
-import uuid
 from datetime import datetime, timezone, timedelta
-from decimal import Decimal
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -194,8 +192,6 @@ async def test_publisher_happy_path_with_clean_citations(db_session):
     from bot.db.models import (
         ChatMessage,
         Digest,
-        KnowledgeCard,
-        CardSource,
         MessageVersion,
     )
     from bot.db.repos.user import UserRepo

--- a/tests/services/test_digest_publisher.py
+++ b/tests/services/test_digest_publisher.py
@@ -1,0 +1,386 @@
+"""Tests for T7-05 — digest_publisher, digest_renderer, digest_redactor.
+
+Covers Phase 7 §5.F (publisher single-transaction flow), §5.G (HTML
+rendering), §5.H (forget cascade redactor + bullet masking).
+"""
+
+from __future__ import annotations
+
+import itertools
+import uuid
+from datetime import datetime, timezone, timedelta
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from sqlalchemy import text
+
+pytestmark = pytest.mark.usefixtures("app_env")
+
+_chat_counter = itertools.count(start=8500)
+
+
+def _next_chat_id() -> int:
+    return -1_000_000_000_000 - next(_chat_counter)
+
+
+def _next_uid() -> int:
+    return -1 * (1000 + next(_chat_counter))
+
+
+# ── renderer unit tests ──────────────────────────────────────────────────────
+
+
+def test_renderer_strips_citation_tokens():
+    from bot.services.digest_renderer import render_digest_html
+
+    body = "TL;DR header.\n\n- Topic [[cs:abc-uuid]] body [[mv:123]]"
+    ws = datetime(2026, 5, 15, 9, 0, 0, tzinfo=timezone.utc)
+    out = render_digest_html(body, window_start_utc=ws)
+    assert "[[cs:" not in out
+    assert "[[mv:" not in out
+    assert "Topic" in out
+    assert "body" in out
+
+
+def test_renderer_escapes_html_entities():
+    from bot.services.digest_renderer import render_digest_html
+
+    body = "TL;DR header.\n\n- <script>alert('x')</script> attack"
+    ws = datetime(2026, 5, 15, 9, 0, 0, tzinfo=timezone.utc)
+    out = render_digest_html(body, window_start_utc=ws)
+    assert "<script>" not in out
+    assert "&lt;script&gt;" in out
+
+
+def test_renderer_truncates_long_body():
+    from bot.services.digest_renderer import render_digest_html
+
+    paragraphs = "Lorem ipsum dolor sit amet. " * 200  # > 3800 chars
+    body = f"TL;DR.\n\n{paragraphs}"
+    ws = datetime(2026, 5, 15, 9, 0, 0, tzinfo=timezone.utc)
+    out = render_digest_html(body, window_start_utc=ws)
+    assert len(out) <= 4096
+    # Truncation should produce closing "..." somewhere
+    assert "..." in out
+
+
+def test_renderer_includes_footer_with_msk_date():
+    from bot.services.digest_renderer import render_digest_html
+
+    # window_start = 2026-05-15 00:00 MSK = 2026-05-14 21:00 UTC
+    ws = datetime(2026, 5, 14, 21, 0, 0, tzinfo=timezone.utc)
+    body = "TL;DR.\n\n- One bullet."
+    out = render_digest_html(body, window_start_utc=ws)
+    assert "15.05.2026" in out  # MSK-local date
+    assert "/digest_history" in out
+
+
+def test_renderer_converts_minimal_markdown():
+    from bot.services.digest_renderer import render_digest_html
+
+    body = "TL;DR.\n\n- **bold** and *italic* text"
+    ws = datetime(2026, 5, 15, 9, 0, 0, tzinfo=timezone.utc)
+    out = render_digest_html(body, window_start_utc=ws)
+    assert "<b>bold</b>" in out
+    assert "<i>italic</i>" in out
+
+
+def test_renderer_normalizes_bullets():
+    from bot.services.digest_renderer import render_digest_html
+
+    body = "TL;DR.\n\n- First\n- Second"
+    ws = datetime(2026, 5, 15, 9, 0, 0, tzinfo=timezone.utc)
+    out = render_digest_html(body, window_start_utc=ws)
+    assert "• First" in out
+    assert "• Second" in out
+
+
+# ── redactor unit tests ──────────────────────────────────────────────────────
+
+
+def test_mask_bullets_replaces_indices():
+    from bot.services.digest_redactor import _mask_bullets_in_body
+
+    body = (
+        "TL;DR header.\n"
+        "\n"
+        "- First bullet [[mv:1]]\n"
+        "  detail line\n"
+        "- Second bullet [[mv:2]]\n"
+        "- Third bullet [[cs:abc]]\n"
+    )
+    masked = _mask_bullets_in_body(body, bullet_indices={0, 2})
+    assert "First bullet" not in masked
+    assert "Second bullet" in masked
+    assert "Third bullet" not in masked
+    assert "[REDACTED — забыто]" in masked
+    # TL;DR preserved.
+    assert "TL;DR header." in masked
+
+
+def test_mask_bullets_empty_indices_returns_body_unchanged():
+    from bot.services.digest_redactor import _mask_bullets_in_body
+
+    body = "TL;DR.\n\n- One [[mv:1]]"
+    assert _mask_bullets_in_body(body, bullet_indices=set()) == body
+
+
+# ── publisher tests (DB-light, mocked Bot) ───────────────────────────────────
+
+
+async def test_publisher_skipped_no_destination(db_session):
+    """destination_chat_id=None → status='skipped_no_destination', no send."""
+    from bot.db.models import Digest
+    from bot.services.digest_publisher import publish_digest
+    from bot.services.digests import DigestConfig
+
+    digest = Digest(
+        type="daily",
+        window_start=datetime.now(timezone.utc) - timedelta(days=1),
+        window_end=datetime.now(timezone.utc),
+        body_markdown="TL;DR.\n\n- One [[mv:1]]",
+        citations=[{"kind": "message_version", "id": 1, "position": 0}],
+        status="draft",
+    )
+    db_session.add(digest)
+    await db_session.flush()
+
+    cfg = DigestConfig(destination_chat_id=None)
+    bot_mock = MagicMock()
+    bot_mock.send_message = AsyncMock()
+
+    result = await publish_digest(
+        db_session, bot=bot_mock, digest=digest, digest_config=cfg
+    )
+    assert result.status == "skipped_no_destination"
+    bot_mock.send_message.assert_not_called()
+
+
+async def test_publisher_rejects_non_draft_status(db_session):
+    """Calling publish on a posted row → DigestPublisherInvalidState."""
+    from bot.db.models import Digest
+    from bot.services.digest_publisher import (
+        DigestPublisherInvalidState,
+        publish_digest,
+    )
+    from bot.services.digests import DigestConfig
+
+    digest = Digest(
+        type="daily",
+        window_start=datetime.now(timezone.utc) - timedelta(days=1),
+        window_end=datetime.now(timezone.utc),
+        body_markdown="TL;DR.\n\n- One [[mv:1]]",
+        citations=[{"kind": "message_version", "id": 1, "position": 0}],
+        status="posted",
+        posted_chat_id=-42,
+        posted_message_id=999,
+        posted_at=datetime.now(timezone.utc),
+    )
+    db_session.add(digest)
+    await db_session.flush()
+
+    cfg = DigestConfig(destination_chat_id=-42)
+    bot_mock = MagicMock()
+    with pytest.raises(DigestPublisherInvalidState):
+        await publish_digest(
+            db_session, bot=bot_mock, digest=digest, digest_config=cfg
+        )
+
+
+async def test_publisher_happy_path_with_clean_citations(db_session):
+    """Insert real message+version + card+source, citations point to them,
+    publisher transitions draft→posting→posted."""
+    from bot.db.models import (
+        ChatMessage,
+        Digest,
+        KnowledgeCard,
+        CardSource,
+        MessageVersion,
+    )
+    from bot.db.repos.user import UserRepo
+    from bot.services.digest_publisher import publish_digest
+    from bot.services.digests import DigestConfig
+
+    chat_id = _next_chat_id()
+    uid = -1 * (5000 + next(_chat_counter))
+    await UserRepo.upsert(
+        db_session, telegram_id=uid, username=f"u{uid}", first_name="T", last_name=None
+    )
+    now = datetime.now(timezone.utc)
+    cm = ChatMessage(
+        message_id=900_000 + next(_chat_counter),
+        chat_id=chat_id,
+        user_id=uid,
+        text="hello",
+        date=now - timedelta(hours=6),
+        raw_json={"text": "hello"},
+        memory_policy="normal",
+        is_redacted=False,
+    )
+    db_session.add(cm)
+    await db_session.flush()
+    mv = MessageVersion(
+        chat_message_id=cm.id,
+        version_seq=1,
+        text="hello",
+        normalized_text="hello",
+        entities_json={"entities": []},
+        content_hash=f"h-{cm.id}",
+        is_redacted=False,
+    )
+    db_session.add(mv)
+    await db_session.flush()
+    cm.current_version_id = mv.id
+    await db_session.flush()
+
+    digest = Digest(
+        type="daily",
+        window_start=now - timedelta(days=1),
+        window_end=now,
+        body_markdown="TL;DR.\n\n- One bullet about hello.",
+        citations=[{"kind": "message_version", "id": mv.id, "position": 0}],
+        status="draft",
+    )
+    db_session.add(digest)
+    await db_session.flush()
+
+    cfg = DigestConfig(destination_chat_id=-1001234567890)
+    bot_mock = MagicMock()
+    bot_mock.send_message = AsyncMock()
+    sent_msg = MagicMock()
+    sent_msg.message_id = 777
+    bot_mock.send_message.return_value = sent_msg
+
+    result = await publish_digest(
+        db_session, bot=bot_mock, digest=digest, digest_config=cfg
+    )
+    assert result.status == "posted", f"got status={result.status} err={result.error_text}"
+    assert result.posted_message_id == 777
+    assert result.posted_chat_id == cfg.destination_chat_id
+    bot_mock.send_message.assert_awaited_once()
+
+
+async def test_redactor_masks_affected_bullet(db_session):
+    """Redactor with affected_mvids={mv.id} → bullet 0 masked, surviving cits filtered."""
+    from bot.db.models import Digest
+    from bot.services.digest_redactor import redact_digest_for_forget
+
+    digest = Digest(
+        type="daily",
+        window_start=datetime.now(timezone.utc) - timedelta(days=1),
+        window_end=datetime.now(timezone.utc),
+        body_markdown="TL;DR.\n\n- First [[mv:1]]\n- Second [[mv:2]]",
+        citations=[
+            {"kind": "message_version", "id": 1, "position": 0},
+            {"kind": "message_version", "id": 2, "position": 1},
+        ],
+        status="draft",
+    )
+    db_session.add(digest)
+    await db_session.flush()
+    did = digest.id
+
+    await redact_digest_for_forget(
+        db_session,
+        digest_id=did,
+        affected_mvids={1},
+        affected_card_source_ids=set(),
+        bot=None,  # no Telegram side-effect in test
+    )
+
+    # Re-fetch
+    row = (await db_session.execute(
+        text("SELECT body_markdown, citations, status FROM digests WHERE id = :id"),
+        {"id": did},
+    )).mappings().one()
+    assert row["status"] == "redacted"
+    assert "[REDACTED — забыто]" in row["body_markdown"]
+    assert "First" not in row["body_markdown"]
+    assert "Second" in row["body_markdown"]
+    # Surviving citation is mv:2.
+    assert len(row["citations"]) == 1
+    assert int(row["citations"][0]["id"]) == 2
+
+
+async def test_cascade_digests_layer_redacts_via_cascade_worker(db_session):
+    """Insert message + digest citing it, fire forget_event on the message,
+    run cascade worker → digest redacted, status='redacted'."""
+    from bot.db.models import (
+        ChatMessage,
+        Digest,
+        ForgetEvent,
+        MessageVersion,
+    )
+    from bot.db.repos.user import UserRepo
+    from bot.services.forget_cascade import run_cascade_worker_once
+
+    chat_id = _next_chat_id()
+    uid = -1 * (6000 + next(_chat_counter))
+    await UserRepo.upsert(
+        db_session, telegram_id=uid, username=f"u{uid}", first_name="T", last_name=None
+    )
+    now = datetime.now(timezone.utc)
+    cm = ChatMessage(
+        message_id=950_000 + next(_chat_counter),
+        chat_id=chat_id,
+        user_id=uid,
+        text="secret content",
+        date=now - timedelta(hours=6),
+        raw_json={"text": "secret content"},
+        memory_policy="normal",
+        is_redacted=False,
+    )
+    db_session.add(cm)
+    await db_session.flush()
+    mv = MessageVersion(
+        chat_message_id=cm.id,
+        version_seq=1,
+        text="secret content",
+        normalized_text="secret content",
+        entities_json={"entities": []},
+        content_hash=f"h-{cm.id}",
+        is_redacted=False,
+    )
+    db_session.add(mv)
+    await db_session.flush()
+    cm.current_version_id = mv.id
+
+    digest = Digest(
+        type="daily",
+        window_start=now - timedelta(days=1),
+        window_end=now,
+        body_markdown="TL;DR.\n\n- One bullet [[mv:" + str(mv.id) + "]]",
+        citations=[{"kind": "message_version", "id": mv.id, "position": 0}],
+        status="draft",
+    )
+    db_session.add(digest)
+    await db_session.flush()
+    did = digest.id
+
+    # Insert forget_event targeting this chat_message.
+    fe = ForgetEvent(
+        target_type="message",
+        target_id=str(cm.id),
+        actor_user_id=None,
+        authorized_by="self",
+        tombstone_key=f"message:{chat_id}:{cm.id}",
+        policy="forgotten",
+        status="pending",
+    )
+    db_session.add(fe)
+    await db_session.flush()
+
+    # Run cascade worker. This DOES touch many tables; we test only the
+    # contract: after the worker tick, the digest is status='redacted' and
+    # the body contains the REDACTED marker.
+    await run_cascade_worker_once(db_session, batch_size=10)
+
+    row = (await db_session.execute(
+        text("SELECT status, body_markdown FROM digests WHERE id = :id"),
+        {"id": did},
+    )).mappings().one()
+    assert row["status"] in ("redacted", "redacted_edit_failed"), (
+        f"got status={row['status']}"
+    )
+    assert "[REDACTED — забыто]" in row["body_markdown"]


### PR DESCRIPTION
## Summary

Phase 7 Wave 2, T7-05 — biggest sprint. Completes daily-digest side-effects (Telegram publish + forget cascade redaction).

## New modules

- `digest_renderer.py` — `render_digest_html()`. Strips citation tokens, truncates plain MD BEFORE escape+convert, tag-balance fallback, MSK footer.
- `digest_admin_notify.py` — `notify_admins_digest_failure()`. DM admin on actionable failures.
- `digest_publisher.py` — `publish_digest()` single-transaction publish holding row lock across `bot.send_message`. NOWAIT FOR UPDATE + 3 backoff retries. Defense-in-depth revalidation. Status state machine.
- `digest_redactor.py` — `redact_digest_for_forget()`. Masks bullets by citation `position` (bullet index, not token ordinal — #295 HIGH fix). Unconditional `bot.edit_message_text` + erratum follow-up on TelegramBadRequest + admin notify on TelegramForbiddenError.

## Extensions

- `forget_cascade.py`: new `_cascade_digests` layer placed BEFORE `card_sources` (per §5.H — card_source ids must be resolvable when JSONB scan runs). Uses typed bindparams (`PG_ARRAY(BigInteger)`, `PG_ARRAY(String)`) — semgrep-safe.
- `llm_gateway.py::_parse_digest_citations`: citation `position` is now 0-based BULLET INDEX (Codex finding from #295 HIGH).

## Test plan

- [x] 13 new tests pass: 6 renderer + 2 redactor (unit) + 4 publisher + 1 E2E cascade.
- [x] 33/33 existing forget_cascade tests still pass — no regression.
- [x] 53 Phase 7 tests total pass (digest_context + digests_run + scheduler + publisher).

## Phase 7.5 carryover addressed

Fixes HIGH item from #295 (bullet-index for redactor).

## What's NOT in this PR

- T7-06: admin handlers `/digest_now`, `/digest_preview`, `/digest_history`
- T7-07: Phase 11 binding tests (L7a/b + C6 + I5a/b/c)
- T7-08: closure docs

Tracks #111. Addresses #295 HIGH.

🤖 Generated with [Claude Code](https://claude.com/claude-code)