### PR TITLE
feat(p8-t8-05): scheduler digest_weekly_job + digest_stale_review_reaper_job

### DIFF
--- a/bot/services/scheduler.py
+++ b/bot/services/scheduler.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 from aiogram import Bot
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
@@ -425,6 +425,344 @@ async def digest_stale_posting_reaper_job() -> None:
         logger.exception("digest_stale_posting_reaper crashed")
 
 
+# ─── T8-05: Phase 8 weekly-digest scheduler jobs ────────────────────────────
+
+
+async def digest_weekly_job(bot: Bot) -> None:
+    """Weekly digest run trigger — fires Mon ``DIGEST_WEEKLY_HOUR_MSK`` MSK.
+
+    Per PHASE8_PLAN.md §5.G. Strict no-op when ``memory.digests.weekly.enabled``
+    is OFF. Window is the most recently completed ISO week:
+    ``last_monday 00:00 MSK..this_monday 00:00 MSK`` (stored as UTC).
+
+    H8 stagger: registered at 09:15 MSK so the LLM gateway has 15 minutes of
+    slack past the daily 09:00 cron — avoids contention on Mondays.
+
+    H4 status-aware match block: ``run_digest`` may return either a fresh
+    ``draft`` (happy path → transition to ``awaiting_review`` + admin DM)
+    or — via the per-(type,ws,we) idempotency lock — an EXISTING row in any
+    status. Each branch handles the discovered terminal state explicitly;
+    cron NEVER auto-regenerates rejected runs. The wrapping try/except
+    chain ensures apscheduler never sees an exception — every outcome is
+    persisted via ``digests`` / ``digest_runs`` rows.
+
+    T8-04 (parallel sprint) owns ``bot.services.digest_review``. If the
+    module isn't merged yet the import is guarded and the job logs a
+    warning — the draft row is still created, just not advanced.
+    """
+    try:
+        async with async_session() as session:
+            from bot.db.repos.feature_flag import FeatureFlagRepo
+
+            flag_enabled = await FeatureFlagRepo.get(
+                session, "memory.digests.weekly.enabled"
+            )
+            if not flag_enabled:
+                logger.info("digest_weekly_job: flag disabled, skipping")
+                return
+
+            from zoneinfo import ZoneInfo
+
+            from bot.services.digests import load_digest_config, run_digest
+
+            msk = ZoneInfo("Europe/Moscow")
+            now_msk = datetime.now(tz=msk)
+            today_msk_midnight = now_msk.replace(
+                hour=0, minute=0, second=0, microsecond=0
+            )
+            # ISO: Mon=1, Tue=2, ..., Sun=7. days_since_monday=0 when cron
+            # fires on Mon. The "most recent Monday 00:00 MSK" is therefore
+            # ``today_msk_midnight - timedelta(days=days_since_monday)``.
+            days_since_monday = today_msk_midnight.isoweekday() - 1
+            this_monday_msk = today_msk_midnight - timedelta(days=days_since_monday)
+            last_monday_msk = this_monday_msk - timedelta(days=7)
+
+            window_start = last_monday_msk.astimezone(timezone.utc)
+            window_end = this_monday_msk.astimezone(timezone.utc)
+
+            digest_config = load_digest_config()
+            gateway_config = load_gateway_config()
+            try:
+                digest = await run_digest(
+                    session,
+                    type="weekly",
+                    window_start=window_start,
+                    window_end=window_end,
+                    ledger_repo=LedgerRepo(),
+                    provider=resolve_provider(gateway_config.provider),
+                    config=gateway_config,
+                    digest_config=digest_config,
+                )
+                await session.commit()
+                logger.info(
+                    "digest_weekly_job: ws=%s we=%s digest_id=%s status=%s",
+                    window_start.isoformat(),
+                    window_end.isoformat(),
+                    digest.id,
+                    digest.status,
+                )
+
+                # H4 status-aware match block — see §5.G.
+                if digest.status == "draft":
+                    # Happy path: fresh draft → review-gate transition.
+                    try:
+                        from bot.services.digest_review import (
+                            transition_to_awaiting_review,
+                        )
+                    except ImportError:
+                        logger.warning(
+                            "digest_weekly_job: bot.services.digest_review not "
+                            "merged yet (T8-04 parallel sprint); weekly draft "
+                            "id=%s created but cannot transition to "
+                            "awaiting_review",
+                            digest.id,
+                        )
+                        return
+
+                    try:
+                        await transition_to_awaiting_review(
+                            session, digest_id=digest.id
+                        )
+                        await session.commit()
+                        # §5.J: weekly_awaiting_review handoff DM.
+                        from bot.services.digest_admin_notify import (
+                            notify_admins_digest_failure,
+                        )
+
+                        await notify_admins_digest_failure(
+                            bot,
+                            digest_id=digest.id,
+                            status="awaiting_review",
+                            error_text="weekly_awaiting_review",
+                        )
+                    except Exception:
+                        try:
+                            await session.rollback()
+                        except Exception:
+                            logger.exception(
+                                "digest_weekly_job: review transition "
+                                "rollback failed"
+                            )
+                        logger.exception(
+                            "digest_weekly_job: transition_to_awaiting_review failed"
+                        )
+                elif digest.status in (
+                    "awaiting_review",
+                    "approved_for_publish",
+                    "posting",
+                    "posted",
+                ):
+                    # Idempotency hit: prior cycle already advanced this
+                    # window. No-op — admin is already in the loop.
+                    logger.info(
+                        "digest_weekly_job: existing %s row id=%s, no-op",
+                        digest.status,
+                        digest.id,
+                    )
+                elif digest.status in ("rejected_by_admin", "rejected_by_reaper"):
+                    # Cron does NOT auto-regenerate. Admin must run
+                    # /digest_now weekly --regenerate.
+                    logger.info(
+                        "digest_weekly_job: window has rejected run id=%s "
+                        "status=%s, awaiting admin /digest_now weekly --regenerate",
+                        digest.id,
+                        digest.status,
+                    )
+                elif digest.status in ("failed", "cost_exceeded"):
+                    # Surface to admin DM.
+                    from bot.services.digest_admin_notify import (
+                        notify_admins_digest_failure,
+                    )
+
+                    await notify_admins_digest_failure(
+                        bot,
+                        digest_id=digest.id,
+                        status=digest.status,
+                        error_text=(
+                            digest.error_text
+                            or "weekly_digest_window_in_error_state"
+                        ),
+                    )
+                    logger.error(
+                        "digest_weekly_job: window in error state %s id=%s, "
+                        "admin DM dispatched",
+                        digest.status,
+                        digest.id,
+                    )
+                elif digest.status in ("skipped", "skipped_no_destination"):
+                    logger.info(
+                        "digest_weekly_job: window status=%s id=%s, no action",
+                        digest.status,
+                        digest.id,
+                    )
+                elif digest.status in ("redacted", "redacted_edit_failed"):
+                    logger.info(
+                        "digest_weekly_job: window redacted id=%s status=%s",
+                        digest.id,
+                        digest.status,
+                    )
+                else:
+                    logger.error(
+                        "digest_weekly_job: unexpected status %s for digest_id=%s",
+                        digest.status,
+                        digest.id,
+                    )
+
+            except Exception:
+                try:
+                    await session.rollback()
+                except Exception:
+                    logger.exception("digest_weekly_job rollback failed")
+                logger.exception("digest_weekly_job: run_digest crashed")
+    except Exception:
+        # Catch-all — apscheduler must never see an exception or it would
+        # mark the job as failed and stop firing.
+        logger.exception("digest_weekly_job: session setup failed")
+
+
+async def digest_stale_review_reaper_job(bot: Bot) -> None:
+    """48h DM + 7d auto-reject for ``awaiting_review`` weekly digests.
+
+    Per PHASE8_PLAN.md §5.G + §13 AC7. Runs every 30 min, NOT flag-gated —
+    even after a flag flip-OFF, any rows already in ``awaiting_review`` must
+    still be reaped to bound queue size.
+
+    Two passes per tick:
+
+    1. **7d auto-reject pass FIRST.** Guarded UPDATE transitions
+       ``awaiting_review`` rows older than 7 days to ``rejected_by_reaper``.
+       Audit row inserted with ``error_text='review_deadline_exceeded'``.
+       Admin DM fires with ``error_text='review_7d_auto_rejected'``. Doing
+       the 7d pass FIRST means an 8d row terminates this tick rather than
+       getting a 48h DM (which would then be terminated next tick).
+
+    2. **48h DM pass.** M4 guarded UPDATE: SELECT candidate rows where
+       ``awaiting_review_at < now() - 48h`` AND the ``[48h_notified]`` marker
+       is absent from ``review_notes``. For each, attempt a guarded UPDATE
+       gated on ``status='awaiting_review'`` — rowcount=0 means an admin
+       advanced the state between SELECT and UPDATE; skip the DM cleanly.
+       Rowcount=1 → DM fires AFTER the marker landed, guaranteeing at-most-
+       once notification per row.
+
+    The wrapping try/except so a reaper crash does not disrupt other
+    scheduler jobs.
+    """
+    try:
+        from sqlalchemy import text as _text
+
+        async with async_session() as session:
+            # Step 1: 7d auto-reject pass. Guarded UPDATE — type + status +
+            # age all enforced in WHERE; rowcount drives audit insert and
+            # admin DM.
+            seven_d_rows = (
+                await session.execute(
+                    _text(
+                        """
+                        UPDATE digests
+                        SET status='rejected_by_reaper',
+                            review_notes=COALESCE(review_notes,'') || '[stale_7d]',
+                            updated_at=now()
+                        WHERE type='weekly'
+                          AND status='awaiting_review'
+                          AND awaiting_review_at < now() - interval '7 days'
+                        RETURNING id
+                        """
+                    )
+                )
+            ).fetchall()
+            seven_d_ids = [row.id for row in seven_d_rows]
+            for digest_id in seven_d_ids:
+                await session.execute(
+                    _text(
+                        "INSERT INTO digest_runs (digest_id, status, "
+                        "error_text, started_at, finished_at) "
+                        "VALUES (:id, 'rejected_by_reaper', "
+                        "'review_deadline_exceeded', now(), now())"
+                    ),
+                    {"id": digest_id},
+                )
+                logger.warning(
+                    "digest_stale_review_reaper: rejected digest_id=%s", digest_id
+                )
+            await session.commit()
+            # 7d-pass admin DMs — dispatched after commit so the row is durable
+            # before the side-effect.
+            if seven_d_ids:
+                from bot.services.digest_admin_notify import (
+                    notify_admins_digest_failure,
+                )
+
+                for digest_id in seven_d_ids:
+                    await notify_admins_digest_failure(
+                        bot,
+                        digest_id=digest_id,
+                        status="rejected_by_reaper",
+                        error_text="review_7d_auto_rejected",
+                    )
+
+            # Step 2: 48h notify pass — DM at most once per row via marker.
+            candidate_rows = (
+                await session.execute(
+                    _text(
+                        """
+                        SELECT id
+                        FROM digests
+                        WHERE type='weekly'
+                          AND status='awaiting_review'
+                          AND awaiting_review_at < now() - interval '48 hours'
+                          AND (review_notes IS NULL
+                               OR review_notes NOT LIKE '%[48h_notified]%')
+                        """
+                    )
+                )
+            ).fetchall()
+
+            notified_ids: list[int] = []
+            for row in candidate_rows:
+                # M4: guarded UPDATE — admin may have approved / rejected
+                # between SELECT and UPDATE. Marker must only land on rows
+                # STILL in awaiting_review. rowcount=0 → log + skip DM.
+                update_result = await session.execute(
+                    _text(
+                        "UPDATE digests SET "
+                        "review_notes=COALESCE(review_notes,'') "
+                        "|| '[48h_notified]', "
+                        "updated_at=now() "
+                        "WHERE id=:id AND status='awaiting_review' "
+                        "RETURNING id"
+                    ),
+                    {"id": row.id},
+                )
+                if update_result.rowcount == 0:
+                    logger.info(
+                        "digest_stale_review_reaper: digest_id=%s no longer "
+                        "awaiting_review, skipping 48h DM (state advanced)",
+                        row.id,
+                    )
+                    continue
+                notified_ids.append(row.id)
+            await session.commit()
+
+            if notified_ids:
+                from bot.services.digest_admin_notify import (
+                    notify_admins_digest_failure,
+                )
+
+                for digest_id in notified_ids:
+                    # DM AFTER successful guarded marker — order guarantees
+                    # at-most-once notification per row.
+                    await notify_admins_digest_failure(
+                        bot,
+                        digest_id=digest_id,
+                        status="awaiting_review",
+                        error_text="review_48h_reminder",
+                    )
+    except Exception:
+        # Reaper crash must NEVER propagate — apscheduler would stop firing
+        # the job. Log + continue.
+        logger.exception("digest_stale_review_reaper crashed")
+
+
 def start_scheduler(bot: Bot) -> None:
     """Configure and start the scheduler."""
     scheduler.add_job(
@@ -526,6 +864,40 @@ def start_scheduler(bot: Bot) -> None:
         max_instances=1,
         coalesce=True,
         misfire_grace_time=60,
+    )
+    # T8-05: Phase 8 weekly digest. Mon 09:15 MSK — H8 stagger past the daily
+    # 09:00 cron so the LLM gateway has 15 minutes of slack on Mondays.
+    # Gated by feature flag ``memory.digests.weekly.enabled`` (default OFF);
+    # job body re-checks the flag and is a strict no-op when disabled.
+    digest_weekly_hour_msk = int(getattr(settings, "DIGEST_WEEKLY_HOUR_MSK", 9))
+    digest_weekly_minute_msk = int(getattr(settings, "DIGEST_WEEKLY_MINUTE_MSK", 15))
+    scheduler.add_job(
+        digest_weekly_job,
+        "cron",
+        day_of_week="mon",
+        hour=digest_weekly_hour_msk,
+        minute=digest_weekly_minute_msk,
+        args=[bot],
+        id="digest_weekly",
+        replace_existing=True,
+        max_instances=1,
+        coalesce=True,
+        misfire_grace_time=3600,  # 1h grace — weekly cadence is forgiving
+        timezone=msk,
+    )
+    # T8-05: Phase 8 stale-review reaper. Every 30 min, no flag gate —
+    # rows already in awaiting_review must still be bounded even after a
+    # flag flip-OFF. Two passes per tick: 7d auto-reject + 48h DM.
+    scheduler.add_job(
+        digest_stale_review_reaper_job,
+        "interval",
+        minutes=30,
+        args=[bot],
+        id="digest_stale_review_reaper",
+        replace_existing=True,
+        max_instances=1,
+        coalesce=True,
+        misfire_grace_time=300,
     )
     scheduler.start()
     logger.info("Scheduler started")

