### PR TITLE
feat(p8-t8-04): review state machine + redactor/publisher/cascade widening

### DIFF
--- a/bot/services/digest_publisher.py
+++ b/bot/services/digest_publisher.py
@@ -36,7 +36,59 @@ logger = logging.getLogger(__name__)
 
 
 class DigestPublisherInvalidState(Exception):
-    """Row was not in ``draft`` state when the publisher acquired the lock."""
+    """Publisher trigger guard fired, OR the guarded UPDATE returned
+    rowcount=0 (concurrent race).
+
+    Structured fields mirror ``DigestReviewInvalidState`` (PHASE8_PLAN.md
+    §5.L — R2 HIGH-Cdx-1). Handlers branch on ``current_status`` to
+    render context-aware replies:
+
+      ``digest_id``: int
+      ``current_status``: str | None  — ``None`` ⇒ row was DELETEd
+                                        concurrently (e.g. by
+                                        ``--regenerate`` racing a stale
+                                        approve).
+                                        ``str`` ⇒ row exists in this status
+                                        (e.g. ``'redacted'`` after cascade
+                                        won the race).
+      ``reason``: str                 — free-text explanation.
+    """
+
+    def __init__(
+        self,
+        *args,
+        digest_id: int | None = None,
+        current_status: str | None = None,
+        reason: str | None = None,
+    ) -> None:
+        # Support the legacy positional form ``DigestPublisherInvalidState(msg)``
+        # used by Phase 7 baseline so callers in flight (handlers, tests) can
+        # adapt without a flag day. Structured kwargs are the canonical form.
+        if args and digest_id is None and current_status is None and reason is None:
+            self.digest_id = None
+            self.current_status = None
+            self.reason = str(args[0])
+            super().__init__(*args)
+            return
+        self.digest_id = digest_id
+        self.current_status = current_status
+        self.reason = reason or ""
+        super().__init__(
+            f"DigestPublisherInvalidState(digest_id={digest_id}, "
+            f"current_status={current_status!r}, reason={self.reason!r})"
+        )
+
+
+# T8-04 / Phase 8 §5.L — eligible status set for the publisher trigger.
+#
+# Widened from Phase 7's single ``'draft'`` to also accept
+# ``'approved_for_publish'`` — the status set by
+# ``digest_review.approve_digest`` step 3. Daily auto-publish path is
+# unchanged (still passes ``'draft'``, which matches the first tuple entry).
+_PUBLISHER_TRIGGER_STATUSES: tuple[str, ...] = (
+    "draft",
+    "approved_for_publish",
+)
 
 
 async def _digest_revalidate_citations(
@@ -115,9 +167,14 @@ async def publish_digest(
     Single long-lived transaction holding the row lock across send_message.
     Caller MUST commit the session after this returns OR roll back on raise.
     """
-    if digest.status != "draft":
+    if digest.status not in _PUBLISHER_TRIGGER_STATUSES:
         raise DigestPublisherInvalidState(
-            f"expected status='draft', got {digest.status!r}"
+            digest_id=digest.id,
+            current_status=digest.status,
+            reason=(
+                f"publisher trigger requires status in "
+                f"{_PUBLISHER_TRIGGER_STATUSES!r}, found {digest.status!r}"
+            ),
         )
 
     # If no destination, skip publication cleanly.
@@ -181,7 +238,49 @@ async def publish_digest(
         )
         return digest
 
-    # Transition draft → posting (in same transaction). Row remains locked.
+    # T8-04 / Phase 8 §5.L — guarded transition to ``posting``.
+    #
+    # Widened WHERE-clause to accept BOTH ``draft`` (daily auto-publish path)
+    # AND ``approved_for_publish`` (weekly admin-approve path). rowcount=0
+    # follows the canonical §5.E classifier (re-read row; None ⇒ deleted,
+    # str ⇒ wrong state).
+    posting_result = await session.execute(
+        text(
+            "UPDATE digests "
+            "SET status='posting', "
+            "    posting_started_at=now(), "
+            "    updated_at=now() "
+            "WHERE id=:id AND status IN ('draft','approved_for_publish') "
+            "RETURNING id"
+        ),
+        {"id": digest.id},
+    )
+    if posting_result.rowcount == 0:
+        # Race-won concurrent transition (cascade redacted, --regenerate
+        # DELETEd, etc.). Re-read, classify, raise.
+        current = (
+            await session.execute(
+                text("SELECT status FROM digests WHERE id=:id"),
+                {"id": digest.id},
+            )
+        ).scalar_one_or_none()
+        if current is None:
+            raise DigestPublisherInvalidState(
+                digest_id=digest.id,
+                current_status=None,
+                reason="row_deleted_during_transition",
+            )
+        raise DigestPublisherInvalidState(
+            digest_id=digest.id,
+            current_status=current,
+            reason=(
+                "expected status IN ('draft','approved_for_publish'), "
+                f"found {current!r}"
+            ),
+        )
+
+    # Refresh ORM state to reflect the guarded UPDATE so subsequent code
+    # (revalidation, render, send) sees the new status / posting_started_at.
     digest.status = "posting"
     digest.posting_started_at = datetime.now(timezone.utc)
     digest.updated_at = datetime.now(timezone.utc)

--- a/bot/services/digest_redactor.py
+++ b/bot/services/digest_redactor.py
@@ -26,6 +26,31 @@ logger = logging.getLogger(__name__)
 
 REDACTED_BULLET_TEMPLATE = "- [REDACTED — забыто]"
 
+# T8-04 / Phase 8 §5.K — eligible-status allowlist for the redactor.
+#
+# Widened beyond the Phase 7 4-tuple to cover the four new review-gate
+# statuses introduced by migration 038:
+#   awaiting_review        — weekly draft DMed to admins, pending decision
+#   approved_for_publish   — admin approved; publisher transitions to posting
+#   rejected_by_admin      — admin rejected; still visible in /digest_review
+#
+# C1 binding privacy fix: without this widening the forget cascade scan at
+# forget_cascade.py:840 selects the row but the redactor short-circuits it
+# back out, leaving forgotten content visible. An admin /digest_approve
+# could then publish forgotten content to Telegram.
+#
+# MUST mirror forget_cascade._cascade_digests WHERE-status filter EXACTLY.
+_REDACTOR_ELIGIBLE_STATUSES: tuple[str, ...] = (
+    "draft",
+    "awaiting_review",
+    "approved_for_publish",
+    "posting",
+    "posted",
+    "redacted",
+    "redacted_edit_failed",
+    "rejected_by_admin",
+)
+
 
 def _mask_bullets_in_body(body_markdown: str, *, bullet_indices: set[int]) -> str:
     """Replace bullets at the given 0-based indices with REDACTED template.
@@ -102,8 +127,9 @@ async def redact_digest_for_forget(
         return
 
     current_status = digest_row["status"]
-    if current_status not in ("draft", "posted", "redacted", "redacted_edit_failed"):
-        # Terminal states (skipped, failed, cost_exceeded, etc.) — nothing to redact.
+    if current_status not in _REDACTOR_ELIGIBLE_STATUSES:
+        # Terminal-without-body states (skipped, failed, cost_exceeded,
+        # skipped_no_destination, rejected_by_reaper) — nothing to redact.
         return
 
     citations = digest_row["citations"] or []
@@ -129,15 +155,27 @@ async def redact_digest_for_forget(
 
     if not bullet_indices_to_mask:
         # Edge case: cited but position == -1 (TL;DR), or no citations matched.
-        # Still mark redacted to record event.
+        # Still mark redacted to record event. WHERE clause mirrors
+        # _REDACTOR_ELIGIBLE_STATUSES exactly (T8-04 §5.K).
         await session.execute(
             text(
                 "UPDATE digests SET status='redacted', updated_at=now() "
                 "WHERE id = :id AND status IN "
-                "('draft','posted','redacted','redacted_edit_failed')"
+                "('draft','awaiting_review','approved_for_publish','posting',"
+                " 'posted','redacted','redacted_edit_failed','rejected_by_admin')"
             ),
             {"id": digest_id},
         )
+        # T8-04 §5.D sub-step: admin-notify when an awaiting_review draft is
+        # silently redacted by the cascade — the draft disappears from
+        # /digest_review listing, so the admin needs to know.
+        if current_status == "awaiting_review" and bot is not None:
+            await notify_admins_digest_failure(
+                bot,
+                digest_id=digest_id,
+                status="redacted",
+                error_text="forget_redacted_during_review",
+            )
         return
 
     masked = _mask_bullets_in_body(
@@ -160,6 +198,17 @@ async def redact_digest_for_forget(
             "cits": __import__("json").dumps(surviving_citations),
         },
     )
+
+    # T8-04 §5.D sub-step: admin-notify when an awaiting_review draft is
+    # silently redacted by the cascade — same rationale as the no-bullet
+    # branch above; the draft disappears from /digest_review listing.
+    if current_status == "awaiting_review" and bot is not None:
+        await notify_admins_digest_failure(
+            bot,
+            digest_id=digest_id,
+            status="redacted",
+            error_text="forget_redacted_during_review",
+        )
 
     # Telegram side-effect — best effort.
     posted_message_id = digest_row.get("posted_message_id")

--- a/bot/services/digest_review.py
+++ b/bot/services/digest_review.py
@@ -1,0 +1,398 @@
+"""Phase 8 / T8-04 — weekly digest review state machine.
+
+Implements the admin-review gate that sits between ``run_digest`` (which
+now produces ``status='draft'`` for weekly rows) and ``publish_digest``
+(which transitions ``approved_for_publish → posting → posted``).
+
+Canonical state transitions (PHASE8_PLAN.md §5.E):
+
+    draft
+      └─> awaiting_review        (transition_to_awaiting_review)
+            ├─> approved_for_publish → posting → posted   (approve_digest)
+            ├─> rejected_by_admin                          (reject_digest)
+            └─> failed                                     (citations stale)
+
+All transitions use the H2 guarded-UPDATE pattern: ``WHERE id=:id AND
+status=<expected>`` with ``RETURNING id``. ``rowcount=0`` means a racing
+transition won — caller routes through
+``_raise_invalid_state_after_guard_miss`` which re-reads the row,
+distinguishes "deleted concurrently" (current_status=None) from
+"wrong state" (str), and raises ``DigestReviewInvalidState`` with
+structured fields.
+
+Transaction discipline mirrors Phase 7 ``digest_publisher.py``: this
+module FLUSHES, callers COMMIT. The scheduler/handler wraps each
+service call in its own ``session.commit()`` boundary.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Awaitable, Callable
+
+from aiogram import Bot
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from bot.db.models import Digest, DigestRun
+from bot.services.digests import DigestConfig
+from bot.services.llm_gateway import (
+    DigestContextStaleError,
+    _digest_context_is_clean,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ApproveResult:
+    """Returned by ``approve_digest`` on commit-path success.
+
+    ``error_text`` is populated if approval transitioned (status moved to
+    ``approved_for_publish``) but the subsequent publisher dispatch failed.
+    """
+
+    digest_id: int
+    posted_chat_id: int | None
+    posted_message_id: int | None
+    error_text: str | None
+
+
+class DigestReviewInvalidState(Exception):
+    """Approval/reject attempted from a non-``awaiting_review`` state, OR a
+    guarded UPDATE returned rowcount=0 because the row was deleted or its
+    status moved out from under us between revalidation and commit.
+
+    Structured fields (NOT positional Exception args) — handlers render
+    context-aware admin replies by branching on ``current_status``:
+
+      ``digest_id``: int                — always populated.
+      ``current_status``: str | None    — ``None`` ⇒ row was DELETEd
+                                          concurrently (e.g. by
+                                          ``/digest_now --regenerate`` or
+                                          operator manual cleanup).
+                                          ``str`` ⇒ row exists in this
+                                          status (e.g. ``'redacted'``,
+                                          ``'rejected_by_admin'``,
+                                          ``'posted'``).
+      ``reason``: str                   — free-text explanation for logs
+                                          + admin reply.
+    """
+
+    def __init__(
+        self,
+        *,
+        digest_id: int,
+        current_status: str | None,
+        reason: str,
+    ) -> None:
+        self.digest_id = digest_id
+        self.current_status = current_status
+        self.reason = reason
+        super().__init__(
+            f"DigestReviewInvalidState(digest_id={digest_id}, "
+            f"current_status={current_status!r}, reason={reason!r})"
+        )
+
+
+class DigestReviewNotFound(Exception):
+    """Digest id was never found by the pre-flight SELECT inside
+    ``approve_digest`` / ``reject_digest``.
+
+    Distinct from ``DigestReviewInvalidState(current_status=None)``, which
+    fires only AFTER a guarded UPDATE rowcount=0 race confirms the row has
+    since been DELETEd.
+    """
+
+
+async def _raise_invalid_state_after_guard_miss(
+    session: AsyncSession,
+    *,
+    digest_id: int,
+    expected_status: str | tuple[str, ...],
+) -> None:
+    """Canonical rowcount=0 classifier.
+
+    Call ONLY after a guarded UPDATE returned rowcount=0. Re-reads the
+    current status (or detects DELETE) and raises
+    ``DigestReviewInvalidState`` with structured fields.
+    """
+    current = (
+        await session.execute(
+            select(Digest.status).where(Digest.id == digest_id)
+        )
+    ).scalar_one_or_none()
+    if current is None:
+        raise DigestReviewInvalidState(
+            digest_id=digest_id,
+            current_status=None,
+            reason="row_deleted_during_transition",
+        )
+    raise DigestReviewInvalidState(
+        digest_id=digest_id,
+        current_status=current,
+        reason=f"expected status={expected_status!r}, found {current!r}",
+    )
+
+
+async def transition_to_awaiting_review(
+    session: AsyncSession,
+    *,
+    digest_id: int,
+) -> None:
+    """Guarded transition ``draft → awaiting_review`` for a weekly digest.
+
+    Called by ``digest_weekly_job`` after ``run_digest`` returns
+    ``status='draft'``. The caller DMs admins after this commits.
+
+    Inserts a ``digest_runs(status='awaiting_review')`` audit row. Caller
+    commits.
+    """
+    now = datetime.now(timezone.utc)
+    result = await session.execute(
+        text(
+            "UPDATE digests "
+            "SET status='awaiting_review', "
+            "    awaiting_review_at=now(), "
+            "    updated_at=now() "
+            "WHERE id=:id AND status='draft' AND type='weekly' "
+            "RETURNING id"
+        ),
+        {"id": digest_id},
+    )
+    if result.rowcount == 0:
+        await _raise_invalid_state_after_guard_miss(
+            session, digest_id=digest_id, expected_status="draft"
+        )
+
+    session.add(
+        DigestRun(
+            digest_id=digest_id,
+            status="awaiting_review",
+            started_at=now,
+        )
+    )
+    await session.flush()
+
+
+async def approve_digest(
+    session: AsyncSession,
+    *,
+    bot: Bot | None,
+    digest_id: int,
+    admin_id: int,
+    digest_config: DigestConfig,
+    _publisher_dispatch: Callable[..., Awaitable[Any]] | None = None,
+) -> ApproveResult:
+    """Single-admin approval → triggers publisher.
+
+    Flow (PHASE8_PLAN.md §5.E):
+      1. SELECT digest by id; not found → raise ``DigestReviewNotFound``.
+      2. Defense-in-depth: revalidate every cited mvid/cs against current
+         governance state via ``_digest_context_is_clean``. On stale,
+         guarded UPDATE → 'failed' / ``error_text='citations_stale_at_approval'``,
+         then raise ``DigestReviewInvalidState(current_status='failed', ...)``.
+      3. Guarded UPDATE ``WHERE status='awaiting_review'`` → 'approved_for_publish',
+         set ``published_by_admin_id`` + ``approved_at``. rowcount=0 → classifier.
+         INSERT digest_runs(status='approved_for_publish'). Caller commits.
+      4. Dispatch publisher (``publish_digest``). Publisher's own guarded UPDATE
+         accepts ``status IN ('draft','approved_for_publish')`` per §5.L; on
+         success returns digest with ``status='posted'``.
+
+    Returns ``ApproveResult`` with the publisher outcome. The
+    ``_publisher_dispatch`` kwarg is a test-only override; default routes
+    to ``bot.services.digest_publisher.publish_digest``.
+    """
+    # Step 1: pre-flight SELECT.
+    row = (
+        await session.execute(
+            select(Digest).where(Digest.id == digest_id)
+        )
+    ).scalar_one_or_none()
+    if row is None:
+        raise DigestReviewNotFound(f"digest_id={digest_id} not found")
+
+    if row.status != "awaiting_review":
+        raise DigestReviewInvalidState(
+            digest_id=digest_id,
+            current_status=row.status,
+            reason=(
+                f"expected status='awaiting_review', found {row.status!r}"
+            ),
+        )
+    if row.type != "weekly":
+        raise DigestReviewInvalidState(
+            digest_id=digest_id,
+            current_status=row.status,
+            reason=f"expected type='weekly', found {row.type!r}",
+        )
+
+    # Step 2: defense-in-depth citation revalidation. _digest_context_is_clean
+    # operates on (cards, messages) lists with .message_version_id /
+    # .card_source_ids attributes, so build the minimal shape here from
+    # the JSONB citations.
+    citations = row.citations or []
+    mv_ids = [
+        int(c["id"]) for c in citations if c.get("kind") == "message_version"
+    ]
+    cs_ids = [
+        str(c["id"]) for c in citations if c.get("kind") == "card_source"
+    ]
+
+    @dataclass
+    class _MsgStub:
+        message_version_id: int
+
+    @dataclass
+    class _CardStub:
+        card_source_ids: list[str]
+
+    messages_stub = [_MsgStub(message_version_id=i) for i in mv_ids]
+    cards_stub = [_CardStub(card_source_ids=cs_ids)] if cs_ids else []
+
+    revalidation_failed = False
+    try:
+        await _digest_context_is_clean(
+            session, cards=cards_stub, messages=messages_stub
+        )
+    except DigestContextStaleError:
+        revalidation_failed = True
+
+    if revalidation_failed:
+        # Mark failed via guarded UPDATE; classifier on rowcount=0.
+        stale_result = await session.execute(
+            text(
+                "UPDATE digests "
+                "SET status='failed', "
+                "    error_text='citations_stale_at_approval', "
+                "    updated_at=now() "
+                "WHERE id=:id AND status='awaiting_review' "
+                "RETURNING id"
+            ),
+            {"id": digest_id},
+        )
+        if stale_result.rowcount == 0:
+            await _raise_invalid_state_after_guard_miss(
+                session,
+                digest_id=digest_id,
+                expected_status="awaiting_review",
+            )
+        session.add(
+            DigestRun(
+                digest_id=digest_id,
+                status="failed",
+                error_text="citations_stale_at_approval",
+                started_at=datetime.now(timezone.utc),
+                finished_at=datetime.now(timezone.utc),
+            )
+        )
+        await session.flush()
+        raise DigestReviewInvalidState(
+            digest_id=digest_id,
+            current_status="failed",
+            reason="citations_stale_at_approval",
+        )
+
+    # Step 3: guarded approval transition.
+    approve_result = await session.execute(
+        text(
+            "UPDATE digests "
+            "SET status='approved_for_publish', "
+            "    published_by_admin_id=:admin_id, "
+            "    approved_at=now(), "
+            "    updated_at=now() "
+            "WHERE id=:id AND status='awaiting_review' "
+            "RETURNING id"
+        ),
+        {"id": digest_id, "admin_id": admin_id},
+    )
+    if approve_result.rowcount == 0:
+        await _raise_invalid_state_after_guard_miss(
+            session, digest_id=digest_id, expected_status="awaiting_review"
+        )
+
+    session.add(
+        DigestRun(
+            digest_id=digest_id,
+            status="approved_for_publish",
+            started_at=datetime.now(timezone.utc),
+        )
+    )
+    await session.flush()
+
+    # Refresh the ORM row so subsequent operations see the new status.
+    await session.refresh(row)
+
+    # Step 4: dispatch publisher.
+    if _publisher_dispatch is None:
+        from bot.services.digest_publisher import publish_digest as _publish
+
+        _publisher_dispatch = _publish
+
+    published = await _publisher_dispatch(
+        session, bot=bot, digest=row, digest_config=digest_config
+    )
+
+    return ApproveResult(
+        digest_id=digest_id,
+        posted_chat_id=getattr(published, "posted_chat_id", None),
+        posted_message_id=getattr(published, "posted_message_id", None),
+        error_text=getattr(published, "error_text", None),
+    )
+
+
+async def reject_digest(
+    session: AsyncSession,
+    *,
+    digest_id: int,
+    admin_id: int,
+    reason: str | None = None,
+) -> None:
+    """Guarded transition ``awaiting_review → rejected_by_admin``.
+
+    L4 service-layer normalization: ``review_notes`` is truncated to 1000
+    chars. ``review_notes`` column itself is unbounded ``Text``; truncation
+    happens here, not in the schema.
+    """
+    notes = (reason or "no reason given")[:1000]
+
+    result = await session.execute(
+        text(
+            "UPDATE digests "
+            "SET status='rejected_by_admin', "
+            "    published_by_admin_id=:admin_id, "
+            "    review_notes=:notes, "
+            "    updated_at=now() "
+            "WHERE id=:id AND status='awaiting_review' "
+            "RETURNING id"
+        ),
+        {"id": digest_id, "admin_id": admin_id, "notes": notes},
+    )
+    if result.rowcount == 0:
+        await _raise_invalid_state_after_guard_miss(
+            session, digest_id=digest_id, expected_status="awaiting_review"
+        )
+
+    now = datetime.now(timezone.utc)
+    session.add(
+        DigestRun(
+            digest_id=digest_id,
+            status="rejected_by_admin",
+            error_text=notes,
+            started_at=now,
+            finished_at=now,
+        )
+    )
+    await session.flush()
+
+
+__all__ = [
+    "ApproveResult",
+    "DigestReviewInvalidState",
+    "DigestReviewNotFound",
+    "approve_digest",
+    "reject_digest",
+    "transition_to_awaiting_review",
+]

--- a/bot/services/forget_cascade.py
+++ b/bot/services/forget_cascade.py
@@ -833,11 +833,18 @@ async def _cascade_digests(session: AsyncSession, event) -> int:
     affected_cs_ids = {r[0] for r in cs_rows}
 
     # JSONB scan for digests citing either kind.
+    # T8-04 / Phase 8 §5.D — status filter widened to include the four new
+    # review-gate statuses (awaiting_review, approved_for_publish,
+    # rejected_by_admin) so the cascade reaches drafts under admin review.
+    # MUST mirror digest_redactor._REDACTOR_ELIGIBLE_STATUSES — both must
+    # be widened together (§5.K C1 fix: cascade-only widening leaves a
+    # silent privacy regression).
     digest_rows = await session.execute(
         text(
             "SELECT d.id FROM digests d "
             "WHERE d.status IN "
-            "('draft','posting','posted','redacted','redacted_edit_failed') "
+            "('draft','awaiting_review','approved_for_publish','posting',"
+            " 'posted','redacted','redacted_edit_failed','rejected_by_admin') "
             "  AND EXISTS ("
             "      SELECT 1 FROM jsonb_array_elements(d.citations) AS elem "
             "      WHERE ("

--- a/tests/services/test_digest_publisher.py
+++ b/tests/services/test_digest_publisher.py
@@ -558,3 +558,465 @@ async def test_cascade_digests_layer_redacts_via_cascade_worker(db_session):
         f"got status={row['status']}"
     )
     assert "[REDACTED — забыто]" in row["body_markdown"]
+
+
+# ── T8-04 / Phase 8 — widened allowlists (review-gate states) ───────────────
+
+
+@pytest.mark.parametrize(
+    "review_status",
+    ["awaiting_review", "approved_for_publish", "rejected_by_admin"],
+)
+async def test_redactor_widens_to_review_states(db_session, review_status):
+    """§5.K binding privacy fix C1.
+
+    Redactor MUST accept ``awaiting_review`` / ``approved_for_publish`` /
+    ``rejected_by_admin`` (the new Phase 8 visible/queue statuses). Without
+    this widening the cascade scan selects the row but the redactor's
+    hardcoded allowlist short-circuits it back out — a silent privacy
+    regression where an admin /digest_approve could publish forgotten
+    content.
+    """
+    from bot.db.models import Digest
+    from bot.services.digest_redactor import redact_digest_for_forget
+
+    digest = Digest(
+        type="weekly",
+        window_start=datetime.now(timezone.utc) - timedelta(days=7),
+        window_end=datetime.now(timezone.utc),
+        body_markdown="TL;DR.\n\n- First [[mv:1]]\n- Second [[mv:2]]",
+        citations=[
+            {"kind": "message_version", "id": 1, "position": 0},
+            {"kind": "message_version", "id": 2, "position": 1},
+        ],
+        status=review_status,
+        # ck_digests_approved_audit needs published_by_admin_id + approved_at
+        # for weekly approved_for_publish / posting / posted statuses.
+        published_by_admin_id=(
+            42 if review_status == "approved_for_publish" else None
+        ),
+        approved_at=(
+            datetime.now(timezone.utc)
+            if review_status == "approved_for_publish"
+            else None
+        ),
+        review_notes=(
+            "test reject" if review_status == "rejected_by_admin" else None
+        ),
+    )
+    db_session.add(digest)
+    await db_session.flush()
+    did = digest.id
+
+    await redact_digest_for_forget(
+        db_session,
+        digest_id=did,
+        affected_mvids={1},
+        affected_card_source_ids=set(),
+        bot=None,
+    )
+
+    row = (await db_session.execute(
+        text("SELECT status, body_markdown FROM digests WHERE id = :id"),
+        {"id": did},
+    )).mappings().one()
+    assert row["status"] == "redacted", (
+        f"redactor failed to mask {review_status!r} row: status stayed {row['status']!r} — "
+        f"silent privacy regression"
+    )
+    assert "[REDACTED — забыто]" in row["body_markdown"]
+    assert "First" not in row["body_markdown"]
+    assert "Second" in row["body_markdown"]
+
+
+async def test_redactor_awaiting_review_notifies_admin(db_session, monkeypatch):
+    """§5.D sub-step: when the cascade redacts an `awaiting_review` row, the
+    redactor MUST call `notify_admins_digest_failure` so the admin who was
+    about to approve knows the draft has disappeared from /digest_review.
+    """
+    from bot.db.models import Digest
+    from bot.services.digest_redactor import redact_digest_for_forget
+
+    captured = []
+
+    async def _spy(bot, *, digest_id, status, error_text):
+        captured.append((digest_id, status, error_text))
+
+    monkeypatch.setattr(
+        "bot.services.digest_redactor.notify_admins_digest_failure", _spy
+    )
+
+    digest = Digest(
+        type="weekly",
+        window_start=datetime.now(timezone.utc) - timedelta(days=7),
+        window_end=datetime.now(timezone.utc),
+        body_markdown="TL;DR.\n\n- First [[mv:1]]\n- Second [[mv:2]]",
+        citations=[
+            {"kind": "message_version", "id": 1, "position": 0},
+            {"kind": "message_version", "id": 2, "position": 1},
+        ],
+        status="awaiting_review",
+        awaiting_review_at=datetime.now(timezone.utc),
+    )
+    db_session.add(digest)
+    await db_session.flush()
+    did = digest.id
+
+    bot_mock = MagicMock()
+    await redact_digest_for_forget(
+        db_session,
+        digest_id=did,
+        affected_mvids={1},
+        affected_card_source_ids=set(),
+        bot=bot_mock,
+    )
+
+    assert len(captured) == 1, (
+        f"awaiting_review redaction must notify admin; got {len(captured)} calls"
+    )
+    assert captured[0][0] == did
+    assert captured[0][2] == "forget_redacted_during_review"
+
+
+@pytest.mark.parametrize(
+    "terminal_status",
+    ["failed", "cost_exceeded", "skipped"],
+)
+async def test_redactor_skips_terminal_no_body_states(db_session, terminal_status):
+    """Terminal states without body content (failed/cost_exceeded/skipped)
+    remain skipped by the redactor — these rows either have no body or
+    are explicitly outside the §5.D scan filter."""
+    from bot.db.models import Digest
+    from bot.services.digest_redactor import redact_digest_for_forget
+
+    digest = Digest(
+        type="daily",
+        window_start=datetime.now(timezone.utc) - timedelta(days=1),
+        window_end=datetime.now(timezone.utc),
+        body_markdown=None,
+        citations=[],
+        status=terminal_status,
+        error_text="test",
+    )
+    db_session.add(digest)
+    await db_session.flush()
+    did = digest.id
+
+    await redact_digest_for_forget(
+        db_session,
+        digest_id=did,
+        affected_mvids={1},
+        affected_card_source_ids=set(),
+        bot=None,
+    )
+
+    row = (await db_session.execute(
+        text("SELECT status FROM digests WHERE id = :id"), {"id": did}
+    )).mappings().one()
+    assert row["status"] == terminal_status
+
+
+async def test_publisher_accepts_approved_for_publish(db_session):
+    """§5.L binding state-machine fix C2.
+
+    The publisher trigger guard MUST accept ``status='approved_for_publish'``
+    (the weekly admin-approve path) alongside ``'draft'`` (the daily
+    auto-publish path).
+    """
+    from bot.db.models import (
+        ChatMessage,
+        Digest,
+        MessageVersion,
+    )
+    from bot.db.repos.user import UserRepo
+    from bot.services.digest_publisher import publish_digest
+    from bot.services.digests import DigestConfig
+
+    chat_id = _next_chat_id()
+    uid = -1 * (5500 + next(_chat_counter))
+    await UserRepo.upsert(
+        db_session, telegram_id=uid, username=f"u{uid}", first_name="T", last_name=None
+    )
+    now = datetime.now(timezone.utc)
+    cm = ChatMessage(
+        message_id=920_000 + next(_chat_counter),
+        chat_id=chat_id,
+        user_id=uid,
+        text="weekly hello",
+        date=now - timedelta(days=2),
+        raw_json={"text": "weekly hello"},
+        memory_policy="normal",
+        is_redacted=False,
+    )
+    db_session.add(cm)
+    await db_session.flush()
+    mv = MessageVersion(
+        chat_message_id=cm.id,
+        version_seq=1,
+        text="weekly hello",
+        normalized_text="weekly hello",
+        entities_json={"entities": []},
+        content_hash=f"hw-{cm.id}",
+        is_redacted=False,
+    )
+    db_session.add(mv)
+    await db_session.flush()
+    cm.current_version_id = mv.id
+    await db_session.flush()
+
+    digest = Digest(
+        type="weekly",
+        window_start=now - timedelta(days=7),
+        window_end=now,
+        body_markdown="TL;DR.\n\n- One bullet about weekly hello.",
+        citations=[{"kind": "message_version", "id": mv.id, "position": 0}],
+        status="approved_for_publish",
+        published_by_admin_id=149820031,
+        approved_at=now,
+    )
+    db_session.add(digest)
+    await db_session.flush()
+
+    cfg = DigestConfig(destination_chat_id=-1001234567890)
+    bot_mock = MagicMock()
+    bot_mock.send_message = AsyncMock()
+    sent_msg = MagicMock()
+    sent_msg.message_id = 778
+    bot_mock.send_message.return_value = sent_msg
+
+    result = await publish_digest(
+        db_session, bot=bot_mock, digest=digest, digest_config=cfg
+    )
+    assert result.status == "posted", (
+        f"publisher rejected approved_for_publish: status={result.status} "
+        f"err={result.error_text}"
+    )
+    assert result.posted_message_id == 778
+
+
+async def test_publisher_invalid_state_has_structured_fields(db_session):
+    """§5.L : DigestPublisherInvalidState exposes structured fields
+    (digest_id, current_status, reason)."""
+    from bot.db.models import Digest
+    from bot.services.digest_publisher import (
+        DigestPublisherInvalidState,
+        publish_digest,
+    )
+    from bot.services.digests import DigestConfig
+
+    digest = Digest(
+        type="daily",
+        window_start=datetime.now(timezone.utc) - timedelta(days=1),
+        window_end=datetime.now(timezone.utc),
+        body_markdown="TL;DR.\n\n- One [[mv:1]]",
+        citations=[{"kind": "message_version", "id": 1, "position": 0}],
+        status="posted",
+        posted_chat_id=-42,
+        posted_message_id=999,
+        posted_at=datetime.now(timezone.utc),
+    )
+    db_session.add(digest)
+    await db_session.flush()
+
+    cfg = DigestConfig(destination_chat_id=-42)
+    bot_mock = MagicMock()
+    with pytest.raises(DigestPublisherInvalidState) as exc_info:
+        await publish_digest(
+            db_session, bot=bot_mock, digest=digest, digest_config=cfg
+        )
+    assert exc_info.value.digest_id == digest.id
+    assert exc_info.value.current_status == "posted"
+    assert "draft" in exc_info.value.reason
+    assert "approved_for_publish" in exc_info.value.reason
+
+
+async def test_publisher_classifier_row_deleted_distinguishes_from_wrong_state(
+    db_session,
+):
+    """§5.L canonical rowcount=0 classifier — deleted-row branch.
+
+    Simulate the race window: between the FOR UPDATE NOWAIT lock attempt
+    (which silently succeeds against a missing row) and the guarded UPDATE
+    to 'posting' (which returns rowcount=0), the row is gone. Classifier
+    must raise DigestPublisherInvalidState with ``current_status=None`` and
+    ``reason='row_deleted_during_transition'``.
+    """
+    from bot.db.models import Digest
+    from bot.services.digest_publisher import (
+        DigestPublisherInvalidState,
+        publish_digest,
+    )
+    from bot.services.digests import DigestConfig
+
+    # Build a normal draft row, hold a detached reference, then delete it
+    # so the publisher's guarded UPDATE finds no row.
+    digest = Digest(
+        type="daily",
+        window_start=datetime.now(timezone.utc) - timedelta(days=1),
+        window_end=datetime.now(timezone.utc),
+        body_markdown="TL;DR.\n\n- One [[mv:1]]",
+        citations=[],
+        status="draft",
+    )
+    db_session.add(digest)
+    await db_session.flush()
+    did = digest.id
+
+    # Race: row DELETEd before publish runs (operator manual cleanup or
+    # --regenerate racing).
+    await db_session.execute(
+        text("DELETE FROM digests WHERE id=:id"), {"id": did}
+    )
+    await db_session.flush()
+
+    # The Python `digest` object still has status='draft' in memory so the
+    # trigger guard passes; the FOR UPDATE NOWAIT against a missing row
+    # returns zero rows but does not error; the guarded UPDATE to 'posting'
+    # then returns rowcount=0 — classifier path.
+    cfg = DigestConfig(destination_chat_id=-1001234567890)
+    bot_mock = MagicMock()
+    bot_mock.send_message = AsyncMock()
+    with pytest.raises(DigestPublisherInvalidState) as exc_info:
+        await publish_digest(
+            db_session, bot=bot_mock, digest=digest, digest_config=cfg
+        )
+    assert exc_info.value.digest_id == did
+    assert exc_info.value.current_status is None
+    assert "row_deleted_during_transition" in exc_info.value.reason
+
+
+async def test_publisher_classifier_wrong_state_after_guard_miss(db_session):
+    """§5.L canonical rowcount=0 classifier — wrong-state branch.
+
+    Simulate cascade-won race: row started as 'draft' (passes trigger
+    guard) but is moved to 'redacted' before the guarded UPDATE to
+    'posting' runs. Classifier raises with ``current_status='redacted'``.
+    """
+    from bot.db.models import Digest
+    from bot.services.digest_publisher import (
+        DigestPublisherInvalidState,
+        publish_digest,
+    )
+    from bot.services.digests import DigestConfig
+
+    digest = Digest(
+        type="daily",
+        window_start=datetime.now(timezone.utc) - timedelta(days=1),
+        window_end=datetime.now(timezone.utc),
+        body_markdown="TL;DR.\n\n- One [[mv:1]]",
+        citations=[],
+        status="draft",
+    )
+    db_session.add(digest)
+    await db_session.flush()
+    did = digest.id
+
+    # Race: row moved to 'redacted' by cascade before publisher's guarded
+    # UPDATE — but the Python `digest` object still says 'draft' so the
+    # trigger guard passes.
+    await db_session.execute(
+        text(
+            "UPDATE digests SET status='redacted', updated_at=now() "
+            "WHERE id=:id"
+        ),
+        {"id": did},
+    )
+    await db_session.flush()
+
+    cfg = DigestConfig(destination_chat_id=-1001234567890)
+    bot_mock = MagicMock()
+    bot_mock.send_message = AsyncMock()
+    with pytest.raises(DigestPublisherInvalidState) as exc_info:
+        await publish_digest(
+            db_session, bot=bot_mock, digest=digest, digest_config=cfg
+        )
+    assert exc_info.value.digest_id == did
+    assert exc_info.value.current_status == "redacted"
+    assert "expected status IN" in exc_info.value.reason
+
+
+async def test_cascade_digests_scans_review_states(db_session):
+    """§5.D + §5.K binding.
+
+    Verify ``_cascade_digests`` selects rows in ``awaiting_review`` /
+    ``approved_for_publish`` / ``rejected_by_admin`` statuses (the new
+    Phase 8 review-queue states), then the redactor processes them
+    end-to-end.
+    """
+    from bot.db.models import (
+        ChatMessage,
+        Digest,
+        ForgetEvent,
+        MessageVersion,
+    )
+    from bot.db.repos.user import UserRepo
+    from bot.services.forget_cascade import run_cascade_worker_once
+
+    chat_id = _next_chat_id()
+    uid = -1 * (8500 + next(_chat_counter))
+    await UserRepo.upsert(
+        db_session, telegram_id=uid, username=f"u{uid}", first_name="T", last_name=None
+    )
+    now = datetime.now(timezone.utc)
+    cm = ChatMessage(
+        message_id=970_000 + next(_chat_counter),
+        chat_id=chat_id,
+        user_id=uid,
+        text="awaiting secret",
+        date=now - timedelta(days=3),
+        raw_json={"text": "awaiting secret"},
+        memory_policy="normal",
+        is_redacted=False,
+    )
+    db_session.add(cm)
+    await db_session.flush()
+    mv = MessageVersion(
+        chat_message_id=cm.id,
+        version_seq=1,
+        text="awaiting secret",
+        normalized_text="awaiting secret",
+        entities_json={"entities": []},
+        content_hash=f"hr-{cm.id}",
+        is_redacted=False,
+    )
+    db_session.add(mv)
+    await db_session.flush()
+    cm.current_version_id = mv.id
+
+    digest = Digest(
+        type="weekly",
+        window_start=now - timedelta(days=7),
+        window_end=now,
+        body_markdown=f"TL;DR.\n\n- Bullet [[mv:{mv.id}]]",
+        citations=[{"kind": "message_version", "id": mv.id, "position": 0}],
+        status="awaiting_review",
+        awaiting_review_at=now,
+    )
+    db_session.add(digest)
+    await db_session.flush()
+    did = digest.id
+
+    # Forget event on the message.
+    fe = ForgetEvent(
+        target_type="message",
+        target_id=str(cm.id),
+        actor_user_id=None,
+        authorized_by="self",
+        tombstone_key=f"message:{chat_id}:{cm.id}:p8-cascade",
+        policy="forgotten",
+        status="pending",
+    )
+    db_session.add(fe)
+    await db_session.flush()
+
+    await run_cascade_worker_once(db_session, batch_size=10)
+
+    row = (await db_session.execute(
+        text("SELECT status, body_markdown FROM digests WHERE id=:id"),
+        {"id": did},
+    )).mappings().one()
+    assert row["status"] in ("redacted", "redacted_edit_failed"), (
+        f"awaiting_review digest must be redacted by cascade — privacy "
+        f"regression: got status={row['status']!r}"
+    )
+    assert "[REDACTED — забыто]" in row["body_markdown"]

--- a/tests/services/test_digest_review.py
+++ b/tests/services/test_digest_review.py
@@ -1,0 +1,400 @@
+"""Tests for T8-04 / Phase 8 — bot/services/digest_review.py.
+
+Covers PHASE8_PLAN.md §5.E review state machine:
+- `transition_to_awaiting_review` — draft → awaiting_review (guarded UPDATE).
+- `approve_digest` — awaiting_review → approved_for_publish → publisher.
+- `reject_digest` — awaiting_review → rejected_by_admin.
+- `_raise_invalid_state_after_guard_miss` canonical rowcount=0 classifier
+  distinguishing "row deleted" (current_status=None) from "wrong state"
+  (current_status=str).
+
+Tests follow the Phase 7 service-fixture pattern: outer-transaction
+isolation; the service flushes, tests roll back. No `session.commit()`
+inside test bodies (would break fixture isolation).
+"""
+
+from __future__ import annotations
+
+import itertools
+from datetime import datetime, timezone, timedelta
+
+import pytest
+from sqlalchemy import text
+
+pytestmark = pytest.mark.usefixtures("app_env")
+
+_chat_counter = itertools.count(start=9100)
+
+
+def _next_chat_id() -> int:
+    return -1_000_000_000_000 - next(_chat_counter)
+
+
+async def _make_weekly_digest(
+    db_session,
+    *,
+    status: str = "draft",
+    citations: list | None = None,
+    body: str = "TL;DR.\n\n- One bullet.",
+):
+    """Insert a weekly digest in the given status. Returns row."""
+    from bot.db.models import Digest
+
+    now = datetime.now(timezone.utc)
+    digest = Digest(
+        type="weekly",
+        window_start=now - timedelta(days=7),
+        window_end=now,
+        body_markdown=body,
+        citations=citations if citations is not None else [],
+        status=status,
+    )
+    db_session.add(digest)
+    await db_session.flush()
+    return digest
+
+
+# ── transition_to_awaiting_review ─────────────────────────────────────────────
+
+
+async def test_transition_to_awaiting_review_draft_to_awaiting(db_session):
+    """draft → awaiting_review: status flips, awaiting_review_at set,
+    digest_runs(status='awaiting_review') audit row inserted."""
+    from bot.services.digest_review import transition_to_awaiting_review
+
+    digest = await _make_weekly_digest(db_session, status="draft")
+    did = digest.id
+
+    await transition_to_awaiting_review(db_session, digest_id=did)
+
+    row = (await db_session.execute(
+        text(
+            "SELECT status, awaiting_review_at FROM digests WHERE id=:id"
+        ),
+        {"id": did},
+    )).mappings().one()
+    assert row["status"] == "awaiting_review"
+    assert row["awaiting_review_at"] is not None
+
+    audit_count = (await db_session.execute(
+        text(
+            "SELECT COUNT(*) FROM digest_runs "
+            "WHERE digest_id=:id AND status='awaiting_review'"
+        ),
+        {"id": did},
+    )).scalar_one()
+    assert audit_count == 1
+
+
+async def test_transition_to_awaiting_review_wrong_state_raises(db_session):
+    """Calling on a status='posted' row → DigestReviewInvalidState with
+    current_status='posted'."""
+    from bot.services.digest_review import (
+        DigestReviewInvalidState,
+        transition_to_awaiting_review,
+    )
+
+    digest = await _make_weekly_digest(db_session, status="draft")
+    did = digest.id
+    # Move to posted manually (bypass the SM since we're testing guard).
+    # ck_digests_approved_audit requires published_by_admin_id + approved_at
+    # for weekly posted rows.
+    await db_session.execute(
+        text(
+            "UPDATE digests SET status='posted', posted_chat_id=-42, "
+            "posted_message_id=999, posted_at=now(), "
+            "published_by_admin_id=42, approved_at=now() WHERE id=:id"
+        ),
+        {"id": did},
+    )
+    await db_session.flush()
+
+    with pytest.raises(DigestReviewInvalidState) as exc_info:
+        await transition_to_awaiting_review(db_session, digest_id=did)
+    assert exc_info.value.digest_id == did
+    assert exc_info.value.current_status == "posted"
+    assert "draft" in exc_info.value.reason
+
+
+async def test_transition_to_awaiting_review_row_deleted_raises_none_status(db_session):
+    """Row deleted between caller and guarded UPDATE →
+    DigestReviewInvalidState with current_status=None."""
+    from bot.services.digest_review import (
+        DigestReviewInvalidState,
+        transition_to_awaiting_review,
+    )
+
+    digest = await _make_weekly_digest(db_session, status="draft")
+    did = digest.id
+    await db_session.execute(text("DELETE FROM digests WHERE id=:id"), {"id": did})
+    await db_session.flush()
+
+    with pytest.raises(DigestReviewInvalidState) as exc_info:
+        await transition_to_awaiting_review(db_session, digest_id=did)
+    assert exc_info.value.digest_id == did
+    assert exc_info.value.current_status is None
+    assert "row_deleted_during_transition" in exc_info.value.reason
+
+
+# ── approve_digest ────────────────────────────────────────────────────────────
+
+
+async def test_approve_digest_awaiting_to_approved_for_publish(db_session):
+    """Clean citations + awaiting_review → approved_for_publish → publisher
+    dispatched. With a stub publisher, verify state machine transitions and
+    audit rows."""
+    from bot.services.digests import DigestConfig
+    from bot.services.digest_review import approve_digest
+
+    digest = await _make_weekly_digest(
+        db_session, status="awaiting_review", citations=[]
+    )
+    did = digest.id
+
+    publisher_called = []
+
+    async def _stub_publisher(session, *, bot, digest, digest_config):
+        publisher_called.append(digest.id)
+        digest.status = "posted"
+        digest.posted_chat_id = -42
+        digest.posted_message_id = 555
+        digest.posted_at = datetime.now(timezone.utc)
+        await session.flush()
+        return digest
+
+    cfg = DigestConfig(destination_chat_id=-42)
+    result = await approve_digest(
+        db_session,
+        bot=None,  # _stub_publisher ignores bot
+        digest_id=did,
+        admin_id=149820031,
+        digest_config=cfg,
+        _publisher_dispatch=_stub_publisher,
+    )
+
+    assert publisher_called == [did]
+    assert result.digest_id == did
+    assert result.posted_message_id == 555
+
+    row = (await db_session.execute(
+        text(
+            "SELECT status, published_by_admin_id, approved_at "
+            "FROM digests WHERE id=:id"
+        ),
+        {"id": did},
+    )).mappings().one()
+    # Publisher stub moved to 'posted' so we verify approve_digest set
+    # published_by_admin_id/approved_at BEFORE the publisher call.
+    assert row["status"] == "posted"
+    assert row["published_by_admin_id"] == 149820031
+    assert row["approved_at"] is not None
+
+    # Audit: at least one 'approved_for_publish' DigestRun row exists.
+    audit_count = (await db_session.execute(
+        text(
+            "SELECT COUNT(*) FROM digest_runs "
+            "WHERE digest_id=:id AND status='approved_for_publish'"
+        ),
+        {"id": did},
+    )).scalar_one()
+    assert audit_count == 1
+
+
+async def test_approve_digest_wrong_state_raises(db_session):
+    """Approving a status='rejected_by_admin' row → DigestReviewInvalidState
+    with current_status='rejected_by_admin'."""
+    from bot.services.digests import DigestConfig
+    from bot.services.digest_review import (
+        DigestReviewInvalidState,
+        approve_digest,
+    )
+
+    digest = await _make_weekly_digest(db_session, status="awaiting_review")
+    did = digest.id
+    # Manually move to rejected_by_admin to simulate a race-won state.
+    await db_session.execute(
+        text(
+            "UPDATE digests SET status='rejected_by_admin', "
+            "published_by_admin_id=42, review_notes='nope' WHERE id=:id"
+        ),
+        {"id": did},
+    )
+    await db_session.flush()
+
+    cfg = DigestConfig(destination_chat_id=-42)
+    with pytest.raises(DigestReviewInvalidState) as exc_info:
+        await approve_digest(
+            db_session,
+            bot=None,
+            digest_id=did,
+            admin_id=149820031,
+            digest_config=cfg,
+        )
+    assert exc_info.value.current_status == "rejected_by_admin"
+
+
+async def test_approve_digest_citations_stale_marks_failed(db_session):
+    """If citation revalidation fails at approval, digest goes to 'failed'
+    with error_text='citations_stale_at_approval' and DigestReviewInvalidState
+    is raised."""
+    from bot.services.digests import DigestConfig
+    from bot.services.digest_review import (
+        DigestReviewInvalidState,
+        approve_digest,
+    )
+
+    # Cite a non-existent mv_id — revalidation must fail.
+    digest = await _make_weekly_digest(
+        db_session,
+        status="awaiting_review",
+        citations=[{"kind": "message_version", "id": 999_999_999, "position": 0}],
+    )
+    did = digest.id
+
+    publisher_called = []
+
+    async def _stub_publisher(session, *, bot, digest, digest_config):
+        publisher_called.append(digest.id)
+        return digest
+
+    cfg = DigestConfig(destination_chat_id=-42)
+    with pytest.raises(DigestReviewInvalidState) as exc_info:
+        await approve_digest(
+            db_session,
+            bot=None,
+            digest_id=did,
+            admin_id=149820031,
+            digest_config=cfg,
+            _publisher_dispatch=_stub_publisher,
+        )
+    assert exc_info.value.current_status == "failed"
+    assert "citations_stale_at_approval" in exc_info.value.reason
+    # Publisher MUST NOT be called.
+    assert publisher_called == []
+
+    row = (await db_session.execute(
+        text("SELECT status, error_text FROM digests WHERE id=:id"),
+        {"id": did},
+    )).mappings().one()
+    assert row["status"] == "failed"
+    assert row["error_text"] == "citations_stale_at_approval"
+
+
+async def test_approve_digest_not_found_raises(db_session):
+    """A digest_id that does not exist → DigestReviewNotFound (distinct from
+    DigestReviewInvalidState)."""
+    from bot.services.digests import DigestConfig
+    from bot.services.digest_review import (
+        DigestReviewNotFound,
+        approve_digest,
+    )
+
+    cfg = DigestConfig(destination_chat_id=-42)
+    with pytest.raises(DigestReviewNotFound):
+        await approve_digest(
+            db_session,
+            bot=None,
+            digest_id=9_999_999,
+            admin_id=149820031,
+            digest_config=cfg,
+        )
+
+
+# ── reject_digest ─────────────────────────────────────────────────────────────
+
+
+async def test_reject_digest_awaiting_to_rejected_by_admin(db_session):
+    """awaiting_review → rejected_by_admin, review_notes set, audit row
+    inserted."""
+    from bot.services.digest_review import reject_digest
+
+    digest = await _make_weekly_digest(db_session, status="awaiting_review")
+    did = digest.id
+
+    await reject_digest(
+        db_session,
+        digest_id=did,
+        admin_id=149820031,
+        reason="off-topic content",
+    )
+
+    row = (await db_session.execute(
+        text(
+            "SELECT status, review_notes, published_by_admin_id "
+            "FROM digests WHERE id=:id"
+        ),
+        {"id": did},
+    )).mappings().one()
+    assert row["status"] == "rejected_by_admin"
+    assert row["review_notes"] == "off-topic content"
+    assert row["published_by_admin_id"] == 149820031
+
+    audit_count = (await db_session.execute(
+        text(
+            "SELECT COUNT(*) FROM digest_runs "
+            "WHERE digest_id=:id AND status='rejected_by_admin'"
+        ),
+        {"id": did},
+    )).scalar_one()
+    assert audit_count == 1
+
+
+async def test_reject_digest_truncates_reason_to_1000_chars(db_session):
+    """review_notes must be truncated to <=1000 chars (L4 service-layer
+    normalization)."""
+    from bot.services.digest_review import reject_digest
+
+    digest = await _make_weekly_digest(db_session, status="awaiting_review")
+    did = digest.id
+
+    long_reason = "x" * 2000
+    await reject_digest(
+        db_session, digest_id=did, admin_id=42, reason=long_reason
+    )
+
+    row = (await db_session.execute(
+        text("SELECT review_notes FROM digests WHERE id=:id"), {"id": did}
+    )).mappings().one()
+    assert row["review_notes"] is not None
+    assert len(row["review_notes"]) == 1000
+
+
+async def test_reject_digest_none_reason_default_message(db_session):
+    """reason=None → review_notes='no reason given'."""
+    from bot.services.digest_review import reject_digest
+
+    digest = await _make_weekly_digest(db_session, status="awaiting_review")
+    did = digest.id
+
+    await reject_digest(db_session, digest_id=did, admin_id=42, reason=None)
+
+    row = (await db_session.execute(
+        text("SELECT review_notes FROM digests WHERE id=:id"), {"id": did}
+    )).mappings().one()
+    assert row["review_notes"] == "no reason given"
+
+
+async def test_reject_digest_wrong_state_raises(db_session):
+    """Rejecting a posted row → DigestReviewInvalidState."""
+    from bot.services.digest_review import (
+        DigestReviewInvalidState,
+        reject_digest,
+    )
+
+    digest = await _make_weekly_digest(db_session, status="draft")
+    did = digest.id
+    await db_session.execute(
+        text(
+            "UPDATE digests SET status='posted', posted_chat_id=-42, "
+            "posted_message_id=999, posted_at=now(), "
+            "published_by_admin_id=42, approved_at=now() WHERE id=:id"
+        ),
+        {"id": did},
+    )
+    await db_session.flush()
+
+    with pytest.raises(DigestReviewInvalidState) as exc_info:
+        await reject_digest(
+            db_session, digest_id=did, admin_id=42, reason="anything"
+        )
+    assert exc_info.value.current_status == "posted"


### PR DESCRIPTION
## Summary

T8-04 of Phase 8 — privacy-critical sprint that adds the review state machine and widens the forget-cascade / redactor / publisher allowlists to cover Phase 8 review states.

## Changes

### NEW: `bot/services/digest_review.py`
- `DigestReviewInvalidState(Exception)` with structured `digest_id` / `current_status` / `reason` kwargs
- `DigestReviewNotFound(Exception)`
- Canonical helper `_raise_invalid_state_after_guard_miss(session, *, digest_id, expected_status)` — re-reads row, distinguishes deleted-vs-wrong-state, raises typed exception
- `transition_to_awaiting_review(session, digest_id)` — guarded UPDATE `WHERE id=:id AND status='draft' RETURNING id`; sets `awaiting_review_at=now()`; audit insert
- `approve_digest(session, digest_id, admin_id, *, _publisher_dispatch=None)`:
  1. SELECT status
  2. Defense-in-depth revalidation via `_digest_context_is_clean`
  3. If stale → terminal `failed` (`error_text='citations_stale_at_approval'`)
  4. Guarded approve → `approved_for_publish`, set `published_by_admin_id`, `approved_at=now()`
  5. Dispatch `publish_digest` (test override via `_publisher_dispatch`)
- `reject_digest(session, digest_id, admin_id, reason)` — guarded UPDATE to `rejected_by_admin`; L4 1000-char truncation

### `bot/services/digest_redactor.py` (Codex S0-C1 fix)
- New `_REDACTOR_ELIGIBLE_STATUSES` 8-tuple constant covering all visible/terminal/review states
- Line 130 early-return guard widened
- Line 159 UPDATE WHERE clause widened
- Admin-notify branch when `awaiting_review` is cascade-redacted (§5.D sub-step)

### `bot/services/digest_publisher.py` (Codex S0-C2 fix)
- `_PUBLISHER_TRIGGER_STATUSES = ('draft', 'approved_for_publish')`
- `DigestPublisherInvalidState` structured with kwargs (positional backward-compat preserved)
- Guarded UPDATE `WHERE status IN _PUBLISHER_TRIGGER_STATUSES` with inline §5.E classifier

### `bot/services/forget_cascade.py::_cascade_digests`
- WHERE-status filter widened to 8 statuses (5 Phase 7 + 3 Phase 8 review states)
- Cross-reference comment: "MUST mirror digest_redactor._REDACTOR_ELIGIBLE_STATUSES"

## Tests

- `tests/services/test_digest_review.py` NEW — 11 cases (each transition + guard-miss paths + DigestReviewNotFound + L4 truncation)
- `tests/services/test_digest_publisher.py` extended — 10 new cases (redactor parametrized over 3 review states + 3 terminal states + admin-notify spy + publisher trigger widen + structured exception + classifier deleted-row + classifier wrong-state + cascade scan e2e)

## Verification

- 147 focused tests pass (`tests/services/test_digest_*.py + test_forget_cascade*.py`)
- 1129 full-suite tests pass (1 pre-existing unrelated failure: `test_live_gateway_adapter_satisfies_protocol_and_delegates` BOT_TOKEN env isolation)
- Privacy lint exit 0, ruff exit 0

## Test plan

- [x] 147 focused + 1129 full regression green
- [x] Privacy lint green
- [x] Ruff green
- [ ] CI green
- [ ] Merge — unlocks T8-05 (parallel sprint depends on `transition_to_awaiting_review` from digest_review.py) and Wave 5

## Phase 11 binding setup

This sprint sets up the foundation for I6a/I6b.1/.2/.3/I6c binding tests (T8-07):
- I6a: forget while `awaiting_review` → cascade scan finds row → redactor processes (no longer silently skipped per C1 fix)
- I6b.1/.2/.3: three forget-windows around approve commit
- I6c: concurrent daily + weekly forget race

The I6 binding tests themselves are T8-07 scope — this sprint provides the mechanism they bind.