### PR TITLE
feat(p8-t8-03): weekly build_digest_context — 7-day window + larger budget

### DIFF
--- a/bot/services/digest_context.py
+++ b/bot/services/digest_context.py
@@ -4,6 +4,15 @@ T7-03 / Phase 7 Wave 1: produces a structured context bundle for the digest
 LLM synthesis step. The output is fed into `llm_gateway.synthesize_digest`
 (T7-02, separate PR).
 
+T8-03 / Phase 8 Wave 3: widens `type` to `Literal['daily','weekly']`. The
+weekly path reuses the SAME two SQL queries as daily (no third inline copy
+of the forget-events predicate — see comment block below). Only the
+parameter values change: window bounds (7d span vs 24h), cards LIMIT
+(100 vs 30), raw-message LIMIT (`weekly_raw_message_top_n` vs
+`raw_message_top_n`), token budget (`weekly_token_budget_input - 1000` vs
+`token_budget_input - 1000`), and the min-cards fallback threshold
+(`weekly_min_cards_threshold` vs `min_cards_threshold`).
+
 Governance filter (all sources):
 - chat_messages.memory_policy = 'normal' (excludes nomem, offrecord, forgotten)
 - message_versions.is_redacted = FALSE   (excludes cascade-redacted rows)
@@ -17,6 +26,15 @@ SHOULD eventually be extracted into a shared helper used by both this module
 and `bot/services/forget_cascade.py` (DRY guard against drift). This PR
 INLINES the predicate (does not extract). The match logic must stay in sync
 with `forget_cascade._resolve_affected_mvids` (forget_cascade.py:812+).