--- a/tests/services/test_digest_scheduler_weekly.py
+++ b/tests/services/test_digest_scheduler_weekly.py
@@ -1,0 +1,636 @@
+"""Tests for T8-05 — Phase 8 weekly-digest scheduler jobs.
+
+Covers:
+- ``digest_weekly_job``: flag-OFF strict no-op
+- ``digest_weekly_job``: ISO week window calc (last Mon 00:00 MSK → this Mon
+  00:00 MSK, stored as UTC)
+- ``digest_weekly_job``: draft → ``transition_to_awaiting_review`` happy path
+- ``digest_weekly_job``: idempotency-return non-draft statuses do NOT trigger
+  the review transition
+- ``digest_weekly_job``: ``failed``/``cost_exceeded`` paths fire admin DM
+- ``digest_weekly_job``: registered as Mon 09:15 MSK cron with the H8 stagger
+- ``digest_stale_review_reaper_job``: 48h DM marker append (M4 guarded UPDATE)
+- ``digest_stale_review_reaper_job``: 48h DM is idempotent (marker present →
+  no-op)
+- ``digest_stale_review_reaper_job``: 7d auto-reject → ``rejected_by_reaper``
+  terminal + audit insert
+- ``digest_stale_review_reaper_job``: guarded UPDATE no-ops when an admin
+  approves between the SELECT and the UPDATE
+- ``digest_stale_review_reaper_job``: registered as 30-min interval
+
+PHASE8_PLAN.md §5.G + §13 AC1 + §13 AC7.
+"""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from sqlalchemy import text
+
+pytestmark = pytest.mark.usefixtures("app_env")
+
+
+# ── helpers ─────────────────────────────────────────────────────────────────
+
+
+async def _set_flag(db_session, key: str, enabled: bool) -> None:
+    from bot.db.repos.feature_flag import FeatureFlagRepo
+
+    await FeatureFlagRepo.set_enabled(db_session, flag_key=key, enabled=enabled)
+
+
+def _fake_session_ctx(db_session):
+    """Build a context manager that yields the test ``db_session``.
+
+    The job body opens its own ``async_session()``; we patch the symbol so the
+    job operates on the test transaction (which gets rolled back at fixture
+    teardown).
+    """
+
+    @asynccontextmanager
+    async def _ctx():
+        yield db_session
+
+    return _ctx
+
+
+# ── digest_weekly_job: flag-OFF strict no-op ────────────────────────────────
+
+
+async def test_digest_weekly_job_skipped_when_flag_off(db_session, monkeypatch):
+    """AC1: flag default OFF → ``run_digest`` must NOT be invoked.
+
+    The job body's first action is the feature-flag check; if the flag is
+    False the function returns immediately. We assert by mocking
+    ``run_digest`` and verifying zero calls.
+    """
+    await _set_flag(db_session, "memory.digests.weekly.enabled", False)
+    await db_session.flush()
+
+    import bot.services.scheduler as scheduler_mod
+
+    monkeypatch.setattr(scheduler_mod, "async_session", _fake_session_ctx(db_session))
+
+    run_digest_mock = AsyncMock()
+    monkeypatch.setattr("bot.services.digests.run_digest", run_digest_mock)
+
+    fake_bot = MagicMock()
+    await scheduler_mod.digest_weekly_job(fake_bot)
+
+    assert run_digest_mock.await_count == 0, (
+        "run_digest must not be invoked when memory.digests.weekly.enabled is OFF"
+    )
+
+
+# ── digest_weekly_job: ISO week window ──────────────────────────────────────
+
+
+async def test_digest_weekly_job_window_is_iso_mon_to_mon_msk(
+    db_session, monkeypatch
+):
+    """AC1 / §5.G: window_start = last Mon 00:00 MSK; window_end = this Mon
+    00:00 MSK. Both must be passed to ``run_digest`` in UTC.
+
+    We pin ``datetime.now`` via a stub on ``bot.services.scheduler.datetime``
+    to a known Mon 09:15 MSK so the math is deterministic.
+    """
+    await _set_flag(db_session, "memory.digests.weekly.enabled", True)
+    await db_session.flush()
+
+    import bot.services.scheduler as scheduler_mod
+
+    monkeypatch.setattr(scheduler_mod, "async_session", _fake_session_ctx(db_session))
+
+    # Pin the scheduler's datetime.now() — Mon 2026-05-18 09:15 MSK.
+    from zoneinfo import ZoneInfo
+
+    msk = ZoneInfo("Europe/Moscow")
+    pinned_now_msk = datetime(2026, 5, 18, 9, 15, 0, tzinfo=msk)
+
+    class _FakeDatetime(datetime):
+        @classmethod
+        def now(cls, tz=None):  # type: ignore[override]
+            if tz is None:
+                return pinned_now_msk.astimezone(timezone.utc).replace(tzinfo=None)
+            return pinned_now_msk.astimezone(tz)
+
+    monkeypatch.setattr(scheduler_mod, "datetime", _FakeDatetime)
+
+    captured = {}
+
+    async def _fake_run_digest(session, **kwargs):
+        captured["window_start"] = kwargs["window_start"]
+        captured["window_end"] = kwargs["window_end"]
+        captured["type"] = kwargs["type"]
+        # Return a stub with a status that bypasses the rest of the job body.
+        digest = MagicMock()
+        digest.id = 999
+        digest.status = "skipped"
+        return digest
+
+    monkeypatch.setattr("bot.services.digests.run_digest", _fake_run_digest)
+
+    fake_bot = MagicMock()
+    await scheduler_mod.digest_weekly_job(fake_bot)
+
+    # Expected: this Mon 00:00 MSK = 2026-05-18 00:00 MSK = 2026-05-17 21:00 UTC
+    # Last Mon 00:00 MSK = 2026-05-11 00:00 MSK = 2026-05-10 21:00 UTC
+    expected_start = datetime(2026, 5, 10, 21, 0, 0, tzinfo=timezone.utc)
+    expected_end = datetime(2026, 5, 17, 21, 0, 0, tzinfo=timezone.utc)
+    assert captured["type"] == "weekly"
+    assert captured["window_start"] == expected_start, captured
+    assert captured["window_end"] == expected_end, captured
+    # 7-day span:
+    assert (captured["window_end"] - captured["window_start"]).total_seconds() == 7 * 86400
+
+
+# ── digest_weekly_job: draft → transition_to_awaiting_review ───────────────
+
+
+async def test_digest_weekly_job_transitions_draft_to_awaiting_review(
+    db_session, monkeypatch
+):
+    """Happy path: ``run_digest`` returns ``status='draft'`` →
+    ``transition_to_awaiting_review`` is called with the digest id, then
+    admin DM fires for ``weekly_awaiting_review``.
+    """
+    await _set_flag(db_session, "memory.digests.weekly.enabled", True)
+    await db_session.flush()
+
+    import bot.services.scheduler as scheduler_mod
+
+    monkeypatch.setattr(scheduler_mod, "async_session", _fake_session_ctx(db_session))
+
+    digest = MagicMock()
+    digest.id = 4242
+    digest.status = "draft"
+    digest.error_text = None
+
+    monkeypatch.setattr(
+        "bot.services.digests.run_digest", AsyncMock(return_value=digest)
+    )
+
+    transition_mock = AsyncMock()
+    notify_mock = AsyncMock()
+
+    # Provide a fake digest_review module so the import-guard inside the job
+    # body finds the symbol. T8-04 is a parallel sprint; this test pretends
+    # the module is already merged.
+    import sys
+    import types
+
+    fake_review = types.ModuleType("bot.services.digest_review")
+    fake_review.transition_to_awaiting_review = transition_mock
+    monkeypatch.setitem(sys.modules, "bot.services.digest_review", fake_review)
+
+    monkeypatch.setattr(
+        "bot.services.digest_admin_notify.notify_admins_digest_failure",
+        notify_mock,
+    )
+
+    fake_bot = MagicMock()
+    await scheduler_mod.digest_weekly_job(fake_bot)
+
+    assert transition_mock.await_count == 1, (
+        f"transition_to_awaiting_review must be called exactly once; got {transition_mock.await_count}"
+    )
+    call_kwargs = transition_mock.await_args.kwargs
+    assert call_kwargs["digest_id"] == 4242
+
+    # Admin DM should have been dispatched with the weekly_awaiting_review tag.
+    assert notify_mock.await_count == 1, (
+        "admin DM must fire for weekly_awaiting_review handoff"
+    )
+    notify_kwargs = notify_mock.await_args.kwargs
+    assert notify_kwargs["digest_id"] == 4242
+    assert notify_kwargs["status"] == "awaiting_review"
+    assert notify_kwargs["error_text"] == "weekly_awaiting_review"
+
+
+# ── digest_weekly_job: idempotency-return non-draft statuses ───────────────
+
+
+@pytest.mark.parametrize(
+    "existing_status",
+    ["awaiting_review", "approved_for_publish", "posting", "posted"],
+)
+async def test_digest_weekly_job_skips_transition_on_non_draft_status(
+    db_session, monkeypatch, existing_status
+):
+    """H4 cron status-aware match block: when ``run_digest`` returns an
+    EXISTING row in an advanced status, ``transition_to_awaiting_review``
+    is NOT called (a prior cycle / admin already advanced the state).
+    """
+    await _set_flag(db_session, "memory.digests.weekly.enabled", True)
+    await db_session.flush()
+
+    import bot.services.scheduler as scheduler_mod
+
+    monkeypatch.setattr(scheduler_mod, "async_session", _fake_session_ctx(db_session))
+
+    digest = MagicMock()
+    digest.id = 555
+    digest.status = existing_status
+
+    monkeypatch.setattr(
+        "bot.services.digests.run_digest", AsyncMock(return_value=digest)
+    )
+
+    transition_mock = AsyncMock()
+    import sys
+    import types
+
+    fake_review = types.ModuleType("bot.services.digest_review")
+    fake_review.transition_to_awaiting_review = transition_mock
+    monkeypatch.setitem(sys.modules, "bot.services.digest_review", fake_review)
+
+    fake_bot = MagicMock()
+    await scheduler_mod.digest_weekly_job(fake_bot)
+
+    assert transition_mock.await_count == 0, (
+        f"transition_to_awaiting_review must NOT be called for status={existing_status!r}"
+    )
+
+
+# ── digest_weekly_job: failed / cost_exceeded → admin DM ─────────────────
+
+
+@pytest.mark.parametrize("error_status", ["failed", "cost_exceeded"])
+async def test_digest_weekly_job_admin_dm_on_error_status(
+    db_session, monkeypatch, error_status
+):
+    """H4: ``failed`` / ``cost_exceeded`` paths route to
+    ``notify_admins_digest_failure`` so the admin sees the error explicitly.
+    """
+    await _set_flag(db_session, "memory.digests.weekly.enabled", True)
+    await db_session.flush()
+
+    import bot.services.scheduler as scheduler_mod
+
+    monkeypatch.setattr(scheduler_mod, "async_session", _fake_session_ctx(db_session))
+
+    digest = MagicMock()
+    digest.id = 777
+    digest.status = error_status
+    digest.error_text = "weekly_test_error"
+
+    monkeypatch.setattr(
+        "bot.services.digests.run_digest", AsyncMock(return_value=digest)
+    )
+
+    notify_mock = AsyncMock()
+    monkeypatch.setattr(
+        "bot.services.digest_admin_notify.notify_admins_digest_failure",
+        notify_mock,
+    )
+
+    fake_bot = MagicMock()
+    await scheduler_mod.digest_weekly_job(fake_bot)
+
+    assert notify_mock.await_count == 1, (
+        f"admin DM must fire for status={error_status!r}; got {notify_mock.await_count} calls"
+    )
+    call_kwargs = notify_mock.await_args.kwargs
+    assert call_kwargs["digest_id"] == 777
+    assert call_kwargs["status"] == error_status
+
+
+# ── digest_weekly_job: APScheduler cron registration ────────────────────────
+
+
+async def test_digest_weekly_job_registered_at_mon_09_15_msk():
+    """AC1 + H8 stagger: weekly cron registered at Mon 09:15 MSK.
+
+    Inspects the APScheduler registration via ``get_job``. The trigger is
+    a ``CronTrigger`` with fields ``day_of_week='mon'``, ``hour=9``,
+    ``minute=15``, ``timezone=Europe/Moscow``. Distinct from the daily
+    cron (every day, hour=9, minute=0).
+    """
+    from bot.services import scheduler as scheduler_mod
+
+    # Snapshot original start() so the test never actually starts the loop.
+    started = []
+    real_start = scheduler_mod.scheduler.start
+    scheduler_mod.scheduler.start = lambda: started.append(True)  # type: ignore[assignment]
+    try:
+
+        class _FakeBot:
+            pass
+
+        scheduler_mod.start_scheduler(_FakeBot())  # type: ignore[arg-type]
+        job = scheduler_mod.scheduler.get_job("digest_weekly")
+        assert job is not None, "digest_weekly must be registered by start_scheduler"
+
+        trigger = job.trigger
+        # CronTrigger.fields is a list of Field instances with .name + .expressions.
+        fields_by_name = {f.name: f for f in trigger.fields}
+        assert "Moscow" in str(trigger.timezone), (
+            f"expected Europe/Moscow timezone, got {trigger.timezone!r}"
+        )
+
+        # day_of_week='mon' is rendered by apscheduler as the field having
+        # 'mon' in its expression list. Compare via str(expressions[0]).
+        dow = fields_by_name["day_of_week"]
+        assert "mon" in str(dow).lower(), f"day_of_week field={dow!r}"
+        hour = fields_by_name["hour"]
+        assert "9" in str(hour), f"hour field={hour!r}"
+        minute = fields_by_name["minute"]
+        assert "15" in str(minute), f"minute field={minute!r}"
+    finally:
+        scheduler_mod.scheduler.start = real_start  # type: ignore[assignment]
+        for jid in (
+            "digest_weekly",
+            "digest_stale_review_reaper",
+            "digest_daily",
+            "digest_stale_posting_reaper",
+            "process_invite_outbox",
+            "check_vouch_deadlines",
+            "check_intro_refresh",
+            "sync_google_sheets",
+            "forget_cascade_worker",
+            "extraction_scheduler_tick",
+        ):
+            try:
+                scheduler_mod.scheduler.remove_job(jid)
+            except Exception:
+                pass
+
+
+# ── digest_stale_review_reaper_job: 48h DM + marker append ─────────────────
+
+
+async def test_digest_stale_review_reaper_48h_dm_and_marker(db_session, monkeypatch):
+    """AC7 first pass: row in ``awaiting_review`` with
+    ``awaiting_review_at`` 49h ago and no ``[48h_notified]`` marker →
+    reaper appends marker and dispatches an admin DM.
+    """
+    from bot.db.models import Digest
+
+    now = datetime.now(timezone.utc)
+    digest = Digest(
+        type="weekly",
+        window_start=now - timedelta(days=14),
+        window_end=now - timedelta(days=7),
+        body_markdown="weekly draft",
+        citations=[],
+        status="awaiting_review",
+        awaiting_review_at=now - timedelta(hours=49),
+        review_notes=None,
+    )
+    db_session.add(digest)
+    await db_session.flush()
+    digest_id = digest.id
+
+    import bot.services.scheduler as scheduler_mod
+
+    monkeypatch.setattr(scheduler_mod, "async_session", _fake_session_ctx(db_session))
+
+    notify_mock = AsyncMock()
+    monkeypatch.setattr(
+        "bot.services.digest_admin_notify.notify_admins_digest_failure",
+        notify_mock,
+    )
+
+    fake_bot = MagicMock()
+    await scheduler_mod.digest_stale_review_reaper_job(fake_bot)
+
+    # DM fired with the right error_text:
+    assert notify_mock.await_count == 1, "48h DM must fire exactly once for this row"
+    kwargs = notify_mock.await_args.kwargs
+    assert kwargs["digest_id"] == digest_id
+    assert kwargs["error_text"] == "review_48h_reminder"
+
+    # Marker appended in review_notes:
+    refreshed = await db_session.execute(
+        text("SELECT review_notes, status FROM digests WHERE id = :id"),
+        {"id": digest_id},
+    )
+    row = refreshed.mappings().one()
+    assert row["status"] == "awaiting_review", (
+        "48h pass must NOT terminate the row — only the 7d pass does"
+    )
+    assert "[48h_notified]" in (row["review_notes"] or ""), (
+        f"expected marker in review_notes; got {row['review_notes']!r}"
+    )
+
+
+async def test_digest_stale_review_reaper_48h_skips_if_already_notified(
+    db_session, monkeypatch
+):
+    """AC7 idempotency: a row already marked ``[48h_notified]`` is NOT
+    re-DM'd on the next reaper tick.
+    """
+    from bot.db.models import Digest
+
+    now = datetime.now(timezone.utc)
+    digest = Digest(
+        type="weekly",
+        window_start=now - timedelta(days=14),
+        window_end=now - timedelta(days=7),
+        body_markdown="weekly draft",
+        citations=[],
+        status="awaiting_review",
+        awaiting_review_at=now - timedelta(hours=60),
+        # Per PHASE8_PLAN.md §5.G, the marker is the literal token
+        # ``[48h_notified]`` (no timestamp) — that's what the reaper's LIKE
+        # filter ``review_notes NOT LIKE '%[48h_notified]%'`` matches.
+        review_notes="[48h_notified]",
+    )
+    db_session.add(digest)
+    await db_session.flush()
+
+    import bot.services.scheduler as scheduler_mod
+
+    monkeypatch.setattr(scheduler_mod, "async_session", _fake_session_ctx(db_session))
+
+    notify_mock = AsyncMock()
+    monkeypatch.setattr(
+        "bot.services.digest_admin_notify.notify_admins_digest_failure",
+        notify_mock,
+    )
+
+    fake_bot = MagicMock()
+    await scheduler_mod.digest_stale_review_reaper_job(fake_bot)
+
+    # No 48h DM (row already marked) and no 7d auto-reject (not yet 7d).
+    assert notify_mock.await_count == 0, (
+        f"reaper must be a no-op for already-marked row; got {notify_mock.await_count} DM calls"
+    )
+
+
+# ── digest_stale_review_reaper_job: 7d auto-reject ─────────────────────────
+
+
+async def test_digest_stale_review_reaper_7d_auto_reject(db_session, monkeypatch):
+    """AC7 second pass: row in ``awaiting_review`` with
+    ``awaiting_review_at`` 8d ago → transition to ``rejected_by_reaper``
+    + ``digest_runs`` audit row + admin DM with ``review_7d_auto_rejected``
+    error_text.
+    """
+    from bot.db.models import Digest
+
+    now = datetime.now(timezone.utc)
+    digest = Digest(
+        type="weekly",
+        window_start=now - timedelta(days=15),
+        window_end=now - timedelta(days=8),
+        body_markdown="weekly draft body",
+        citations=[],
+        status="awaiting_review",
+        awaiting_review_at=now - timedelta(days=8),
+        review_notes="[48h_notified]",
+    )
+    db_session.add(digest)
+    await db_session.flush()
+    digest_id = digest.id
+
+    import bot.services.scheduler as scheduler_mod
+
+    monkeypatch.setattr(scheduler_mod, "async_session", _fake_session_ctx(db_session))
+
+    notify_mock = AsyncMock()
+    monkeypatch.setattr(
+        "bot.services.digest_admin_notify.notify_admins_digest_failure",
+        notify_mock,
+    )
+
+    fake_bot = MagicMock()
+    await scheduler_mod.digest_stale_review_reaper_job(fake_bot)
+
+    # Row terminated as rejected_by_reaper.
+    refreshed = await db_session.execute(
+        text("SELECT status, review_notes FROM digests WHERE id = :id"),
+        {"id": digest_id},
+    )
+    row = refreshed.mappings().one()
+    assert row["status"] == "rejected_by_reaper", (
+        f"7d auto-reject must transition status to rejected_by_reaper; got {row['status']!r}"
+    )
+    assert "[stale_7d]" in (row["review_notes"] or "")
+
+    # digest_runs audit row written.
+    audit = await db_session.execute(
+        text(
+            "SELECT status, error_text FROM digest_runs "
+            "WHERE digest_id = :id ORDER BY id DESC LIMIT 1"
+        ),
+        {"id": digest_id},
+    )
+    audit_row = audit.mappings().one()
+    assert audit_row["status"] == "rejected_by_reaper"
+    assert audit_row["error_text"] == "review_deadline_exceeded"
+
+    # Admin DM fired with review_7d_auto_rejected tag.
+    assert notify_mock.await_count == 1
+    kwargs = notify_mock.await_args.kwargs
+    assert kwargs["digest_id"] == digest_id
+    assert kwargs["error_text"] == "review_7d_auto_rejected"
+
+
+async def test_digest_stale_review_reaper_guarded_update_no_op_after_admin_approval(
+    db_session, monkeypatch
+):
+    """M4 guarded UPDATE: if a row was at 49h awaiting_review but an admin
+    APPROVED it between the reaper's SELECT and the marker UPDATE, the
+    guarded UPDATE rowcount=0 — no DM fires, no marker appended.
+
+    We simulate this race by pre-advancing the row to
+    ``approved_for_publish`` BEFORE the reaper runs. Since the reaper's
+    SELECT filter is ``status='awaiting_review'``, the row is NOT selected
+    and no DM fires. This is the same observable outcome as the race —
+    rowcount=0 protection.
+    """
+    from bot.db.models import Digest
+
+    now = datetime.now(timezone.utc)
+    digest = Digest(
+        type="weekly",
+        window_start=now - timedelta(days=14),
+        window_end=now - timedelta(days=7),
+        body_markdown="weekly draft",
+        citations=[],
+        # Pre-advanced — admin won the race.
+        status="approved_for_publish",
+        awaiting_review_at=now - timedelta(hours=49),
+        # ck_digests_approved_audit: status='approved_for_publish' rows must
+        # have BOTH published_by_admin_id AND approved_at set.
+        approved_at=now - timedelta(minutes=1),
+        published_by_admin_id=149820031,
+        review_notes=None,
+    )
+    db_session.add(digest)
+    await db_session.flush()
+    digest_id = digest.id
+
+    import bot.services.scheduler as scheduler_mod
+
+    monkeypatch.setattr(scheduler_mod, "async_session", _fake_session_ctx(db_session))
+
+    notify_mock = AsyncMock()
+    monkeypatch.setattr(
+        "bot.services.digest_admin_notify.notify_admins_digest_failure",
+        notify_mock,
+    )
+
+    fake_bot = MagicMock()
+    await scheduler_mod.digest_stale_review_reaper_job(fake_bot)
+
+    # No DM, no marker, status unchanged.
+    assert notify_mock.await_count == 0, (
+        "reaper must NOT DM a row that was advanced by admin between cycles"
+    )
+    refreshed = await db_session.execute(
+        text("SELECT status, review_notes FROM digests WHERE id = :id"),
+        {"id": digest_id},
+    )
+    row = refreshed.mappings().one()
+    assert row["status"] == "approved_for_publish"
+    assert row["review_notes"] is None or "[48h_notified]" not in row["review_notes"]
+
+
+# ── digest_stale_review_reaper: APScheduler interval registration ──────────
+
+
+async def test_digest_stale_review_reaper_registered_30min_interval():
+    """AC7: reaper registered as 30-min interval job."""
+    from bot.services import scheduler as scheduler_mod
+
+    started = []
+    real_start = scheduler_mod.scheduler.start
+    scheduler_mod.scheduler.start = lambda: started.append(True)  # type: ignore[assignment]
+    try:
+
+        class _FakeBot:
+            pass
+
+        scheduler_mod.start_scheduler(_FakeBot())  # type: ignore[arg-type]
+        job = scheduler_mod.scheduler.get_job("digest_stale_review_reaper")
+        assert job is not None, "digest_stale_review_reaper must be registered"
+        trigger = job.trigger
+        # IntervalTrigger has .interval (timedelta).
+        interval = getattr(trigger, "interval", None)
+        assert interval is not None, f"expected IntervalTrigger; got {trigger!r}"
+        assert interval.total_seconds() == 30 * 60, (
+            f"expected 30-min interval (1800s); got {interval.total_seconds()}s"
+        )
+    finally:
+        scheduler_mod.scheduler.start = real_start  # type: ignore[assignment]
+        for jid in (
+            "digest_weekly",
+            "digest_stale_review_reaper",
+            "digest_daily",
+            "digest_stale_posting_reaper",
+            "process_invite_outbox",
+            "check_vouch_deadlines",
+            "check_intro_refresh",
+            "sync_google_sheets",
+            "forget_cascade_worker",
+            "extraction_scheduler_tick",
+        ):
+            try:
+                scheduler_mod.scheduler.remove_job(jid)
+            except Exception:
+                pass


