### PR TITLE
feat(p8-t8-02): weekly run_digest + synthesize_digest gateway + cost ceiling type filter

### DIFF
--- a/bot/services/digests.py
+++ b/bot/services/digests.py
@@ -51,11 +51,16 @@ DIGEST_LOCK_NAMESPACE = "phase7:digest_idempotency"
 
 @dataclass(frozen=True)
 class DigestConfig:
-    """Phase 7 runtime config — separate cost bucket + scheduling tunables.
+    """Phase 7 / Phase 8 runtime config — separate cost buckets + scheduling
+    tunables. Loaded by ``load_digest_config()`` from env vars.
 
-    Loaded by ``load_digest_config()`` from env vars per PHASE7_PLAN.md §12.
+    Phase 7 fields drive the daily digest. Phase 8 ``weekly_*`` fields drive
+    the weekly editorial digest (PHASE8_PLAN.md §5.B). The two are
+    INDEPENDENT — the weekly cost ceiling is NOT required to be less than
+    the daily ceiling (Q7 / §6 — C5 reformulation).
     """
 
+    # Phase 7 (unchanged)
     daily_cost_ceiling_usd: Decimal = Decimal("1.00")
     monthly_cost_ceiling_usd: Decimal = Decimal("10.00")
     source_chat_id: int = 0
@@ -64,6 +69,17 @@ class DigestConfig:
     min_cards_threshold: int = 3
     raw_message_top_n: int = 15
     token_budget_input: int = 8000
+    # Phase 8 additions — weekly digest tunables. Independent of daily; see
+    # PHASE8_PLAN.md §5.B and §6 Q7.
+    weekly_cost_ceiling_usd: Decimal = Decimal("5.00")
+    weekly_monthly_cost_ceiling_usd: Decimal = Decimal("20.00")
+    # L5: weekly min-cards-threshold bumped to 8 (vs daily 3) — weekly window
+    # is 7× larger but admin-approved cards over the full week are a
+    # higher-quality cohort, so 8 is the empirical middle between daily-3 and
+    # linearly-scaled 21.
+    weekly_min_cards_threshold: int = 8
+    weekly_raw_message_top_n: int = 60
+    weekly_token_budget_input: int = 24000
 
     def to_context_config(self) -> _DigestCtxConfig:
         return _DigestCtxConfig(
@@ -98,38 +114,80 @@ def load_digest_config() -> DigestConfig:
         min_cards_threshold=int(os.environ.get("DIGEST_MIN_CARDS_THRESHOLD", "3")),
         raw_message_top_n=int(os.environ.get("DIGEST_RAW_MESSAGE_TOP_N", "15")),
         token_budget_input=int(os.environ.get("DIGEST_TOKEN_BUDGET_INPUT", "8000")),
+        # Phase 8 weekly knobs — independent of daily.
+        weekly_cost_ceiling_usd=Decimal(
+            os.environ.get("DIGEST_WEEKLY_USD_CEILING", "5.00")
+        ),
+        weekly_monthly_cost_ceiling_usd=Decimal(
+            os.environ.get("DIGEST_WEEKLY_MONTHLY_USD_CEILING", "20.00")
+        ),
+        weekly_token_budget_input=int(
+            os.environ.get("DIGEST_WEEKLY_TOKEN_BUDGET", "24000")
+        ),
+        weekly_min_cards_threshold=int(
+            os.environ.get("DIGEST_WEEKLY_MIN_CARDS_THRESHOLD", "8")
+        ),
+        weekly_raw_message_top_n=int(
+            os.environ.get("DIGEST_WEEKLY_RAW_MESSAGE_TOP_N", "60")
+        ),
     )
 
 
 async def _cost_ceiling_breached(
-    session: AsyncSession, *, digest_config: DigestConfig
+    session: AsyncSession,
+    *,
+    digest_config: DigestConfig,
+    type: Literal["daily", "weekly"] = "daily",
 ) -> bool:
-    """Phase 7 separate cost bucket: SUM(cost_usd) from llm_usage_ledger
-    JOIN digests WHERE digests.created_at >= today_00_utc.
+    """Type-aware separate cost bucket per PHASE8_PLAN.md §5.B (H6).
 
-    Returns True if daily or monthly ceiling reached.
+    SUM(cost_usd) from llm_usage_ledger JOIN digests, filtered by
+    ``WHERE d.type = :type`` so daily and weekly costs accumulate to
+    INDEPENDENT monthly buckets. Phase 7 callsite uses the default
+    ``type='daily'`` (back-compat); Phase 8 weekly callsite passes
+    ``type='weekly'``.
+
+    Reads the bucket-specific ceiling out of ``digest_config`` based on
+    the ``type`` arg:
+      - daily  → ``daily_cost_ceiling_usd`` / ``monthly_cost_ceiling_usd``
+      - weekly → ``weekly_cost_ceiling_usd`` / ``weekly_monthly_cost_ceiling_usd``
+
+    Returns True if the daily-bucket OR monthly-bucket ceiling for the
+    requested type has been reached.
     """
+    if type == "weekly":
+        daily_ceiling = digest_config.weekly_cost_ceiling_usd
+        monthly_ceiling = digest_config.weekly_monthly_cost_ceiling_usd
+    else:
+        daily_ceiling = digest_config.daily_cost_ceiling_usd
+        monthly_ceiling = digest_config.monthly_cost_ceiling_usd
     sql_daily = text(
         """
         SELECT COALESCE(SUM(l.cost_usd), 0)
         FROM llm_usage_ledger l
         JOIN digests d ON d.llm_usage_ledger_id = l.id
-        WHERE d.created_at >= date_trunc('day', now() AT TIME ZONE 'UTC') AT TIME ZONE 'UTC'
+        WHERE d.type = :type
+          AND d.created_at >= date_trunc('day', now() AT TIME ZONE 'UTC') AT TIME ZONE 'UTC'
         """
     )
-    daily = (await session.execute(sql_daily)).scalar_one_or_none() or Decimal("0")
-    if Decimal(str(daily)) >= digest_config.daily_cost_ceiling_usd:
+    daily = (
+        await session.execute(sql_daily, {"type": type})
+    ).scalar_one_or_none() or Decimal("0")
+    if Decimal(str(daily)) >= daily_ceiling:
         return True
     sql_monthly = text(
         """
         SELECT COALESCE(SUM(l.cost_usd), 0)
         FROM llm_usage_ledger l
         JOIN digests d ON d.llm_usage_ledger_id = l.id
-        WHERE d.created_at >= date_trunc('month', now() AT TIME ZONE 'UTC') AT TIME ZONE 'UTC'
+        WHERE d.type = :type
+          AND d.created_at >= date_trunc('month', now() AT TIME ZONE 'UTC') AT TIME ZONE 'UTC'
         """
     )
-    monthly = (await session.execute(sql_monthly)).scalar_one_or_none() or Decimal("0")
-    if Decimal(str(monthly)) >= digest_config.monthly_cost_ceiling_usd:
+    monthly = (
+        await session.execute(sql_monthly, {"type": type})
+    ).scalar_one_or_none() or Decimal("0")
+    if Decimal(str(monthly)) >= monthly_ceiling:
         return True
     return False
 
