### PR TITLE
feat(p8-t8-06): admin handlers — /digest_now weekly + /digest_review + /digest_approve + /digest_reject

### DIFF
--- a/bot/handlers/digest.py
+++ b/bot/handlers/digest.py
@@ -1,6 +1,6 @@
-"""Phase 7 / T7-06 — admin Telegram handlers for daily digests.
+"""Phase 7 + Phase 8 — admin Telegram handlers for digests.
 
-Three admin-only commands:
+Phase 7 (daily — preserved byte-for-byte):
 - ``/digest_now [daily]`` — manual trigger. Bypasses
   ``memory.digests.daily.enabled`` feature flag (always runs when admin
   invokes). Still respects cost ceiling (separate Phase 7 bucket).
@@ -11,7 +11,23 @@ Three admin-only commands:
 - ``/digest_history`` — list last 14 digest rows with status, citation
   count, posted message link if available.
 
-Non-admin calls: silent no-op (matches \\``/stats`` / ``/admin_extract``
+Phase 8 (weekly — T8-06, PHASE8_PLAN.md §5.H):
+- ``/digest_now weekly`` — run_digest(type='weekly') → on fresh draft
+  transitions to ``awaiting_review`` (NOT publish). Status-aware match
+  block for the existing-row branches (idempotency lock returns).
+- ``/digest_now weekly --regenerate`` — atomic lock+audit+delete+re-run
+  flow for ``rejected_by_admin`` / ``rejected_by_reaper`` only (H3
+  single-transaction).
+- ``/digest_review`` — list awaiting_review weekly digests (ORDER BY
+  awaiting_review_at ASC, LIMIT 20). Each row shows id + window + body
+  length + citations count + hours waiting + truncated body preview.
+- ``/digest_approve <id>`` — dispatches ``digest_review.approve_digest``;
+  renders context-aware replies for ``DigestReviewInvalidState`` /
+  ``DigestReviewNotFound``.
+- ``/digest_reject <id> [reason]`` — dispatches
+  ``digest_review.reject_digest`` (service truncates to 1000 chars).
+
+Non-admin calls: silent no-op (matches ``/stats`` / ``/admin_extract``
 precedent — no leak of digest content or even acknowledgement that
 digests exist).
 """
@@ -34,7 +50,18 @@ from bot.filters.chat_type import PrivateChatFilter
 from bot.html_escape import html_escape
 from bot.services.digest_publisher import publish_digest
 from bot.services.digest_renderer import render_digest_html
-from bot.services.digests import load_digest_config, run_digest
+from bot.services.digest_review import (
+    DigestReviewInvalidState,
+    DigestReviewNotFound,
+    approve_digest,
+    reject_digest,
+    transition_to_awaiting_review,
+)
+from bot.services.digests import (
+    _acquire_idempotency_lock,
+    load_digest_config,
+    run_digest,
+)
 from bot.services.llm_gateway import load_gateway_config, resolve_provider
 
 logger = logging.getLogger(__name__)
@@ -61,6 +88,21 @@ def _daily_window_for_today_msk() -> tuple[datetime, datetime]:
     )
 
 
+def _weekly_window_for_now_msk() -> tuple[datetime, datetime]:
+    """Return the most recently completed ISO week (last Mon 00:00 MSK
+    → this Mon 00:00 MSK), stored as UTC. Matches digest_weekly_job."""
+    msk = ZoneInfo("Europe/Moscow")
+    now_msk = datetime.now(tz=msk)
+    today_msk_midnight = now_msk.replace(hour=0, minute=0, second=0, microsecond=0)
+    days_since_monday = today_msk_midnight.isoweekday() - 1
+    this_monday_msk = today_msk_midnight - timedelta(days=days_since_monday)
+    last_monday_msk = this_monday_msk - timedelta(days=7)
+    return (
+        last_monday_msk.astimezone(timezone.utc),
+        this_monday_msk.astimezone(timezone.utc),
+    )
+
+
 def _parse_date_for_preview(date_str: str) -> tuple[datetime, datetime]:
     """Parse YYYY-MM-DD as a MSK day. Returns (window_start_utc, window_end_utc)."""
     msk = ZoneInfo("Europe/Moscow")
@@ -73,31 +115,23 @@ def _parse_date_for_preview(date_str: str) -> tuple[datetime, datetime]:
     )
 
 
-@router.message(Command("digest_now"), PrivateChatFilter())
-async def cmd_digest_now(
+def _format_posted_link(chat_id: int | None, message_id: int | None) -> str:
+    """Render a ``t.me/c/<tail>/<message_id>`` link or empty if not posted."""
+    if not chat_id or not message_id:
+        return ""
+    chat_id_abs = abs(chat_id)
+    if str(chat_id_abs).startswith("100"):
+        tail = str(chat_id_abs)[3:]
+        return f"https://t.me/c/{tail}/{message_id}"
+    return ""
+
+
+async def _handle_daily_digest_now(
     message: Message,
     bot: Bot,
     session: AsyncSession,
-    command: CommandObject,
 ) -> None:
-    """Manual digest trigger (admin-only)."""
-    if not _is_admin(message):
-        return
-
-    arg = (command.args or "").strip().lower()
-    if not arg:
-        arg = "daily"
-    if arg == "weekly":
-        await message.answer(
-            "Weekly дайджест появится в Phase 8.", parse_mode="HTML"
-        )
-        return
-    if arg != "daily":
-        await message.answer(
-            "Использование: <code>/digest_now [daily]</code>", parse_mode="HTML"
-        )
-        return
-
+    """Phase 7 daily path. Preserved byte-for-byte from the Phase 7 baseline."""
     window_start, window_end = _daily_window_for_today_msk()
     digest_config = load_digest_config()
     gateway_config = load_gateway_config()
@@ -153,15 +187,10 @@ async def cmd_digest_now(
         status = digest.status
 
     if status == "posted":
-        link = ""
-        if digest.posted_chat_id and digest.posted_message_id:
-            # Convert -100xxxxx → public-link form for supergroups.
-            chat_id_abs = abs(digest.posted_chat_id)
-            if str(chat_id_abs).startswith("100"):
-                tail = str(chat_id_abs)[3:]
-                link = f"\nhttps://t.me/c/{tail}/{digest.posted_message_id}"
+        link = _format_posted_link(digest.posted_chat_id, digest.posted_message_id)
+        link_block = f"\n{link}" if link else ""
         await message.answer(
-            f"✅ Posted. digest_id=<code>{digest.id}</code>{link}",
+            f"✅ Posted. digest_id=<code>{digest.id}</code>{link_block}",
             parse_mode="HTML",
         )
     elif status == "skipped":
@@ -193,6 +222,290 @@ async def cmd_digest_now(
             f"error=<code>{html_escape(digest.error_text or '')}</code>",
             parse_mode="HTML",
         )
+
+
+async def _reply_weekly_status(
+    message: Message,
+    digest,
+    window_start: datetime,
+) -> None:
+    """Render the §5.H status-aware reply for the various existing-row
+    statuses returned by run_digest (idempotency hits) or after a fresh
+    draft transition.
+
+    Caller MUST handle the ``draft`` happy path separately (this function
+    assumes the draft has already been transitioned to ``awaiting_review``
+    and renders the awaiting-review reply for that case).
+    """
+    status = digest.status
+    if status == "awaiting_review":
+        await message.answer(
+            f"📝 Weekly digest #<code>{digest.id}</code> ожидает одобрения админом. "
+            f"Используйте <code>/digest_approve {digest.id}</code> или "
+            f"<code>/digest_reject {digest.id} [причина]</code>.",
+            parse_mode="HTML",
+        )
+    elif status == "approved_for_publish":
+        admin_label = (
+            html_escape(str(digest.published_by_admin_id))
+            if digest.published_by_admin_id
+            else "?"
+        )
+        await message.answer(
+            f"⏳ Digest #<code>{digest.id}</code> одобрен админом "
+            f"#<code>{admin_label}</code>, ожидает публикации. "
+            f"Подождите или проверьте <code>/digest_history</code>.",
+            parse_mode="HTML",
+        )
+    elif status == "posting":
+        await message.answer(
+            f"⏳ Weekly digest #<code>{digest.id}</code> уже публикуется, "
+            "попробуйте через минуту.",
+            parse_mode="HTML",
+        )
+    elif status == "posted":
+        link = _format_posted_link(digest.posted_chat_id, digest.posted_message_id)
+        link_block = f"\n{link}" if link else ""
+        await message.answer(
+            f"✅ Weekly digest #<code>{digest.id}</code> уже опубликован.{link_block}",
+            parse_mode="HTML",
+        )
+    elif status in ("rejected_by_admin", "rejected_by_reaper"):
+        await message.answer(
+            f"🚫 Weekly digest #<code>{digest.id}</code> отклонён "
+            f"(<code>{status}</code>). Используйте "
+            "<code>/digest_now weekly --regenerate</code>, чтобы пересоздать.",
+            parse_mode="HTML",
+        )
+    elif status == "skipped":
+        await message.answer(
+            f"⏭️ Skipped — недельное окно за {window_start.strftime('%Y-%m-%d')} пустое.",
+            parse_mode="HTML",
+        )
+    elif status == "skipped_no_destination":
+        await message.answer(
+            f"⚠️ Draft создан (id=<code>{digest.id}</code>), но "
+            "<code>DIGEST_DESTINATION_CHAT_ID</code> не настроен.",
+            parse_mode="HTML",
+        )
+    elif status == "cost_exceeded":
+        await message.answer(
+            f"💰 Cost ceiling exceeded — <code>{html_escape(digest.error_text or '')}</code>",
+            parse_mode="HTML",
+        )
+    elif status in ("redacted", "redacted_edit_failed"):
+        await message.answer(
+            f"⚠️ Weekly digest #<code>{digest.id}</code> был отредактирован "
+            f"после forget-события (<code>{status}</code>). "
+            "Use <code>/digest_history</code> for audit.",
+            parse_mode="HTML",
+        )
+    else:
+        await message.answer(
+            f"❌ status=<code>{html_escape(status)}</code> "
+            f"error=<code>{html_escape(digest.error_text or '')}</code>",
+            parse_mode="HTML",
+        )
+
+
+async def _handle_weekly_digest_now(
+    message: Message,
+    bot: Bot,
+    session: AsyncSession,
+    regenerate: bool,
+) -> None:
+    """Phase 8 weekly path (PHASE8_PLAN.md §5.H)."""
+    window_start, window_end = _weekly_window_for_now_msk()
+    digest_config = load_digest_config()
+    gateway_config = load_gateway_config()
+    admin_user_id = message.from_user.id if message.from_user else 0
+
+    if regenerate:
+        # H3 — single-transaction lock+audit+delete+rerun.
+        # Pre-check: must find an existing row in rejected_* status.
+        existing_id_status = (
+            await session.execute(
+                text(
+                    "SELECT id, status FROM digests "
+                    "WHERE type='weekly' AND window_start=:ws AND window_end=:we "
+                    "ORDER BY id DESC LIMIT 1"
+                ),
+                {"ws": window_start, "we": window_end},
+            )
+        ).mappings().one_or_none()
+        if existing_id_status is None:
+            await message.answer(
+                "Нет существующего weekly-дайджеста для этого окна — "
+                "не нужен <code>--regenerate</code>; запустите без флага.",
+                parse_mode="HTML",
+            )
+            return
+        if existing_id_status["status"] not in ("rejected_by_admin", "rejected_by_reaper"):
+            await message.answer(
+                f"⚠️ <code>--regenerate</code> доступен только для "
+                "<code>rejected_by_admin</code> / <code>rejected_by_reaper</code>. "
+                f"Текущий статус digest #<code>{existing_id_status['id']}</code>: "
+                f"<code>{html_escape(existing_id_status['status'])}</code>.",
+                parse_mode="HTML",
+            )
+            return
+
+        old_id = int(existing_id_status["id"])
+        old_status = existing_id_status["status"]
+
+        # H3 single-transaction: lock → audit → DELETE → run_digest.
+        try:
+            await _acquire_idempotency_lock(
+                session, type="weekly", window_start=window_start, window_end=window_end
+            )
+            now = datetime.now(timezone.utc)
+            await session.execute(
+                text(
+                    "INSERT INTO digest_runs ("
+                    "  digest_id, status, started_at, finished_at, error_text"
+                    ") VALUES ("
+                    "  :did, 'regenerated_by_admin', :ts, :ts, :err"
+                    ")"
+                ),
+                {
+                    "did": old_id,
+                    "ts": now,
+                    "err": f"regenerated from {old_status} by admin {admin_user_id}",
+                },
+            )
+            await session.execute(
+                text(
+                    "DELETE FROM digests "
+                    "WHERE id=:id AND status IN ('rejected_by_admin','rejected_by_reaper')"
+                ),
+                {"id": old_id},
+            )
+            await session.flush()
+            new_digest = await run_digest(
+                session,
+                type="weekly",
+                window_start=window_start,
+                window_end=window_end,
+                ledger_repo=LedgerRepo(),
+                provider=resolve_provider(gateway_config.provider),
+                config=gateway_config,
+                digest_config=digest_config,
+            )
+        except Exception as exc:
+            logger.exception("cmd_digest_now weekly --regenerate crashed")
+            await message.answer(
+                f"❌ regenerate crashed: <code>{html_escape(str(exc)[:300])}</code>",
+                parse_mode="HTML",
+            )
+            return
+
+        # Transition fresh draft → awaiting_review (separate from regenerate
+        # transaction per §5.H pseudocode).
+        if new_digest.status == "draft":
+            try:
+                await transition_to_awaiting_review(session, digest_id=new_digest.id)
+            except DigestReviewInvalidState:
+                logger.exception(
+                    "cmd_digest_now weekly --regenerate: transition_to_awaiting_review failed"
+                )
+            await session.refresh(new_digest)
+            await message.answer(
+                f"♻️ Regenerated. Weekly digest #<code>{new_digest.id}</code> "
+                "ожидает одобрения админом. Используйте "
+                f"<code>/digest_approve {new_digest.id}</code> или "
+                f"<code>/digest_reject {new_digest.id} [причина]</code>.",
+                parse_mode="HTML",
+            )
+            return
+        # If for some reason the new run did not produce a draft (skipped /
+        # cost_exceeded / etc.), surface its status via the standard reply.
+        await _reply_weekly_status(message, new_digest, window_start)
+        return
+
+    # No --regenerate — standard /digest_now weekly path.
+    try:
+        digest = await run_digest(
+            session,
+            type="weekly",
+            window_start=window_start,
+            window_end=window_end,
+            ledger_repo=LedgerRepo(),
+            provider=resolve_provider(gateway_config.provider),
+            config=gateway_config,
+            digest_config=digest_config,
+        )
+    except Exception as exc:
+        logger.exception("cmd_digest_now weekly: run_digest crashed")
+        await message.answer(
+            f"❌ <code>run_digest</code> crashed: <code>{html_escape(str(exc)[:300])}</code>",
+            parse_mode="HTML",
+        )
+        return
+
+    if digest.status == "draft":
+        try:
+            await transition_to_awaiting_review(session, digest_id=digest.id)
+        except DigestReviewInvalidState as exc:
+            logger.warning(
+                "cmd_digest_now weekly: transition_to_awaiting_review raced "
+                "(digest_id=%s, current_status=%s)",
+                digest.id,
+                exc.current_status,
+            )
+            await session.refresh(digest)
+            await _reply_weekly_status(message, digest, window_start)
+            return
+        await session.refresh(digest)
+        await message.answer(
+            f"📝 Weekly digest #<code>{digest.id}</code> создан и ожидает одобрения "
+            f"админом — <code>/digest_approve {digest.id}</code> или "
+            f"<code>/digest_reject {digest.id} [причина]</code>.",
+            parse_mode="HTML",
+        )
+        return
+
+    # Existing-row branches: dispatch to the status-aware reply matrix.
+    await _reply_weekly_status(message, digest, window_start)
+
+
+@router.message(Command("digest_now"), PrivateChatFilter())
+async def cmd_digest_now(
+    message: Message,
+    bot: Bot,
+    session: AsyncSession,
+    command: CommandObject,
+) -> None:
+    """Manual digest trigger (admin-only). Supports daily + weekly."""
+    if not _is_admin(message):
+        return
+
+    raw = (command.args or "").strip()
+    tokens = raw.split() if raw else []
+    type_arg = tokens[0].strip().lower() if tokens else "daily"
+    regenerate = any(
+        tok.lower() in ("--regenerate", "regenerate") for tok in tokens[1:]
+    )
+
+    if type_arg == "weekly":
+        await _handle_weekly_digest_now(message, bot, session, regenerate=regenerate)
+        return
+
+    if type_arg != "daily":
+        await message.answer(
+            "Использование: <code>/digest_now [daily|weekly] [--regenerate]</code>",
+            parse_mode="HTML",
+        )
+        return
+
+    if regenerate:
+        await message.answer(
+            "<code>--regenerate</code> поддерживается только для "
+            "<code>/digest_now weekly</code>.",
+            parse_mode="HTML",
+        )
+        return
+
+    await _handle_daily_digest_now(message, bot, session)
 
 
 @router.message(Command("digest_preview"), PrivateChatFilter())
@@ -333,6 +646,263 @@ async def cmd_digest_history(
     if len(body) > 4000:
         body = body[:3997] + "..."
     await message.answer(body, parse_mode="HTML", disable_web_page_preview=True)
+
+
+@router.message(Command("digest_review"), PrivateChatFilter())
+async def cmd_digest_review(
+    message: Message,
+    session: AsyncSession,
+) -> None:
+    """List weekly digests in ``awaiting_review`` (PHASE8_PLAN.md §5.H).
+
+    SELECT id, window_start, body_markdown, jsonb_array_length(citations),
+           awaiting_review_at FROM digests
+    WHERE type='weekly' AND status='awaiting_review'
+    ORDER BY awaiting_review_at ASC LIMIT 20.
+    """
+    if not _is_admin(message):
+        return
+
+    rows = (
+        await session.execute(
+            text(
+                "SELECT id, window_start, window_end, body_markdown, "
+                "       jsonb_array_length(citations) AS citation_count, "
+                "       awaiting_review_at, "
+                "       EXTRACT(EPOCH FROM (now() - awaiting_review_at))/3600.0 AS hours_waiting "
+                "FROM digests "
+                "WHERE type='weekly' AND status='awaiting_review' "
+                "ORDER BY awaiting_review_at ASC NULLS LAST "
+                "LIMIT 20"
+            )
+        )
+    ).mappings().all()
+
+    if not rows:
+        await message.answer(
+            "Нет дайджестов на ревью — список пуст.", parse_mode="HTML"
+        )
+        return
+
+    msk = ZoneInfo("Europe/Moscow")
+    lines = ["<b>Weekly digests на ревью</b>\n"]
+    for r in rows:
+        ws_msk = r["window_start"].astimezone(msk) if r["window_start"] else None
+        date_label = ws_msk.strftime("%d.%m.%Y") if ws_msk else "?"
+        body_len = len(r["body_markdown"] or "")
+        hours = float(r["hours_waiting"]) if r["hours_waiting"] is not None else 0.0
+        # Truncated body preview — first 300 chars of raw markdown.
+        preview = (r["body_markdown"] or "")[:300]
+        if r["body_markdown"] and len(r["body_markdown"]) > 300:
+            preview += "…"
+        line = (
+            f"<code>#{r['id']}</code> {date_label} "
+            f"body=<code>{body_len}</code> "
+            f"cites=<code>{r['citation_count']}</code> "
+            f"waiting=<code>{hours:.1f}h</code>\n"
+            f"<i>{html_escape(preview)}</i>"
+        )
+        lines.append(line)
+    body = "\n\n".join(lines)
+    if len(body) > 4000:
+        body = body[:3997] + "..."
+    await message.answer(body, parse_mode="HTML", disable_web_page_preview=True)
+
+
+def _render_invalid_state_reply(exc: DigestReviewInvalidState) -> str:
+    """Format a Russian context-aware reply for the various current_status
+    cases of ``DigestReviewInvalidState``."""
+    did = exc.digest_id
+    cs = exc.current_status
+    if cs is None:
+        return (
+            f"⚠️ Digest #<code>{did}</code> был удалён или больше не существует."
+        )
+    if cs == "rejected_by_admin":
+        return (
+            f"🚫 Digest #<code>{did}</code> уже отклонён "
+            "(<code>rejected_by_admin</code>). Используйте "
+            f"<code>/digest_now weekly --regenerate</code>, чтобы пересоздать."
+        )
+    if cs == "rejected_by_reaper":
+        return (
+            f"🚫 Digest #<code>{did}</code> авто-отклонён ревизором "
+            "(<code>rejected_by_reaper</code>). Используйте "
+            f"<code>/digest_now weekly --regenerate</code>, чтобы пересоздать."
+        )
+    if cs == "posted":
+        return (
+            f"✅ Digest #<code>{did}</code> уже опубликован "
+            "(<code>posted</code>). Действие неприменимо."
+        )
+    if cs == "approved_for_publish":
+        return (
+            f"⏳ Digest #<code>{did}</code> уже одобрен и ожидает публикации "
+            "(<code>approved_for_publish</code>)."
+        )
+    if cs == "posting":
+        return (
+            f"⏳ Digest #<code>{did}</code> сейчас публикуется "
+            "(<code>posting</code>) — попробуйте через минуту."
+        )
+    if cs == "failed":
+        return (
+            f"❌ Digest #<code>{did}</code> в статусе <code>failed</code> "
+            f"(<code>{html_escape(exc.reason[:200])}</code>)."
+        )
+    return (
+        f"⚠️ Digest #<code>{did}</code> в статусе "
+        f"<code>{html_escape(cs)}</code> — действие неприменимо."
+    )
+
+
+@router.message(Command("digest_approve"), PrivateChatFilter())
+async def cmd_digest_approve(
+    message: Message,
+    bot: Bot,
+    session: AsyncSession,
+    command: CommandObject,
+) -> None:
+    """Approve a weekly digest → triggers publish (PHASE8_PLAN.md §5.H).
+
+    Usage: ``/digest_approve <digest_id>``
+    """
+    if not _is_admin(message):
+        return
+
+    raw = (command.args or "").strip()
+    if not raw:
+        await message.answer(
+            "Использование: <code>/digest_approve &lt;digest_id&gt;</code>",
+            parse_mode="HTML",
+        )
+        return
+    try:
+        digest_id = int(raw.split()[0])
+    except (ValueError, IndexError):
+        await message.answer(
+            f"Неверный <code>digest_id</code>: <code>{html_escape(raw[:50])}</code>.",
+            parse_mode="HTML",
+        )
+        return
+
+    admin_id = message.from_user.id if message.from_user else 0
+    digest_config = load_digest_config()
+
+    try:
+        result = await approve_digest(
+            session,
+            bot=bot,
+            digest_id=digest_id,
+            admin_id=admin_id,
+            digest_config=digest_config,
+        )
+    except DigestReviewNotFound:
+        await message.answer(
+            f"⚠️ Digest #<code>{digest_id}</code> не найден.",
+            parse_mode="HTML",
+        )
+        return
+    except DigestReviewInvalidState as exc:
+        await message.answer(
+            _render_invalid_state_reply(exc), parse_mode="HTML"
+        )
+        return
+    except Exception as exc:
+        logger.exception("cmd_digest_approve: approve_digest crashed")
+        await message.answer(
+            f"❌ <code>approve_digest</code> crashed: "
+            f"<code>{html_escape(str(exc)[:300])}</code>",
+            parse_mode="HTML",
+        )
+        return
+
+    link = _format_posted_link(result.posted_chat_id, result.posted_message_id)
+    link_block = f"\n{link}" if link else ""
+    extra = (
+        f"\nerror: <code>{html_escape(result.error_text[:200])}</code>"
+        if result.error_text
+        else ""
+    )
+    await message.answer(
+        f"✅ Digest #<code>{result.digest_id}</code> опубликован.{link_block}{extra}",
+        parse_mode="HTML",
+        disable_web_page_preview=True,
+    )
+
+
+@router.message(Command("digest_reject"), PrivateChatFilter())
+async def cmd_digest_reject(
+    message: Message,
+    session: AsyncSession,
+    command: CommandObject,
+) -> None:
+    """Reject a weekly digest → terminal ``rejected_by_admin``
+    (PHASE8_PLAN.md §5.H).
+
+    Usage: ``/digest_reject <digest_id> [reason]``
+    Reason is optional free text (service truncates to 1000 chars).
+    """
+    if not _is_admin(message):
+        return
+
+    raw = (command.args or "").strip()
+    if not raw:
+        await message.answer(
+            "Использование: <code>/digest_reject &lt;digest_id&gt; [причина]</code>",
+            parse_mode="HTML",
+        )
+        return
+    parts = raw.split(maxsplit=1)
+    try:
+        digest_id = int(parts[0])
+    except ValueError:
+        await message.answer(
+            f"Неверный <code>digest_id</code>: <code>{html_escape(parts[0][:50])}</code>.",
+            parse_mode="HTML",
+        )
+        return
+    reason: str | None = parts[1].strip() if len(parts) > 1 else None
+    if reason == "":
+        reason = None
+
+    admin_id = message.from_user.id if message.from_user else 0
+
+    try:
+        await reject_digest(
+            session,
+            digest_id=digest_id,
+            admin_id=admin_id,
+            reason=reason,
+        )
+    except DigestReviewNotFound:
+        await message.answer(
+            f"⚠️ Digest #<code>{digest_id}</code> не найден.",
+            parse_mode="HTML",
+        )
+        return
+    except DigestReviewInvalidState as exc:
+        await message.answer(
+            _render_invalid_state_reply(exc), parse_mode="HTML"
+        )
+        return
+    except Exception as exc:
+        logger.exception("cmd_digest_reject: reject_digest crashed")
+        await message.answer(
+            f"❌ <code>reject_digest</code> crashed: "
+            f"<code>{html_escape(str(exc)[:300])}</code>",
+            parse_mode="HTML",
+        )
+        return
+
+    reason_echo = (
+        f" Причина: <code>{html_escape(reason[:200])}</code>." if reason else ""
+    )
+    await message.answer(
+        f"❌ Digest #<code>{digest_id}</code> отклонён.{reason_echo} "
+        f"<code>/digest_now weekly --regenerate</code> — пересоздать.",
+        parse_mode="HTML",
+    )
 
 
 __all__ = ["router"]

--- a/tests/services/test_digest_handlers.py
+++ b/tests/services/test_digest_handlers.py
@@ -112,23 +112,6 @@ async def test_digest_now_non_admin_silent_no_op(db_session):
     msg.answer.assert_not_called()
 
 
-async def test_digest_now_weekly_returns_phase8_message(db_session, monkeypatch):
-    """admin invokes /digest_now weekly → Phase 8 message."""
-    from bot.config import settings
-    from bot.handlers.digest import cmd_digest_now
-
-    admin_id = list(settings.ADMIN_IDS)[0] if settings.ADMIN_IDS else 1
-    bot_mock = MagicMock()
-    msg = _mk_msg(user_id=admin_id)
-    await cmd_digest_now(
-        msg, bot=bot_mock, session=db_session, command=_mk_command_obj("weekly")
-    )
-    msg.answer.assert_awaited_once()
-    args, kwargs = msg.answer.call_args
-    body = args[0] if args else kwargs.get("text", "")
-    assert "Phase 8" in body or "weekly" in body.lower()
-
-
 async def test_digest_now_invalid_arg(db_session):
     """admin invokes /digest_now garbage → usage message."""
     from bot.config import settings

--- a/tests/services/test_digest_handlers_weekly.py
+++ b/tests/services/test_digest_handlers_weekly.py
@@ -1,0 +1,716 @@
+"""Tests for T8-06 — Phase 8 weekly admin digest handlers.
+
+Covers PHASE8_PLAN.md §5.H:
+- ``/digest_now weekly``: creates draft → transitions to awaiting_review;
+  status-aware reply matrix.
+- ``/digest_now weekly --regenerate``: atomic lock+audit+delete+re-run; only
+  valid from ``rejected_by_admin`` / ``rejected_by_reaper`` states.
+- ``/digest_review``: lists ``awaiting_review`` weekly digests (ORDER BY
+  awaiting_review_at ASC, LIMIT 20).
+- ``/digest_approve <id>``: calls ``approve_digest``; renders context-aware
+  replies for ``DigestReviewInvalidState`` / ``DigestReviewNotFound``.
+- ``/digest_reject <id> [reason]``: calls ``reject_digest`` with truncated
+  reason; same error mapping.
+- Non-admin invocations: silent no-op (no DB writes, no replies).
+
+Tests follow the Phase 7 service-fixture pattern: outer-transaction
+isolation; service flushes, tests roll back. No ``session.commit()``
+inside test bodies (would break fixture isolation).
+"""
+
+from __future__ import annotations
+
+import itertools
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from sqlalchemy import text
+
+pytestmark = pytest.mark.usefixtures("app_env")
+
+
+_chat_counter = itertools.count(start=8800)
+
+
+def _next_chat_id() -> int:
+    return -1_000_000_000_000 - next(_chat_counter)
+
+
+def _mk_command_obj(args: str | None) -> MagicMock:
+    obj = MagicMock()
+    obj.args = args
+    return obj
+
+
+def _mk_msg(user_id: int) -> MagicMock:
+    m = MagicMock()
+    m.from_user = MagicMock()
+    m.from_user.id = user_id
+    m.answer = AsyncMock()
+    return m
+
+
+def _current_weekly_window() -> tuple[datetime, datetime]:
+    """Mirror of ``bot.handlers.digest._weekly_window_for_now_msk`` for use in
+    fixtures that need to pre-seed a row matching the handler's lookup
+    window."""
+    from bot.handlers.digest import _weekly_window_for_now_msk
+
+    return _weekly_window_for_now_msk()
+
+
+async def _make_weekly_digest(
+    db_session,
+    *,
+    status: str = "draft",
+    window_start: datetime | None = None,
+    window_end: datetime | None = None,
+    citations: list | None = None,
+    body: str = "TL;DR.\n\n- One bullet.",
+    awaiting_review_at: datetime | None = None,
+    published_by_admin_id: int | None = None,
+    approved_at: datetime | None = None,
+    review_notes: str | None = None,
+):
+    """Insert a weekly digest in the given status. Returns ORM row.
+
+    By default the window matches the current weekly window so the row
+    aligns with ``cmd_digest_now weekly`` lookups; pass ``window_start``
+    / ``window_end`` to override (e.g. /digest_review tests need rows at
+    different windows to assert ORDER BY).
+    """
+    from bot.db.models import Digest
+
+    if window_start is None or window_end is None:
+        cur_ws, cur_we = _current_weekly_window()
+        ws = window_start if window_start is not None else cur_ws
+        we = window_end if window_end is not None else cur_we
+    else:
+        ws = window_start
+        we = window_end
+    digest = Digest(
+        type="weekly",
+        window_start=ws,
+        window_end=we,
+        body_markdown=body,
+        citations=citations if citations is not None else [],
+        status=status,
+        awaiting_review_at=awaiting_review_at,
+        published_by_admin_id=published_by_admin_id,
+        approved_at=approved_at,
+        review_notes=review_notes,
+    )
+    db_session.add(digest)
+    await db_session.flush()
+    return digest
+
+
+# ── /digest_now weekly ──────────────────────────────────────────────────────
+
+
+async def test_digest_now_weekly_creates_draft_and_transitions_to_awaiting_review(
+    db_session, monkeypatch
+):
+    """Happy path: admin invokes /digest_now weekly → run_digest returns
+    a fresh draft → transition_to_awaiting_review runs → reply mentions
+    awaiting admin approval (with the new digest_id)."""
+    from bot.config import settings
+    from bot.handlers.digest import cmd_digest_now
+
+    admin_id = list(settings.ADMIN_IDS)[0] if settings.ADMIN_IDS else 1
+
+    draft = await _make_weekly_digest(db_session, status="draft")
+
+    async def _fake_run_digest(*args, **kwargs):
+        return draft
+
+    monkeypatch.setattr("bot.handlers.digest.run_digest", _fake_run_digest)
+
+    bot_mock = MagicMock()
+    msg = _mk_msg(user_id=admin_id)
+    await cmd_digest_now(
+        msg, bot=bot_mock, session=db_session, command=_mk_command_obj("weekly")
+    )
+
+    # Row must now be in awaiting_review.
+    row = (
+        await db_session.execute(
+            text(
+                "SELECT status, awaiting_review_at FROM digests WHERE id=:id"
+            ),
+            {"id": draft.id},
+        )
+    ).mappings().one()
+    assert row["status"] == "awaiting_review"
+    assert row["awaiting_review_at"] is not None
+
+    msg.answer.assert_awaited_once()
+    args, kwargs = msg.answer.call_args
+    body = args[0] if args else kwargs.get("text", "")
+    assert str(draft.id) in body
+    assert (
+        "ожидает одобрения" in body.lower()
+        or "одобрения админ" in body.lower()
+        or "awaiting" in body.lower()
+    ), f"expected awaiting-admin reply, got: {body!r}"
+    # Should hint at approve / reject commands.
+    assert "digest_approve" in body and "digest_reject" in body
+
+
+async def test_digest_now_weekly_regenerate_after_rejected_by_admin(
+    db_session, monkeypatch
+):
+    """/digest_now weekly --regenerate on a rejected_by_admin row:
+    1. Acquires lock + audit insert (regenerated_by_admin) BEFORE delete.
+    2. DELETEs old row.
+    3. Calls run_digest fresh; new draft → transition_to_awaiting_review.
+    4. Reply mentions new digest_id (NOT the old one)."""
+    from bot.config import settings
+    from bot.handlers.digest import cmd_digest_now
+    from bot.db.models import Digest
+
+    admin_id = list(settings.ADMIN_IDS)[0] if settings.ADMIN_IDS else 1
+
+    old = await _make_weekly_digest(
+        db_session,
+        status="rejected_by_admin",
+        published_by_admin_id=admin_id,
+        review_notes="off-topic",
+    )
+    old_id = old.id
+
+    new_draft_holder: dict = {}
+
+    async def _fake_run_digest(session, *, type, window_start, window_end, **kwargs):
+        # New draft for the same window.
+        new = Digest(
+            type=type,
+            window_start=window_start,
+            window_end=window_end,
+            body_markdown="New TL;DR.\n\n- Fresh bullet.",
+            citations=[],
+            status="draft",
+        )
+        session.add(new)
+        await session.flush()
+        new_draft_holder["digest"] = new
+        return new
+
+    monkeypatch.setattr("bot.handlers.digest.run_digest", _fake_run_digest)
+
+    bot_mock = MagicMock()
+    msg = _mk_msg(user_id=admin_id)
+    await cmd_digest_now(
+        msg,
+        bot=bot_mock,
+        session=db_session,
+        command=_mk_command_obj("weekly --regenerate"),
+    )
+
+    # Audit row for regenerated_by_admin must exist. After the DELETE the
+    # FK ``digest_id`` is reset to NULL via ON DELETE SET NULL (so the audit
+    # survives even when the parent row goes away). Look up by status +
+    # error_text trail instead.
+    audit_count = (
+        await db_session.execute(
+            text(
+                "SELECT COUNT(*) FROM digest_runs "
+                "WHERE status='regenerated_by_admin' "
+                "  AND error_text LIKE :pat"
+            ),
+            {"pat": f"%from rejected_by_admin by admin {admin_id}%"},
+        )
+    ).scalar_one()
+    assert audit_count == 1, (
+        f"expected one regenerated_by_admin audit row for old digest {old_id}, "
+        f"got {audit_count}"
+    )
+
+    # Old row must be deleted.
+    deleted = (
+        await db_session.execute(
+            text("SELECT 1 FROM digests WHERE id=:id"), {"id": old_id}
+        )
+    ).scalar_one_or_none()
+    assert deleted is None, f"old digest {old_id} must be deleted"
+
+    # New draft row must exist and be transitioned to awaiting_review.
+    new = new_draft_holder["digest"]
+    assert new.id != old_id
+    row = (
+        await db_session.execute(
+            text("SELECT status FROM digests WHERE id=:id"), {"id": new.id}
+        )
+    ).mappings().one()
+    assert row["status"] == "awaiting_review"
+
+    # Reply mentions the NEW digest id.
+    msg.answer.assert_awaited_once()
+    args, kwargs = msg.answer.call_args
+    body = args[0] if args else kwargs.get("text", "")
+    assert str(new.id) in body
+    assert str(old_id) not in body or body.count(str(new.id)) >= 1
+
+
+async def test_digest_now_weekly_regenerate_rejects_non_rejected_status(
+    db_session, monkeypatch
+):
+    """/digest_now weekly --regenerate when existing row is awaiting_review →
+    error reply naming current status; no audit insert, no DELETE, no
+    run_digest call."""
+    from bot.config import settings
+    from bot.handlers.digest import cmd_digest_now
+
+    admin_id = list(settings.ADMIN_IDS)[0] if settings.ADMIN_IDS else 1
+
+    existing = await _make_weekly_digest(
+        db_session,
+        status="awaiting_review",
+        awaiting_review_at=datetime.now(timezone.utc),
+    )
+    existing_id = existing.id
+
+    run_called = []
+
+    async def _fake_run_digest(*args, **kwargs):  # pragma: no cover — must not run
+        run_called.append(True)
+        raise AssertionError("run_digest must NOT be called when regen blocked")
+
+    monkeypatch.setattr("bot.handlers.digest.run_digest", _fake_run_digest)
+
+    bot_mock = MagicMock()
+    msg = _mk_msg(user_id=admin_id)
+    await cmd_digest_now(
+        msg,
+        bot=bot_mock,
+        session=db_session,
+        command=_mk_command_obj("weekly --regenerate"),
+    )
+
+    assert run_called == [], "run_digest must not run when current row is awaiting_review"
+
+    # Row remains untouched.
+    row = (
+        await db_session.execute(
+            text("SELECT status FROM digests WHERE id=:id"),
+            {"id": existing_id},
+        )
+    ).mappings().one()
+    assert row["status"] == "awaiting_review"
+
+    # No regenerated_by_admin audit row.
+    audit_count = (
+        await db_session.execute(
+            text(
+                "SELECT COUNT(*) FROM digest_runs "
+                "WHERE digest_id=:id AND status='regenerated_by_admin'"
+            ),
+            {"id": existing_id},
+        )
+    ).scalar_one()
+    assert audit_count == 0
+
+    msg.answer.assert_awaited_once()
+    args, kwargs = msg.answer.call_args
+    body = args[0] if args else kwargs.get("text", "")
+    assert "awaiting_review" in body or "ожидает" in body.lower()
+
+
+async def test_digest_now_weekly_posting_state_replies_with_retry_hint(
+    db_session, monkeypatch
+):
+    """H2 / Phase 7 F6 extension: when run_digest returns the existing row in
+    status='posting' for weekly, handler must NOT attempt to publish/transition
+    and must reply with a polite retry message."""
+    from bot.config import settings
+    from bot.db.models import Digest
+    from bot.handlers.digest import cmd_digest_now
+
+    admin_id = list(settings.ADMIN_IDS)[0] if settings.ADMIN_IDS else 1
+
+    now = datetime.now(timezone.utc)
+    posting = Digest(
+        type="weekly",
+        window_start=now - timedelta(days=7),
+        window_end=now,
+        body_markdown="TL;DR.\n\n- One [[mv:1]]",
+        citations=[{"kind": "message_version", "id": 1, "position": 0}],
+        status="posting",
+        published_by_admin_id=admin_id,
+        approved_at=now,
+        posting_started_at=now,
+    )
+    db_session.add(posting)
+    await db_session.flush()
+
+    async def _fake_run_digest(*args, **kwargs):
+        return posting
+
+    monkeypatch.setattr("bot.handlers.digest.run_digest", _fake_run_digest)
+
+    bot_mock = MagicMock()
+    msg = _mk_msg(user_id=admin_id)
+    await cmd_digest_now(
+        msg, bot=bot_mock, session=db_session, command=_mk_command_obj("weekly")
+    )
+
+    msg.answer.assert_awaited_once()
+    args, kwargs = msg.answer.call_args
+    body = args[0] if args else kwargs.get("text", "")
+    assert not body.startswith("❌"), (
+        f"expected friendly retry, got error reply: {body!r}"
+    )
+    # Friendly retry hint mentions trying later (Russian wording).
+    assert "попробуйте" in body.lower() or "позже" in body.lower() or "посл" in body.lower(), (
+        f"expected polite retry hint, got: {body!r}"
+    )
+    # Row must still be in 'posting' (no state change).
+    row = (
+        await db_session.execute(
+            text("SELECT status FROM digests WHERE id=:id"), {"id": posting.id}
+        )
+    ).mappings().one()
+    assert row["status"] == "posting"
+
+
+# ── /digest_review ──────────────────────────────────────────────────────────
+
+
+async def test_digest_review_lists_awaiting_review_digests(db_session):
+    """List ORDER BY awaiting_review_at ASC, LIMIT 20.
+
+    Inserts 2 awaiting_review rows; the older one comes first in the reply.
+    Body preview truncated."""
+    from bot.config import settings
+    from bot.handlers.digest import cmd_digest_review
+
+    admin_id = list(settings.ADMIN_IDS)[0] if settings.ADMIN_IDS else 1
+
+    # Wipe pre-existing rows for stable assertion.
+    await db_session.execute(text("DELETE FROM digest_runs"))
+    await db_session.execute(text("DELETE FROM digests"))
+    await db_session.flush()
+
+    now = datetime.now(timezone.utc)
+    older = await _make_weekly_digest(
+        db_session,
+        status="awaiting_review",
+        window_start=now - timedelta(days=14),
+        window_end=now - timedelta(days=7),
+        awaiting_review_at=now - timedelta(hours=10),
+        body="Old TL;DR." + "A" * 400 + "\n- bullet",
+    )
+    newer = await _make_weekly_digest(
+        db_session,
+        status="awaiting_review",
+        window_start=now - timedelta(days=7),
+        window_end=now,
+        awaiting_review_at=now - timedelta(hours=2),
+        body="New TL;DR." + "B" * 200,
+    )
+
+    msg = _mk_msg(user_id=admin_id)
+    await cmd_digest_review(msg, session=db_session)
+
+    msg.answer.assert_awaited_once()
+    args, kwargs = msg.answer.call_args
+    body = args[0] if args else kwargs.get("text", "")
+
+    # Both ids present
+    assert str(older.id) in body
+    assert str(newer.id) in body
+
+    # Older (longer awaiting_review_at) should appear first.
+    older_pos = body.find(f"#{older.id}")
+    newer_pos = body.find(f"#{newer.id}")
+    assert older_pos != -1 and newer_pos != -1
+    assert older_pos < newer_pos, (
+        f"older digest {older.id} should appear before newer {newer.id} (ASC by awaiting_review_at); "
+        f"got older@{older_pos}, newer@{newer_pos}"
+    )
+
+    # Truncation: the 400×'A' body must NOT appear verbatim in full.
+    assert "A" * 400 not in body
+
+
+async def test_digest_review_empty_state(db_session):
+    """No awaiting_review rows → 'no pending digests' reply."""
+    from bot.config import settings
+    from bot.handlers.digest import cmd_digest_review
+
+    admin_id = list(settings.ADMIN_IDS)[0] if settings.ADMIN_IDS else 1
+
+    await db_session.execute(text("DELETE FROM digest_runs"))
+    await db_session.execute(text("DELETE FROM digests"))
+    await db_session.flush()
+
+    msg = _mk_msg(user_id=admin_id)
+    await cmd_digest_review(msg, session=db_session)
+
+    msg.answer.assert_awaited_once()
+    args, kwargs = msg.answer.call_args
+    body = args[0] if args else kwargs.get("text", "")
+    assert (
+        "нет дайджестов" in body.lower()
+        or "пусто" in body.lower()
+        or "пуст" in body.lower()
+    ), f"expected empty-state reply, got: {body!r}"
+
+
+# ── /digest_approve ─────────────────────────────────────────────────────────
+
+
+async def test_digest_approve_success(db_session, monkeypatch):
+    """admin invokes /digest_approve <id> for an awaiting_review row →
+    approve_digest is called; reply shows 'опубликован' + chat link."""
+    from bot.config import settings
+    from bot.handlers.digest import cmd_digest_approve
+
+    admin_id = list(settings.ADMIN_IDS)[0] if settings.ADMIN_IDS else 1
+
+    digest = await _make_weekly_digest(db_session, status="awaiting_review")
+    did = digest.id
+
+    captured = {}
+
+    async def _fake_approve(session, *, bot, digest_id, admin_id, digest_config):
+        captured["digest_id"] = digest_id
+        captured["admin_id"] = admin_id
+        from bot.services.digest_review import ApproveResult
+
+        return ApproveResult(
+            digest_id=digest_id,
+            posted_chat_id=-1_001_234_567_890,
+            posted_message_id=4242,
+            error_text=None,
+        )
+
+    monkeypatch.setattr("bot.handlers.digest.approve_digest", _fake_approve)
+
+    bot_mock = MagicMock()
+    msg = _mk_msg(user_id=admin_id)
+    await cmd_digest_approve(
+        msg, bot=bot_mock, session=db_session, command=_mk_command_obj(str(did))
+    )
+
+    assert captured["digest_id"] == did
+    assert captured["admin_id"] == admin_id
+
+    msg.answer.assert_awaited_once()
+    args, kwargs = msg.answer.call_args
+    body = args[0] if args else kwargs.get("text", "")
+    assert "✅" in body or "опубликован" in body.lower() or "posted" in body.lower()
+    # link rendering
+    assert "t.me/c/" in body
+
+
+async def test_digest_approve_invalid_state_posted(db_session, monkeypatch):
+    """If approve_digest raises DigestReviewInvalidState with
+    current_status='posted', reply explains current status."""
+    from bot.config import settings
+    from bot.handlers.digest import cmd_digest_approve
+    from bot.services.digest_review import DigestReviewInvalidState
+
+    admin_id = list(settings.ADMIN_IDS)[0] if settings.ADMIN_IDS else 1
+
+    digest = await _make_weekly_digest(db_session, status="awaiting_review")
+    did = digest.id
+
+    async def _fake_approve(session, **kwargs):
+        raise DigestReviewInvalidState(
+            digest_id=did,
+            current_status="posted",
+            reason="already posted",
+        )
+
+    monkeypatch.setattr("bot.handlers.digest.approve_digest", _fake_approve)
+
+    bot_mock = MagicMock()
+    msg = _mk_msg(user_id=admin_id)
+    await cmd_digest_approve(
+        msg, bot=bot_mock, session=db_session, command=_mk_command_obj(str(did))
+    )
+
+    msg.answer.assert_awaited_once()
+    args, kwargs = msg.answer.call_args
+    body = args[0] if args else kwargs.get("text", "")
+    assert "posted" in body.lower()
+    assert str(did) in body
+
+
+async def test_digest_approve_invalid_state_rejected_by_admin_suggests_regenerate(
+    db_session, monkeypatch
+):
+    """If approve_digest raises with current_status='rejected_by_admin', reply
+    suggests /digest_now weekly --regenerate."""
+    from bot.config import settings
+    from bot.handlers.digest import cmd_digest_approve
+    from bot.services.digest_review import DigestReviewInvalidState
+
+    admin_id = list(settings.ADMIN_IDS)[0] if settings.ADMIN_IDS else 1
+
+    digest = await _make_weekly_digest(db_session, status="awaiting_review")
+    did = digest.id
+
+    async def _fake_approve(session, **kwargs):
+        raise DigestReviewInvalidState(
+            digest_id=did,
+            current_status="rejected_by_admin",
+            reason="already rejected",
+        )
+
+    monkeypatch.setattr("bot.handlers.digest.approve_digest", _fake_approve)
+
+    bot_mock = MagicMock()
+    msg = _mk_msg(user_id=admin_id)
+    await cmd_digest_approve(
+        msg, bot=bot_mock, session=db_session, command=_mk_command_obj(str(did))
+    )
+
+    msg.answer.assert_awaited_once()
+    args, kwargs = msg.answer.call_args
+    body = args[0] if args else kwargs.get("text", "")
+    assert "regenerate" in body.lower() or "регенер" in body.lower() or "--regenerate" in body
+    assert "rejected_by_admin" in body or "отклон" in body.lower()
+
+
+async def test_digest_approve_not_found(db_session, monkeypatch):
+    """If approve_digest raises DigestReviewNotFound → 'не найден' reply."""
+    from bot.config import settings
+    from bot.handlers.digest import cmd_digest_approve
+    from bot.services.digest_review import DigestReviewNotFound
+
+    admin_id = list(settings.ADMIN_IDS)[0] if settings.ADMIN_IDS else 1
+
+    async def _fake_approve(session, **kwargs):
+        raise DigestReviewNotFound("not found")
+
+    monkeypatch.setattr("bot.handlers.digest.approve_digest", _fake_approve)
+
+    bot_mock = MagicMock()
+    msg = _mk_msg(user_id=admin_id)
+    await cmd_digest_approve(
+        msg, bot=bot_mock, session=db_session, command=_mk_command_obj("999999")
+    )
+
+    msg.answer.assert_awaited_once()
+    args, kwargs = msg.answer.call_args
+    body = args[0] if args else kwargs.get("text", "")
+    assert "не найден" in body.lower() or "not found" in body.lower()
+    assert "999999" in body
+
+
+# ── /digest_reject ──────────────────────────────────────────────────────────
+
+
+async def test_digest_reject_with_reason(db_session, monkeypatch):
+    """admin invokes /digest_reject <id> off-topic content → reject_digest is
+    called with the reason; reply confirms rejection."""
+    from bot.config import settings
+    from bot.handlers.digest import cmd_digest_reject
+
+    admin_id = list(settings.ADMIN_IDS)[0] if settings.ADMIN_IDS else 1
+
+    digest = await _make_weekly_digest(db_session, status="awaiting_review")
+    did = digest.id
+
+    captured = {}
+
+    async def _fake_reject(session, *, digest_id, admin_id, reason):
+        captured["digest_id"] = digest_id
+        captured["admin_id"] = admin_id
+        captured["reason"] = reason
+
+    monkeypatch.setattr("bot.handlers.digest.reject_digest", _fake_reject)
+
+    msg = _mk_msg(user_id=admin_id)
+    await cmd_digest_reject(
+        msg,
+        session=db_session,
+        command=_mk_command_obj(f"{did} off-topic content"),
+    )
+
+    assert captured["digest_id"] == did
+    assert captured["admin_id"] == admin_id
+    assert captured["reason"] == "off-topic content"
+
+    msg.answer.assert_awaited_once()
+    args, kwargs = msg.answer.call_args
+    body = args[0] if args else kwargs.get("text", "")
+    assert "❌" in body or "отклон" in body.lower() or "rejected" in body.lower()
+    assert "off-topic content" in body
+
+
+async def test_digest_reject_no_reason_defaults_to_placeholder(db_session, monkeypatch):
+    """admin invokes /digest_reject <id> (no reason) → reject_digest is called
+    with reason=None (service layer defaults to 'no reason given')."""
+    from bot.config import settings
+    from bot.handlers.digest import cmd_digest_reject
+
+    admin_id = list(settings.ADMIN_IDS)[0] if settings.ADMIN_IDS else 1
+
+    digest = await _make_weekly_digest(db_session, status="awaiting_review")
+    did = digest.id
+
+    captured = {}
+
+    async def _fake_reject(session, *, digest_id, admin_id, reason):
+        captured["digest_id"] = digest_id
+        captured["reason"] = reason
+
+    monkeypatch.setattr("bot.handlers.digest.reject_digest", _fake_reject)
+
+    msg = _mk_msg(user_id=admin_id)
+    await cmd_digest_reject(
+        msg, session=db_session, command=_mk_command_obj(str(did))
+    )
+
+    assert captured["digest_id"] == did
+    # Handler passes None (or empty) when no reason given — service defaults
+    # to 'no reason given' per digest_review.py line 359.
+    assert captured["reason"] is None or captured["reason"] == ""
+
+
+# ── non-admin silent no-op ──────────────────────────────────────────────────
+
+
+async def test_digest_handlers_non_admin_silent_no_op(db_session):
+    """Non-admin user invokes any of the 4 commands → handler returns
+    silently; no DB writes, no message.answer call."""
+    from bot.handlers.digest import (
+        cmd_digest_approve,
+        cmd_digest_now,
+        cmd_digest_reject,
+        cmd_digest_review,
+    )
+
+    non_admin_id = 99_999_999
+
+    bot_mock = MagicMock()
+
+    # /digest_now weekly
+    m1 = _mk_msg(user_id=non_admin_id)
+    await cmd_digest_now(
+        m1, bot=bot_mock, session=db_session, command=_mk_command_obj("weekly")
+    )
+    m1.answer.assert_not_called()
+
+    # /digest_review
+    m2 = _mk_msg(user_id=non_admin_id)
+    await cmd_digest_review(m2, session=db_session)
+    m2.answer.assert_not_called()
+
+    # /digest_approve
+    m3 = _mk_msg(user_id=non_admin_id)
+    await cmd_digest_approve(
+        m3, bot=bot_mock, session=db_session, command=_mk_command_obj("1")
+    )
+    m3.answer.assert_not_called()
+
+    # /digest_reject
+    m4 = _mk_msg(user_id=non_admin_id)
+    await cmd_digest_reject(
+        m4, session=db_session, command=_mk_command_obj("1 reason")
+    )
+    m4.answer.assert_not_called()


### PR DESCRIPTION
## Summary

T8-06 of Phase 8 — admin handlers per `PHASE8_PLAN.md §5.H + §13 AC2-AC4`.

## Changes

- `bot/handlers/digest.py`:
  - `cmd_digest_now` accepts `weekly` arg; daily refactored into `_handle_daily_digest_now`
  - `_handle_weekly_digest_now`: on draft → `transition_to_awaiting_review`; status-aware reply matrix for idempotency hits (awaiting_review / approved_for_publish / posting [F6 retry] / posted / rejected_* / redacted_* / cost_exceeded / skipped*)
  - `--regenerate` flag (H3 single-transaction): advisory lock → audit insert (digest_runs.error_text trail since FK SET NULL on delete) → DELETE → run_digest → transition_to_awaiting_review
  - `cmd_digest_review` — list awaiting_review weekly rows (ORDER BY awaiting_review_at ASC LIMIT 20) with body preview + hours-waiting
  - `cmd_digest_approve <id>` — dispatch `approve_digest`; context-aware Russian replies via `_render_invalid_state_reply` per `DigestReviewInvalidState.current_status`
  - `cmd_digest_reject <id> [reason]` — dispatch `reject_digest`; reply echoes reason + `--regenerate` hint
  - All admin-gated (existing `_is_admin`); non-admin silent no-op per Phase 6/7 pattern
- `tests/services/test_digest_handlers_weekly.py` NEW — 13 cases (TDD red-then-green discipline confirmed)
- `tests/services/test_digest_handlers.py` — dropped stale Phase 8 placeholder test

## Verification

- 23 focused tests pass + 272 broader regression + 1157 full suite (1 pre-existing unrelated failure: BOT_TOKEN env isolation in test_live_gateway_adapter)
- Privacy lint exit 0, ruff exit 0

## Out of scope

- §5.I renderer extension (section header bolding, weekly footer) — flagged by implementer as separate from this brief; tracked for T8-08 closure or small follow-up sprint.

## Test plan

- [x] 23/23 + 272 regression green
- [x] Privacy lint + ruff clean
- [ ] CI green
- [ ] Merge