### PR DESCRIPTION
## Summary

T8-05 of Phase 8 — weekly cron + stale-review reaper per `PHASE8_PLAN.md §5.G + §13 AC1/AC7`.

## Changes

### `bot/services/scheduler.py`
- `digest_weekly_job(bot)`: flag-gated (`memory.digests.weekly.enabled`), ISO-week window (`last_mon..this_mon` 00:00 MSK → UTC), calls `run_digest(type='weekly', ...)`. H4 status-aware match block handles all idempotency-return statuses (draft / awaiting_review / approved_for_publish / posting / posted / rejected_by_admin / rejected_by_reaper / failed / cost_exceeded / skipped* / redacted*).
- Import of `bot.services.digest_review.transition_to_awaiting_review` guarded (T8-04 parallel; T8-04 PR opens in same wave).
- `digest_stale_review_reaper_job(bot)`: NOT flag-gated. 7d pass FIRST (guarded UPDATE → `rejected_by_reaper` + `digest_runs` audit + admin DM `review_7d_auto_rejected`), then 48h pass (SELECT candidates without `[48h_notified]` marker, per-row M4 guarded UPDATE `WHERE id=:id AND status='awaiting_review'`, rowcount=0 skip-DM, rowcount=1 DM `review_48h_reminder`).
- Registration: `digest_weekly` (cron `day_of_week='mon'`, `hour=9`, `minute=15`, tz='Europe/Moscow', `misfire_grace_time=3600`, `max_instances=1`, `coalesce=True`) + `digest_stale_review_reaper` (interval `minutes=30`, `misfire_grace_time=300`).
- H8 stagger comment near weekly cron explaining 15-min offset past daily 09:00.