@@ -164,7 +222,7 @@ async def _acquire_idempotency_lock(
 async def run_digest(
     session: AsyncSession,
     *,
-    type: Literal["daily"],
+    type: Literal["daily", "weekly"],
     window_start: datetime,
     window_end: datetime,
     ledger_repo: LedgerRepoProtocol,
@@ -172,9 +230,20 @@ async def run_digest(
     config: LLMGatewayConfig,
     digest_config: DigestConfig,
 ) -> Digest:
-    """Orchestrate a digest run. Always returns a Digest row."""
-    if type != "daily":
-        raise ValueError(f"Phase 7 only supports type='daily', got {type!r}")
+    """Orchestrate a digest run. Always returns a Digest row.
+
+    Type widening (Phase 8 / T8-02 — PHASE8_PLAN.md §5.B): now accepts
+    ``type='weekly'``. The auto-pipeline terminal state for weekly is
+    ``status='draft'``; the transition to ``awaiting_review`` happens in
+    ``digest_weekly_job`` after this function returns (T8-04 / T8-05
+    territory). This keeps ``run_digest`` type-agnostic in its terminal
+    contract.
+
+    Cost ceiling routes via ``_cost_ceiling_breached(type=type)`` (H6
+    type filter) so daily and weekly buckets are INDEPENDENT.
+    """
+    if type not in ("daily", "weekly"):
+        raise ValueError(f"unsupported digest type {type!r}; expected 'daily' or 'weekly'")
 
     # Step 1 — race-safe idempotency.
     await _acquire_idempotency_lock(
@@ -203,8 +272,10 @@ async def run_digest(
             raise RuntimeError(f"digest {existing} disappeared after FOR UPDATE")
         return digest
 
-    # Step 2 — Phase 7 separate-bucket cost ceiling pre-check.
-    if await _cost_ceiling_breached(session, digest_config=digest_config):
+    # Step 2 — separate-bucket cost ceiling pre-check. Daily and weekly
+    # buckets are INDEPENDENT (PHASE8_PLAN.md §6 Q7 / AC6).
+    if await _cost_ceiling_breached(session, digest_config=digest_config, type=type):
+        budget_err = f"{type} digest budget exceeded"
         digest = Digest(
             type=type,
             window_start=window_start,
@@ -212,14 +283,14 @@ async def run_digest(
             body_markdown=None,
             citations=[],
             status="cost_exceeded",
-            error_text="daily digest budget exceeded",
+            error_text=budget_err,
         )
         session.add(digest)
         await session.flush()
         run = DigestRun(
             digest_id=digest.id,
             status="cost_exceeded",
-            error_text="daily digest budget exceeded",
+            error_text=budget_err,
             finished_at=datetime.now(timezone.utc),
         )
         session.add(run)
@@ -241,7 +312,8 @@ async def run_digest(
     session.add(run)
     await session.flush()
 
-    # Step 5 — build context.
+    # Step 5 — build context. Weekly path support lands in T8-03 (parallel
+    # sprint); the call passes `type=type` per spec §5.B step 5.
     try:
         ctx = await build_digest_context(
             session,
@@ -253,7 +325,9 @@ async def run_digest(
         )
     except Exception as exc:
         digest.status = "failed"
-        digest.error_text = f"context_build_failed:{type(exc).__name__}"
+        # Use ``exc.__class__.__name__`` rather than ``type(exc).__name__``
+        # — ``type`` is a kwarg in this scope and shadows the builtin.
+        digest.error_text = f"context_build_failed:{exc.__class__.__name__}"
         run.status = "failed"
         run.error_text = str(exc)[:2000]
         run.finished_at = datetime.now(timezone.utc)
@@ -268,7 +342,8 @@ async def run_digest(
         await session.flush()
         return digest
 
-    # Step 7 — synthesize.
+    # Step 7 — synthesize. Type-aware routing into the correct prompt template
+    # module happens inside ``synthesize_digest`` (§5.F).
     try:
         result = await synthesize_digest(
             session,
@@ -276,6 +351,7 @@ async def run_digest(
             config=config,
             ledger_repo=ledger_repo,
             provider=provider,
+            type=type,
         )
     except DigestEmptyWindowError:
         digest.status = "skipped"
@@ -301,7 +377,8 @@ async def run_digest(
         return digest
     except (DigestProviderError, DigestCitationValidationError) as exc:
         digest.status = "failed"
-        digest.error_text = type(exc).__name__
+        # Same ``type`` shadowing — use ``exc.__class__.__name__``.
+        digest.error_text = exc.__class__.__name__
         run.status = "failed"
         run.error_text = str(exc)[:2000]
         run.finished_at = datetime.now(timezone.utc)
@@ -309,7 +386,7 @@ async def run_digest(
         return digest
     except Exception as exc:
         digest.status = "failed"
-        digest.error_text = f"unexpected:{type(exc).__name__}"
+        digest.error_text = f"unexpected:{exc.__class__.__name__}"
         run.status = "failed"
         run.error_text = str(exc)[:2000]
         run.finished_at = datetime.now(timezone.utc)

--- a/bot/services/llm_gateway.py
+++ b/bot/services/llm_gateway.py
@@ -1411,6 +1411,42 @@ class SynthesizeDigestResult:
 
 _CITATION_TOKEN_RE = re.compile(r"\[\[(cs|mv|card):([^\]]+)\]\]")
 
+# §5.F: section header pattern for weekly digests. Matches lines of the form
+# `## Раздел: <title>` at line-start; title is captured.
+_SECTION_HEADER_RE = re.compile(r"^##\s+Раздел:\s+(.+)$", re.MULTILINE)
+
+
+def _extract_sections(body_markdown: str) -> list[tuple[str, list[str]]]:
+    """Parse `## Раздел: <name>` section headers + their bullets.
+
+    Returns a list of `(section_title, bullet_lines)` tuples in document
+    order. ``bullet_lines`` collects raw ``- `` / ``• `` line-start lines
+    appearing between this header and the next header (or end of body).
+    Lines that are not bullets and not headers are ignored.
+
+    Used by the weekly digest renderer (T8-06) and by the M1 section title
+    allowlist soft-validator in `synthesize_digest`. Returns an empty list
+    for bodies with no `## Раздел: …` headers.
+    """
+    lines = body_markdown.splitlines()
+    sections: list[tuple[str, list[str]]] = []
+    current_title: str | None = None
+    current_bullets: list[str] = []
+    for line in lines:
+        m = _SECTION_HEADER_RE.match(line)
+        if m is not None:
+            if current_title is not None:
+                sections.append((current_title, current_bullets))
+            current_title = m.group(1).strip()
+            current_bullets = []
+            continue
+        if line.startswith("- ") or line.startswith("• "):
+            if current_title is not None:
+                current_bullets.append(line)
+    if current_title is not None:
+        sections.append((current_title, current_bullets))
+    return sections
+
 
 def _bullet_index_at_offset(body_markdown: str, char_offset: int) -> int:
     """Return the 0-based index of the bullet that contains ``char_offset``.
@@ -1594,15 +1630,41 @@ async def synthesize_digest(
     config: LLMGatewayConfig,
     ledger_repo: LedgerRepoProtocol,
     provider: LLMProvider,
-    prompt_template_version: str = "digest-v0.1.0",
+    type: Literal["daily", "weekly"] = "daily",
 ) -> SynthesizeDigestResult:
-    """T7-02 — synthesize daily digest. See PHASE7_PLAN.md §5.D."""
+    """Synthesize a digest body via the LLM gateway.
+
+    Routes by ``type`` (PHASE8_PLAN.md §5.F):
+      - ``daily``  → ``digest_v0_1_0`` (Phase 7 / T7-02 — unchanged).
+      - ``weekly`` → ``digest_weekly_v0_1_0`` (Phase 8 / T8-02 — section-aware
+        editorial recap with five-name section title allowlist as a soft contract).
+
+    Pre-provider revalidation (`_digest_context_is_clean`) and bullet-level
+    citation invariant are identical across both paths. Section headers
+    `## Раздел: …` are inert at parse-time — the bullet tokenizer counts
+    only ``- `` / ``• `` line-starts.
+
+    Soft contract (M1): when the body returned by the provider contains a
+    `## Раздел: …` header whose title is NOT in the weekly module's
+    ``SECTION_NAME_ALLOWLIST``, a structured warning is logged but the run
+    is NOT failed. Hard enforcement is Phase 8.5 backlog.
+    """
     await _digest_context_is_clean(session, cards=context.cards, messages=context.messages)
 
-    from bot.services.llm_prompts.digest_v0_1_0 import (
-        SYSTEM_PROMPT,
-        build_user_prompt,
-    )
+    if type == "weekly":
+        from bot.services.llm_prompts.digest_weekly_v0_1_0 import (
+            PROMPT_VERSION,
+            SECTION_NAME_ALLOWLIST,
+            SYSTEM_PROMPT,
+            build_user_prompt,
+        )
+    else:
+        from bot.services.llm_prompts.digest_v0_1_0 import (
+            PROMPT_VERSION,
+            SYSTEM_PROMPT,
+            build_user_prompt,
+        )
+        SECTION_NAME_ALLOWLIST = None  # daily path has no allowlist; warning skipped
 
     user_prompt = build_user_prompt(
         window_start_msk=context.window_start.isoformat(),
@@ -1612,6 +1674,9 @@ async def synthesize_digest(
     )
     full_prompt = f"{SYSTEM_PROMPT}\n\n{user_prompt}"
     prompt_hash = _prompt_hash(full_prompt)
+    # PROMPT_VERSION is module-level — keep available for downstream ledger
+    # logging if the gateway grows a template-version field later.
+    _ = PROMPT_VERSION
 
     valid_card_source_ids: frozenset[str] = frozenset(
         str(s) for c in context.cards for s in c.card_source_ids
@@ -1718,6 +1783,21 @@ async def synthesize_digest(
             prompt_hash[:12],
             placeholder_row.id,
         )
+
+    # §5.F M1 — section title allowlist soft check (weekly only). The five-name
+    # allowlist is a soft contract on the LLM prompt; any off-allowlist title
+    # logs a structured warning but does NOT fail the run. Phase 8.5 backlog
+    # item: hard-enforce if drift is observed.
+    if SECTION_NAME_ALLOWLIST is not None:
+        for section_title, _bullets in _extract_sections(body_text):
+            if section_title not in SECTION_NAME_ALLOWLIST:
+                logger.warning(
+                    "synthesize_digest: off-allowlist section title %r "
+                    "(prompt_hash=%s, ledger_id=%d)",
+                    section_title,
+                    prompt_hash[:12],
+                    placeholder_row.id,
+                )
 
     valid_tokens: set[str] = set()
     for cit in citations:

--- a/bot/services/llm_prompts/digest_weekly_v0_1_0.py
+++ b/bot/services/llm_prompts/digest_weekly_v0_1_0.py
@@ -1,0 +1,93 @@
+"""Weekly digest synthesis prompt template — v0.1.0 (Phase 8 / T8-02).
+
+Used by `bot/services/llm_gateway.py::synthesize_digest(type='weekly')`
+per `docs/memory-system/PHASE8_PLAN.md` §5.F. Output format is enforced by
+parsing in the caller — if the LLM violates the bullet-level citation
+invariant the caller raises `DigestCitationValidationError` and the digest
+is marked `failed`.
+
+Section header format is a SOFT contract: the prompt asks the LLM to use
+one of five Russian titles (`SECTION_NAME_ALLOWLIST`), but the caller emits
+a structured warning rather than failing when an off-allowlist title is
+returned. Hard enforcement is a Phase 8.5 backlog item.
+"""
+
+from __future__ import annotations
+
+PROMPT_VERSION = "digest-weekly-v0.1.0"
+
+# §5.F M1 — five canonical Russian section titles. The prompt instructs the
+# LLM to use only these; the caller emits a structured warning if a returned
+# section header carries an off-allowlist title (soft contract).
+SECTION_NAME_ALLOWLIST: frozenset[str] = frozenset({
+    "Объявления",
+    "Обсуждения",
+    "Знания и ресурсы",
+    "Встречи и события",
+    "Прочее",
+})
+
+SYSTEM_PROMPT = """You are writing an editorial WEEKLY digest for a private community chat.
+This will be reviewed by an admin before publishing — do not assume it
+will be sent verbatim. Write the best draft you can; the admin will
+approve or reject.
+
+Output format (strict):
+  Line 1-4: TL;DR — 3-4 short sentences in Russian, prose. Cover the
+            week's main themes at a high level.
+  Blank line.
+  Then 2-5 SECTIONS, each separated by a blank line. Section header
+  format (strict, used by the renderer to bold the heading):
+    ## Раздел: {section_title}
+  Section title MUST be one of these allowed prefixes (in Russian):
+    - Объявления
+    - Обсуждения
+    - Знания и ресурсы
+    - Встречи и события
+    - Прочее
+  Within each section, 3-7 bullets:
+    - Topic title (≤10 words).
+    - 1-2 sentence summary.
+    - Citation tokens: [[cs:UUID]] for an approved card source,
+      [[mv:INT]] for a raw message version. EVERY bullet MUST contain
+      at least one citation token referencing input ids verbatim.
+  Skip a section entirely if there is no material for it. Do NOT
+  invent section names. Do NOT cite ids absent from the input.
+
+Use Russian. Be neutral. Do not invent facts.
+If the input has no cards and no messages, return exactly: EMPTY_WINDOW
+"""
+
+
+def build_user_prompt(
+    *,
+    window_start_msk: str,
+    window_end_msk: str,
+    cards: list,
+    messages: list,
+) -> str:
+    """Compose the user-side of the weekly digest prompt. Returns a single string.
+
+    Mirrors `digest_v0_1_0.build_user_prompt` shape — cards section + messages
+    section, separated by `---`. Window framing names "ISO week" to clarify
+    the weekly cadence to the LLM.
+    """
+    lines = [
+        f"Window: {window_start_msk} .. {window_end_msk} (Europe/Moscow, ISO week)",
+        f"Cards ({len(cards)}):",
+    ]
+    for c in cards:
+        sids_csv = ", ".join(str(s) for s in c.card_source_ids)
+        lines.append(
+            f'  Card "{c.title}" (approved). Source ids you may cite: {sids_csv}'
+        )
+        lines.append(f"  Card body: {c.body_markdown}")
+        lines.append("  ---")
+    lines.append(f"Messages ({len(messages)}):")
+    for m in messages:
+        lines.append(
+            f"  [mv:{m.message_version_id}] {m.author_display},"
+            f" {m.ts.isoformat()}: {m.text}"
+        )
+        lines.append("  ---")
+    return "\n".join(lines)

--- a/tests/services/test_digests_run.py
+++ b/tests/services/test_digests_run.py
@@ -287,19 +287,21 @@ def test_validate_every_bullet_has_citation_passes_when_all_covered():
 # ── DB-dependent tests ───────────────────────────────────────────────────────
 
 
-async def test_run_digest_rejects_weekly(db_session):
+async def test_run_digest_rejects_unknown_type(db_session):
+    """T8-02 widening: run_digest now accepts both 'daily' and 'weekly'.
+    Other type values are still rejected with a clear ValueError."""
     from bot.services.digests import run_digest
 
     cfg = _make_gateway_config()
     dcfg = _make_digest_config()
-    with pytest.raises(ValueError, match="daily"):
+    with pytest.raises(ValueError, match="unsupported digest type"):
         await run_digest(
             db_session,
-            type="weekly",  # type: ignore[arg-type]
+            type="monthly",  # type: ignore[arg-type]
             window_start=datetime.now(timezone.utc) - timedelta(days=1),
             window_end=datetime.now(timezone.utc),
-            ledger_repo=None,  # not reached
-            provider=None,  # not reached
+            ledger_repo=None,
+            provider=None,
             config=cfg,
             digest_config=dcfg,
         )

--- a/tests/services/test_digests_weekly.py
+++ b/tests/services/test_digests_weekly.py
@@ -1,0 +1,1007 @@
+"""Tests for Phase 8 / T8-02 — weekly digest path.
+
+Covers:
+- `bot/services/llm_prompts/digest_weekly_v0_1_0.py` — prompt module shape
+  (PROMPT_VERSION, SYSTEM_PROMPT, SECTION_NAME_ALLOWLIST, build_user_prompt).
+- `bot/services/digests.py`:
+  - `DigestConfig` weekly fields (defaults per §5.B).
+  - `load_digest_config()` reads weekly env vars.
+  - `_cost_ceiling_breached(type='weekly')` SQL filter independence.
+  - `run_digest(type='weekly', ...)` accepts weekly, ends at `status='draft'`,
+    weekly cost-ceiling pre-check fires, idempotency.
+- `bot/services/llm_gateway.py`:
+  - `synthesize_digest(type='weekly', ...)` imports weekly prompt module.
+  - `_extract_sections` parses `## Раздел: <name>` headers + bullets.
+  - Section header tolerance: bullet-index parser skips headers (no false bullet).
+  - Section title allowlist soft warning (M1).
+"""
+
+from __future__ import annotations
+
+import itertools
+import logging
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+
+import pytest
+
+pytestmark = pytest.mark.usefixtures("app_env")
+
+_user_counter = itertools.count(start=8_400_000_000)
+_msg_counter = itertools.count(start=840_000)
+_chat_counter = itertools.count(start=8400)
+
+
+def _next_uid() -> int:
+    return next(_user_counter)
+
+
+def _next_msg_id() -> int:
+    return next(_msg_counter)
+
+
+def _next_chat_id() -> int:
+    return -1_000_000_000_000 - next(_chat_counter)
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+
+async def _make_user(db_session) -> int:
+    from bot.db.repos.user import UserRepo
+
+    uid = _next_uid()
+    await UserRepo.upsert(
+        db_session,
+        telegram_id=uid,
+        username=f"u{uid}",
+        first_name="T",
+        last_name=None,
+    )
+    return uid
+
+
+async def _make_msg_and_version(
+    db_session, *, chat_id: int, ts: datetime, text: str = "hello",
+) -> tuple[int, int]:
+    from bot.db.models import ChatMessage, MessageVersion
+
+    uid = await _make_user(db_session)
+    msg_id = _next_msg_id()
+    msg = ChatMessage(
+        message_id=msg_id,
+        chat_id=chat_id,
+        user_id=uid,
+        text=text,
+        date=ts,
+        raw_json={"text": text},
+        memory_policy="normal",
+        is_redacted=False,
+    )
+    db_session.add(msg)
+    await db_session.flush()
+    mv = MessageVersion(
+        chat_message_id=msg.id,
+        version_seq=1,
+        text=text,
+        normalized_text=text,
+        entities_json={"entities": []},
+        content_hash=f"hash-{msg_id}",
+        is_redacted=False,
+    )
+    db_session.add(mv)
+    await db_session.flush()
+    msg.current_version_id = mv.id
+    await db_session.flush()
+    return msg.id, mv.id
+
+
+def _make_gateway_config():
+    from bot.services.llm_gateway import LLMGatewayConfig
+
+    return LLMGatewayConfig(
+        provider="anthropic",
+        model="claude-haiku-4-5-20251001",
+        daily_ceiling_usd=Decimal("10.00"),
+        monthly_ceiling_usd=Decimal("100.00"),
+        prompt_template_version="digest-weekly-v0.1.0",
+    )
+
+
+def _make_digest_config(**overrides):
+    from bot.services.digests import DigestConfig
+
+    defaults = {
+        "daily_cost_ceiling_usd": Decimal("1.00"),
+        "monthly_cost_ceiling_usd": Decimal("10.00"),
+        "source_chat_id": 0,
+        "destination_chat_id": None,
+        "hour_msk": 9,
+        "min_cards_threshold": 3,
+        "raw_message_top_n": 15,
+        "token_budget_input": 8000,
+        "weekly_cost_ceiling_usd": Decimal("5.00"),
+        "weekly_monthly_cost_ceiling_usd": Decimal("20.00"),
+        "weekly_token_budget_input": 24000,
+        "weekly_min_cards_threshold": 8,
+        "weekly_raw_message_top_n": 60,
+    }
+    defaults.update(overrides)
+    return DigestConfig(**defaults)
+
+
+# ── 1. Prompt module shape ───────────────────────────────────────────────────
+
+
+def test_weekly_prompt_module_exports_required_symbols():
+    """digest_weekly_v0_1_0 mirrors digest_v0_1_0 shape: PROMPT_VERSION,
+    SYSTEM_PROMPT, build_user_prompt; adds SECTION_NAME_ALLOWLIST (M1)."""
+    from bot.services.llm_prompts import digest_weekly_v0_1_0 as mod
+
+    assert mod.PROMPT_VERSION == "digest-weekly-v0.1.0"
+    assert isinstance(mod.SYSTEM_PROMPT, str) and "EMPTY_WINDOW" in mod.SYSTEM_PROMPT
+    assert isinstance(mod.SECTION_NAME_ALLOWLIST, frozenset)
+    assert mod.SECTION_NAME_ALLOWLIST == frozenset({
+        "Объявления",
+        "Обсуждения",
+        "Знания и ресурсы",
+        "Встречи и события",
+        "Прочее",
+    })
+    assert callable(mod.build_user_prompt)
+
+
+def test_weekly_prompt_system_block_demands_section_format_and_citations():
+    """§5.F SYSTEM contract: section header format `## Раздел: …`, EVERY bullet
+    must contain at least one citation token, Russian neutral framing."""
+    from bot.services.llm_prompts.digest_weekly_v0_1_0 import SYSTEM_PROMPT
+
+    assert "## Раздел:" in SYSTEM_PROMPT
+    assert "[[cs:UUID]]" in SYSTEM_PROMPT
+    assert "[[mv:INT]]" in SYSTEM_PROMPT
+    assert "EVERY bullet" in SYSTEM_PROMPT
+    # Russian community + weekly framing
+    assert "WEEKLY" in SYSTEM_PROMPT
+
+
+def test_weekly_prompt_user_template_emits_window_and_cards_and_messages():
+    """build_user_prompt returns a single-string layout: window line, cards
+    section, messages section. Mirrors digest_v0_1_0 contract."""
+    from dataclasses import dataclass
+
+    from bot.services.llm_prompts.digest_weekly_v0_1_0 import build_user_prompt
+
+    @dataclass(frozen=True)
+    class _Card:
+        title: str
+        body_markdown: str
+        card_source_ids: list
+
+    @dataclass(frozen=True)
+    class _Msg:
+        message_version_id: int
+        author_display: str
+        text: str
+        ts: datetime
+
+    cards = [_Card(title="C1", body_markdown="body", card_source_ids=["uuid-a"])]
+    msgs = [_Msg(
+        message_version_id=12345,
+        author_display="Alice",
+        text="hello world",
+        ts=datetime(2026, 5, 10, 12, 0, tzinfo=timezone.utc),
+    )]
+    out = build_user_prompt(
+        window_start_msk="2026-05-04T00:00:00",
+        window_end_msk="2026-05-11T00:00:00",
+        cards=cards,
+        messages=msgs,
+    )
+    assert "Window: 2026-05-04T00:00:00 .. 2026-05-11T00:00:00" in out
+    assert "Cards (1)" in out
+    assert "uuid-a" in out
+    assert "Messages (1)" in out
+    assert "[mv:12345]" in out
+    assert "hello world" in out
+
+
+# ── 2. DigestConfig + load_digest_config weekly fields ───────────────────────
+
+
+def test_digest_config_has_weekly_fields_with_defaults():
+    """§5.B DigestConfig extension — weekly defaults independent of daily."""
+    from bot.services.digests import DigestConfig
+
+    cfg = DigestConfig()
+    # Phase 7 (unchanged)
+    assert cfg.daily_cost_ceiling_usd == Decimal("1.00")
+    # Phase 8 additions
+    assert cfg.weekly_cost_ceiling_usd == Decimal("5.00")
+    assert cfg.weekly_monthly_cost_ceiling_usd == Decimal("20.00")
+    assert cfg.weekly_token_budget_input == 24000
+    assert cfg.weekly_min_cards_threshold == 8
+    assert cfg.weekly_raw_message_top_n == 60
+
+
+def test_load_digest_config_reads_weekly_env_vars(monkeypatch):
+    """§5.B load_digest_config reads DIGEST_WEEKLY_* env vars."""
+    monkeypatch.setenv("DIGEST_WEEKLY_USD_CEILING", "7.00")
+    monkeypatch.setenv("DIGEST_WEEKLY_MONTHLY_USD_CEILING", "30.00")
+    monkeypatch.setenv("DIGEST_WEEKLY_TOKEN_BUDGET", "12000")
+    monkeypatch.setenv("DIGEST_WEEKLY_MIN_CARDS_THRESHOLD", "10")
+    monkeypatch.setenv("DIGEST_WEEKLY_RAW_MESSAGE_TOP_N", "40")
+
+    from bot.services.digests import load_digest_config
+
+    cfg = load_digest_config()
+    assert cfg.weekly_cost_ceiling_usd == Decimal("7.00")
+    assert cfg.weekly_monthly_cost_ceiling_usd == Decimal("30.00")
+    assert cfg.weekly_token_budget_input == 12000
+    assert cfg.weekly_min_cards_threshold == 10
+    assert cfg.weekly_raw_message_top_n == 40
+
+
+# ── 3. _cost_ceiling_breached type filter ────────────────────────────────────
+
+
+async def test_cost_ceiling_breached_weekly_independent_of_daily(db_session):
+    """H6 / Q7: a daily-type digest ledger row does NOT trip the weekly bucket
+    and vice-versa. SQL `WHERE d.type=:type` enforces separation."""
+    from bot.db.models import Digest, LlmUsageLedger
+    from bot.services.digests import _cost_ceiling_breached
+
+    # Insert a *daily* digest pinned to a $5.00 ledger entry. The daily ceiling
+    # is $1.00 (will trip); the weekly ceiling is $5.00 (must NOT trip — no
+    # weekly row present yet).
+    ledger = LlmUsageLedger(
+        provider="anthropic",
+        model="haiku",
+        prompt_hash="d" * 64,
+        response_hash="r" * 64,
+        tokens_in=100,
+        tokens_out=50,
+        cost_usd=Decimal("5.00"),
+        latency_ms=10,
+        request_id="r1",
+        cache_hit=False,
+        error=None,
+    )
+    db_session.add(ledger)
+    await db_session.flush()
+    daily_digest = Digest(
+        type="daily",
+        window_start=datetime.now(timezone.utc) - timedelta(days=2),
+        window_end=datetime.now(timezone.utc) - timedelta(days=1),
+        body_markdown="prior daily",
+        citations=[],
+        status="draft",
+        llm_usage_ledger_id=ledger.id,
+    )
+    db_session.add(daily_digest)
+    await db_session.flush()
+
+    dcfg = _make_digest_config(
+        daily_cost_ceiling_usd=Decimal("1.00"),
+        weekly_cost_ceiling_usd=Decimal("5.00"),
+    )
+    # Daily bucket trips (5.00 >= 1.00 daily ceiling).
+    assert await _cost_ceiling_breached(db_session, digest_config=dcfg, type="daily") is True
+    # Weekly bucket does NOT trip — no weekly-type row present.
+    assert await _cost_ceiling_breached(db_session, digest_config=dcfg, type="weekly") is False
+
+
+async def test_cost_ceiling_breached_weekly_trips_on_weekly_ledger_row(db_session):
+    """A weekly-type digest+ledger row trips the weekly ceiling."""
+    from bot.db.models import Digest, LlmUsageLedger
+    from bot.services.digests import _cost_ceiling_breached
+
+    ledger = LlmUsageLedger(
+        provider="anthropic",
+        model="haiku",
+        prompt_hash="w" * 64,
+        response_hash="r" * 64,
+        tokens_in=2000,
+        tokens_out=500,
+        cost_usd=Decimal("6.00"),  # > 5.00 weekly ceiling
+        latency_ms=20,
+        request_id="r2",
+        cache_hit=False,
+        error=None,
+    )
+    db_session.add(ledger)
+    await db_session.flush()
+    weekly_digest = Digest(
+        type="weekly",
+        window_start=datetime.now(timezone.utc) - timedelta(days=8),
+        window_end=datetime.now(timezone.utc) - timedelta(days=1),
+        body_markdown="prior weekly",
+        citations=[],
+        status="draft",
+        llm_usage_ledger_id=ledger.id,
+    )
+    db_session.add(weekly_digest)
+    await db_session.flush()
+
+    dcfg = _make_digest_config(
+        daily_cost_ceiling_usd=Decimal("1.00"),
+        weekly_cost_ceiling_usd=Decimal("5.00"),
+    )
+    # Weekly bucket trips.
+    assert await _cost_ceiling_breached(db_session, digest_config=dcfg, type="weekly") is True
+    # Daily bucket does NOT trip — no daily-type row.
+    assert await _cost_ceiling_breached(db_session, digest_config=dcfg, type="daily") is False
+
+
+async def test_cost_ceiling_breached_default_type_is_daily(db_session):
+    """Back-compat: existing Phase 7 callsite (no `type=` kwarg) defaults to
+    `type='daily'` and behaves identically to pre-T8-02 implementation."""
+    from bot.db.models import Digest, LlmUsageLedger
+    from bot.services.digests import _cost_ceiling_breached
+
+    ledger = LlmUsageLedger(
+        provider="anthropic",
+        model="haiku",
+        prompt_hash="x" * 64,
+        response_hash="r" * 64,
+        tokens_in=100,
+        tokens_out=50,
+        cost_usd=Decimal("1.50"),
+        latency_ms=10,
+        request_id="r",
+        cache_hit=False,
+        error=None,
+    )
+    db_session.add(ledger)
+    await db_session.flush()
+    daily_digest = Digest(
+        type="daily",
+        window_start=datetime.now(timezone.utc) - timedelta(days=2),
+        window_end=datetime.now(timezone.utc) - timedelta(days=1),
+        body_markdown="prior",
+        citations=[],
+        status="draft",
+        llm_usage_ledger_id=ledger.id,
+    )
+    db_session.add(daily_digest)
+    await db_session.flush()
+
+    dcfg = _make_digest_config(daily_cost_ceiling_usd=Decimal("1.00"))
+    # No `type=` kwarg — default daily.
+    assert await _cost_ceiling_breached(db_session, digest_config=dcfg) is True
+
+
+# ── 4. run_digest type='weekly' path ─────────────────────────────────────────
+
+
+async def test_run_digest_accepts_weekly_type_and_calls_context_with_weekly(
+    db_session, monkeypatch
+):
+    """T8-02 widening: run_digest accepts type='weekly' (no longer raises
+    `ValueError(\"Phase 7 only supports type='daily'\")`) and dispatches
+    `build_digest_context` with `type='weekly'` per §5.B step 5.
+
+    `build_digest_context` weekly handling lands in T8-03 (parallel sprint),
+    so we mock it here to verify the call-chain wiring is correct.
+    """
+    from bot.services.digest_context import DigestContext
+    from bot.services import digests as digests_module
+    from bot.services.digests import run_digest
+
+    chat_id = _next_chat_id()
+    dcfg = _make_digest_config(source_chat_id=chat_id)
+    cfg = _make_gateway_config()
+    now = datetime.now(timezone.utc)
+    ws = now - timedelta(days=8)
+    we = now - timedelta(days=1)
+
+    captured: dict = {}
+
+    async def _stub_build_context(session, **kwargs):
+        captured.update(kwargs)
+        # Return empty context to short-circuit downstream.
+        return DigestContext(
+            type="daily",  # T8-03 widens to 'weekly'
+            window_start=kwargs["window_start"],
+            window_end=kwargs["window_end"],
+            source_chat_id=kwargs["source_chat_id"],
+            cards=[],
+            messages=[],
+        )
+
+    monkeypatch.setattr(digests_module, "build_digest_context", _stub_build_context)
+
+    digest = await run_digest(
+        db_session,
+        type="weekly",
+        window_start=ws,
+        window_end=we,
+        ledger_repo=None,
+        provider=None,
+        config=cfg,
+        digest_config=dcfg,
+    )
+    # build_digest_context was called with type='weekly'.
+    assert captured.get("type") == "weekly", f"got kwargs={captured}"
+    assert captured["window_start"] == ws
+    assert captured["window_end"] == we
+    # Row exists with type='weekly', skipped on empty window.
+    assert digest.type == "weekly"
+    assert digest.status == "skipped"
+
+
+async def test_run_digest_weekly_cost_ceiling_fires_before_llm(db_session):
+    """T8-02 AC4 / AC6: weekly bucket pre-check fires using `type='weekly'`
+    filter. No LLM call. Creates digests + digest_runs rows with
+    `status='cost_exceeded'` and the weekly-specific error_text."""
+    from bot.db.models import Digest, DigestRun, LlmUsageLedger
+    from bot.services.digests import run_digest
+    from sqlalchemy import select
+
+    chat_id = _next_chat_id()
+    # Pre-insert weekly ledger row exceeding weekly ceiling.
+    ledger = LlmUsageLedger(
+        provider="anthropic",
+        model="haiku",
+        prompt_hash="w" * 64,
+        response_hash="r" * 64,
+        tokens_in=2000,
+        tokens_out=500,
+        cost_usd=Decimal("6.00"),  # > 5.00 weekly ceiling
+        latency_ms=20,
+        request_id="r0",
+        cache_hit=False,
+        error=None,
+    )
+    db_session.add(ledger)
+    await db_session.flush()
+    prior = Digest(
+        type="weekly",
+        window_start=datetime.now(timezone.utc) - timedelta(days=15),
+        window_end=datetime.now(timezone.utc) - timedelta(days=8),
+        body_markdown="prior weekly",
+        citations=[],
+        status="draft",
+        llm_usage_ledger_id=ledger.id,
+    )
+    db_session.add(prior)
+    await db_session.flush()
+
+    dcfg = _make_digest_config(
+        source_chat_id=chat_id,
+        weekly_cost_ceiling_usd=Decimal("5.00"),
+    )
+    cfg = _make_gateway_config()
+    now = datetime.now(timezone.utc)
+    digest = await run_digest(
+        db_session,
+        type="weekly",
+        window_start=now - timedelta(days=7),
+        window_end=now,
+        ledger_repo=None,  # not reached
+        provider=None,
+        config=cfg,
+        digest_config=dcfg,
+    )
+    assert digest.type == "weekly"
+    assert digest.status == "cost_exceeded"
+    assert digest.error_text == "weekly digest budget exceeded"
+    # digest_runs row also created.
+    run_row = (await db_session.execute(
+        select(DigestRun).where(DigestRun.digest_id == digest.id)
+    )).scalar_one()
+    assert run_row.status == "cost_exceeded"
+    assert run_row.error_text == "weekly digest budget exceeded"
+
+
+async def test_run_digest_weekly_idempotency(db_session, monkeypatch):
+    """T8-02 acceptance: re-run for same (type='weekly', ws, we) returns the
+    same digest row without re-invoking the gateway. Mirrors Phase 7 daily
+    idempotency. `build_digest_context` is mocked (T8-03 territory)."""
+    from bot.services.digest_context import DigestContext
+    from bot.services import digests as digests_module
+    from bot.services.digests import run_digest
+
+    chat_id = _next_chat_id()
+    dcfg = _make_digest_config(source_chat_id=chat_id)
+    cfg = _make_gateway_config()
+    now = datetime.now(timezone.utc)
+    ws = now - timedelta(days=7)
+    we = now
+
+    async def _stub_build_context(session, **kwargs):
+        return DigestContext(
+            type="daily",
+            window_start=kwargs["window_start"],
+            window_end=kwargs["window_end"],
+            source_chat_id=kwargs["source_chat_id"],
+            cards=[],
+            messages=[],
+        )
+
+    monkeypatch.setattr(digests_module, "build_digest_context", _stub_build_context)
+
+    d1 = await run_digest(
+        db_session, type="weekly", window_start=ws, window_end=we,
+        ledger_repo=None, provider=None, config=cfg, digest_config=dcfg,
+    )
+    await db_session.flush()
+    d2 = await run_digest(
+        db_session, type="weekly", window_start=ws, window_end=we,
+        ledger_repo=None, provider=None, config=cfg, digest_config=dcfg,
+    )
+    assert d1.id == d2.id
+    assert d2.type == "weekly"
+    assert d2.status == "skipped"
+
+
+async def test_run_digest_weekly_daily_cost_buckets_are_isolated(
+    db_session, monkeypatch
+):
+    """A weekly run does NOT trip the daily bucket and vice versa (Q7).
+
+    `build_digest_context` is mocked (T8-03 territory) — the assertion is
+    about the cost-bucket pre-check, not context-build behaviour.
+    """
+    from bot.db.models import Digest, LlmUsageLedger
+    from bot.services.digest_context import DigestContext
+    from bot.services import digests as digests_module
+    from bot.services.digests import run_digest
+
+    chat_id = _next_chat_id()
+    # Pre-insert a DAILY ledger row > daily ceiling.
+    ledger = LlmUsageLedger(
+        provider="anthropic",
+        model="haiku",
+        prompt_hash="d" * 64,
+        response_hash="r" * 64,
+        tokens_in=100,
+        tokens_out=50,
+        cost_usd=Decimal("2.00"),  # > $1.00 daily ceiling
+        latency_ms=10,
+        request_id="r",
+        cache_hit=False,
+        error=None,
+    )
+    db_session.add(ledger)
+    await db_session.flush()
+    daily_row = Digest(
+        type="daily",
+        window_start=datetime.now(timezone.utc) - timedelta(days=2),
+        window_end=datetime.now(timezone.utc) - timedelta(days=1),
+        body_markdown="prior daily",
+        citations=[],
+        status="draft",
+        llm_usage_ledger_id=ledger.id,
+    )
+    db_session.add(daily_row)
+    await db_session.flush()
+
+    dcfg = _make_digest_config(
+        source_chat_id=chat_id,
+        daily_cost_ceiling_usd=Decimal("1.00"),
+        weekly_cost_ceiling_usd=Decimal("5.00"),
+    )
+    cfg = _make_gateway_config()
+    now = datetime.now(timezone.utc)
+
+    async def _stub_build_context(session, **kwargs):
+        return DigestContext(
+            type="daily",
+            window_start=kwargs["window_start"],
+            window_end=kwargs["window_end"],
+            source_chat_id=kwargs["source_chat_id"],
+            cards=[],
+            messages=[],
+        )
+
+    monkeypatch.setattr(digests_module, "build_digest_context", _stub_build_context)
+
+    # Weekly call: daily ledger row does NOT trip weekly bucket — should not
+    # be cost_exceeded.
+    weekly = await run_digest(
+        db_session, type="weekly",
+        window_start=now - timedelta(days=7), window_end=now,
+        ledger_repo=None, provider=None, config=cfg, digest_config=dcfg,
+    )
+    assert weekly.status == "skipped", (
+        f"weekly cost ceiling falsely tripped by daily ledger; got {weekly.status!r}, "
+        f"error_text={weekly.error_text!r}"
+    )
+
+
+# ── 5. synthesize_digest type='weekly' routing ───────────────────────────────
+
+
+async def test_synthesize_digest_type_weekly_uses_weekly_prompt(db_session):
+    """§5.B step 7 / §5.F: synthesize_digest(type='weekly') imports the weekly
+    prompt module (PROMPT_VERSION='digest-weekly-v0.1.0'); body composition
+    uses the weekly SYSTEM_PROMPT."""
+    from bot.db.repos.llm_usage_ledger import LedgerRepo
+    from bot.services.digest_context import DigestContext, DigestContextMessage
+    from bot.services.llm_gateway import synthesize_digest
+
+    chat_id = _next_chat_id()
+    _cm_id, mv_id = await _make_msg_and_version(
+        db_session,
+        chat_id=chat_id,
+        ts=datetime.now(timezone.utc) - timedelta(days=3),
+        text="weekly recap material",
+    )
+    await db_session.flush()
+
+    # Build a weekly-shaped DigestContext (the dataclass widens type → 'weekly'
+    # in T8-03; for T8-02 we test via the existing daily-typed DigestContext
+    # — the gateway routing reads the explicit `type=` kwarg, not the context's
+    # internal type field).
+    now = datetime.now(timezone.utc)
+    ctx = DigestContext(
+        type="daily",  # T8-03 widens; T8-02 routes via explicit kwarg
+        window_start=now - timedelta(days=7),
+        window_end=now,
+        source_chat_id=chat_id,
+        cards=[],
+        messages=[
+            DigestContextMessage(
+                message_version_id=mv_id,
+                chat_message_id=_cm_id,
+                author_display="Alice",
+                text="weekly recap material",
+                ts=now - timedelta(days=3),
+            )
+        ],
+    )
+
+    # Capture the prompt the provider receives so we can verify it uses the
+    # weekly SYSTEM_PROMPT block.
+    seen_prompts: list[str] = []
+
+    class _CapturingProvider:
+        async def call(self, *, prompt: str, model: str):
+            from bot.services.llm_providers import ProviderResult
+
+            seen_prompts.append(prompt)
+            body = (
+                "TL;DR недельный итог в трёх предложениях. "
+                "Вторая сводная фраза. Третья замыкающая.\n"
+                "\n"
+                "## Раздел: Обсуждения\n"
+                f"- Тема обсуждения [[mv:{mv_id}]] краткое резюме\n"
+            )
+            return ProviderResult(
+                answer_text=body,
+                citation_ids=(),
+                tokens_in=200,
+                tokens_out=100,
+                request_id="rw",
+                raw_latency_ms=10,
+            )
+
+    cfg = _make_gateway_config()
+    result = await synthesize_digest(
+        db_session,
+        context=ctx,
+        config=cfg,
+        ledger_repo=LedgerRepo(),
+        provider=_CapturingProvider(),
+        type="weekly",
+    )
+    # Weekly prompt module's SYSTEM block must have been used.
+    assert seen_prompts, "provider was not called"
+    assert "WEEKLY" in seen_prompts[0], (
+        "synthesize_digest(type='weekly') must use the weekly prompt module"
+    )
+    # Citations parsed correctly with section header present (header not
+    # mistaken for a bullet).
+    assert len(result.citations) == 1
+    assert result.citations[0]["kind"] == "message_version"
+    assert result.citations[0]["id"] == mv_id
+    # First bullet is at position 0 — section header `## Раздел: …` did NOT
+    # count as a bullet (existing _bullet_index_at_offset already filters
+    # by `- `/`• ` line-start; verified for weekly section headers).
+    assert result.citations[0]["position"] == 0
+
+
+async def test_synthesize_digest_type_daily_keeps_daily_prompt(db_session):
+    """Back-compat: synthesize_digest with type='daily' (default) still imports
+    the daily prompt module. Existing Phase 7 daily behaviour byte-for-byte."""
+    from bot.db.repos.llm_usage_ledger import LedgerRepo
+    from bot.services.digest_context import DigestContext, DigestContextMessage
+    from bot.services.llm_gateway import synthesize_digest
+
+    chat_id = _next_chat_id()
+    _cm_id, mv_id = await _make_msg_and_version(
+        db_session,
+        chat_id=chat_id,
+        ts=datetime.now(timezone.utc) - timedelta(hours=6),
+    )
+    await db_session.flush()
+
+    now = datetime.now(timezone.utc)
+    ctx = DigestContext(
+        type="daily",
+        window_start=now - timedelta(days=1),
+        window_end=now,
+        source_chat_id=chat_id,
+        cards=[],
+        messages=[
+            DigestContextMessage(
+                message_version_id=mv_id,
+                chat_message_id=_cm_id,
+                author_display="Bob",
+                text="hello",
+                ts=now - timedelta(hours=6),
+            )
+        ],
+    )
+
+    seen_prompts: list[str] = []
+
+    class _CapturingProvider:
+        async def call(self, *, prompt: str, model: str):
+            from bot.services.llm_providers import ProviderResult
+
+            seen_prompts.append(prompt)
+            body = (
+                "TL;DR одна фраза. Вторая. Третья.\n"
+                "\n"
+                f"- Topic [[mv:{mv_id}]] summary\n"
+            )
+            return ProviderResult(
+                answer_text=body,
+                citation_ids=(),
+                tokens_in=100,
+                tokens_out=40,
+                request_id="rd",
+                raw_latency_ms=10,
+            )
+
+    cfg = _make_gateway_config()
+    # Default type='daily' (no kwarg).
+    await synthesize_digest(
+        db_session,
+        context=ctx,
+        config=cfg,
+        ledger_repo=LedgerRepo(),
+        provider=_CapturingProvider(),
+    )
+    # Daily SYSTEM block uses "daily digest" wording, NOT "WEEKLY".
+    assert "WEEKLY" not in seen_prompts[0]
+    assert "daily digest" in seen_prompts[0]
+
+
+# ── 6. Section parsing helpers + allowlist warning (M1) ──────────────────────
+
+
+def test_extract_sections_returns_title_and_bullets():
+    """§5.F `_extract_sections(body_markdown) -> list[tuple[str, list[str]]]`."""
+    from bot.services.llm_gateway import _extract_sections
+
+    body = (
+        "TL;DR прозой первая фраза. Вторая. Третья.\n"
+        "\n"
+        "## Раздел: Объявления\n"
+        "- Анонс собрания [[mv:1]] coffee Friday\n"
+        "- Второй пункт [[cs:abc-uuid]] объявление\n"
+        "\n"
+        "## Раздел: Обсуждения\n"
+        "- Дискуссия про X [[mv:2]] резюме\n"
+    )
+    sections = _extract_sections(body)
+    assert len(sections) == 2
+    assert sections[0][0] == "Объявления"
+    assert sections[0][1] == [
+        "- Анонс собрания [[mv:1]] coffee Friday",
+        "- Второй пункт [[cs:abc-uuid]] объявление",
+    ]
+    assert sections[1][0] == "Обсуждения"
+    assert sections[1][1] == ["- Дискуссия про X [[mv:2]] резюме"]
+
+
+def test_extract_sections_empty_body_returns_empty_list():
+    from bot.services.llm_gateway import _extract_sections
+
+    assert _extract_sections("just some prose without headers") == []
+
+
+def test_extract_sections_handles_no_bullets_under_header():
+    """Header with no bullets returns the empty list under that title."""
+    from bot.services.llm_gateway import _extract_sections
+
+    body = "## Раздел: Прочее\n\n## Раздел: Обсуждения\n- a [[mv:1]]\n"
+    sections = _extract_sections(body)
+    titles = [t for t, _ in sections]
+    assert titles == ["Прочее", "Обсуждения"]
+    assert sections[0][1] == []
+    assert sections[1][1] == ["- a [[mv:1]]"]
+
+
+async def test_synthesize_digest_weekly_warns_on_off_allowlist_section(
+    db_session, caplog
+):
+    """M1 soft contract: a section title outside SECTION_NAME_ALLOWLIST logs a
+    structured warning but does NOT raise."""
+    from bot.db.repos.llm_usage_ledger import LedgerRepo
+    from bot.services.digest_context import DigestContext, DigestContextMessage
+    from bot.services.llm_gateway import synthesize_digest
+
+    chat_id = _next_chat_id()
+    _cm_id, mv_id = await _make_msg_and_version(
+        db_session,
+        chat_id=chat_id,
+        ts=datetime.now(timezone.utc) - timedelta(days=3),
+    )
+    await db_session.flush()
+    now = datetime.now(timezone.utc)
+    ctx = DigestContext(
+        type="daily",
+        window_start=now - timedelta(days=7),
+        window_end=now,
+        source_chat_id=chat_id,
+        cards=[],
+        messages=[
+            DigestContextMessage(
+                message_version_id=mv_id,
+                chat_message_id=_cm_id,
+                author_display="A",
+                text="t",
+                ts=now - timedelta(days=3),
+            )
+        ],
+    )
+
+    body = (
+        "TL;DR a. b. c.\n"
+        "\n"
+        "## Раздел: Совет\n"  # NOT in allowlist
+        f"- topic [[mv:{mv_id}]] summary\n"
+    )
+
+    class _Provider:
+        async def call(self, *, prompt: str, model: str):
+            from bot.services.llm_providers import ProviderResult
+
+            return ProviderResult(
+                answer_text=body,
+                citation_ids=(),
+                tokens_in=100,
+                tokens_out=40,
+                request_id="rs",
+                raw_latency_ms=5,
+            )
+
+    cfg = _make_gateway_config()
+    with caplog.at_level(logging.WARNING, logger="bot.services.llm_gateway"):
+        result = await synthesize_digest(
+            db_session,
+            context=ctx,
+            config=cfg,
+            ledger_repo=LedgerRepo(),
+            provider=_Provider(),
+            type="weekly",
+        )
+    # No raise — soft contract.
+    assert len(result.citations) == 1
+    # Warning emitted, naming the off-allowlist title.
+    warn_records = [
+        r for r in caplog.records
+        if r.levelno == logging.WARNING and "Совет" in r.getMessage()
+    ]
+    assert len(warn_records) == 1, (
+        f"expected exactly one allowlist warning naming 'Совет'; got "
+        f"{[r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]}"
+    )
+
+
+async def test_synthesize_digest_weekly_no_warning_when_all_titles_in_allowlist(
+    db_session, caplog
+):
+    """No allowlist-warning emitted when every section title is allowlisted."""
+    from bot.db.repos.llm_usage_ledger import LedgerRepo
+    from bot.services.digest_context import DigestContext, DigestContextMessage
+    from bot.services.llm_gateway import synthesize_digest
+
+    chat_id = _next_chat_id()
+    _cm_id, mv_id = await _make_msg_and_version(
+        db_session,
+        chat_id=chat_id,
+        ts=datetime.now(timezone.utc) - timedelta(days=3),
+    )
+    await db_session.flush()
+    now = datetime.now(timezone.utc)
+    ctx = DigestContext(
+        type="daily",
+        window_start=now - timedelta(days=7),
+        window_end=now,
+        source_chat_id=chat_id,
+        cards=[],
+        messages=[
+            DigestContextMessage(
+                message_version_id=mv_id,
+                chat_message_id=_cm_id,
+                author_display="A",
+                text="t",
+                ts=now - timedelta(days=3),
+            )
+        ],
+    )
+
+    body = (
+        "TL;DR a. b. c.\n"
+        "\n"
+        "## Раздел: Обсуждения\n"
+        f"- topic [[mv:{mv_id}]] summary\n"
+    )
+
+    class _Provider:
+        async def call(self, *, prompt: str, model: str):
+            from bot.services.llm_providers import ProviderResult
+
+            return ProviderResult(
+                answer_text=body,
+                citation_ids=(),
+                tokens_in=100,
+                tokens_out=40,
+                request_id="rs2",
+                raw_latency_ms=5,
+            )
+
+    cfg = _make_gateway_config()
+    with caplog.at_level(logging.WARNING, logger="bot.services.llm_gateway"):
+        await synthesize_digest(
+            db_session,
+            context=ctx,
+            config=cfg,
+            ledger_repo=LedgerRepo(),
+            provider=_Provider(),
+            type="weekly",
+        )
+    # No allowlist-related warning. ("Совет" / "off-allowlist" should not appear.)
+    off_warns = [
+        r for r in caplog.records
+        if r.levelno == logging.WARNING
+        and ("off-allowlist" in r.getMessage().lower()
+             or "not in allowlist" in r.getMessage().lower())
+    ]
+    assert off_warns == []
+
+
+# ── 7. Defense-in-depth: section header is not counted as a bullet ───────────
+
+
+def test_bullet_index_at_offset_skips_section_header():
+    """§5.F: existing `_bullet_index_at_offset` MUST count only `- ` / `• `
+    line-starts as bullets — section header `## Раздел: …` must NOT increment
+    the bullet index. Regression guard against future tokenizer drift."""
+    from bot.services.llm_gateway import _bullet_index_at_offset
+
+    body = (
+        "TL;DR text.\n"
+        "\n"
+        "## Раздел: Обсуждения\n"  # NOT a bullet
+        "- First bullet [[mv:1]] X\n"
+        "- Second bullet [[mv:2]] Y\n"
+    )
+    # offset inside the first real bullet → index 0
+    first_idx = body.index("First bullet")
+    assert _bullet_index_at_offset(body, first_idx) == 0
+    # offset inside the second real bullet → index 1
+    second_idx = body.index("Second bullet")
+    assert _bullet_index_at_offset(body, second_idx) == 1
+
+
+def test_validate_every_bullet_has_citation_passes_with_section_headers():
+    """§5.F: section headers don't fire bullet-level invariant — only `- ` lines do."""
+    from bot.services.llm_gateway import _validate_every_bullet_has_citation
+
+    body = (
+        "TL;DR.\n"
+        "\n"
+        "## Раздел: Объявления\n"
+        "- Topic [[mv:1]] a\n"
+        "\n"
+        "## Раздел: Обсуждения\n"
+        "- Topic2 [[mv:2]] b\n"
+    )
+    _validate_every_bullet_has_citation(
+        body, valid_citation_tokens={"[[mv:1]]", "[[mv:2]]"}
+    )  # no raise


### PR DESCRIPTION
## Summary

T8-02 of Phase 8 — widen run_digest + synthesize_digest gateway for weekly digest type per `PHASE8_PLAN.md §5.B/§5.D/§5.F/§6 Q7`.

## Changes

- `bot/services/digests.py`:
  - DigestConfig widened with 5 weekly fields (defaults: `weekly_cost_ceiling_usd=$5.00`, `weekly_monthly_cost_ceiling_usd=$20.00`, `weekly_token_budget_input=24000`, `weekly_min_cards_threshold=8`, `weekly_raw_message_top_n=60`)
  - `load_digest_config()` reads `DIGEST_WEEKLY_*` env vars
  - `_cost_ceiling_breached(*, type: Literal['daily','weekly']='daily')` — adds `WHERE d.type=:type` to both daily-bucket and monthly-bucket SQL (Codex H6). Independent buckets per Q7 reformulation. Phase 7 callsite preserved byte-for-byte via back-compat default.
  - `run_digest(type: Literal['daily','weekly'], ...)` — weekly callsite passes type into _cost_ceiling_breached, build_digest_context, synthesize_digest. Weekly success terminal is `'draft'` (transition to `awaiting_review` is T8-04 territory).
  - Latent `type` builtin shadowing fix in 3 exception branches (use `exc.__class__.__name__`)
- `bot/services/llm_prompts/digest_weekly_v0_1_0.py` (NEW): weekly prompt with section-aware structure (5-name Russian allowlist: Объявления / Обсуждения / Знания и ресурсы / Встречи и события / Прочее), bullet citation contract, EMPTY_WINDOW sentinel
- `bot/services/llm_gateway.py`:
  - `synthesize_digest(*, type=...)` routes by type (weekly → digest_weekly_v0_1_0, daily → digest_v0_1_0)
  - `_extract_sections(body_markdown)` helper for `## Раздел:` headers
  - Soft M1 allowlist validator: off-allowlist section title logs structured warning (does NOT raise) per PHASE8_PLAN §6/M1
  - Existing `_bullet_index_at_offset` + `_validate_every_bullet_has_citation` already filter on `- `/`• ` line-starts so section headers don't count as bullets — covered by 2 regression tests

## Tests

`tests/services/test_digests_weekly.py` NEW — 21 tests:
- Prompt module exports / system block / user template
- DigestConfig weekly defaults + env loading
- Cost ceiling: weekly independent of daily, separate bucket trip, default type=daily back-compat
- run_digest weekly path: type widening, cost ceiling pre-check, idempotency, daily/weekly bucket isolation
- synthesize_digest type routing: weekly → weekly prompt, daily → daily prompt unchanged
- Section parsing + allowlist warn + bullet-index helpers correctly skip section headers

`tests/services/test_digests_run.py` — replaced `test_run_digest_rejects_weekly` with `test_run_digest_rejects_unknown_type`.

## Verification

- 21/21 new tests pass + 130 broader regression
- Phase 7 baseline 15/15 + Phase 11 binding 6/6 preserved
- Privacy lint exit 0, ruff repo-wide exit 0

## Test plan

- [x] Local: 130 pass
- [x] Privacy lint green
- [x] Ruff green
- [ ] CI green
- [ ] Merge (parallel with T8-02 PR — no file conflict)

## Out-of-scope notes

- T8-02 tests mock `build_digest_context(type='weekly')` because T8-03 (parallel sprint) widens it. Once T8-03 merges (separate PR), mocks become unnecessary; cleanup folded into T8-03 closure or T8-08.
- Daily `prompt_template_version` kwarg removed from gateway signature — was unused (the ledger side carries `LLMGatewayConfig.prompt_template_version`). Zero callsite impact.