+
+TODO(#291): extract `_forget_excludes_predicate` to a shared helper. Today
+the predicate is inlined verbatim in TWO queries in this file (cards-first
++ raw fallback) and once in `forget_cascade.py:255+` — i.e. three textual
+copies in production. Phase 8 T8-03 does NOT add a fourth copy: the weekly
+path reuses the same two queries with different parameter values. If #291
+lands before Phase 9, the helper extraction collapses all three to one and
+any future widening (e.g. Phase 9 reflection layer) inherits the predicate
+automatically.
 """
 
 from __future__ import annotations
@@ -48,15 +66,33 @@ from sqlalchemy.ext.asyncio import AsyncSession
 # shared helper used by both this module and `forget_cascade`.
 
 
+# Cards SQL LIMIT per digest type. Daily window is 24h; weekly is 7d
+# (7× more coverage) so the cap widens correspondingly.
+_CARDS_LIMIT_BY_TYPE: dict[str, int] = {
+    "daily": 30,
+    "weekly": 100,
+}
+
+
 @dataclass(frozen=True)
 class DigestConfig:
     """Minimal DigestConfig for T7-03. T7-02 moves this to `bot/services/digests.py`
     with `load_digest_config()` for env var loading.
+
+    Phase 8 (T8-03) adds `weekly_*` fields. The parent `DigestConfig` in
+    `bot/services/digests.py` is the env-loaded one; its `to_context_config()`
+    helper forwards both daily and weekly fields into this dataclass so the
+    SQL builder reads from a single source.
     """
 
+    # Phase 7 (daily) fields
     min_cards_threshold: int = 3
     raw_message_top_n: int = 15
     token_budget_input: int = 8000
+    # Phase 8 (weekly) fields — defaults mirror PHASE8_PLAN.md §5.B.
+    weekly_min_cards_threshold: int = 8
+    weekly_raw_message_top_n: int = 60
+    weekly_token_budget_input: int = 24000
 
 
 @dataclass(frozen=True)
@@ -81,7 +117,7 @@ class DigestContextMessage:
 
 @dataclass(frozen=True)
 class DigestContext:
-    type: Literal["daily"]
+    type: Literal["daily", "weekly"]
     window_start: datetime
     window_end: datetime
     source_chat_id: int
@@ -89,10 +125,35 @@ class DigestContext:
     messages: list[DigestContextMessage]
 
 
+def _weekly_overrides(
+    digest_config: DigestConfig, *, type: Literal["daily", "weekly"]
+) -> tuple[int, int, int, int]:
+    """Type-aware param resolution in one place — keeps the SQL builder
+    reading from a single source.
+
+    Returns:
+        (cards_limit, raw_top_n, token_budget_input, min_cards_threshold)
+    """
+    if type == "weekly":
+        return (
+            _CARDS_LIMIT_BY_TYPE["weekly"],
+            digest_config.weekly_raw_message_top_n,
+            digest_config.weekly_token_budget_input,
+            digest_config.weekly_min_cards_threshold,
+        )
+    # daily
+    return (
+        _CARDS_LIMIT_BY_TYPE["daily"],
+        digest_config.raw_message_top_n,
+        digest_config.token_budget_input,
+        digest_config.min_cards_threshold,
+    )
+
+
 async def build_digest_context(
     session: AsyncSession,
     *,
-    type: Literal["daily"],
+    type: Literal["daily", "weekly"],
     window_start: datetime,
     window_end: datetime,
     source_chat_id: int,
@@ -101,10 +162,15 @@ async def build_digest_context(
     """Build governance-filtered context for digest synthesis.
 
     Returns approved Phase 6 cards in window first; falls back to raw
-    chronological messages if fewer than `min_cards_threshold` cards.
-    Drops raw messages from the tail to fit `token_budget_input`.
+    chronological messages if fewer than the type-aware min-cards threshold.
+    Drops raw messages from the tail to fit the type-aware token budget.
 
-    Governance filter applied to all sources:
+    For ``type='daily'`` uses `digest_config.{min_cards_threshold,
+    raw_message_top_n, token_budget_input}` (Phase 7 defaults).
+    For ``type='weekly'`` uses `digest_config.weekly_*` counterparts and
+    widens the cards SQL LIMIT from 30 → 100.
+
+    Governance filter applied to all sources (identical for daily and weekly):
     - chat_messages.memory_policy = 'normal'  (excludes nomem, offrecord, forgotten)
     - message_versions.is_redacted = FALSE     (excludes cascade-redacted rows)
     - chat_messages.chat_id = :source_chat_id  (single-chat MVP)
@@ -112,8 +178,15 @@ async def build_digest_context(
     - cards: knowledge_cards.card_status = 'approved'
     - cards: linked message_versions also pass the above filter
     """
-    if type != "daily":
-        raise ValueError(f"T7-03 only supports type='daily', got {type!r}")
+    if type not in ("daily", "weekly"):
+        raise ValueError(
+            f"build_digest_context: unsupported type {type!r}; "
+            "expected 'daily' or 'weekly'"
+        )
+
+    cards_limit, raw_top_n, token_budget, min_threshold = _weekly_overrides(
+        digest_config, type=type
+    )
 
     # ---- cards-first query ----
     cards_sql = text("""
@@ -146,12 +219,17 @@ async def build_digest_context(
           )
         GROUP BY kc.id, kc.title, kc.body_markdown, kc.approved_at
         ORDER BY kc.approved_at DESC NULLS LAST
-        LIMIT 30
+        LIMIT :cards_limit
     """)
     card_rows = (
         await session.execute(
             cards_sql,
-            {"source_chat_id": source_chat_id, "ws": window_start, "we": window_end},
+            {
+                "source_chat_id": source_chat_id,
+                "ws": window_start,
+                "we": window_end,
+                "cards_limit": cards_limit,
+            },
         )
     ).mappings().all()
 
@@ -169,7 +247,7 @@ async def build_digest_context(
 
     # ---- raw fallback only when cards too few ----
     messages: list[DigestContextMessage] = []
-    if len(cards) < digest_config.min_cards_threshold:
+    if len(cards) < min_threshold:
         raw_sql = text("""
             SELECT
                 mv.id AS message_version_id,
@@ -207,13 +285,16 @@ async def build_digest_context(
                     "source_chat_id": source_chat_id,
                     "ws": window_start,
                     "we": window_end,
-                    "top_n": digest_config.raw_message_top_n,
+                    "top_n": raw_top_n,
                 },
             )
         ).mappings().all()
 