## Tests

`tests/services/test_digest_scheduler_weekly.py` NEW — 15 tests:
- Flag-off no-op
- ISO window math (Mon 00:00 MSK → next Mon 00:00 MSK)
- draft → transition_to_awaiting_review call (mocked T8-04 import)
- Non-draft status skip transition (parametrized over awaiting_review/approved_for_publish/posting/posted)
- Admin DM on failed / cost_exceeded
- Registered at Mon 09:15 MSK
- Reaper 48h DM + marker append
- Reaper 48h skips if marker present
- Reaper 7d auto-reject + audit insert
- Reaper guarded UPDATE no-op on race with admin approval
- Reaper registered at 30min interval

## Verification

- 15/15 new tests pass + 106 broader regression (Phase 7 daily flow byte-for-byte preserved — all 7 daily scheduler tests + 99 other digest tests green)
- Privacy lint exit 0, ruff exit 0
- Pre-existing unrelated failure (BOT_TOKEN env isolation) verified on baseline `main@733ad8f`

## Spec deviations + why

1. Job functions live in `scheduler.py` (Phase 7 precedent), not `digests.py` (PHASE8_PLAN.md §5.G:996 internal contradiction with the daily-job reference).
2. 48h marker is exact literal `[48h_notified]` (PostgreSQL `LIKE '%[48h_notified]%'` requires this — adding a timestamp inside breaks idempotency).
3. No new env vars added to `DigestConfig` — 48h/7d are hardcoded SQL `interval` literals per §5.G code block; `DIGEST_WEEKLY_HOUR_MSK`/`MINUTE_MSK` read via `getattr(settings, ..., default)` mirroring Phase 7 pattern.

## Test plan

- [x] 15/15 + 106 regression green
- [x] Privacy lint + ruff clean
- [ ] CI green
- [ ] Merge (after T8-04 lands — depends on `transition_to_awaiting_review`)