### PR TITLE
fix(p7-fhr): 6 closure-blocking FHR fixes for Phase 7 daily digests

### DIFF
--- a/bot/handlers/digest.py
+++ b/bot/handlers/digest.py
@@ -121,6 +121,23 @@ async def cmd_digest_now(
         return
 
     status = digest.status
+
+    # F6: handle concurrent publish in-flight — reaper will clean up stale
+    # 'posting' rows; admin should retry in a moment rather than re-publishing.
+    if status == "posting":
+        import asyncio
+
+        await asyncio.sleep(1)
+        await session.refresh(digest)
+        status = digest.status
+        if status == "posting":
+            await message.answer(
+                "Дайджест уже публикуется, попробуйте через минуту.",
+                parse_mode="HTML",
+            )
+            return
+        # fall through with refreshed status
+
     if status == "draft":
         try:
             digest = await publish_digest(

--- a/bot/services/digests.py
+++ b/bot/services/digests.py
@@ -24,7 +24,7 @@ import os
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from decimal import Decimal
-from typing import Any, Literal
+from typing import Literal
 
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -73,15 +73,27 @@ class DigestConfig:
         )
 
 
+class ConfigurationError(Exception):
+    """Digest configuration invariant violated."""
+
+
 def load_digest_config() -> DigestConfig:
+    src = int(os.environ.get("DIGEST_SOURCE_CHAT_ID", "0"))
     dest_env = os.environ.get("DIGEST_DESTINATION_CHAT_ID")
+    dst = int(dest_env) if dest_env else None
+    if src and dst is not None and src == dst:
+        raise ConfigurationError(
+            f"DIGEST_SOURCE_CHAT_ID ({src}) must not equal "
+            "DIGEST_DESTINATION_CHAT_ID — digest would post into the same "
+            "chat it summarizes (echo loop)."
+        )
     return DigestConfig(
         daily_cost_ceiling_usd=Decimal(os.environ.get("DIGEST_DAILY_USD_CEILING", "1.00")),
         monthly_cost_ceiling_usd=Decimal(
             os.environ.get("DIGEST_MONTHLY_USD_CEILING", "10.00")
         ),
-        source_chat_id=int(os.environ.get("DIGEST_SOURCE_CHAT_ID", "0")),
-        destination_chat_id=int(dest_env) if dest_env else None,
+        source_chat_id=src,
+        destination_chat_id=dst,
         hour_msk=int(os.environ.get("DIGEST_HOUR_MSK", "9")),
         min_cards_threshold=int(os.environ.get("DIGEST_MIN_CARDS_THRESHOLD", "3")),
         raw_message_top_n=int(os.environ.get("DIGEST_RAW_MESSAGE_TOP_N", "15")),
@@ -182,11 +194,14 @@ async def run_digest(
         )
     ).scalar_one_or_none()
     if existing is not None:
-        result = await session.execute(
-            text("SELECT * FROM digests WHERE id = :id"), {"id": existing}
-        )
-        row = result.mappings().one()
-        return _row_to_digest(row)
+        # Use session.get() so the returned object is session-tracked (identity map).
+        # _row_to_digest() returned a detached Digest() whose state mutations would
+        # NOT propagate to the DB — publisher state transitions (draft→posting→posted)
+        # would silently fail.
+        digest = await session.get(Digest, existing)
+        if digest is None:
+            raise RuntimeError(f"digest {existing} disappeared after FOR UPDATE")
+        return digest
 
     # Step 2 — Phase 7 separate-bucket cost ceiling pre-check.
     if await _cost_ceiling_breached(session, digest_config=digest_config):
@@ -312,20 +327,3 @@ async def run_digest(
     return digest
 
 
-def _row_to_digest(row: Any) -> Digest:
-    """Hydrate an in-flight Digest ORM object from a mappings row."""
-    return Digest(
-        id=row["id"],
-        type=row["type"],
-        window_start=row["window_start"],
-        window_end=row["window_end"],
-        body_markdown=row["body_markdown"],
-        citations=row["citations"],
-        status=row["status"],
-        llm_usage_ledger_id=row.get("llm_usage_ledger_id"),
-        posted_chat_id=row.get("posted_chat_id"),
-        posted_message_id=row.get("posted_message_id"),
-        posted_at=row.get("posted_at"),
-        posting_started_at=row.get("posting_started_at"),
-        error_text=row.get("error_text"),
-    )

--- a/bot/services/forget_cascade.py
+++ b/bot/services/forget_cascade.py
@@ -38,6 +38,7 @@ import logging
 import struct
 from typing import Any
 
+from aiogram import Bot
 from sqlalchemy import delete, func, select, text, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -962,7 +963,7 @@ async def _resolve_affected_mvids(session: AsyncSession, event) -> list[int]:
     return []
 
 
-async def _process_one_event(session: AsyncSession, event) -> None:
+async def _process_one_event(session: AsyncSession, event, bot: Bot | None = None) -> None:
     """Run the full cascade for a single (already-claimed) forget_event row.
 
     **Naming note (issue #260 / PHASE6_PLAN.md §5.A.5):** This function IS the
@@ -999,6 +1000,10 @@ async def _process_one_event(session: AsyncSession, event) -> None:
     outer transaction. Closes H-Cdx-2 race window: ``/approve`` and cascade
     cannot interleave on the same mvid set.
     """
+    # Thread bot through to _cascade_digests → redact_digest_for_forget so the
+    # Telegram edit_message_text side-effect fires in production (F2 fix).
+    event._runtime_bot = bot
+
     # Snapshot current per-layer progress so we can resume.
     cascade_state: dict[str, Any] = dict(event.cascade_status or {})
 
@@ -1135,6 +1140,7 @@ async def _process_one_event(session: AsyncSession, event) -> None:
 async def run_cascade_worker_once(
     session: AsyncSession,
     *,
+    bot: Bot | None = None,
     batch_size: int = 10,
 ) -> dict[str, int]:
     """Process up to ``batch_size`` pending forget_events.
@@ -1148,6 +1154,9 @@ async def run_cascade_worker_once(
     Per-event isolation: a failure in one event's cascade marks ONLY that event
     as ``failed`` and continues with the rest of the batch. The function returns
     normally even if some events failed.
+
+    ``bot`` is threaded through to ``_process_one_event`` so the Telegram
+    redaction side-effect (``bot.edit_message_text``) fires for posted digests.
     """
     pending = await ForgetEventRepo.list_pending(session, limit=batch_size)
     stats = {"claimed": 0, "processed": 0, "failed": 0}
@@ -1169,7 +1178,7 @@ async def run_cascade_worker_once(
         stats["claimed"] += 1
 
         try:
-            await _process_one_event(session, claimed)
+            await _process_one_event(session, claimed, bot=bot)
             stats["processed"] += 1
         except Exception:
             logger.exception(
@@ -1183,6 +1192,7 @@ async def run_cascade_worker_once(
 
 
 async def cascade_worker_tick(
+    bot: Bot | None = None,
     session: AsyncSession | None = None,
     *,
     batch_size: int = 10,
@@ -1199,6 +1209,8 @@ async def cascade_worker_tick(
     - Production: APScheduler tick. ``session`` is None — the function opens
       its own session via ``async_session()`` and commits at the end (same
       pattern as ``process_invite_outbox`` and ``check_intro_refresh``).
+      ``bot`` is the first positional arg to match APScheduler ``args=[bot]``
+      registration so the Telegram redaction side-effect fires in production.
     - Tests: an explicit ``session`` is passed; the function uses it directly
       WITHOUT committing, so outer-tx isolation is preserved.
 
@@ -1208,14 +1220,16 @@ async def cascade_worker_tick(
     if session is not None:
         if not await FeatureFlagRepo.get(session, CASCADE_WORKER_FLAG):
             return {"claimed": 0, "processed": 0, "failed": 0}
-        return await run_cascade_worker_once(session, batch_size=batch_size)
+        return await run_cascade_worker_once(session, bot=bot, batch_size=batch_size)
 
     # Production path: own session + commit on success.
     async with async_session() as own_session:
         if not await FeatureFlagRepo.get(own_session, CASCADE_WORKER_FLAG):
             return {"claimed": 0, "processed": 0, "failed": 0}
         try:
-            stats = await run_cascade_worker_once(own_session, batch_size=batch_size)
+            stats = await run_cascade_worker_once(
+                own_session, bot=bot, batch_size=batch_size
+            )
             await own_session.commit()
             return stats
         except Exception:

--- a/bot/services/llm_gateway.py
+++ b/bot/services/llm_gateway.py
@@ -1449,7 +1449,9 @@ def _parse_digest_citations(
     """
     citations: list[dict[str, Any]] = []
     dropped: list[str] = []
-    seen_keys: set[tuple[str, str]] = set()
+    # No dedup by (kind, id): the same source may appear in multiple bullets, each
+    # occurrence must produce its own entry with the correct bullet position so the
+    # redactor can mask every affected bullet on forget cascade.
     for match in _CITATION_TOKEN_RE.finditer(body_markdown):
         kind_raw, id_raw = match.group(1), match.group(2)
         token = match.group(0)
@@ -1461,10 +1463,6 @@ def _parse_digest_citations(
             if id_raw not in valid_card_source_ids:
                 dropped.append(token)
                 continue
-            key = ("card_source", id_raw)
-            if key in seen_keys:
-                continue
-            seen_keys.add(key)
             citations.append(
                 {"kind": "card_source", "id": id_raw, "position": bullet_idx}
             )
@@ -1477,10 +1475,6 @@ def _parse_digest_citations(
             if mv_int not in valid_mv_ids:
                 dropped.append(token)
                 continue
-            key = ("message_version", str(mv_int))
-            if key in seen_keys:
-                continue
-            seen_keys.add(key)
             citations.append(
                 {"kind": "message_version", "id": mv_int, "position": bullet_idx}
             )

--- a/bot/services/scheduler.py
+++ b/bot/services/scheduler.py
@@ -340,6 +340,28 @@ async def digest_daily_job(bot: Bot) -> None:
                     digest.id,
                     digest.status,
                 )
+
+                # AC #6: auto-post draft digest to destination channel.
+                if digest.status == "draft":
+                    try:
+                        from bot.services.digest_publisher import publish_digest
+
+                        await publish_digest(
+                            session,
+                            bot=bot,
+                            digest=digest,
+                            digest_config=digest_config,
+                        )
+                        await session.commit()
+                    except Exception:
+                        try:
+                            await session.rollback()
+                        except Exception:
+                            logger.exception(
+                                "digest_daily_job: publish rollback failed"
+                            )
+                        logger.exception("digest_daily_job: publish_digest failed")
+
             except Exception:
                 try:
                     await session.rollback()
@@ -449,6 +471,7 @@ def start_scheduler(bot: Bot) -> None:
         cascade_worker_tick,
         "interval",
         seconds=30,
+        args=[bot],  # F2: thread bot through so Telegram redaction side-effect fires
         id="forget_cascade_worker",
         replace_existing=True,
         max_instances=1,

--- a/tests/services/test_digest_handlers.py
+++ b/tests/services/test_digest_handlers.py
@@ -47,6 +47,59 @@ def _mk_msg(user_id: int) -> MagicMock:
 # ── /digest_now ──────────────────────────────────────────────────────────────
 
 
+async def test_digest_now_posting_status_returns_wait_message(db_session, monkeypatch):
+    """F6: when run_digest returns status='posting', cmd_digest_now must NOT attempt
+    to publish again and must reply with a 'try later' message."""
+    from bot.config import settings
+    from bot.db.models import Digest
+    from bot.handlers.digest import cmd_digest_now
+
+    admin_id = list(settings.ADMIN_IDS)[0] if settings.ADMIN_IDS else 1
+
+    # Insert a digest that is stuck in 'posting' status
+    now = datetime.now(timezone.utc)
+    posting_digest = Digest(
+        type="daily",
+        window_start=now - timedelta(days=1),
+        window_end=now,
+        body_markdown="TL;DR.\n\n- Bullet [[mv:1]]",
+        citations=[{"kind": "message_version", "id": 1, "position": 0}],
+        status="posting",
+    )
+    db_session.add(posting_digest)
+    await db_session.flush()
+
+    publish_called = []
+
+    async def _fake_run_digest(*args, **kwargs):
+        return posting_digest
+
+    async def _fake_publish(*args, **kwargs):
+        publish_called.append(True)
+        return posting_digest
+
+    monkeypatch.setattr("bot.handlers.digest.run_digest", _fake_run_digest)
+    monkeypatch.setattr("bot.handlers.digest.publish_digest", _fake_publish)
+
+    bot_mock = MagicMock()
+    msg = _mk_msg(user_id=admin_id)
+    await cmd_digest_now(
+        msg, bot=bot_mock, session=db_session, command=_mk_command_obj("daily")
+    )
+
+    assert len(publish_called) == 0, "publish_digest must NOT be called when status='posting'"
+    msg.answer.assert_awaited_once()
+    args, kwargs = msg.answer.call_args
+    body = args[0] if args else kwargs.get("text", "")
+    # Must be a friendly "try again" message, NOT the generic error reply (which starts with "❌")
+    assert not body.startswith("❌"), (
+        f"Expected friendly wait-message for 'posting' status, but got error reply: {body!r}"
+    )
+    assert "попробуйте" in body.lower(), (
+        f"Expected 'попробуйте' in reply for posting status, got: {body!r}"
+    )
+
+
 async def test_digest_now_non_admin_silent_no_op(db_session):
     """Non-admin user: handler returns silently — no message.answer call."""
     from bot.handlers.digest import cmd_digest_now

--- a/tests/services/test_digest_publisher.py
+++ b/tests/services/test_digest_publisher.py
@@ -299,6 +299,184 @@ async def test_redactor_masks_affected_bullet(db_session):
     assert int(row["citations"][0]["id"]) == 2
 
 
+async def test_idempotency_path_returns_session_attached_digest(db_session):
+    """F4: when run_digest returns a digest via the idempotency path (row already exists),
+    the returned object must be session-attached so mutations to its state persist.
+
+    Previously _row_to_digest() returned a detached Digest() constructed with the
+    primary key from a raw SQL SELECT — SQLAlchemy would NOT track mutations on that
+    object. After the fix (session.get(Digest, id)), the same ORM identity is returned
+    and mutations propagate to the DB on flush.
+    """
+    from decimal import Decimal
+    from bot.db.models import Digest
+    from bot.db.repos.llm_usage_ledger import LedgerRepo
+    from bot.services.digests import DigestConfig, run_digest
+    from bot.services.llm_gateway import LLMGatewayConfig
+
+    chat_id = _next_chat_id()
+    now = datetime.now(timezone.utc)
+    ws = now - timedelta(days=1)
+    we = now
+
+    # Pre-insert a draft digest for the same window (simulates first run)
+    pre_existing = Digest(
+        type="daily",
+        window_start=ws,
+        window_end=we,
+        body_markdown="TL;DR.\n\n- Pre-existing",
+        citations=[],
+        status="draft",
+    )
+    db_session.add(pre_existing)
+    await db_session.flush()
+    pre_id = pre_existing.id
+
+    # Second call with the same window — must hit idempotency path
+    gateway_config = LLMGatewayConfig(
+        provider="anthropic",
+        model="claude-haiku-4-5-20251001",
+        daily_ceiling_usd=Decimal("10.00"),
+        monthly_ceiling_usd=Decimal("100.00"),
+        prompt_template_version="digest-v0.1.0",
+    )
+    digest_config = DigestConfig(source_chat_id=chat_id)
+    idempotency_digest = await run_digest(
+        db_session,
+        type="daily",
+        window_start=ws,
+        window_end=we,
+        ledger_repo=LedgerRepo(),
+        provider=None,  # not reached — idempotency returns early
+        config=gateway_config,
+        digest_config=digest_config,
+    )
+    assert idempotency_digest.id == pre_id, "idempotency must return same row"
+
+    # Critical: verify the returned object is session-attached.
+    # If it were detached, `session.get(Digest, pre_id)` would return a DIFFERENT
+    # Python object (the identity-map entry) and mutations on `idempotency_digest`
+    # would not be visible. With session.get(), both must be the same object.
+    attached_from_session = await db_session.get(Digest, pre_id)
+    assert attached_from_session is idempotency_digest, (
+        "run_digest idempotency path must return the session-tracked ORM identity, "
+        "not a detached copy. If this fails, state mutations (draft→posting→posted) "
+        "silently do not persist."
+    )
+
+    # Also verify that mutating the returned object does persist to the DB.
+    idempotency_digest.status = "posting"
+    await db_session.flush()
+    row = (await db_session.execute(
+        __import__("sqlalchemy").text("SELECT status FROM digests WHERE id = :id"),
+        {"id": pre_id},
+    )).mappings().one()
+    assert row["status"] == "posting", (
+        f"Mutation on idempotency-returned digest must persist, got {row['status']!r}"
+    )
+
+
+async def test_cascade_worker_with_bot_calls_edit_message_text(db_session):
+    """F2: when bot is threaded through cascade_worker_tick → run_cascade_worker_once
+    → _process_one_event → _cascade_digests → redact_digest_for_forget, the
+    bot.edit_message_text call must happen for a 'posted' digest.
+
+    Without the fix, bot is never passed through the call chain and the
+    Telegram side-effect (_cascade_digests calls redact_digest_for_forget(bot=None))
+    is silently skipped in production.
+    """
+    from bot.db.models import (
+        ChatMessage,
+        Digest,
+        ForgetEvent,
+        MessageVersion,
+    )
+    from bot.db.repos.user import UserRepo
+    from bot.services.forget_cascade import run_cascade_worker_once
+
+    chat_id = _next_chat_id()
+    uid = -1 * (7000 + next(_chat_counter))
+    await UserRepo.upsert(
+        db_session, telegram_id=uid, username=f"u{uid}", first_name="T", last_name=None
+    )
+    now = datetime.now(timezone.utc)
+    cm = ChatMessage(
+        message_id=960_000 + next(_chat_counter),
+        chat_id=chat_id,
+        user_id=uid,
+        text="secret content",
+        date=now - timedelta(hours=6),
+        raw_json={"text": "secret content"},
+        memory_policy="normal",
+        is_redacted=False,
+    )
+    db_session.add(cm)
+    await db_session.flush()
+    mv = MessageVersion(
+        chat_message_id=cm.id,
+        version_seq=1,
+        text="secret content",
+        normalized_text="secret content",
+        entities_json={"entities": []},
+        content_hash=f"h2-{cm.id}",
+        is_redacted=False,
+    )
+    db_session.add(mv)
+    await db_session.flush()
+    cm.current_version_id = mv.id
+
+    # Digest is 'posted' — has a posted_message_id so redactor will try edit_message_text
+    digest = Digest(
+        type="daily",
+        window_start=now - timedelta(days=1),
+        window_end=now,
+        body_markdown=f"TL;DR.\n\n- One bullet [[mv:{mv.id}]]",
+        citations=[{"kind": "message_version", "id": mv.id, "position": 0}],
+        status="posted",
+        posted_chat_id=-1009999999999,
+        posted_message_id=555,
+        posted_at=now - timedelta(minutes=5),
+    )
+    db_session.add(digest)
+    await db_session.flush()
+    did = digest.id
+
+    fe = ForgetEvent(
+        target_type="message",
+        target_id=str(cm.id),
+        actor_user_id=None,
+        authorized_by="self",
+        tombstone_key=f"message:{chat_id}:{cm.id}:b2",
+        policy="forgotten",
+        status="pending",
+    )
+    db_session.add(fe)
+    await db_session.flush()
+
+    # Set up bot mock — edit_message_text must be called
+    bot_mock = MagicMock()
+    bot_mock.edit_message_text = AsyncMock(return_value=MagicMock())
+
+    # Pass bot through the cascade chain
+    await run_cascade_worker_once(db_session, bot=bot_mock, batch_size=10)
+
+    # The bot.edit_message_text call must have happened — proves bot threading works
+    assert bot_mock.edit_message_text.called, (
+        "bot.edit_message_text must be called when bot is threaded through "
+        "run_cascade_worker_once. Without F2 fix, bot is never forwarded and "
+        "the Telegram redaction side-effect is silently skipped."
+    )
+
+    # Verify the digest was also properly redacted in the DB
+    row = (await db_session.execute(
+        __import__("sqlalchemy").text("SELECT status FROM digests WHERE id = :id"),
+        {"id": did},
+    )).mappings().one()
+    assert row["status"] in ("redacted", "redacted_edit_failed"), (
+        f"Digest must be redacted after cascade, got status={row['status']!r}"
+    )
+
+
 async def test_cascade_digests_layer_redacts_via_cascade_worker(db_session):
     """Insert message + digest citing it, fire forget_event on the message,
     run cascade worker → digest redacted, status='redacted'."""

--- a/tests/services/test_digest_scheduler.py
+++ b/tests/services/test_digest_scheduler.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import itertools
 from datetime import datetime, timezone, timedelta
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from sqlalchemy import text

--- a/tests/services/test_digest_scheduler.py
+++ b/tests/services/test_digest_scheduler.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import itertools
 from datetime import datetime, timezone, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from sqlalchemy import text
@@ -152,6 +153,116 @@ async def test_digest_daily_job_no_op_when_flag_off(db_session, monkeypatch):
         text("SELECT COUNT(*) FROM digests")
     )).scalar_one()
     assert count_after == count_before
+
+
+async def test_digest_daily_job_calls_publish_when_draft(db_session, monkeypatch):
+    """F1: digest_daily_job must call publish_digest when run_digest returns status='draft'.
+
+    This exercises the full job path via monkeypatching:
+    - async_session() replaced with a context manager yielding db_session
+    - FeatureFlagRepo.get patched to return True
+    - run_digest patched to return a stub draft digest
+    - publish_digest patched to assert it is called
+    """
+    from bot.db.models import Digest as DigestModel
+
+    # A stub digest in 'draft' status
+    stub_digest = DigestModel(
+        type="daily",
+        window_start=datetime.now(timezone.utc) - timedelta(days=1),
+        window_end=datetime.now(timezone.utc),
+        body_markdown="- A [[mv:1]]",
+        citations=[{"kind": "message_version", "id": 1, "position": 0}],
+        status="draft",
+    )
+
+    publish_called = []
+
+    import bot.services.scheduler as scheduler_mod
+
+    # Patch async_session to use our test session
+    from contextlib import asynccontextmanager
+
+    @asynccontextmanager
+    async def _fake_async_session():
+        yield db_session
+
+    monkeypatch.setattr(scheduler_mod, "async_session", _fake_async_session)
+    monkeypatch.setattr(
+        "bot.db.repos.feature_flag.FeatureFlagRepo.get",
+        AsyncMock(return_value=True),
+    )
+    monkeypatch.setattr(
+        "bot.services.digests.run_digest",
+        AsyncMock(return_value=stub_digest),
+    )
+
+    async def _fake_publish(session, *, bot, digest, digest_config):
+        publish_called.append(digest)
+        digest.status = "posted"
+        return digest
+
+    monkeypatch.setattr(
+        "bot.services.digest_publisher.publish_digest",
+        _fake_publish,
+    )
+
+    fake_bot = MagicMock()
+    await scheduler_mod.digest_daily_job(fake_bot)
+
+    assert len(publish_called) == 1, (
+        f"publish_digest must be called exactly once when digest is 'draft', got {len(publish_called)} calls"
+    )
+
+
+async def test_digest_daily_job_skips_publish_when_skipped(db_session, monkeypatch):
+    """F1: digest_daily_job must NOT call publish_digest when run_digest returns status='skipped'."""
+    from bot.db.models import Digest as DigestModel
+
+    stub_digest = DigestModel(
+        type="daily",
+        window_start=datetime.now(timezone.utc) - timedelta(days=1),
+        window_end=datetime.now(timezone.utc),
+        body_markdown=None,
+        citations=[],
+        status="skipped",
+    )
+
+    publish_called = []
+
+    import bot.services.scheduler as scheduler_mod
+
+    from contextlib import asynccontextmanager
+
+    @asynccontextmanager
+    async def _fake_async_session():
+        yield db_session
+
+    monkeypatch.setattr(scheduler_mod, "async_session", _fake_async_session)
+    monkeypatch.setattr(
+        "bot.db.repos.feature_flag.FeatureFlagRepo.get",
+        AsyncMock(return_value=True),
+    )
+    monkeypatch.setattr(
+        "bot.services.digests.run_digest",
+        AsyncMock(return_value=stub_digest),
+    )
+
+    async def _fake_publish(session, *, bot, digest, digest_config):
+        publish_called.append(digest)
+        return digest
+
+    monkeypatch.setattr(
+        "bot.services.digest_publisher.publish_digest",
+        _fake_publish,
+    )
+
+    fake_bot = MagicMock()
+    await scheduler_mod.digest_daily_job(fake_bot)
+
+    assert len(publish_called) == 0, (
+        f"publish_digest must NOT be called for skipped digest, got {len(publish_called)} calls"
+    )
 
 
 async def test_digest_daily_job_window_computation():

--- a/tests/services/test_digests_run.py
+++ b/tests/services/test_digests_run.py
@@ -196,6 +196,17 @@ def test_load_digest_config_reads_env_vars(monkeypatch):
     assert cfg.token_budget_input == 4000
 
 
+def test_load_digest_config_raises_when_src_equals_dst(monkeypatch):
+    """F5: src==dst is an echo-loop misconfiguration and must raise ConfigurationError."""
+    monkeypatch.setenv("DIGEST_SOURCE_CHAT_ID", "-99999")
+    monkeypatch.setenv("DIGEST_DESTINATION_CHAT_ID", "-99999")
+
+    from bot.services.digests import ConfigurationError, load_digest_config
+
+    with pytest.raises(ConfigurationError, match="echo loop"):
+        load_digest_config()
+
+
 def test_parse_citations_drops_card_kind_token():
     from bot.services.llm_gateway import _parse_digest_citations
 
@@ -228,6 +239,29 @@ def test_parse_citations_keeps_valid_mv():
     assert len(citations) == 1
     assert citations[0]["kind"] == "message_version"
     assert citations[0]["id"] == 123
+
+
+def test_parse_citations_preserves_duplicate_positions():
+    """F3: same source cited in two bullets must produce two citation entries with
+    distinct positions — dedup by (kind, id) is a privacy gap for the redactor."""
+    from bot.services.llm_gateway import _parse_digest_citations
+
+    # Same mv:123 cited in two different bullets (positions 0 and 1)
+    body = (
+        "TL;DR text.\n"
+        "\n"
+        "- Bullet A [[mv:123]] first mention\n"
+        "- Bullet B [[mv:123]] second mention\n"
+    )
+    citations, dropped = _parse_digest_citations(
+        body, valid_card_source_ids=frozenset(), valid_mv_ids=frozenset({123})
+    )
+    assert dropped == [], f"unexpected drops: {dropped}"
+    assert len(citations) == 2, (
+        f"Expected 2 citations (one per bullet), got {len(citations)}: {citations}"
+    )
+    positions = {c["position"] for c in citations}
+    assert len(positions) == 2, f"Both citations must have distinct positions: {citations}"
 
 
 def test_validate_every_bullet_has_citation_raises_on_empty():


### PR DESCRIPTION
## Summary

Final Holistic Review for Phase 7 (combined Claude `deep-product-reviewer` + Codex deep-technical) returned **NEEDS_FIXES**. 6 items independently verified against source. This PR closes all of them.

## Fixes

| # | Sev | File | What was broken | Fix |
|---|-----|------|-----------------|-----|
| F1 | CRIT (C1) | `bot/services/scheduler.py` | `digest_daily_job` returned drafts but never called `publish_digest` → Charter AC #6 violated, no Telegram message ever posted by cron | After `run_digest` commit, if `status='draft'` → call `publish_digest`. EMPTY_WINDOW / cost_exceeded / skipped paths NOT auto-published. |
| F2 | CRIT (C2) | `bot/services/scheduler.py` + `bot/services/forget_cascade.py` | `cascade_worker_tick` registered without `args=[bot]`; nothing set `event._runtime_bot`. Result: `digest_redactor.py` skipped `bot.edit_message_text` in prod → forgotten content stayed visible in posted Telegram digests forever | Threaded `bot` through `cascade_worker_tick → run_cascade_worker_once → _process_one_event`; set `event._runtime_bot = bot` before cascade layer dispatch. Scheduler reg uses `args=[bot]`. |
| F3 | CRIT (Codex-C2) | `bot/services/llm_gateway.py` | `_parse_digest_citations` deduped by `(kind, id)` → multi-bullet citations to same source kept only first `position`. Forget masked only one bullet, leaving forgotten-source-derived content in others | Removed `seen_keys` dedup for `mv`/`cs`; all bullet positions preserved. Redactor's existing `bullet_indices_to_mask` set handles repeats correctly. |
| F4 | CRIT (Codex-C3) | `bot/services/digests.py` | Idempotency-collision path returned `_row_to_digest(row)` — a detached `Digest()` instance. Publisher's `digest.status='posting'` mutation never persisted → guarded `posted` UPDATE saw `draft` and failed → untracked external Telegram post | Replaced with `await session.get(Digest, existing)` → session-attached ORM object. Removed now-unused `_row_to_digest` + `Any` import. |
| F5 | HIGH (H1) | `bot/services/digests.py` | `load_digest_config()` read `DIGEST_SOURCE_CHAT_ID` and `DIGEST_DESTINATION_CHAT_ID` but never compared → digest could post into the same chat it summarizes (echo loop). Plan §8 explicitly required stop signal | Added `ConfigurationError` raised on `src == dst` (non-zero). |
| F6 | HIGH (H2) | `bot/handlers/digest.py` | `/digest_now` had no `status='posting'` branch — concurrent admin invocation fell through to catch-all error. Plan §5.I required polite retry message | Added `elif status == 'posting'` branch: refresh once after 1s; if still posting → reply "Дайджест уже публикуется, попробуйте через минуту." |

## Tests added (all went red → green)

- F1: `test_digest_daily_job_calls_publish_when_draft`, `test_digest_daily_job_skips_publish_when_skipped`
- F2: `test_cascade_worker_with_bot_calls_edit_message_text`
- F3: `test_parse_citations_preserves_duplicate_positions`
- F4: `test_idempotency_path_returns_session_attached_digest`
- F5: `test_load_digest_config_raises_when_src_equals_dst`
- F6: `test_digest_now_posting_status_returns_wait_message`

## Verification

- Full suite local: **1128 passed, 1 skipped, 1 pre-existing failure** unrelated to this PR (`test_llm_gateway_extract_candidates.py::test_live_gateway_adapter_satisfies_protocol_and_delegates` — missing `@pytest.mark.usefixtures("app_env")`; reproducible on `main@ca96e6e`).
- `scripts/lint_privacy_check.sh` exit `0`.

## Out of scope (carryovers)

- #291 shared forget-events predicate refactor — separate ticket
- FHR Medium items: provider-error categorization (#295), GIN index choice for `digests.citations`, prompt-injection hardening in `llm_prompts/digest_v0_1_0.py`, admin rate limiting
- FHR Low items: renderer 4096-char edge, `author_display` raw `first_name`, `__import__("json")` cosmetic
- The pre-existing `test_live_gateway_adapter_satisfies_protocol_and_delegates` failure

## Test plan

- [x] Unit tests for each fix
- [x] Privacy lint green
- [x] Full local suite — no regressions
- [ ] CI green on PR
- [ ] FHR re-review on fix diff (smaller surface)