-        # Apply token budget — drop from tail
-        headroom = digest_config.token_budget_input - 1000
+        # Apply token budget — drop from tail.
+        # `-1000` headroom mirrors Phase 7 behaviour: leaves room for the
+        # prompt template overhead so the gateway does not have to do a
+        # second pass on overflow.
+        headroom = token_budget - 1000
         used = 0
         # Rough estimate: len(text) // 3.5 ≈ tokens
         for row in raw_rows:

--- a/tests/services/test_digest_context.py
+++ b/tests/services/test_digest_context.py
@@ -546,8 +546,8 @@ async def test_build_context_token_budget_drops_tail(db_session) -> None:
     assert timestamps == sorted(timestamps), "messages must be chronological"
 
 
-async def test_build_context_rejects_non_daily_type(db_session) -> None:
-    """type != 'daily' raises ValueError (weekly is Phase 8 scope)."""
+async def test_build_context_rejects_unknown_type(db_session) -> None:
+    """type not in {'daily','weekly'} raises ValueError (Phase 8 widens daily → daily+weekly)."""
     from bot.services.digest_context import build_digest_context, DigestConfig
 
     chat_id = _next_chat_id()
@@ -555,12 +555,321 @@ async def test_build_context_rejects_non_daily_type(db_session) -> None:
     ws = now - timedelta(hours=24)
     we = now
 
-    with pytest.raises(ValueError, match="daily"):
+    with pytest.raises(ValueError, match="daily.*weekly|weekly.*daily|unsupported"):
         await build_digest_context(
             db_session,
-            type="weekly",  # type: ignore[arg-type]
+            type="monthly",  # type: ignore[arg-type]
             window_start=ws,
             window_end=we,
             source_chat_id=chat_id,
             digest_config=DigestConfig(),
         )
