### PR TITLE
feat(p8-t8-01): migration 038 — Phase 8 review-gate schema extension

### DIFF
--- a/alembic/versions/038_extend_digests_review_states.py
+++ b/alembic/versions/038_extend_digests_review_states.py
@@ -1,0 +1,266 @@
+"""extend_digests_review_states
+
+T8-01 / Phase 8: extend the Phase 7 ``digests`` + ``digest_runs`` schema for
+the weekly editorial digest review-gate state machine.
+
+Upgrade (see ``PHASE8_PLAN.md §5.A`` for the full rationale):
+
+1. Widen ``ck_digests_status`` from 10 → 14 values, adding ``awaiting_review``,
+   ``approved_for_publish``, ``rejected_by_admin``, ``rejected_by_reaper``.
+2. Widen ``ck_digest_runs_status`` from 6 → 11 audit values, adding
+   ``awaiting_review``, ``approved_for_publish``, ``rejected_by_admin``,
+   ``rejected_by_reaper``, ``regenerated_by_admin``.
+3. Add 4 nullable columns supporting admin attribution + reviewer-bookkeeping
+   on ``digests``: ``published_by_admin_id BIGINT``, ``approved_at TIMESTAMPTZ``,
+   ``review_notes TEXT``, ``awaiting_review_at TIMESTAMPTZ``.
+4. Widen ``ck_digests_body_markdown_not_null_for_visible_statuses`` to include
+   ``awaiting_review``, ``approved_for_publish``, ``rejected_by_admin``,
+   ``rejected_by_reaper`` (body required for visible / audit-trail states).
+5. Add partial index ``ix_digests_status_awaiting_review`` keyed on
+   ``awaiting_review_at`` WHERE ``status='awaiting_review'`` — drives the
+   stale-review reaper scan.
+6. Add ``ck_digests_approved_audit``: when ``type='weekly'`` AND
+   ``status='approved_for_publish'``, both ``published_by_admin_id`` and
+   ``approved_at`` MUST be NOT NULL. Daily digests are exempt (auto-publish
+   leaves the audit columns NULL forever).
+
+H1 — every CHECK addition uses the ``NOT VALID`` + ``VALIDATE`` pattern: drop
+the existing constraint (brief AccessExclusiveLock, ≤ms), add the new one as
+``NOT VALID`` (instant), then ``VALIDATE`` it (scans the table without blocking
+writers). For the small ``digests`` / ``digest_runs`` tables this is paranoid
+optimization, but it is the project-wide alembic convention.
+
+Downgrade pre-flight: ``DO $$ ... $$`` block raises RAISE EXCEPTION if ANY row
+exists with status in the Phase-8 review-only set OR in ``posting`` (H2 — both
+daily AND weekly ``posting`` rows block, because dropping the audit columns
+under an in-flight publish breaks the publisher's ``RETURNING`` clause /
+columns the publisher reads). The error message points operators to the
+stale-posting reaper (which sweeps every 5 minutes) and to the downgrade
+runbook section in ``PHASE8_ROLLOUT.md`` (when present).
+
+Rollback scope: only ``digests`` table CHECK constraints + new columns + the
+partial index + the ``digest_runs.status`` CHECK. No other tables, no FK
+changes, no data migration.
+
+Revision ID: 038
+Revises: 037
+Create Date: 2026-05-15
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "038"
+down_revision: Union[str, Sequence[str], None] = "037"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+# Status constants for readability ─────────────────────────────────────────────
+_DIGESTS_STATUS_PHASE7 = (
+    "'running','draft','posting','posted','failed','skipped',"
+    "'cost_exceeded','skipped_no_destination','redacted',"
+    "'redacted_edit_failed'"
+)
+_DIGESTS_STATUS_PHASE8 = (
+    _DIGESTS_STATUS_PHASE7 + "," + "'awaiting_review','approved_for_publish',"
+    "'rejected_by_admin','rejected_by_reaper'"
+)
+_RUNS_STATUS_PHASE7 = (
+    "'running','finished','failed','skipped','cost_exceeded','skipped_no_destination'"
+)
+_RUNS_STATUS_PHASE8 = (
+    _RUNS_STATUS_PHASE7 + "," + "'awaiting_review','approved_for_publish',"
+    "'rejected_by_admin','rejected_by_reaper','regenerated_by_admin'"
+)
+
+
+def upgrade() -> None:
+    # ── Group 1: widen digests.status CHECK (10 → 14 values) ────────────────
+    op.execute("ALTER TABLE digests DROP CONSTRAINT ck_digests_status")
+    op.execute(
+        f"""
+        ALTER TABLE digests ADD CONSTRAINT ck_digests_status CHECK (
+            status IN ({_DIGESTS_STATUS_PHASE8})
+        ) NOT VALID
+        """
+    )
+    op.execute("ALTER TABLE digests VALIDATE CONSTRAINT ck_digests_status")
+
+    # ── Group 2: widen digest_runs.status CHECK (6 → 11 audit values) ───────
+    op.execute("ALTER TABLE digest_runs DROP CONSTRAINT ck_digest_runs_status")
+    op.execute(
+        f"""
+        ALTER TABLE digest_runs ADD CONSTRAINT ck_digest_runs_status CHECK (
+            status IN ({_RUNS_STATUS_PHASE8})
+        ) NOT VALID
+        """
+    )
+    op.execute("ALTER TABLE digest_runs VALIDATE CONSTRAINT ck_digest_runs_status")
+
+    # ── Group 3: new columns supporting the review workflow ─────────────────
+    op.execute("ALTER TABLE digests ADD COLUMN published_by_admin_id BIGINT NULL")
+    op.execute("ALTER TABLE digests ADD COLUMN approved_at TIMESTAMP WITH TIME ZONE NULL")
+    op.execute("ALTER TABLE digests ADD COLUMN review_notes TEXT NULL")
+    op.execute("ALTER TABLE digests ADD COLUMN awaiting_review_at TIMESTAMP WITH TIME ZONE NULL")
+
+    # ── Group 4: widen body-NOT-NULL invariant to review-bearing statuses ───
+    op.execute(
+        "ALTER TABLE digests DROP CONSTRAINT ck_digests_body_markdown_not_null_for_visible_statuses"
+    )
+    op.execute(
+        """
+        ALTER TABLE digests ADD CONSTRAINT
+        ck_digests_body_markdown_not_null_for_visible_statuses CHECK (
+            status NOT IN (
+                'draft','posting','posted','redacted','redacted_edit_failed',
+                'awaiting_review','approved_for_publish','rejected_by_admin',
+                'rejected_by_reaper'
+            )
+            OR body_markdown IS NOT NULL
+        ) NOT VALID
+        """
+    )
+    op.execute(
+        "ALTER TABLE digests VALIDATE CONSTRAINT "
+        "ck_digests_body_markdown_not_null_for_visible_statuses"
+    )
+
+    # ── Group 5: partial index + approval-audit CHECK ───────────────────────
+    op.execute(
+        """
+        CREATE INDEX ix_digests_status_awaiting_review
+            ON digests (awaiting_review_at)
+            WHERE status='awaiting_review'
+        """
+    )
+
+    # Audit CHECK: when status='approved_for_publish' AND type='weekly',
+    # both admin attribution columns MUST be NOT NULL. Daily digests are
+    # exempt (auto-publish leaves audit cols NULL by design). Posting /
+    # posted weekly rows must also have these set, but the constraint only
+    # asserts the implication for the approved_for_publish snapshot — the
+    # publisher copies these cols forward across the posting → posted edge.
+    op.execute(
+        """
+        ALTER TABLE digests ADD CONSTRAINT ck_digests_approved_audit CHECK (
+            status NOT IN ('approved_for_publish','posting','posted')
+            OR type <> 'weekly'
+            OR (
+                published_by_admin_id IS NOT NULL
+                AND approved_at IS NOT NULL
+            )
+        ) NOT VALID
+        """
+    )
+    op.execute("ALTER TABLE digests VALIDATE CONSTRAINT ck_digests_approved_audit")
+
+
+def downgrade() -> None:
+    # ── Downgrade pre-flight: fail hard on Phase-8 state in either table ───
+    #
+    # M5: once Phase 8 has been exercised, downgrade is an operator decision
+    # that requires explicit cleanup. The RAISE EXCEPTION text guides the
+    # operator to the PHASE8_ROLLOUT.md "downgrade" runbook section.
+    #
+    # R2 HIGH-Cdx-2: the pre-flight MUST also block `posting` rows. `posting`
+    # itself is a Phase 7 status (in the narrower restored CHECK), so it
+    # survives the constraint swap — but a row stuck in `posting` represents
+    # an in-transit publish for either daily OR weekly. A weekly publish in
+    # `posting` was triggered by admin /digest_approve and is mid-
+    # `bot.send_message`; downgrading underneath drops the audit columns the
+    # publisher relies on, races the stale-posting reaper, and may surface as
+    # a "publish silently lost" incident. Blocking ALL `posting` rows
+    # (daily + weekly) is the safer default — neither flavor is acceptable to
+    # drop schema cols underneath.
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF EXISTS (
+                SELECT 1 FROM digests WHERE status IN (
+                    'awaiting_review','approved_for_publish',
+                    'rejected_by_admin','rejected_by_reaper',
+                    'posting'
+                )
+            ) THEN
+                RAISE EXCEPTION
+                    'cannot downgrade: digests rows in Phase 8 review states '
+                    '(awaiting_review/approved_for_publish/rejected_by_admin/'
+                    'rejected_by_reaper) OR in-transit ''posting'' state exist '
+                    '- wait for in-flight publishes to terminate '
+                    '(stale_posting_reaper runs every 5 min) then manually '
+                    'transition or DELETE Phase-8 review rows per '
+                    'PHASE8_ROLLOUT.md "downgrade" runbook section before '
+                    're-running downgrade';
+            END IF;
+            IF EXISTS (
+                SELECT 1 FROM digest_runs WHERE status IN (
+                    'awaiting_review','approved_for_publish',
+                    'rejected_by_admin','rejected_by_reaper','regenerated_by_admin'
+                )
+            ) THEN
+                RAISE EXCEPTION
+                    'cannot downgrade: digest_runs rows in Phase 8 audit '
+                    'states (awaiting_review/approved_for_publish/'
+                    'rejected_by_admin/rejected_by_reaper/regenerated_by_admin) '
+                    'exist - DELETE the audit rows per PHASE8_ROLLOUT.md '
+                    '"downgrade" runbook section before re-running downgrade';
+            END IF;
+        END
+        $$
+        """
+    )
+
+    # ── Drop the partial index + audit CHECK ────────────────────────────────
+    op.execute("DROP INDEX ix_digests_status_awaiting_review")
+    op.execute("ALTER TABLE digests DROP CONSTRAINT ck_digests_approved_audit")
+
+    # ── Restore Phase 7 body-NOT-NULL CHECK ────────────────────────────────
+    op.execute(
+        "ALTER TABLE digests DROP CONSTRAINT ck_digests_body_markdown_not_null_for_visible_statuses"
+    )
+    op.execute(
+        """
+        ALTER TABLE digests ADD CONSTRAINT
+        ck_digests_body_markdown_not_null_for_visible_statuses CHECK (
+            status NOT IN ('draft','posting','posted','redacted','redacted_edit_failed')
+            OR body_markdown IS NOT NULL
+        ) NOT VALID
+        """
+    )
+    op.execute(
+        "ALTER TABLE digests VALIDATE CONSTRAINT "
+        "ck_digests_body_markdown_not_null_for_visible_statuses"
+    )
+
+    # ── Drop the 4 review-gate columns ──────────────────────────────────────
+    op.execute("ALTER TABLE digests DROP COLUMN awaiting_review_at")
+    op.execute("ALTER TABLE digests DROP COLUMN review_notes")
+    op.execute("ALTER TABLE digests DROP COLUMN approved_at")
+    op.execute("ALTER TABLE digests DROP COLUMN published_by_admin_id")
+
+    # ── Restore Phase 7 digest_runs.status CHECK ───────────────────────────
+    op.execute("ALTER TABLE digest_runs DROP CONSTRAINT ck_digest_runs_status")
+    op.execute(
+        f"""
+        ALTER TABLE digest_runs ADD CONSTRAINT ck_digest_runs_status CHECK (
+            status IN ({_RUNS_STATUS_PHASE7})
+        ) NOT VALID
+        """
+    )
+    op.execute("ALTER TABLE digest_runs VALIDATE CONSTRAINT ck_digest_runs_status")
+
+    # ── Restore Phase 7 digests.status CHECK ───────────────────────────────
+    op.execute("ALTER TABLE digests DROP CONSTRAINT ck_digests_status")
+    op.execute(
+        f"""
+        ALTER TABLE digests ADD CONSTRAINT ck_digests_status CHECK (
+            status IN ({_DIGESTS_STATUS_PHASE7})
+        ) NOT VALID
+        """
+    )
+    op.execute("ALTER TABLE digests VALIDATE CONSTRAINT ck_digests_status")