+
+
+# ── Phase 8 / T8-03 weekly tests ─────────────────────────────────────────────
+
+
+async def test_build_digest_context_weekly_window_is_7_days(db_session) -> None:
+    """type='weekly' preserves caller-supplied 7-day window bounds on the returned context."""
+    from bot.services.digest_context import build_digest_context, DigestConfig
+
+    chat_id = _next_chat_id()
+    now = datetime.now(timezone.utc)
+    ws = now - timedelta(days=7)
+    we = now
+
+    ctx = await build_digest_context(
+        db_session,
+        type="weekly",
+        window_start=ws,
+        window_end=we,
+        source_chat_id=chat_id,
+        digest_config=DigestConfig(),
+    )
+
+    assert ctx.type == "weekly"
+    assert ctx.window_start == ws
+    assert ctx.window_end == we
+    assert (ctx.window_end - ctx.window_start) == timedelta(days=7)
+
+
+async def test_build_digest_context_weekly_larger_token_budget(db_session) -> None:
+    """type='weekly' reads weekly_token_budget_input (not the daily one).
+
+    Same raw-message corpus, two calls with the same daily_token=2000 but
+    weekly_token=8000: the weekly path fits strictly more messages.
+    """
+    from bot.services.digest_context import build_digest_context, DigestConfig
+
+    chat_id = _next_chat_id()
+    now = datetime.now(timezone.utc)
+    ws = now - timedelta(days=7)
+    we = now
+
+    # 10 messages × ~1000 chars ≈ ~285 tokens each.
+    # With token_budget_input=2000 (headroom 1000), fits ~3.
+    # With weekly_token_budget_input=8000 (headroom 7000), fits ~10.
+    big_text = "x" * 1000
+    for i in range(10):
+        ts = ws + timedelta(hours=i * 12)
+        await _make_msg_and_version(
+            db_session, chat_id=chat_id, ts=ts, text=big_text
+        )
+
+    cfg = DigestConfig(
+        min_cards_threshold=10,  # daily threshold (forces raw fallback)
+        raw_message_top_n=10,
+        token_budget_input=2000,
+        weekly_min_cards_threshold=10,  # forces raw fallback for weekly path
+        weekly_raw_message_top_n=10,
+        weekly_token_budget_input=8000,
+    )
+
+    ctx_weekly = await build_digest_context(
+        db_session,
+        type="weekly",
+        window_start=ws,
+        window_end=we,
+        source_chat_id=chat_id,
+        digest_config=cfg,
+    )
+
+    ctx_daily = await build_digest_context(
+        db_session,
+        type="daily",
+        window_start=ws,
+        window_end=we,
+        source_chat_id=chat_id,
+        digest_config=cfg,
+    )
+
+    assert len(ctx_weekly.messages) > len(ctx_daily.messages), (
+        f"weekly budget should fit more messages: "
+        f"weekly={len(ctx_weekly.messages)} daily={len(ctx_daily.messages)}"
+    )
+
+
+async def test_build_digest_context_weekly_min_cards_threshold_default_8(
+    db_session,
+) -> None:
+    """When fewer than weekly_min_cards_threshold (default 8) cards exist in the
+    weekly window, raw fallback kicks in for type='weekly'."""
+    from bot.services.digest_context import build_digest_context, DigestConfig
+
+    chat_id = _next_chat_id()
+    now = datetime.now(timezone.utc)
+    ws = now - timedelta(days=7)
+    we = now
+    ts = now - timedelta(days=1)
+
+    # Create 7 approved cards (< default weekly threshold of 8). And one
+    # additional raw message so the fallback has something to surface.
+    for i in range(7):
+        _cm_id, mv_id = await _make_msg_and_version(
+            db_session, chat_id=chat_id, ts=ts, text=f"card source {i}"
+        )
+        await _make_approved_card(
+            db_session, mv_ids=[mv_id], title=f"Card {i}", body=f"body {i}"
+        )
+    await _make_msg_and_version(
+        db_session, chat_id=chat_id, ts=ts, text="raw fallback message"
+    )
+
+    ctx = await build_digest_context(
+        db_session,
+        type="weekly",
+        window_start=ws,
+        window_end=we,
+        source_chat_id=chat_id,
+        digest_config=DigestConfig(),  # weekly_min_cards_threshold default 8
+    )
+
+    assert len(ctx.cards) == 7
+    # 7 < 8, fallback fires → raw message included.
+    assert any(m.text == "raw fallback message" for m in ctx.messages)
+
+
+async def test_build_digest_context_weekly_governance_filter_forget_event(
+    db_session,
+) -> None:
+    """Weekly path: active forget_event excludes target from both cards and raw."""
+    from bot.db.models import ForgetEvent
+    from bot.services.digest_context import build_digest_context, DigestConfig
+
+    chat_id = _next_chat_id()
+    now = datetime.now(timezone.utc)
+    ws = now - timedelta(days=7)
+    we = now
+    ts = now - timedelta(days=2)
+
+    cm_id, mv_id = await _make_msg_and_version(
+        db_session, chat_id=chat_id, ts=ts, memory_policy="normal", is_redacted=False
+    )
+    await _make_approved_card(db_session, mv_ids=[mv_id])
+
+    fe = ForgetEvent(
+        target_type="message",
+        target_id=str(cm_id),
+        actor_user_id=None,
+        authorized_by="self",
+        tombstone_key=f"message:{chat_id}:{cm_id}",
+        policy="forgotten",
+        status="pending",
+    )
+    db_session.add(fe)
+    await db_session.flush()
+
+    ctx = await build_digest_context(
+        db_session,
+        type="weekly",
+        window_start=ws,
+        window_end=we,
+        source_chat_id=chat_id,
+        digest_config=DigestConfig(weekly_min_cards_threshold=10),
+    )
+
+    assert ctx.cards == [], "weekly: active forget_event must exclude card"
+    assert ctx.messages == [], "weekly: active forget_event must exclude raw message"
+
+
+async def test_build_digest_context_weekly_excludes_redacted(db_session) -> None:
+    """Weekly path: message_version.is_redacted=TRUE → excluded from cards and raw."""
+    from bot.services.digest_context import build_digest_context, DigestConfig
+
+    chat_id = _next_chat_id()
+    now = datetime.now(timezone.utc)
+    ws = now - timedelta(days=7)
+    we = now
+    ts = now - timedelta(days=2)
+
+    _cm_id, mv_id = await _make_msg_and_version(
+        db_session, chat_id=chat_id, ts=ts, is_redacted=True
+    )
+    await _make_approved_card(db_session, mv_ids=[mv_id])
+
+    ctx = await build_digest_context(
+        db_session,
+        type="weekly",
+        window_start=ws,
+        window_end=we,
+        source_chat_id=chat_id,
+        digest_config=DigestConfig(weekly_min_cards_threshold=10),
+    )
+
+    assert ctx.cards == []
+    assert ctx.messages == []
+
+
+async def test_build_digest_context_weekly_excludes_non_normal_memory_policy(
+    db_session,
+) -> None:
+    """Weekly path: chat_messages.memory_policy != 'normal' rows excluded.
+
+    Covers offrecord, nomem, forgotten — all should be filtered out of both
+    the cards source-join and the raw fallback.
+    """
+    from bot.services.digest_context import build_digest_context, DigestConfig
+
+    chat_id = _next_chat_id()
+    now = datetime.now(timezone.utc)
+    ws = now - timedelta(days=7)
+    we = now
+    ts = now - timedelta(days=2)
+
+    for policy in ("offrecord", "nomem", "forgotten"):
+        _cm_id, mv_id = await _make_msg_and_version(
+            db_session,
+            chat_id=chat_id,
+            ts=ts,
+            text=f"policy={policy}",
+            memory_policy=policy,
+        )
+        await _make_approved_card(
+            db_session, mv_ids=[mv_id], title=f"Card-{policy}", body=f"body-{policy}"
+        )
+
+    ctx = await build_digest_context(
+        db_session,
+        type="weekly",
+        window_start=ws,
+        window_end=we,
+        source_chat_id=chat_id,
+        digest_config=DigestConfig(weekly_min_cards_threshold=10),
+    )
+
+    assert ctx.cards == []
+    assert ctx.messages == []
+
+
+async def test_build_digest_context_weekly_cards_limit_100(db_session) -> None:
+    """Weekly cards SQL uses LIMIT 100 (vs daily 30).
+
+    Create 31 approved cards in the weekly window; daily would cap at 30 by
+    the SQL LIMIT, weekly is bounded by 100 so all 31 should return.
+    """
+    from bot.services.digest_context import build_digest_context, DigestConfig
+
+    chat_id = _next_chat_id()
+    now = datetime.now(timezone.utc)
+    ws = now - timedelta(days=7)
+    we = now
+    ts = now - timedelta(days=2)
+
+    n = 31
+    for i in range(n):
+        _cm_id, mv_id = await _make_msg_and_version(
+            db_session, chat_id=chat_id, ts=ts, text=f"card src {i}"
+        )
+        # Stagger approved_at so ORDER BY approved_at DESC is deterministic.
+        await _make_approved_card(
+            db_session,
+            mv_ids=[mv_id],
+            title=f"Card {i}",
+            body=f"body {i}",
+            approved_at=now - timedelta(seconds=i),
+        )
+
+    ctx_weekly = await build_digest_context(
+        db_session,
+        type="weekly",
+        window_start=ws,
+        window_end=we,
+        source_chat_id=chat_id,
+        digest_config=DigestConfig(),
+    )
+
+    ctx_daily = await build_digest_context(
+        db_session,
+        type="daily",
+        window_start=ws,
+        window_end=we,
+        source_chat_id=chat_id,
+        digest_config=DigestConfig(),
+    )
+
+    assert len(ctx_weekly.cards) == n, f"weekly LIMIT 100 should return all {n} cards"
+    assert len(ctx_daily.cards) == 30, "daily LIMIT 30 caps at 30"
+
+
+async def test_build_digest_context_weekly_empty_window(db_session) -> None:
+    """Weekly path with zero candidates → empty cards + empty messages."""
+    from bot.services.digest_context import build_digest_context, DigestConfig
+
+    chat_id = _next_chat_id()
+    now = datetime.now(timezone.utc)
+    ws = now - timedelta(days=7)
+    we = now
+
+    ctx = await build_digest_context(
+        db_session,
+        type="weekly",
+        window_start=ws,
+        window_end=we,
+        source_chat_id=chat_id,
+        digest_config=DigestConfig(),
+    )
+
+    assert ctx.cards == []
+    assert ctx.messages == []
+    assert ctx.type == "weekly"
+    assert ctx.source_chat_id == chat_id


### PR DESCRIPTION
## Summary

T8-03 of Phase 8 — widen build_digest_context for weekly type per `PHASE8_PLAN.md §5.C`.

## Changes

- `bot/services/digest_context.py`:
  - `build_digest_context(type: Literal['daily','weekly']='daily', ...)` accepting `'weekly'`
  - `DigestContext.type` field widened to Literal['daily','weekly']
  - Local DigestConfig extended with 3 weekly fields: `weekly_min_cards_threshold=8`, `weekly_raw_message_top_n=60`, `weekly_token_budget_input=24000`
  - Internal `_weekly_overrides` helper: type-aware param resolution in one place
  - Cards SQL `LIMIT` via `_CARDS_LIMIT_BY_TYPE`: 30 (daily) → 100 (weekly)
  - Governance filter (memory_policy='normal' AND is_redacted=FALSE AND NOT EXISTS active forget_events) **unchanged** — Phase 11 binding L8a/L8b will gate this in T8-07
  - TODO(#291) docstring re #291 shared predicate carryover — no third inline copy introduced

## Tests

`tests/services/test_digest_context.py` extended — 8 new weekly tests + 14 baseline preserved = 22 total:
- 7-day window preservation
- Larger token budget (daily 2000 vs weekly 8000 strictly more messages fit)
- weekly_min_cards_threshold=8 triggers raw fallback at 7 cards
- Governance filter exclusions: forget_event, redacted, non-normal memory_policy (offrecord/nomem/forgotten)
- LIMIT 100 cards weekly (31 cards returned vs daily 30)
- Empty window sentinel

Renamed: `test_build_context_rejects_non_daily_type` → `test_build_context_rejects_unknown_type` (now rejects 'monthly' since 'weekly' is valid).

## Verification

- 22/22 focused suite pass
- 70 broader regression pass (test_digest_*.py + test_digests_run.py)
- 21 Phase 11 binding pass (digest_leakage L7a/L7b/C6/I5a/I5b/I5c + digests_run)
- Privacy lint exit 0, ruff exit 0

## Test plan

- [x] Local: 22/22 + 70 regression + 21 binding green
- [x] Privacy lint green
- [x] Ruff green
- [ ] CI green
- [ ] Merge (parallel with T8-02 PR — no file conflict)

## Notes

- Doc drift flagged: §5.C prose says `weekly_min_cards_threshold=5`; §5.B dataclass + §7 AC + L5 comment say 8. Implementation follows §5.B (canonical). Doc reconciliation can be folded into T8-08 closure.
- env-side wiring from `bot/services/digests.py::DigestConfig.to_context_config()` is T8-02 territory; until both merge, calls coming through digests.py use code defaults (8/60/24000), behaviour-equivalent.
- #291 not landed — TODO comment added per §11 M7 advisory; no inline predicate copies introduced.