--- a/bot/db/models.py
+++ b/bot/db/models.py
@@ -857,7 +857,9 @@ class LlmUsageLedger(Base):
     response_hash: Mapped[str | None] = mapped_column(CHAR(64), nullable=True)
     tokens_in: Mapped[int] = mapped_column(Integer, nullable=False, server_default=text("0"))
     tokens_out: Mapped[int] = mapped_column(Integer, nullable=False, server_default=text("0"))
-    cost_usd: Mapped[Decimal] = mapped_column(Numeric(10, 6), nullable=False, server_default=text("0"))
+    cost_usd: Mapped[Decimal] = mapped_column(
+        Numeric(10, 6), nullable=False, server_default=text("0")
+    )
     latency_ms: Mapped[int] = mapped_column(Integer, nullable=False, server_default=text("0"))
     request_id: Mapped[str | None] = mapped_column(String(128), nullable=True)
     cache_hit: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=text("false"))
@@ -887,9 +889,7 @@ class LlmSynthesisCache(Base):
     """
 
     __tablename__ = "llm_synthesis_cache"
-    __table_args__ = (
-        UniqueConstraint("input_hash", name="uq_llm_synthesis_cache_input_hash"),
-    )
+    __table_args__ = (UniqueConstraint("input_hash", name="uq_llm_synthesis_cache_input_hash"),)
 
     id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
     input_hash: Mapped[str] = mapped_column(CHAR(64), nullable=False)
@@ -965,9 +965,7 @@ class ExtractionRun(Base):
     ingestion_window_end: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True
     )
-    candidate_count: Mapped[int] = mapped_column(
-        Integer, nullable=False, server_default=text("0")
-    )
+    candidate_count: Mapped[int] = mapped_column(Integer, nullable=False, server_default=text("0"))
     run_status: Mapped[str] = mapped_column(Text, nullable=False)
     llm_usage_ledger_id: Mapped[int | None] = mapped_column(
         BigInteger,
@@ -981,9 +979,7 @@ class ExtractionRun(Base):
     # Admin who triggered the pass via /admin_extract (alembic 035).
     # NULL when the pass was scheduler-driven (no operator). Stored as
     # Telegram user id (no FK to users.id — see migration 035 rationale).
-    operator_user_id: Mapped[int | None] = mapped_column(
-        BigInteger, nullable=True
-    )
+    operator_user_id: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
     # Provider-level error from llm_gateway.extract_candidates (alembic 036).
     # NULL on success or empty-bundle short-circuit. Non-NULL means the gateway
     # returned ``gateway_error`` — extractor sets run_status='failed' and
@@ -1080,9 +1076,7 @@ class ExtractionCandidate(Base):
         ),
         nullable=True,
     )
-    reviewed_at: Mapped[datetime | None] = mapped_column(
-        DateTime(timezone=True), nullable=True
-    )
+    reviewed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=func.now()
     )
@@ -1151,9 +1145,7 @@ class KnowledgeCard(Base):
         ),
         nullable=True,
     )
-    approved_at: Mapped[datetime | None] = mapped_column(
-        DateTime(timezone=True), nullable=True
-    )
+    approved_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=func.now()
     )
@@ -1220,9 +1212,7 @@ class CardSource(Base):
         ),
         nullable=False,
     )
-    position: Mapped[int] = mapped_column(
-        Integer, nullable=False, server_default=text("0")
-    )
+    position: Mapped[int] = mapped_column(Integer, nullable=False, server_default=text("0"))
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=func.now()
     )
@@ -1331,13 +1321,27 @@ class Digest(Base):
             "type IN ('daily','weekly')",
             name="ck_digests_type",
         ),
+        # T8-01 / Phase 8: status enum widened to 14 values. The 4 new entries
+        # (awaiting_review, approved_for_publish, rejected_by_admin,
+        # rejected_by_reaper) cover the weekly editorial review-gate state
+        # machine. See alembic migration 038.
         CheckConstraint(
-            "status IN ('running','draft','posting','posted','failed','skipped',"
-            "'cost_exceeded','skipped_no_destination','redacted','redacted_edit_failed')",
+            "status IN ("
+            "'running','draft','posting','posted','failed','skipped',"
+            "'cost_exceeded','skipped_no_destination','redacted',"
+            "'redacted_edit_failed',"
+            "'awaiting_review','approved_for_publish',"
+            "'rejected_by_admin','rejected_by_reaper'"
+            ")",
             name="ck_digests_status",
         ),
+        # T8-01: body required across the audit-trail review statuses too.
         CheckConstraint(
-            "status NOT IN ('draft','posting','posted','redacted','redacted_edit_failed')"
+            "status NOT IN ("
+            "'draft','posting','posted','redacted','redacted_edit_failed',"
+            "'awaiting_review','approved_for_publish','rejected_by_admin',"
+            "'rejected_by_reaper'"
+            ")"
             " OR body_markdown IS NOT NULL",
             name="ck_digests_body_markdown_not_null_for_visible_statuses",
         ),
@@ -1347,6 +1351,16 @@ class Digest(Base):
             " AND posted_message_id IS NOT NULL"
             " AND posted_at IS NOT NULL)",
             name="ck_digests_posted_fields_required",
+        ),
+        # T8-01: weekly approval audit — when status crosses approve / publish,
+        # admin attribution columns must be set. Daily exempt by predicate
+        # (auto-publish leaves audit cols NULL by design).
+        CheckConstraint(
+            "status NOT IN ('approved_for_publish','posting','posted')"
+            " OR type <> 'weekly'"
+            " OR (published_by_admin_id IS NOT NULL"
+            " AND approved_at IS NOT NULL)",
+            name="ck_digests_approved_audit",
         ),
         Index(
             "ix_digests_status_draft",
@@ -1363,6 +1377,12 @@ class Digest(Base):
             "ix_digests_posting_started_at",
             "posting_started_at",
             postgresql_where=text("status = 'posting'"),
+        ),
+        # T8-01: stale-review reaper drives off this partial index.
+        Index(
+            "ix_digests_status_awaiting_review",
+            "awaiting_review_at",
+            postgresql_where=text("status = 'awaiting_review'"),
         ),
     )
 
@@ -1395,6 +1415,13 @@ class Digest(Base):
         DateTime(timezone=True), nullable=True
     )
     error_text: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # T8-01 / Phase 8: weekly review-gate workflow columns.
+    awaiting_review_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    published_by_admin_id: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+    approved_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    review_notes: Mapped[str | None] = mapped_column(Text, nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=func.now()
     )
@@ -1415,9 +1442,17 @@ class DigestRun(Base):
 
     __tablename__ = "digest_runs"
     __table_args__ = (
+        # T8-01 / Phase 8: 5 new audit values cover the review-gate state
+        # transitions (awaiting_review, approved_for_publish, rejected_by_admin,
+        # rejected_by_reaper) plus operator regeneration audit
+        # (regenerated_by_admin). See alembic migration 038.
         CheckConstraint(
-            "status IN ('running','finished','failed','skipped',"
-            "'cost_exceeded','skipped_no_destination')",
+            "status IN ("
+            "'running','finished','failed','skipped',"
+            "'cost_exceeded','skipped_no_destination',"
+            "'awaiting_review','approved_for_publish',"
+            "'rejected_by_admin','rejected_by_reaper','regenerated_by_admin'"
+            ")",
             name="ck_digest_runs_status",
         ),
     )

--- a/docs/memory-system/PHASE8_PLAN.md
+++ b/docs/memory-system/PHASE8_PLAN.md
@@ -302,28 +302,39 @@ ALTER TABLE digests DROP CONSTRAINT ck_digests_body_markdown_not_null_for_visibl
 ALTER TABLE digests ADD CONSTRAINT ck_digests_body_markdown_not_null_for_visible_statuses CHECK (
     status NOT IN (
         'draft','posting','posted','redacted','redacted_edit_failed',
-        'awaiting_review','approved_for_publish','rejected_by_admin'
+        'awaiting_review','approved_for_publish','rejected_by_admin',
+        'rejected_by_reaper'
     )
     OR body_markdown IS NOT NULL
 ) NOT VALID;
 ALTER TABLE digests VALIDATE CONSTRAINT ck_digests_body_markdown_not_null_for_visible_statuses;
+-- rejected_by_reaper is included because the reaper may reject a digest that
+-- already has a body (transitioned from awaiting_review where body was required).
+-- Requiring body non-null for this terminal state preserves the audit trail:
+-- the rejected body remains inspectable by admins. NULL body for a rejected
+-- row would hide what content was pending review.
 
 -- ── Group 5: partial index + approval-audit CHECK ─────────────────────
 CREATE INDEX ix_digests_status_awaiting_review
     ON digests (awaiting_review_at)
     WHERE status='awaiting_review';
 
+-- The audit CHECK covers the full admin-approval window: approved_for_publish
+-- (set at /digest_approve time), posting (publisher picked it up), and posted
+-- (Telegram delivery confirmed). All three require admin attribution cols for
+-- weekly digests — they travel together through the approve→posting→posted
+-- pipeline with the same audit cols set at /digest_approve.
 ALTER TABLE digests ADD CONSTRAINT ck_digests_approved_audit CHECK (
-    status NOT IN ('approved_for_publish','posting','posted') OR (
-        type <> 'weekly' OR (
-            published_by_admin_id IS NOT NULL AND approved_at IS NOT NULL
-        )
+    status NOT IN ('approved_for_publish','posting','posted')
+    OR type <> 'weekly'
+    OR (
+        published_by_admin_id IS NOT NULL AND approved_at IS NOT NULL
     )
 ) NOT VALID;
 ALTER TABLE digests VALIDATE CONSTRAINT ck_digests_approved_audit;
 -- Daily digests are exempt: weekly path mandates admin attribution; daily
 -- path is auto-publish and leaves the audit cols NULL forever. The
--- `type <> 'weekly' OR (...)` predicate keeps the constraint type-aware.
+-- `type <> 'weekly'` predicate keeps the constraint type-aware.
 ```
 
 **Downgrade SQL (T8-01 must provide a clean reverse):**
@@ -1628,9 +1639,9 @@ Sprint grid for Phase 8. **L6 wave layout (revised) — Round 1 review correctly
 - `tests/db/test_digests_review_schema.py` asserts:
   - `ck_digests_status` accepts all 14 status values, rejects unknown.
   - **`ck_digest_runs_status` accepts all 11 audit values** (running, finished, failed, skipped, cost_exceeded, skipped_no_destination, awaiting_review, approved_for_publish, rejected_by_admin, rejected_by_reaper, regenerated_by_admin), rejects unknown. (C4: this was missing from the earlier acceptance — explicit test required.)
-  - Body-NOT-NULL invariant extends to `awaiting_review` / `approved_for_publish` / `rejected_by_admin`.
+  - Body-NOT-NULL invariant extends to `awaiting_review` / `approved_for_publish` / `rejected_by_admin` / `rejected_by_reaper`.
   - Partial index `ix_digests_status_awaiting_review` exists.
-  - `ck_digests_approved_audit` rejects `status='approved_for_publish'` rows missing `published_by_admin_id` or `approved_at` when `type='weekly'`, exempts `type='daily'`.
+  - `ck_digests_approved_audit` rejects `status IN ('approved_for_publish','posting','posted')` rows missing `published_by_admin_id` or `approved_at` when `type='weekly'`, exempts `type='daily'`.
 - Downgrade tests:
   - Insert a Phase-8 review-status row on `digests`, attempt downgrade → fails with the expected RAISE EXCEPTION mentioning `PHASE8_ROLLOUT.md`.
   - Insert a Phase-8 audit-status row on `digest_runs`, attempt downgrade → fails with the expected RAISE EXCEPTION for `digest_runs`.

--- a/tests/db/test_digests_review_schema.py
+++ b/tests/db/test_digests_review_schema.py
@@ -1,0 +1,684 @@
+"""T8-01 acceptance tests — digests + digest_runs Phase 8 review-gate schema
+(migration 038 ``extend_digests_review_states``).
+
+Mirrors the pattern of ``test_digests_schema.py``: a temporary isolated postgres
+database is created, ``alembic upgrade head`` is run, then schema-shape and
+constraint assertions are executed via asyncpg. Downgrade-blocking pre-flight
+``DO $$ ... $$`` block is exercised by inserting Phase-8 review-state rows and
+asserting that ``alembic downgrade -1`` fails with the expected RAISE EXCEPTION
+text (surfaced via ``subprocess.CalledProcessError`` because ``_run_alembic``
+uses ``check=True``).
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import uuid
+from collections.abc import AsyncIterator
+from pathlib import Path
+
+import asyncpg
+import pytest
+import pytest_asyncio
+from sqlalchemy.engine.url import URL, make_url
+
+from tests.conftest import DEFAULT_LOCAL_POSTGRES_URL
+
+pytestmark = pytest.mark.usefixtures("app_env")
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _base_test_url() -> URL:
+    raw_url = (
+        os.environ.get("TEST_DATABASE_URL")
+        or os.environ.get("DATABASE_URL")
+        or DEFAULT_LOCAL_POSTGRES_URL
+    )
+    return make_url(raw_url)
+
+
+def _asyncpg_kwargs(url: URL, *, database: str | None = None) -> dict[str, object]:
+    return {
+        "user": url.username,
+        "password": url.password,
+        "host": url.host or "127.0.0.1",
+        "port": url.port or 5432,
+        "database": database or url.database,
+    }
+
+
+def _quote_identifier(identifier: str) -> str:
+    return '"' + identifier.replace('"', '""') + '"'
+
+
+async def _create_database(admin_url: URL, database_name: str) -> None:
+    conn = await asyncpg.connect(**_asyncpg_kwargs(admin_url, database="postgres"))
+    try:
+        await conn.execute(f"CREATE DATABASE {_quote_identifier(database_name)}")
+    finally:
+        await conn.close()
+
+
+async def _drop_database(admin_url: URL, database_name: str) -> None:
+    conn = await asyncpg.connect(**_asyncpg_kwargs(admin_url, database="postgres"))
+    try:
+        await conn.execute(
+            """
+            SELECT pg_terminate_backend(pid)
+            FROM pg_stat_activity
+            WHERE datname = $1 AND pid <> pg_backend_pid()
+            """,
+            database_name,
+        )
+        await conn.execute(f"DROP DATABASE IF EXISTS {_quote_identifier(database_name)}")
+    finally:
+        await conn.close()
+
+
+def _run_alembic(
+    database_url: str,
+    *args: str,
+    check: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["DATABASE_URL"] = database_url
+    return subprocess.run(
+        [sys.executable, "-m", "alembic", *args],
+        cwd=PROJECT_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=120,
+        check=check,
+    )
+
+
+async def _fetch_value(database_url: str, query: str, *args: object) -> object:
+    conn = await asyncpg.connect(**_asyncpg_kwargs(make_url(database_url)))
+    try:
+        return await conn.fetchval(query, *args)
+    finally:
+        await conn.close()
+
+
+@pytest_asyncio.fixture()
+async def temp_database_url() -> AsyncIterator[str]:
+    base_url = _base_test_url()
+    database_name = f"shkoder_digests_p8_{uuid.uuid4().hex[:12]}"
+    try:
+        await _create_database(base_url, database_name)
+    except Exception as exc:  # pragma: no cover - environment guard
+        pytest.skip(f"cannot create temporary postgres database: {exc!s}")
+
+    try:
+        yield base_url.set(database=database_name).render_as_string(hide_password=False)
+    finally:
+        await _drop_database(base_url, database_name)
+
+
+@pytest_asyncio.fixture()
+async def migrated_database_url(temp_database_url: str) -> AsyncIterator[str]:
+    _run_alembic(temp_database_url, "upgrade", "head")
+    yield temp_database_url
+
+
+# ─── Test: head is now 038 ────────────────────────────────────────────────────
+
+
+async def test_alembic_head_is_038(migrated_database_url: str) -> None:
+    """After upgrade head, alembic_version reports 038."""
+    current = await _fetch_value(migrated_database_url, "SELECT version_num FROM alembic_version")
+    assert current == "038"
+
+
+# ─── Test: upgrade adds 4 review columns with correct types/nullability ──────
+
+
+async def test_038_upgrade_adds_review_columns(migrated_database_url: str) -> None:
+    """digests gains published_by_admin_id, approved_at, review_notes, awaiting_review_at."""
+    conn = await asyncpg.connect(**_asyncpg_kwargs(make_url(migrated_database_url)))
+    try:
+        rows = await conn.fetch(
+            """
+            SELECT column_name, data_type, is_nullable
+            FROM information_schema.columns
+            WHERE table_schema='public' AND table_name='digests'
+              AND column_name IN ('published_by_admin_id','approved_at','review_notes',
+                                  'awaiting_review_at')
+            ORDER BY column_name
+            """
+        )
+        # Expected:
+        #   approved_at            timestamp with time zone  YES
+        #   awaiting_review_at     timestamp with time zone  YES
+        #   published_by_admin_id  bigint                    YES
+        #   review_notes           text                      YES
+        seen = {r["column_name"]: (r["data_type"], r["is_nullable"]) for r in rows}
+        assert seen == {
+            "approved_at": ("timestamp with time zone", "YES"),
+            "awaiting_review_at": ("timestamp with time zone", "YES"),
+            "published_by_admin_id": ("bigint", "YES"),
+            "review_notes": ("text", "YES"),
+        }
+    finally:
+        await conn.close()
+
+
+# ─── Test: digests.status enum widened to include Phase 8 review states ──────
+
+
+async def test_038_upgrade_widens_status_enum(migrated_database_url: str) -> None:
+    """INSERT status='awaiting_review' succeeds; INSERT status='bogus' violates CHECK."""
+    conn = await asyncpg.connect(**_asyncpg_kwargs(make_url(migrated_database_url)))
+    try:
+        # awaiting_review is now valid; needs body_markdown (widened body CHECK).
+        row_id = await conn.fetchval(
+            """
+            INSERT INTO digests (type, window_start, window_end, status, citations,
+                                 body_markdown, awaiting_review_at)
+            VALUES (
+                'weekly',
+                '2026-05-04 00:00:00+00',
+                '2026-05-11 00:00:00+00',
+                'awaiting_review',
+                '[]'::jsonb,
+                'body',
+                now()
+            )
+            RETURNING id
+            """
+        )
+        assert row_id is not None
+
+        # All 4 new Phase 8 statuses accepted (with body where required).
+        # Pre-baked literal SQL keeps the test free of asyncpg datetime-binding
+        # quirks; the goal is exercising the CHECK enum, not parameter codec.
+        await conn.execute(
+            """
+            INSERT INTO digests (
+                type, window_start, window_end, status, citations, body_markdown,
+                published_by_admin_id, approved_at
+            )
+            VALUES (
+                'weekly','2026-04-13 00:00:00+00','2026-04-20 00:00:00+00',
+                'approved_for_publish','[]'::jsonb,'body',
+                123456789,'2026-04-20 00:00:00+00'
+            )
+            """
+        )
+        await conn.execute(
+            """
+            INSERT INTO digests (
+                type, window_start, window_end, status, citations, body_markdown
+            )
+            VALUES (
+                'weekly','2026-04-06 00:00:00+00','2026-04-13 00:00:00+00',
+                'rejected_by_admin','[]'::jsonb,'body'
+            )
+            """
+        )
+        # rejected_by_reaper: body still required per widened CHECK (visible/audit).
+        await conn.execute(
+            """
+            INSERT INTO digests (
+                type, window_start, window_end, status, citations, body_markdown
+            )
+            VALUES (
+                'weekly','2026-03-30 00:00:00+00','2026-04-06 00:00:00+00',
+                'rejected_by_reaper','[]'::jsonb,'body'
+            )
+            """
+        )
+
+        # Unknown status rejected.
+        with pytest.raises(asyncpg.exceptions.CheckViolationError):
+            await conn.execute(
+                """
+                INSERT INTO digests (type, window_start, window_end, status, citations,
+                                     body_markdown)
+                VALUES (
+                    'weekly',
+                    '2026-05-04 01:00:00+00',
+                    '2026-05-11 01:00:00+00',
+                    'bogus',
+                    '[]'::jsonb,
+                    'body'
+                )
+                """
+            )
+    finally:
+        await conn.close()
+
+
+# ─── Test: digest_runs.status enum widened to include 5 Phase 8 audit states ─
+
+
+async def test_038_upgrade_widens_runs_status_enum(migrated_database_url: str) -> None:
+    """digest_runs accepts all 5 new audit statuses; unknown rejected."""
+    conn = await asyncpg.connect(**_asyncpg_kwargs(make_url(migrated_database_url)))
+    try:
+        for status in (
+            "awaiting_review",
+            "approved_for_publish",
+            "rejected_by_admin",
+            "rejected_by_reaper",
+            "regenerated_by_admin",
+        ):
+            # Plain string args bind cleanly; status is a Text column with no
+            # special codec quirks (unlike timestamptz).
+            run_id = await conn.fetchval(
+                "INSERT INTO digest_runs (status) VALUES ($1) RETURNING id",
+                status,
+            )
+            assert run_id is not None, f"digest_runs insert for status={status!r} failed"
+
+        with pytest.raises(asyncpg.exceptions.CheckViolationError):
+            await conn.execute("INSERT INTO digest_runs (status) VALUES ('bogus')")
+    finally:
+        await conn.close()
+
+
+# ─── Test: ck_digests_approved_audit — approved_for_publish needs admin id + time ─
+
+
+async def test_038_approved_audit_check_requires_admin_id(
+    migrated_database_url: str,
+) -> None:
+    """approved_for_publish row with NULL published_by_admin_id → CHECK violation (weekly).
+
+    The audit CHECK is type-aware: it MUST fire for weekly digests; daily digests
+    are exempt by predicate.
+    """
+    conn = await asyncpg.connect(**_asyncpg_kwargs(make_url(migrated_database_url)))
+    try:
+        with pytest.raises(asyncpg.exceptions.CheckViolationError):
+            await conn.execute(
+                """
+                INSERT INTO digests (
+                    type, window_start, window_end, status, citations, body_markdown,
+                    published_by_admin_id, approved_at
+                )
+                VALUES (
+                    'weekly',
+                    '2026-05-04 02:00:00+00',
+                    '2026-05-11 02:00:00+00',
+                    'approved_for_publish',
+                    '[]'::jsonb,
+                    'body',
+                    NULL,
+                    '2026-05-11 00:00:00+00'
+                )
+                """
+            )
+
+        # Same shape with NULL approved_at → also violates.
+        with pytest.raises(asyncpg.exceptions.CheckViolationError):
+            await conn.execute(
+                """
+                INSERT INTO digests (
+                    type, window_start, window_end, status, citations, body_markdown,
+                    published_by_admin_id, approved_at
+                )
+                VALUES (
+                    'weekly',
+                    '2026-05-04 03:00:00+00',
+                    '2026-05-11 03:00:00+00',
+                    'approved_for_publish',
+                    '[]'::jsonb,
+                    'body',
+                    123456789,
+                    NULL
+                )
+                """
+            )
+
+        # Type='daily' approved_for_publish is exempt (daily never sets audit cols).
+        row_id = await conn.fetchval(
+            """
+            INSERT INTO digests (
+                type, window_start, window_end, status, citations, body_markdown
+            )
+            VALUES (
+                'daily',
+                '2026-05-13 04:00:00+00',
+                '2026-05-14 04:00:00+00',
+                'approved_for_publish',
+                '[]'::jsonb,
+                'body'
+            )
+            RETURNING id
+            """
+        )
+        assert row_id is not None
+    finally:
+        await conn.close()
+
+
+# ─── Test: body_markdown NOT NULL widens to review states ────────────────────
+
+
+async def test_038_body_markdown_required_for_review_states(
+    migrated_database_url: str,
+) -> None:
+    """status='awaiting_review' / 'approved_for_publish' / 'rejected_by_admin' with body=NULL violates.
+
+    The Phase 7 body CHECK covered draft/posting/posted/redacted/redacted_edit_failed.
+    Phase 8 widens it to also include awaiting_review, approved_for_publish, and
+    rejected_by_admin (visible/audit-trail states). rejected_by_reaper is reaper-only
+    bookkeeping and per §5.A is NOT in the widened body-required set.
+    """
+    conn = await asyncpg.connect(**_asyncpg_kwargs(make_url(migrated_database_url)))
+    try:
+        with pytest.raises(asyncpg.exceptions.CheckViolationError):
+            await conn.execute(
+                """
+                INSERT INTO digests (
+                    type, window_start, window_end, status, citations, body_markdown
+                )
+                VALUES (
+                    'weekly','2026-05-04 10:00:00+00','2026-05-11 10:00:00+00',
+                    'awaiting_review','[]'::jsonb, NULL
+                )
+                """
+            )
+        with pytest.raises(asyncpg.exceptions.CheckViolationError):
+            await conn.execute(
+                """
+                INSERT INTO digests (
+                    type, window_start, window_end, status, citations, body_markdown,
+                    published_by_admin_id, approved_at
+                )
+                VALUES (
+                    'weekly','2026-05-04 11:00:00+00','2026-05-11 11:00:00+00',
+                    'approved_for_publish','[]'::jsonb, NULL,
+                    123456789,'2026-05-11 00:00:00+00'
+                )
+                """
+            )
+        with pytest.raises(asyncpg.exceptions.CheckViolationError):
+            await conn.execute(
+                """
+                INSERT INTO digests (
+                    type, window_start, window_end, status, citations, body_markdown
+                )
+                VALUES (
+                    'weekly','2026-05-04 12:00:00+00','2026-05-11 12:00:00+00',
+                    'rejected_by_admin','[]'::jsonb, NULL
+                )
+                """
+            )
+    finally:
+        await conn.close()
+
+
+# ─── Test: partial index ix_digests_status_awaiting_review exists ────────────
+
+
+async def test_038_awaiting_review_partial_index_exists(
+    migrated_database_url: str,
+) -> None:
+    """ix_digests_status_awaiting_review partial index keyed on awaiting_review_at."""
+    indexdef = await _fetch_value(
+        migrated_database_url,
+        """
+        SELECT indexdef
+        FROM pg_indexes
+        WHERE schemaname = 'public'
+          AND tablename = 'digests'
+          AND indexname = 'ix_digests_status_awaiting_review'
+        """,
+    )
+    assert indexdef is not None, "ix_digests_status_awaiting_review not found"
+    lowered = str(indexdef).lower()
+    assert "where" in lowered
+    assert "awaiting_review" in lowered
+    assert "awaiting_review_at" in lowered
+
+
+# ─── Test: downgrade blocks on review-state rows in digests ──────────────────
+
+
+async def test_038_downgrade_blocks_on_review_state_rows(
+    temp_database_url: str,
+) -> None:
+    """Insert digest row with status='awaiting_review' → downgrade -1 raises."""
+    _run_alembic(temp_database_url, "upgrade", "head")
+
+    conn = await asyncpg.connect(**_asyncpg_kwargs(make_url(temp_database_url)))
+    try:
+        await conn.execute(
+            """
+            INSERT INTO digests (type, window_start, window_end, status, citations,
+                                 body_markdown, awaiting_review_at)
+            VALUES (
+                'weekly',
+                '2026-05-04 05:00:00+00',
+                '2026-05-11 05:00:00+00',
+                'awaiting_review',
+                '[]'::jsonb,
+                'body',
+                now()
+            )
+            """
+        )
+    finally:
+        await conn.close()
+
+    proc = _run_alembic(temp_database_url, "downgrade", "-1", check=False)
+    assert proc.returncode != 0, (
+        f"expected downgrade to fail on review-state row, "
+        f"got rc={proc.returncode} stderr={proc.stderr!r}"
+    )
+    combined = (proc.stdout + proc.stderr).lower()
+    assert "phase 8" in combined or "review" in combined or "awaiting_review" in combined
+
+
+# ─── Test: downgrade blocks on digest_runs Phase-8 audit rows ────────────────
+
+
+async def test_038_downgrade_blocks_on_runs_audit_rows(
+    temp_database_url: str,
+) -> None:
+    """Insert digest_runs row with status='regenerated_by_admin' → downgrade -1 raises."""
+    _run_alembic(temp_database_url, "upgrade", "head")
+
+    conn = await asyncpg.connect(**_asyncpg_kwargs(make_url(temp_database_url)))
+    try:
+        await conn.execute("INSERT INTO digest_runs (status) VALUES ('regenerated_by_admin')")
+    finally:
+        await conn.close()
+
+    proc = _run_alembic(temp_database_url, "downgrade", "-1", check=False)
+    assert proc.returncode != 0
+    combined = (proc.stdout + proc.stderr).lower()
+    assert "digest_runs" in combined
+
+
+# ─── Test: downgrade blocks on posting rows (daily and weekly) ───────────────
+
+
+async def test_038_downgrade_blocks_on_posting_rows_daily(
+    temp_database_url: str,
+) -> None:
+    """Insert daily posting row → downgrade fails mentioning stale_posting_reaper."""
+    _run_alembic(temp_database_url, "upgrade", "head")
+
+    conn = await asyncpg.connect(**_asyncpg_kwargs(make_url(temp_database_url)))
+    try:
+        await conn.execute(
+            """
+            INSERT INTO digests (type, window_start, window_end, status, citations,
+                                 body_markdown, posting_started_at)
+            VALUES (
+                'daily',
+                '2026-05-13 06:00:00+00',
+                '2026-05-14 06:00:00+00',
+                'posting',
+                '[]'::jsonb,
+                'body',
+                now()
+            )
+            """
+        )
+    finally:
+        await conn.close()
+
+    proc = _run_alembic(temp_database_url, "downgrade", "-1", check=False)
+    assert proc.returncode != 0
+    combined = (proc.stdout + proc.stderr).lower()
+    assert "posting" in combined
+    assert "stale_posting_reaper" in combined
+
+
+async def test_038_downgrade_blocks_on_posting_rows_weekly(
+    temp_database_url: str,
+) -> None:
+    """Insert weekly posting row → downgrade fails mentioning stale_posting_reaper.
+
+    A weekly row in ``posting`` is mid-publish triggered by ``/digest_approve``.
+    It satisfies ``ck_digests_approved_audit`` because the approve flow set both
+    ``published_by_admin_id`` and ``approved_at`` before transitioning to
+    ``posting``; the test mirrors that production shape.
+    """
+    _run_alembic(temp_database_url, "upgrade", "head")
+
+    conn = await asyncpg.connect(**_asyncpg_kwargs(make_url(temp_database_url)))
+    try:
+        await conn.execute(
+            """
+            INSERT INTO digests (
+                type, window_start, window_end, status, citations,
+                body_markdown, posting_started_at,
+                published_by_admin_id, approved_at
+            )
+            VALUES (
+                'weekly',
+                '2026-05-04 07:00:00+00',
+                '2026-05-11 07:00:00+00',
+                'posting',
+                '[]'::jsonb,
+                'body',
+                now(),
+                123456789,
+                '2026-05-11 09:00:00+00'
+            )
+            """
+        )
+    finally:
+        await conn.close()
+
+    proc = _run_alembic(temp_database_url, "downgrade", "-1", check=False)
+    assert proc.returncode != 0
+    combined = (proc.stdout + proc.stderr).lower()
+    assert "posting" in combined
+    assert "stale_posting_reaper" in combined
+
+
+# ─── Test: downgrade succeeds on clean Phase-7-only state ────────────────────
+
+
+async def test_038_downgrade_succeeds_when_clean(temp_database_url: str) -> None:
+    """No Phase-8 rows, no posting rows → downgrade -1 restores Phase 7 schema."""
+    _run_alembic(temp_database_url, "upgrade", "head")
+
+    # Insert only Phase-7-safe rows: status='running' is the early lifecycle state.
+    conn = await asyncpg.connect(**_asyncpg_kwargs(make_url(temp_database_url)))
+    try:
+        await conn.execute(
+            """
+            INSERT INTO digests (type, window_start, window_end, status, citations)
+            VALUES (
+                'daily',
+                '2026-05-13 08:00:00+00',
+                '2026-05-14 08:00:00+00',
+                'running',
+                '[]'::jsonb
+            )
+            """
+        )
+    finally:
+        await conn.close()
+
+    _run_alembic(temp_database_url, "downgrade", "-1")
+
+    current = await _fetch_value(temp_database_url, "SELECT version_num FROM alembic_version")
+    assert current == "037"
+
+    # Phase 7 status CHECK is now back: 'awaiting_review' must be rejected.
+    conn = await asyncpg.connect(**_asyncpg_kwargs(make_url(temp_database_url)))
+    try:
+        # Phase 8 cols must be gone after downgrade.
+        cols = await conn.fetch(
+            """
+            SELECT column_name
+            FROM information_schema.columns
+            WHERE table_schema='public' AND table_name='digests'
+              AND column_name IN ('published_by_admin_id','approved_at','review_notes',
+                                  'awaiting_review_at')
+            """
+        )
+        assert cols == [], f"expected Phase-8 cols dropped, found {cols!r}"
+
+        # Phase 8 partial index must be gone.
+        idx_exists = await conn.fetchval(
+            """
+            SELECT EXISTS (
+                SELECT 1 FROM pg_indexes
+                WHERE schemaname='public' AND tablename='digests'
+                  AND indexname='ix_digests_status_awaiting_review'
+            )
+            """
+        )
+        assert idx_exists is False
+
+        # ck_digests_approved_audit must be gone.
+        audit_check_exists = await conn.fetchval(
+            """
+            SELECT EXISTS (
+                SELECT 1 FROM pg_constraint
+                WHERE conname='ck_digests_approved_audit'
+            )
+            """
+        )
+        assert audit_check_exists is False
+
+        # Status enum narrows back: 'awaiting_review' now rejected.
+        with pytest.raises(asyncpg.exceptions.CheckViolationError):
+            await conn.execute(
+                """
+                INSERT INTO digests (type, window_start, window_end, status, citations,
+                                     body_markdown)
+                VALUES (
+                    'weekly',
+                    '2026-05-04 09:00:00+00',
+                    '2026-05-11 09:00:00+00',
+                    'awaiting_review',
+                    '[]'::jsonb,
+                    'body'
+                )
+                """
+            )
+    finally:
+        await conn.close()
+
+
+# ─── Test: ORM Digest mapped class exposes the 4 new fields ──────────────────
+
+
+def test_038_orm_digest_review_columns_registered(app_env) -> None:
+    """Digest mapped class declares 4 new review-gate columns."""
+    from tests.conftest import import_module
+
+    models = import_module("bot.db.models")
+    cols = models.Digest.__table__.columns
+    for name in (
+        "awaiting_review_at",
+        "published_by_admin_id",
+        "approved_at",
+        "review_notes",
+    ):
+        assert name in cols, f"Digest ORM missing {name!r}"
+        assert cols[name].nullable is True, f"{name} must be nullable"

--- a/tests/db/test_digests_review_schema.py
+++ b/tests/db/test_digests_review_schema.py
@@ -366,9 +366,11 @@ async def test_038_body_markdown_required_for_review_states(
     """status='awaiting_review' / 'approved_for_publish' / 'rejected_by_admin' with body=NULL violates.
 
     The Phase 7 body CHECK covered draft/posting/posted/redacted/redacted_edit_failed.
-    Phase 8 widens it to also include awaiting_review, approved_for_publish, and
-    rejected_by_admin (visible/audit-trail states). rejected_by_reaper is reaper-only
-    bookkeeping and per §5.A is NOT in the widened body-required set.
+    Phase 8 widens it to also include awaiting_review, approved_for_publish,
+    rejected_by_admin, and rejected_by_reaper (all review-bearing states that carry an
+    audit trail).  See §5.A: the reaper terminates a digest that was already in
+    awaiting_review (where body was required), so body_markdown IS NOT NULL on entry
+    to rejected_by_reaper — the CHECK preserves this invariant at the DB layer.
     """
     conn = await asyncpg.connect(**_asyncpg_kwargs(make_url(migrated_database_url)))
     try:
@@ -407,6 +409,86 @@ async def test_038_body_markdown_required_for_review_states(
                 VALUES (
                     'weekly','2026-05-04 12:00:00+00','2026-05-11 12:00:00+00',
                     'rejected_by_admin','[]'::jsonb, NULL
+                )
+                """
+            )
+    finally:
+        await conn.close()
+
+
+async def test_038_body_markdown_required_for_rejected_by_reaper(
+    migrated_database_url: str,
+) -> None:
+    """status='rejected_by_reaper' with body=NULL violates ck_digests_body_markdown_not_null.
+
+    rejected_by_reaper transitions FROM awaiting_review (where body was already required).
+    The DB-level CHECK preserves this invariant at the terminal state too — a NULL body
+    would hide what content was pending review from audit inspection.
+    """
+    conn = await asyncpg.connect(**_asyncpg_kwargs(make_url(migrated_database_url)))
+    try:
+        with pytest.raises(asyncpg.exceptions.CheckViolationError):
+            await conn.execute(
+                """
+                INSERT INTO digests (
+                    type, window_start, window_end, status, citations, body_markdown
+                )
+                VALUES (
+                    'weekly','2026-05-04 13:00:00+00','2026-05-11 13:00:00+00',
+                    'rejected_by_reaper','[]'::jsonb, NULL
+                )
+                """
+            )
+    finally:
+        await conn.close()
+
+
+# ─── Test: approved_audit CHECK covers posting + posted statuses ─────────────
+
+
+async def test_038_approved_audit_check_covers_posting_and_posted(
+    migrated_database_url: str,
+) -> None:
+    """ck_digests_approved_audit rejects weekly 'posting'/'posted' rows missing audit cols.
+
+    The CHECK covers status IN ('approved_for_publish','posting','posted') for weekly
+    digests.  All three travel through the same approve→posting→posted pipeline with
+    the audit cols set at /digest_approve time and carried through unchanged.
+    """
+    conn = await asyncpg.connect(**_asyncpg_kwargs(make_url(migrated_database_url)))
+    try:
+        # weekly posting with NULL published_by_admin_id → violates
+        with pytest.raises(asyncpg.exceptions.CheckViolationError):
+            await conn.execute(
+                """
+                INSERT INTO digests (
+                    type, window_start, window_end, status, citations, body_markdown,
+                    posting_started_at, published_by_admin_id, approved_at
+                )
+                VALUES (
+                    'weekly','2026-05-04 14:00:00+00','2026-05-11 14:00:00+00',
+                    'posting','[]'::jsonb,'body',
+                    '2026-05-11 09:00:00+00',
+                    NULL,
+                    '2026-05-11 09:00:00+00'
+                )
+                """
+            )
+        # weekly posted with NULL approved_at → violates
+        with pytest.raises(asyncpg.exceptions.CheckViolationError):
+            await conn.execute(
+                """
+                INSERT INTO digests (
+                    type, window_start, window_end, status, citations, body_markdown,
+                    posted_at, posted_chat_id, posted_message_id,
+                    published_by_admin_id, approved_at
+                )
+                VALUES (
+                    'weekly','2026-05-04 15:00:00+00','2026-05-11 15:00:00+00',
+                    'posted','[]'::jsonb,'body',
+                    '2026-05-11 10:00:00+00', -1001234567890, 42,
+                    123456789,
+                    NULL
                 )
                 """
             )
@@ -575,6 +657,76 @@ async def test_038_downgrade_blocks_on_posting_rows_weekly(
     combined = (proc.stdout + proc.stderr).lower()
     assert "posting" in combined
     assert "stale_posting_reaper" in combined
+
+
+# ─── Test: downgrade succeeds after posting row transitions to terminal state ─
+
+
+async def test_038_downgrade_succeeds_after_posting_terminal_transition(
+    temp_database_url: str,
+) -> None:
+    """posting row blocks downgrade; after UPDATE to posted (terminal) downgrade succeeds.
+
+    Validates the operator recovery path documented in §5.A downgrade note: wait for the
+    stale_posting_reaper to move the row from posting → posted, then downgrade proceeds.
+    The test simulates that by manually UPDATE'ing the row to posted with all required
+    cols set (the reaper sets the same cols on Telegram-delivery success).
+    """
+    _run_alembic(temp_database_url, "upgrade", "head")
+
+    conn = await asyncpg.connect(**_asyncpg_kwargs(make_url(temp_database_url)))
+    row_id: int | None = None
+    try:
+        row_id = await conn.fetchval(
+            """
+            INSERT INTO digests (
+                type, window_start, window_end, status, citations,
+                body_markdown, posting_started_at
+            )
+            VALUES (
+                'daily',
+                '2026-05-13 20:00:00+00',
+                '2026-05-14 20:00:00+00',
+                'posting',
+                '[]'::jsonb,
+                'body',
+                '2026-05-13 20:00:00+00'
+            )
+            RETURNING id
+            """
+        )
+    finally:
+        await conn.close()
+
+    # Attempt downgrade while row is still posting → must fail.
+    proc = _run_alembic(temp_database_url, "downgrade", "-1", check=False)
+    assert proc.returncode != 0, (
+        f"expected downgrade to fail on posting row, got rc={proc.returncode}"
+    )
+    combined = (proc.stdout + proc.stderr).lower()
+    assert "posting" in combined
+
+    # Transition the row to posted (simulates stale_posting_reaper completing delivery).
+    conn = await asyncpg.connect(**_asyncpg_kwargs(make_url(temp_database_url)))
+    try:
+        await conn.execute(
+            """
+            UPDATE digests
+            SET status='posted',
+                posted_at='2026-05-13 20:01:00+00',
+                posted_chat_id=-1001234567890,
+                posted_message_id=99
+            WHERE id=$1
+            """,
+            row_id,
+        )
+    finally:
+        await conn.close()
+
+    # Now downgrade must succeed.
+    _run_alembic(temp_database_url, "downgrade", "-1")
+    current = await _fetch_value(temp_database_url, "SELECT version_num FROM alembic_version")
+    assert current == "037"
 
 
 # ─── Test: downgrade succeeds on clean Phase-7-only state ────────────────────

--- a/tests/db/test_digests_schema.py
+++ b/tests/db/test_digests_schema.py
@@ -125,15 +125,18 @@ async def migrated_database_url(temp_database_url: str) -> AsyncIterator[str]:
     yield temp_database_url
 
 
-# ─── Test 1: head is now 037 ─────────────────────────────────────────────────
+# ─── Test 1: 037 is reachable in the chain ───────────────────────────────────
 
 
-async def test_alembic_head_is_037(migrated_database_url: str) -> None:
-    """After upgrade head, alembic_version reports 037."""
+async def test_alembic_037_in_chain(migrated_database_url: str) -> None:
+    """After upgrade head, alembic_version reports >= 037 (037 stays in the chain)."""
     current = await _fetch_value(
         migrated_database_url, "SELECT version_num FROM alembic_version"
     )
-    assert current == "037"
+    assert current is not None
+    # Heads beyond 037 (e.g. 038) are valid; 037-specific schema assertions in
+    # this file run against the migrated DB regardless of subsequent heads.
+    assert str(current) >= "037"
 
 
 # ─── Test 2: unique constraint on (type, window_start, window_end) ────────────
@@ -353,11 +356,15 @@ async def test_ix_digests_posting_started_at_partial_index_exists(
     assert "posting" in lowered
 
 
-# ─── Test 10: downgrade -1 drops digest_runs then digests ────────────────────
+# ─── Test 10: downgrade to 036 drops digest_runs then digests ────────────────
 
 
 async def test_alembic_downgrade_drops_digest_tables(temp_database_url: str) -> None:
-    """alembic downgrade -1 from 037 drops digest_runs and digests, returns to 036."""
+    """alembic downgrade 036 from head drops digest_runs and digests, returns to 036.
+
+    Uses an explicit revision target instead of ``-1`` so the assertion stays
+    valid as more revisions are added beyond 037 (T8-01 introduced 038).
+    """
     _run_alembic(temp_database_url, "upgrade", "head")
 
     # Verify both tables exist before downgrade
@@ -374,7 +381,7 @@ async def test_alembic_downgrade_drops_digest_tables(temp_database_url: str) -> 
         )
         assert exists is True, f"Expected '{table_name}' to exist before downgrade"
 
-    _run_alembic(temp_database_url, "downgrade", "-1")
+    _run_alembic(temp_database_url, "downgrade", "036")
 
     # Both tables must be gone
     for table_name in ("digests", "digest_runs"):
@@ -398,10 +405,10 @@ async def test_alembic_downgrade_drops_digest_tables(temp_database_url: str) -> 
 
 
 async def test_alembic_037_upgrade_downgrade_upgrade_roundtrip(temp_database_url: str) -> None:
-    """Full roundtrip: upgrade head → downgrade -1 → upgrade head."""
+    """Full roundtrip: upgrade head → downgrade 036 → upgrade 037."""
     _run_alembic(temp_database_url, "upgrade", "head")
-    _run_alembic(temp_database_url, "downgrade", "-1")
-    _run_alembic(temp_database_url, "upgrade", "head")
+    _run_alembic(temp_database_url, "downgrade", "036")
+    _run_alembic(temp_database_url, "upgrade", "037")
 
     current = await _fetch_value(temp_database_url, "SELECT version_num FROM alembic_version")
     assert current == "037"

--- a/tests/db/test_fts_schema.py
+++ b/tests/db/test_fts_schema.py
@@ -182,9 +182,10 @@ async def test_alembic_upgrade_head_on_clean_db_green(migrated_database_url: str
     current = await _fetch_value(migrated_database_url, "SELECT version_num FROM alembic_version")
 
     # T6-01 (030-034) + T6-02 (035 operator_user_id) + Phase 6.5 M-2 (036
-    # gateway_error) + T7-01 (037 digests) advanced the head past 025.
-    # Assert the current head explicitly; revisit when future migrations land.
-    assert current == "037"
+    # gateway_error) + T7-01 (037 digests) + T8-01 (038 review-gate states)
+    # advanced the head past 025. Assert the current head explicitly; revisit
+    # when future migrations land.
+    assert current == "038"
 
 
 async def test_insert_message_versions_generates_search_tsv_from_normalized_text(


### PR DESCRIPTION
## Summary

T8-01 of Phase 8 — alembic migration 038 extends Phase 7 `digests` + `digest_runs` schema for the weekly editorial review-gate state machine per `PHASE8_PLAN.md §5.A`.

## Schema changes (migration 038)

- **`ck_digests_status` enum widening 10 → 14**: + `awaiting_review`, `approved_for_publish`, `rejected_by_admin`, `rejected_by_reaper`
- **`ck_digest_runs_status` enum widening 6 → 11**: + 5 new audit values (incl. `regenerated_by_admin`)
- **4 new nullable columns on `digests`**: `published_by_admin_id BIGINT`, `approved_at TIMESTAMPTZ`, `review_notes TEXT`, `awaiting_review_at TIMESTAMPTZ`
- **Partial index** `ix_digests_status_awaiting_review ON digests(awaiting_review_at) WHERE status='awaiting_review'` — covers stale-review reaper scan
- **`ck_digests_approved_audit`**: weekly rows in (`approved_for_publish`, `posting`, `posted`) MUST have both `published_by_admin_id` AND `approved_at` NOT NULL (daily exempt — auto-publish flow)
- **`ck_digests_body_markdown_not_null_for_visible_statuses`** widened: body NOT NULL for all 4 review states (incl. `rejected_by_reaper` — preserves audit trail content)
- **Downgrade pre-flight DO $$ ... $$ block**: raises MigrationError if any row has status IN (4 review states) OR `posting` (daily or weekly — protects in-flight publish). Operator runbook references `stale_posting_reaper` 5-min wait.
- **NOT VALID + VALIDATE pattern** for every CHECK addition (Codex H1 from S0 review)

## ORM mirror

`bot/db/models.py` Digest + DigestRun extensions match migration 1:1.

## Tests (16 total, all green)

- Schema upgrade: cols, enum values, partial index existence, ORM registration
- CHECK enforcement: approved_audit (weekly required, daily exempt; covers posting+posted), body-NOT-NULL for all 4 review statuses (incl. rejected_by_reaper)
- Downgrade safety: blocks on Phase 8 review-state rows AND posting rows (daily + weekly), succeeds on clean DB, succeeds after posting→posted terminal transition

## Review history

| Round | Claude product | Codex tech |
|-------|----------------|------------|
| 1 | ACCEPTED (M-01 + L-01 + L-02 carryovers) | REQUEST_CHANGES — 3 HIGH (`rejected_by_reaper` impl-vs-spec drift; `ck_digests_approved_audit` scope wider than spec; missing rejected_by_reaper body=NULL test) |
| Follow-up | n/a | n/a — fixes reconcile spec ↔ impl ↔ tests |

## Commits

- `39d4200` initial migration + 13 tests + ORM
- `b008df5` review follow-up: PHASE8_PLAN.md §5.A spec text updated to match impl (rejected_by_reaper in body-NOT-NULL list, audit CHECK scope explicitly enumerated to include posting+posted), 3 new tests added (rejected_by_reaper body=NULL, weekly posting+posted audit CHECK, posting→posted→downgrade recovery), test docstring fix

## Verification

- 16/16 tests pass (focused suite)
- Privacy lint exit 0
- Ruff exit 0

## Test plan

- [x] Local: 16/16 tests pass
- [x] Privacy lint green
- [x] Ruff green
- [ ] CI green
- [ ] Merge → unlocks Wave 3 (T8-02 ∥ T8-03 parallel implementers)