### PR TITLE
fix(p8-fhr): 5 closure-blocking HIGH fixes from Claude+Codex FHR

### DIFF
--- a/bot/handlers/digest.py
+++ b/bot/handlers/digest.py
@@ -322,42 +322,61 @@ async def _handle_weekly_digest_now(
 
     if regenerate:
         # H3 — single-transaction lock+audit+delete+rerun.
-        # Pre-check: must find an existing row in rejected_* status.
-        existing_id_status = (
-            await session.execute(
-                text(
-                    "SELECT id, status FROM digests "
-                    "WHERE type='weekly' AND window_start=:ws AND window_end=:we "
-                    "ORDER BY id DESC LIMIT 1"
-                ),
-                {"ws": window_start, "we": window_end},
-            )
-        ).mappings().one_or_none()
-        if existing_id_status is None:
-            await message.answer(
-                "Нет существующего weekly-дайджеста для этого окна — "
-                "не нужен <code>--regenerate</code>; запустите без флага.",
-                parse_mode="HTML",
-            )
-            return
-        if existing_id_status["status"] not in ("rejected_by_admin", "rejected_by_reaper"):
-            await message.answer(
-                f"⚠️ <code>--regenerate</code> доступен только для "
-                "<code>rejected_by_admin</code> / <code>rejected_by_reaper</code>. "
-                f"Текущий статус digest #<code>{existing_id_status['id']}</code>: "
-                f"<code>{html_escape(existing_id_status['status'])}</code>.",
-                parse_mode="HTML",
-            )
-            return
-
-        old_id = int(existing_id_status["id"])
-        old_status = existing_id_status["status"]
-
-        # H3 single-transaction: lock → audit → DELETE → run_digest.
+        #
+        # FHR HIGH-3: the lock MUST be acquired BEFORE reading the row state.
+        # Without the lock-first ordering, two parallel ``--regenerate`` calls
+        # can both pass the pre-check (both see the row in ``rejected_*``)
+        # then race on the lock; the second caller would audit-insert + DELETE
+        # on a row that no longer matches the expected status, OR FK-violate
+        # if the prior caller already DELETEd it.
+        #
+        # Post-fix flow:
+        #   1. Acquire ``_acquire_idempotency_lock`` — blocks until exclusive.
+        #   2. Re-read the row UNDER lock — state is now authoritative.
+        #   3. If status NOT in ``rejected_*`` (or row missing): refuse and
+        #      surface to the admin. No audit / no DELETE / no rerun.
+        #   4. Insert audit + DELETE + ``run_digest`` (advisory lock is
+        #      re-entrant within the same session, so ``run_digest``'s own
+        #      call to ``_acquire_idempotency_lock`` is a no-op).
         try:
             await _acquire_idempotency_lock(
                 session, type="weekly", window_start=window_start, window_end=window_end
             )
+            # Re-read state UNDER lock — this is the authoritative view.
+            existing_id_status = (
+                await session.execute(
+                    text(
+                        "SELECT id, status FROM digests "
+                        "WHERE type='weekly' AND window_start=:ws AND window_end=:we "
+                        "ORDER BY id DESC LIMIT 1"
+                    ),
+                    {"ws": window_start, "we": window_end},
+                )
+            ).mappings().one_or_none()
+            if existing_id_status is None:
+                await message.answer(
+                    "Нет существующего weekly-дайджеста для этого окна — "
+                    "не нужен <code>--regenerate</code>; запустите без флага.",
+                    parse_mode="HTML",
+                )
+                return
+            if existing_id_status["status"] not in (
+                "rejected_by_admin",
+                "rejected_by_reaper",
+            ):
+                await message.answer(
+                    f"⚠️ <code>--regenerate</code> доступен только для "
+                    "<code>rejected_by_admin</code> / "
+                    "<code>rejected_by_reaper</code>. "
+                    f"Текущий статус digest "
+                    f"#<code>{existing_id_status['id']}</code>: "
+                    f"<code>{html_escape(existing_id_status['status'])}</code>.",
+                    parse_mode="HTML",
+                )
+                return
+
+            old_id = int(existing_id_status["id"])
+            old_status = existing_id_status["status"]
             now = datetime.now(timezone.utc)
             await session.execute(
                 text(

--- a/bot/services/digest_publisher.py
+++ b/bot/services/digest_publisher.py
@@ -309,10 +309,15 @@ async def publish_digest(
         )
         return digest
 
-    # Render + send.
+    # Render + send. Weekly digests need ``window_end_utc`` for the week-range
+    # footer and the ``## Раздел: …`` section-header bolding (Phase 8 §5.I /
+    # FHR HIGH-5). Daily passes only the start so the Phase 7 single-day
+    # footer is preserved byte-for-byte.
     body_html = render_digest_html(
         digest.body_markdown or "",
         window_start_utc=digest.window_start,
+        digest_type=digest.type,
+        window_end_utc=digest.window_end if digest.type == "weekly" else None,
     )
     try:
         sent = await bot.send_message(

--- a/bot/services/digest_renderer.py
+++ b/bot/services/digest_renderer.py
@@ -1,4 +1,4 @@
-"""HTML rendering for daily digests — T7-05.
+"""HTML rendering for daily + weekly digests — T7-05 baseline + T8-06 §5.I.
 
 Converts the LLM-produced Markdown body (with `[[cs:UUID]]` / `[[mv:INT]]`
 citation tokens) into Telegram HTML for the publisher. Citation tokens are
@@ -14,12 +14,27 @@ Key invariants (per PHASE7_PLAN.md §5.G):
 - Tag-balance assertion: if `<b>` / `<i>` open/close counts diverge after
   conversion, strip ALL formatting and fall back to plain-escaped text
   (better dumb-but-valid than malformed-and-silently-dropped).
+
+Phase 8 / §5.I extension (T8-06 sub-component, FHR HIGH-5):
+- New ``digest_type: Literal['daily','weekly']`` kwarg. Default ``'daily'``
+  preserves Phase 7 byte-for-byte.
+- ``digest_type='weekly'``:
+  - Recognizes ``## Раздел: <name>`` Markdown headers and bolds them as
+    ``<b>Раздел: <name></b>`` (per the weekly prompt module's
+    ``SECTION_NAME_ALLOWLIST`` contract).
+  - Switches the footer to "Еженедельный дайджест за {ws} – {we}." using
+    the inclusive week range (we - 1 second).
+- ``digest_type='daily'`` keeps the Phase 7 single-day footer and does NOT
+  apply the section-header bolding (daily prompt template does not emit
+  section headers; the regression-guard test in
+  ``test_digest_renderer_weekly.py`` documents this).
 """
 
 from __future__ import annotations
 
 import re
-from datetime import datetime
+from datetime import datetime, timedelta
+from typing import Literal
 from zoneinfo import ZoneInfo
 
 from bot.html_escape import html_escape
@@ -29,6 +44,13 @@ _MAX_BODY_CHARS_BEFORE_HTML = 3800  # leaves 296 chars for HTML overhead + foote
 _TELEGRAM_HARD_LIMIT = 4096
 _BOLD_RE = re.compile(r"\*\*([^*\n]+)\*\*")
 _ITALIC_RE = re.compile(r"(?<!\*)\*([^*\n]+)\*(?!\*)")
+# Phase 8 §5.I — weekly section header pattern. Applied AFTER html_escape so
+# the input is the literal escaped text "## Раздел: <name>"; we wrap the
+# title in <b>…</b>. Single-line guarantee: regex ends at $ (MULTILINE) so
+# no multi-line <b> spans are introduced; tag-balance assertion still passes.
+_WEEKLY_SECTION_HEADER_RE = re.compile(
+    r"^##\s+Раздел:\s+(.+)$", flags=re.MULTILINE
+)
 
 
 def _strip_citation_tokens(body: str) -> str:
@@ -92,6 +114,8 @@ def render_digest_html(
     *,
     window_start_utc: datetime,
     timezone_name: str = "Europe/Moscow",
+    digest_type: Literal["daily", "weekly"] = "daily",
+    window_end_utc: datetime | None = None,
 ) -> str:
     """Render a digest body for Telegram HTML output.
 
@@ -100,25 +124,75 @@ def render_digest_html(
     2. Truncate plain Markdown.
     3. html_escape (covers LLM-emitted `<`, `>`, `&`).
     4. Convert minimal MD to HTML.
-    5. Append footer with date + admin breadcrumb.
+    4b. (weekly only) Bold ``## Раздел: <name>`` section headers — Phase 8
+       §5.I. The substitution runs AFTER ``html_escape`` so the input pattern
+       matches the escaped text; the wrapped ``<b>…</b>`` is on a single line
+       (regex anchored to ``$`` with MULTILINE) so the tag-balance assertion
+       in step 6 still passes.
+    5. Append footer with date(s) + admin breadcrumb.
+       - daily  → "Дайджест за DD.MM.YYYY."
+       - weekly → "Еженедельный дайджест за DD.MM.YYYY – DD.MM.YYYY."
+         using the inclusive week range (``window_end_utc - 1s``).
     6. Tag-balance assertion; strip formatting on imbalance.
     7. Hard-cap to Telegram limit.
 
-    The output is a single string ready for `bot.send_message(parse_mode='HTML')`.
+    The output is a single string ready for ``bot.send_message(parse_mode='HTML')``.
+
+    Args:
+        body_markdown: LLM-produced body (with citation tokens stripped here).
+        window_start_utc: inclusive lower bound of the digest window (UTC).
+        timezone_name: target timezone for footer formatting (default MSK).
+        digest_type: ``'daily'`` (Phase 7 baseline) or ``'weekly'`` (Phase 8
+            §5.I extension). Default ``'daily'`` keeps the call signature
+            backward-compatible.
+        window_end_utc: required when ``digest_type='weekly'`` — the
+            exclusive upper bound of the week. The inclusive label is
+            ``window_end_utc - 1 second`` so the range reads as
+            Mon..Sun rather than Mon..Mon. Optional for daily; ignored.
     """
     stripped = _strip_citation_tokens(body_markdown).strip()
     truncated = _truncate_plain_markdown(stripped, max_chars=_MAX_BODY_CHARS_BEFORE_HTML)
     escaped = html_escape(truncated)
     converted = _convert_minimal_markdown(escaped)
 
+    # §5.I step 4b — weekly section header bolding. Daily path is byte-for-
+    # byte unchanged (no substitution applied).
+    if digest_type == "weekly":
+        converted = _WEEKLY_SECTION_HEADER_RE.sub(
+            r"<b>Раздел: \1</b>", converted
+        )
+
     # Footer in target timezone.
     tz = ZoneInfo(timezone_name)
     window_local = window_start_utc.astimezone(tz)
-    footer = (
-        "\n\n<i>Дайджест за "
-        f"{window_local.strftime('%d.%m.%Y')}. "
-        "Полный список источников: /digest_history</i>"
-    )
+    if digest_type == "weekly":
+        if window_end_utc is None:
+            # Defensive: weekly mode requires the end window. Fall back to
+            # the daily footer so we never raise from the publisher path;
+            # log via the renderer call-site if this ever fires.
+            footer = (
+                "\n\n<i>Дайджест за "
+                f"{window_local.strftime('%d.%m.%Y')}. "
+                "Полный список источников: /digest_history</i>"
+            )
+        else:
+            # Inclusive end label: subtract 1s so Mon..Mon-exclusive reads as
+            # Mon..Sun.
+            end_inclusive_local = (
+                window_end_utc - timedelta(seconds=1)
+            ).astimezone(tz)
+            footer = (
+                "\n\n<i>Еженедельный дайджест за "
+                f"{window_local.strftime('%d.%m.%Y')} – "
+                f"{end_inclusive_local.strftime('%d.%m.%Y')}. "
+                "Полный список источников: /digest_history</i>"
+            )
+    else:
+        footer = (
+            "\n\n<i>Дайджест за "
+            f"{window_local.strftime('%d.%m.%Y')}. "
+            "Полный список источников: /digest_history</i>"
+        )
 
     body_with_footer = converted + footer
 

--- a/bot/services/digests.py
+++ b/bot/services/digests.py
@@ -82,10 +82,19 @@ class DigestConfig:
     weekly_token_budget_input: int = 24000
 
     def to_context_config(self) -> _DigestCtxConfig:
+        # FHR HIGH-4 fix: forward weekly tunables so operator env-var overrides
+        # (``DIGEST_WEEKLY_TOKEN_BUDGET`` / ``DIGEST_WEEKLY_MIN_CARDS_THRESHOLD``
+        # / ``DIGEST_WEEKLY_RAW_MESSAGE_TOP_N``) actually reach
+        # ``_weekly_overrides`` in ``digest_context.py``. Before the fix only
+        # daily fields were forwarded, so weekly overrides were silently
+        # ignored and the dataclass defaults always won.
         return _DigestCtxConfig(
             min_cards_threshold=self.min_cards_threshold,
             raw_message_top_n=self.raw_message_top_n,
             token_budget_input=self.token_budget_input,
+            weekly_min_cards_threshold=self.weekly_min_cards_threshold,
+            weekly_raw_message_top_n=self.weekly_raw_message_top_n,
+            weekly_token_budget_input=self.weekly_token_budget_input,
         )
 
 

--- a/bot/services/llm_gateway.py
+++ b/bot/services/llm_gateway.py
@@ -1733,6 +1733,11 @@ async def synthesize_digest(
         provider_result = await provider.call(prompt=full_prompt, model=config.model)
     except Exception as exc:
         latency = int((time.monotonic() - started) * 1000)
+        # FHR HIGH-1 fix: ``type`` is a kwarg in this function ('daily'|'weekly')
+        # — it shadows the builtin, so ``type(exc).__name__`` raises
+        # ``TypeError: 'str' object is not callable`` and masks the real provider
+        # error AND skips the ledger placeholder update. Use ``exc.__class__``
+        # to avoid the shadow (same pattern as ``run_digest`` in ``digests.py``).
         await ledger_repo.update_placeholder(
             session,
             llm_call_id=placeholder_row.id,
@@ -1742,7 +1747,7 @@ async def synthesize_digest(
             tokens_out=0,
             request_id=None,
             latency_ms=latency,
-            error=f"{type(exc).__name__}",
+            error=f"{exc.__class__.__name__}",
         )
         raise
 

--- a/bot/services/scheduler.py
+++ b/bot/services/scheduler.py
@@ -377,14 +377,29 @@ async def digest_stale_posting_reaper_job() -> None:
     """Reap orphan ``digests.status='posting'`` rows from publisher crashes.
 
     Runs every 5 minutes (NOT gated by feature flag — even after a flag
-    flip-OFF, any in-flight ``posting`` rows must still be cleaned up).
-    Threshold: 2 minutes since ``posting_started_at``.
+    flip-OFF, any in-flight ``posting`` / ``approved_for_publish`` rows
+    must still be cleaned up).
 
-    Per PHASE7_PLAN.md §5.K — Phase 7 publisher (T7-05) holds the row lock
-    across ``bot.send_message`` in a single transaction. A publisher crash
-    while that transaction is open leaves an orphan ``posting`` row that
-    blocks future cascade redactions and publisher attempts. This reaper
-    transitions the row to ``failed`` so eventual consistency is restored.
+    Two reaping branches in a single UPDATE (PHASE8_PLAN.md §5.G stale-approved
+    reaper extension — kept in this single job rather than a new scheduler
+    entry):
+
+    1. ``status='posting'`` rows older than ``posting_started_at`` + 2 min
+       (Phase 7 §5.K baseline — publisher crash window between row-lock
+       acquisition and ``bot.send_message`` completion).
+    2. ``status='approved_for_publish'`` rows older than ``approved_at`` +
+       5 min (FHR HIGH-2 / Phase 8 §5.G — orchestrator crash window between
+       ``approve_digest`` commit and ``publish_digest`` dispatch). Without
+       this branch, the weekly digest is stuck forever and admin
+       ``/digest_approve <id>`` retries are blocked by the pre-flight guard.
+
+    The 5-min approved threshold is wider than posting's 2-min because the
+    approve-then-publish sequence normally completes in <30s; 5 min handles
+    network hiccups + Telegram retries.
+
+    Per row, ``error_text`` is set to ``stale_posting_reaper`` or
+    ``stale_approved_reaper`` depending on the source status (the RETURNING
+    branch reads it back).
     """
     try:
         from sqlalchemy import text as _text
@@ -394,12 +409,20 @@ async def digest_stale_posting_reaper_job() -> None:
                 _text("""
                     UPDATE digests
                     SET status='failed',
-                        error_text='stale_posting_reaper',
+                        error_text=CASE
+                          WHEN status='posting' THEN 'stale_posting_reaper'
+                          WHEN status='approved_for_publish'
+                              THEN 'stale_approved_reaper'
+                        END,
                         posting_started_at=NULL,
                         updated_at=now()
-                    WHERE status='posting'
-                      AND posting_started_at < now() - interval '2 minutes'
-                    RETURNING id
+                    WHERE
+                        (status='posting'
+                         AND posting_started_at < now() - interval '2 minutes')
+                        OR
+                        (status='approved_for_publish'
+                         AND approved_at < now() - interval '5 minutes')
+                    RETURNING id, error_text
                 """)
             )
             rows = result.fetchall()
@@ -407,16 +430,21 @@ async def digest_stale_posting_reaper_job() -> None:
                 await session.commit()
                 return
             for row in rows:
+                # ``error_text`` was set by the CASE expression in the UPDATE;
+                # use the same value for the audit row so the trail matches.
                 await session.execute(
                     _text(
                         "INSERT INTO digest_runs "
                         "(digest_id, status, error_text, started_at, finished_at) "
-                        "VALUES (:id, 'failed', 'stale_posting_reaper', now(), now())"
+                        "VALUES (:id, 'failed', :err, now(), now())"
                     ),
-                    {"id": row.id},
+                    {"id": row.id, "err": row.error_text},
                 )
                 logger.warning(
-                    "digest_stale_posting_reaper: reaped digest_id=%s", row.id
+                    "digest_stale_posting_reaper: reaped digest_id=%s "
+                    "error_text=%s",
+                    row.id,
+                    row.error_text,
                 )
             await session.commit()
     except Exception:

--- a/tests/services/test_digest_handlers_weekly.py
+++ b/tests/services/test_digest_handlers_weekly.py
@@ -253,6 +253,219 @@ async def test_digest_now_weekly_regenerate_after_rejected_by_admin(
     assert str(old_id) not in body or body.count(str(new.id)) >= 1
 
 
+async def test_digest_now_weekly_regenerate_race_state_changed_post_lock(
+    db_session, monkeypatch
+):
+    """FHR HIGH-3: in the regenerate path, the lock MUST be acquired BEFORE
+    reading the existing row's status. If the row's status changes between
+    the (broken) pre-check SELECT and the lock — e.g. another admin queues
+    a regenerate, drains the row, and a new awaiting_review row lands —
+    the second caller's stale view would proceed to audit-insert + DELETE
+    on a row that no longer matches ``rejected_*``.
+
+    After the fix, the lock is held BEFORE the state read. We simulate the
+    "concurrent admin won the race" outcome by monkeypatching
+    ``_acquire_idempotency_lock`` to flip the row's status inside the lock
+    body (representing the prior holder's effect committed before this
+    waiter got its lock). The handler MUST then refuse to DELETE / audit /
+    rerun and surface the new status to the admin.
+    """
+    from bot.config import settings
+    from bot.handlers.digest import cmd_digest_now
+
+    admin_id = list(settings.ADMIN_IDS)[0] if settings.ADMIN_IDS else 1
+
+    rejected = await _make_weekly_digest(
+        db_session,
+        status="rejected_by_admin",
+        published_by_admin_id=admin_id,
+        review_notes="off-topic",
+    )
+    rejected_id = rejected.id
+
+    # Patch the lock to flip status mid-call — simulates "the other
+    # regenerate transaction committed between my pre-check and my lock
+    # acquire". The handler must NOT proceed to DELETE / audit / rerun
+    # on this stale view.
+    import bot.handlers.digest as digest_mod
+
+    real_lock = digest_mod._acquire_idempotency_lock
+    flipped = {"done": False}
+
+    async def _flipping_lock(session, *, type, window_start, window_end):
+        await real_lock(
+            session, type=type, window_start=window_start, window_end=window_end
+        )
+        if not flipped["done"]:
+            # Simulate: the prior regenerate holder finished — the rejected
+            # row is gone and a new awaiting_review row exists.
+            await session.execute(
+                text(
+                    "UPDATE digests SET status='awaiting_review', "
+                    "awaiting_review_at=now() WHERE id=:id"
+                ),
+                {"id": rejected_id},
+            )
+            await session.flush()
+            flipped["done"] = True
+
+    monkeypatch.setattr(
+        "bot.handlers.digest._acquire_idempotency_lock", _flipping_lock
+    )
+
+    run_called = []
+
+    async def _fake_run_digest(*args, **kwargs):  # pragma: no cover
+        run_called.append(True)
+        raise AssertionError(
+            "run_digest must NOT be called when state changed under lock"
+        )
+
+    monkeypatch.setattr("bot.handlers.digest.run_digest", _fake_run_digest)
+
+    bot_mock = MagicMock()
+    msg = _mk_msg(user_id=admin_id)
+    await cmd_digest_now(
+        msg,
+        bot=bot_mock,
+        session=db_session,
+        command=_mk_command_obj("weekly --regenerate"),
+    )
+
+    # run_digest must NOT have been invoked — the under-lock re-read should
+    # have caught the state change and aborted before delete/rerun.
+    assert run_called == [], (
+        "run_digest must NOT run when the under-lock re-read sees a "
+        "non-rejected status (state changed between pre-check and lock)"
+    )
+
+    # Row must NOT have been deleted (it's now awaiting_review — outside
+    # the regenerate scope).
+    row = (
+        await db_session.execute(
+            text("SELECT status FROM digests WHERE id=:id"),
+            {"id": rejected_id},
+        )
+    ).mappings().one_or_none()
+    assert row is not None, (
+        "the (now-awaiting-review) row must NOT have been deleted by a "
+        "stale regenerate path"
+    )
+    assert row["status"] == "awaiting_review"
+
+    # No regenerated_by_admin audit row inserted — the race-loser must not
+    # leave a trail referencing a state that no longer applies.
+    audit_count = (
+        await db_session.execute(
+            text(
+                "SELECT COUNT(*) FROM digest_runs "
+                "WHERE digest_id=:id AND status='regenerated_by_admin'"
+            ),
+            {"id": rejected_id},
+        )
+    ).scalar_one()
+    assert audit_count == 0, (
+        "race-loser must NOT audit-insert when state already changed"
+    )
+
+    # User-facing reply must surface that the state changed (or that
+    # regenerate is no longer applicable).
+    msg.answer.assert_awaited_once()
+    args, kwargs = msg.answer.call_args
+    body = args[0] if args else kwargs.get("text", "")
+    # Reply text mentions current status or the regenerate-blocked hint.
+    assert ("awaiting_review" in body) or (
+        "regenerate" in body.lower() or "--regenerate" in body
+    ) or ("rejected" not in body.lower()), (
+        f"reply must reflect state change; got: {body!r}"
+    )
+
+
+async def test_digest_now_weekly_regenerate_row_deleted_under_lock(
+    db_session, monkeypatch
+):
+    """FHR HIGH-3 corollary: if the row is DELETED between the (pre-fix)
+    SELECT and the lock acquire — i.e. another regenerate concurrently
+    drained it — the post-fix path MUST treat it as "no existing row"
+    and reply with the hint to run without --regenerate, NOT crash on the
+    audit insert (which FKs digest_id to digests.id)."""
+    from bot.config import settings
+    from bot.handlers.digest import cmd_digest_now
+
+    admin_id = list(settings.ADMIN_IDS)[0] if settings.ADMIN_IDS else 1
+
+    rejected = await _make_weekly_digest(
+        db_session,
+        status="rejected_by_admin",
+        published_by_admin_id=admin_id,
+        review_notes="off-topic",
+    )
+    rejected_id = rejected.id
+
+    import bot.handlers.digest as digest_mod
+
+    real_lock = digest_mod._acquire_idempotency_lock
+    deleted = {"done": False}
+
+    async def _deleting_lock(session, *, type, window_start, window_end):
+        await real_lock(
+            session, type=type, window_start=window_start, window_end=window_end
+        )
+        if not deleted["done"]:
+            # Simulate: prior regenerate holder DELETEd before our lock.
+            await session.execute(
+                text("DELETE FROM digests WHERE id=:id"),
+                {"id": rejected_id},
+            )
+            await session.flush()
+            deleted["done"] = True
+
+    monkeypatch.setattr(
+        "bot.handlers.digest._acquire_idempotency_lock", _deleting_lock
+    )
+
+    run_called = []
+
+    async def _fake_run_digest(*args, **kwargs):  # pragma: no cover
+        run_called.append(True)
+        raise AssertionError(
+            "run_digest must NOT be called when row deleted under lock"
+        )
+
+    monkeypatch.setattr("bot.handlers.digest.run_digest", _fake_run_digest)
+
+    bot_mock = MagicMock()
+    msg = _mk_msg(user_id=admin_id)
+    await cmd_digest_now(
+        msg,
+        bot=bot_mock,
+        session=db_session,
+        command=_mk_command_obj("weekly --regenerate"),
+    )
+
+    assert run_called == []
+
+    # No audit row inserted (would FK-fail anyway since the parent row is gone
+    # — but ON DELETE SET NULL would silently leave a dangling audit which
+    # is worse than the explicit refusal).
+    audit_count = (
+        await db_session.execute(
+            text(
+                "SELECT COUNT(*) FROM digest_runs "
+                "WHERE status='regenerated_by_admin' "
+                "  AND error_text LIKE :pat"
+            ),
+            {"pat": f"%admin {admin_id}%"},
+        )
+    ).scalar_one()
+    assert audit_count == 0, (
+        "race-loser must NOT audit-insert when row was deleted under lock"
+    )
+
+    # Reply surfaces the absent state hint.
+    msg.answer.assert_awaited_once()
+
+
 async def test_digest_now_weekly_regenerate_rejects_non_rejected_status(
     db_session, monkeypatch
 ):

--- a/tests/services/test_digest_renderer_weekly.py
+++ b/tests/services/test_digest_renderer_weekly.py
@@ -1,0 +1,156 @@
+"""Tests for FHR HIGH-5 — Phase 8 / §5.I weekly renderer extension.
+
+Behaviour delta from Phase 7 baseline:
+
+- ``render_digest_html`` accepts a new ``digest_type: Literal['daily','weekly']``
+  kwarg. Default ``'daily'`` keeps the Phase 7 output byte-for-byte preserved.
+- When ``digest_type='weekly'``:
+  1. Section headers ``## Раздел: <name>`` (per ``digest_weekly_v0_1_0``
+     prompt module) are bolded as ``<b>Раздел: <name></b>``. Without the
+     extension, the renderer html-escapes them and admins / community see
+     literal ``## Раздел: Объявления`` text in the published digest.
+  2. The footer switches from the daily single-day format to
+     "Еженедельный дайджест за {ws} – {we}." using a week-range label.
+
+PHASE8_PLAN.md §5.I — T8-06 sub-component.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+pytestmark = pytest.mark.usefixtures("app_env")
+
+
+# ── 1. Weekly: section headers bolded ────────────────────────────────────────
+
+
+def test_renderer_weekly_section_headers_bolded():
+    """``## Раздел: Объявления`` must become ``<b>Раздел: Объявления</b>``
+    when ``digest_type='weekly'`` — NOT a literal ``## Раздел: …`` line in
+    the output."""
+    from bot.services.digest_renderer import render_digest_html
+
+    body = (
+        "TL;DR недельный итог.\n"
+        "\n"
+        "## Раздел: Объявления\n"
+        "- Анонс собрания пятница\n"
+        "\n"
+        "## Раздел: Обсуждения\n"
+        "- Дискуссия про X\n"
+    )
+    # window_start = Mon 2026-05-11 00:00 MSK = Sun 2026-05-10 21:00 UTC
+    ws = datetime(2026, 5, 10, 21, 0, 0, tzinfo=timezone.utc)
+    we = datetime(2026, 5, 17, 21, 0, 0, tzinfo=timezone.utc)
+    out = render_digest_html(
+        body, window_start_utc=ws, window_end_utc=we, digest_type="weekly"
+    )
+    assert "<b>Раздел: Объявления</b>" in out
+    assert "<b>Раздел: Обсуждения</b>" in out
+    # And NOT the literal ## header (admins must not see raw markdown).
+    assert "## Раздел:" not in out
+    # And NOT escaped markdown (e.g. "## " escaped to "##" is still wrong UX).
+    assert "##" not in out
+
+
+# ── 2. Weekly: footer shows week range ────────────────────────────────────
+
+
+def test_renderer_weekly_footer_shows_week_range():
+    """Weekly footer says
+    'Еженедельный дайджест за DD.MM.YYYY – DD.MM.YYYY' instead of the daily
+    'Дайджест за DD.MM.YYYY' single-day format."""
+    from bot.services.digest_renderer import render_digest_html
+
+    body = "TL;DR.\n\n## Раздел: Прочее\n- One bullet\n"
+    # ISO week: Mon 2026-05-11 00:00 MSK..Mon 2026-05-18 00:00 MSK
+    ws = datetime(2026, 5, 10, 21, 0, 0, tzinfo=timezone.utc)
+    we = datetime(2026, 5, 17, 21, 0, 0, tzinfo=timezone.utc)
+    out = render_digest_html(
+        body, window_start_utc=ws, window_end_utc=we, digest_type="weekly"
+    )
+    # Spec §5.I step 2 — display range is ws..(we - 1s) so the inclusive
+    # range reads as 11.05.2026 – 17.05.2026 (Sun is the last day of the
+    # week, not Mon of the next week).
+    assert "Еженедельный дайджест за 11.05.2026 – 17.05.2026" in out
+    assert "/digest_history" in out
+    # Single-day daily footer text MUST be absent.
+    assert "Дайджест за 11.05.2026." not in out
+
+
+# ── 3. Daily: Phase 7 byte-for-byte preserved ─────────────────────────────
+
+
+def test_renderer_daily_unchanged_default_signature():
+    """Default ``digest_type='daily'`` (and the old single-arg call) preserves
+    the Phase 7 daily output byte-for-byte. The renderer extension MUST NOT
+    change the daily path."""
+    from bot.services.digest_renderer import render_digest_html
+
+    body = "TL;DR заголовок.\n\n- Один пункт **bold** *italic*\n"
+    ws = datetime(2026, 5, 14, 21, 0, 0, tzinfo=timezone.utc)  # 15.05.2026 MSK
+
+    # Old Phase 7 call (no digest_type kwarg) — must still work and produce
+    # the daily footer.
+    out_old = render_digest_html(body, window_start_utc=ws)
+    assert "Дайджест за 15.05.2026" in out_old
+    assert "Еженедельный" not in out_old
+    assert "<b>bold</b>" in out_old
+    assert "<i>italic</i>" in out_old
+
+    # Explicit digest_type='daily' must match byte-for-byte.
+    out_explicit = render_digest_html(
+        body, window_start_utc=ws, digest_type="daily"
+    )
+    assert out_old == out_explicit
+
+
+def test_renderer_daily_does_not_bold_section_headers():
+    """Regression guard: even if a daily body happens to contain
+    ``## Раздел: …`` text, daily mode MUST html-escape it as plain
+    text (Phase 7 baseline — no Markdown header recognition for daily).
+
+    Daily prompt template does NOT emit section headers; this test confirms
+    the renderer doesn't accidentally apply the weekly transformation to
+    the daily path.
+    """
+    from bot.services.digest_renderer import render_digest_html
+
+    body = "TL;DR.\n\n## Раздел: Прочее\n- One bullet\n"
+    ws = datetime(2026, 5, 14, 21, 0, 0, tzinfo=timezone.utc)
+    out = render_digest_html(body, window_start_utc=ws)
+    # Daily: section headers are NOT bolded. The bare ## is html-escape
+    # safe (no special chars) so the literal text passes through.
+    assert "<b>Раздел: Прочее</b>" not in out
+
+
+# ── 4. Tag balance preserved with weekly section headers ─────────────────
+
+
+def test_renderer_weekly_keeps_tag_balance_after_section_bolding():
+    """Section bolding regex MUST close every ``<b>`` it opens on the same
+    line (PHASE8_PLAN.md §5.I step 4). After conversion, the tag-balance
+    assertion must pass — no fallback to plain text."""
+    from bot.services.digest_renderer import render_digest_html
+
+    body = (
+        "TL;DR.\n\n"
+        "## Раздел: Знания и ресурсы\n"
+        "- Книга **Foo** [[mv:1]]\n"
+        "\n"
+        "## Раздел: Прочее\n"
+        "- Misc *thing*\n"
+    )
+    ws = datetime(2026, 5, 10, 21, 0, 0, tzinfo=timezone.utc)
+    we = datetime(2026, 5, 17, 21, 0, 0, tzinfo=timezone.utc)
+    out = render_digest_html(
+        body, window_start_utc=ws, window_end_utc=we, digest_type="weekly"
+    )
+    # If tag balance failed, fallback marker appears. It must NOT.
+    assert "tag-balance fallback applied" not in out
+    # Both section heads, bold, italic all converted cleanly.
+    assert out.count("<b>") == out.count("</b>")
+    assert out.count("<i>") == out.count("</i>")

--- a/tests/services/test_digest_scheduler.py
+++ b/tests/services/test_digest_scheduler.py
@@ -5,11 +5,14 @@ Covers:
 - digest_daily_job: flag-ON runs run_digest (empty window → skipped)
 - digest_stale_posting_reaper_job: reaps row with old posting_started_at
 - digest_stale_posting_reaper_job: leaves fresh posting row alone
+- digest_stale_posting_reaper_job: ALSO reaps stale ``approved_for_publish``
+  rows (FHR HIGH-2 — PHASE8_PLAN.md §5.G stale-approved reaper extension)
 """
 
 from __future__ import annotations
 
 import itertools
+from contextlib import asynccontextmanager
 from datetime import datetime, timezone, timedelta
 from unittest.mock import AsyncMock, MagicMock
 
@@ -328,3 +331,169 @@ async def test_digest_daily_job_registers_in_scheduler(monkeypatch):
                 scheduler_mod.scheduler.remove_job(jid)
             except Exception:
                 pass
+
+
+# ── FHR HIGH-2: stale ``approved_for_publish`` reaper gap ──────────────────
+
+
+def _fake_session_ctx(db_session):
+    """Patch ``async_session()`` to yield the test session."""
+
+    @asynccontextmanager
+    async def _ctx():
+        yield db_session
+
+    return _ctx
+
+
+async def test_reaper_reaps_stale_approved_for_publish(db_session, monkeypatch):
+    """FHR HIGH-2 / PHASE8_PLAN.md §5.G — the existing
+    ``digest_stale_posting_reaper_job`` MUST also catch rows stuck in
+    ``status='approved_for_publish'`` older than 5 minutes (publisher crash
+    window between approve commit and posting transition).
+
+    Without this, a weekly digest stays in ``approved_for_publish`` forever —
+    admin re-running ``/digest_approve <id>`` hits the pre-flight guard and
+    the only escape is manual DB intervention.
+    """
+    from bot.db.models import Digest
+
+    now = datetime.now(timezone.utc)
+    digest = Digest(
+        type="weekly",
+        window_start=now - timedelta(days=14),
+        window_end=now - timedelta(days=7),
+        body_markdown="weekly draft",
+        citations=[],
+        status="approved_for_publish",
+        approved_at=now - timedelta(minutes=6),
+        published_by_admin_id=149820031,
+    )
+    db_session.add(digest)
+    await db_session.flush()
+    digest_id = digest.id
+
+    import bot.services.scheduler as scheduler_mod
+
+    monkeypatch.setattr(
+        scheduler_mod, "async_session", _fake_session_ctx(db_session)
+    )
+
+    await scheduler_mod.digest_stale_posting_reaper_job()
+
+    refreshed = await db_session.execute(
+        text(
+            "SELECT status, error_text FROM digests WHERE id = :id"
+        ),
+        {"id": digest_id},
+    )
+    row = refreshed.mappings().one()
+    assert row["status"] == "failed", (
+        f"stale approved_for_publish must be reaped to failed; "
+        f"got {row['status']!r}"
+    )
+    assert row["error_text"] == "stale_approved_reaper", (
+        f"expected error_text='stale_approved_reaper'; "
+        f"got {row['error_text']!r}"
+    )
+
+    # digest_runs audit row must be inserted with matching error_text.
+    audit = (
+        await db_session.execute(
+            text(
+                "SELECT status, error_text FROM digest_runs "
+                "WHERE digest_id = :id "
+                "ORDER BY id DESC LIMIT 1"
+            ),
+            {"id": digest_id},
+        )
+    ).mappings().one_or_none()
+    assert audit is not None
+    assert audit["status"] == "failed"
+    assert audit["error_text"] == "stale_approved_reaper"
+
+
+async def test_reaper_skips_fresh_approved_for_publish(db_session, monkeypatch):
+    """FHR HIGH-2: a recently approved row (< 5 min) MUST stay untouched.
+
+    Mirror of the existing posting-row freshness test — the 5-min threshold
+    for ``approved_for_publish`` is wider than posting's 2-min because the
+    approve-then-publish handoff normally completes in <30s; 5 min handles
+    network hiccups + Telegram retries.
+    """
+    from bot.db.models import Digest
+
+    now = datetime.now(timezone.utc)
+    digest = Digest(
+        type="weekly",
+        window_start=now - timedelta(days=14),
+        window_end=now - timedelta(days=7),
+        body_markdown="weekly draft",
+        citations=[],
+        status="approved_for_publish",
+        approved_at=now - timedelta(minutes=1),
+        published_by_admin_id=149820031,
+    )
+    db_session.add(digest)
+    await db_session.flush()
+    digest_id = digest.id
+
+    import bot.services.scheduler as scheduler_mod
+
+    monkeypatch.setattr(
+        scheduler_mod, "async_session", _fake_session_ctx(db_session)
+    )
+
+    await scheduler_mod.digest_stale_posting_reaper_job()
+
+    refreshed = await db_session.execute(
+        text("SELECT status FROM digests WHERE id = :id"),
+        {"id": digest_id},
+    )
+    row = refreshed.mappings().one()
+    assert row["status"] == "approved_for_publish", (
+        "fresh approved_for_publish row must NOT be reaped"
+    )
+
+
+async def test_reaper_still_reaps_stale_posting_after_widening(
+    db_session, monkeypatch
+):
+    """Regression guard: extending the reaper to handle
+    ``approved_for_publish`` MUST NOT break the existing posting-row reaping
+    (Phase 7 §5.K baseline preserved byte-for-byte)."""
+    from bot.db.models import Digest
+
+    now = datetime.now(timezone.utc)
+    digest = Digest(
+        type="daily",
+        window_start=now - timedelta(days=1),
+        window_end=now,
+        body_markdown="draft body",
+        citations=[],
+        status="posting",
+        posting_started_at=now - timedelta(minutes=3),
+    )
+    db_session.add(digest)
+    await db_session.flush()
+    digest_id = digest.id
+
+    import bot.services.scheduler as scheduler_mod
+
+    monkeypatch.setattr(
+        scheduler_mod, "async_session", _fake_session_ctx(db_session)
+    )
+
+    await scheduler_mod.digest_stale_posting_reaper_job()
+
+    refreshed = await db_session.execute(
+        text(
+            "SELECT status, error_text, posting_started_at "
+            "FROM digests WHERE id = :id"
+        ),
+        {"id": digest_id},
+    )
+    row = refreshed.mappings().one()
+    assert row["status"] == "failed"
+    assert row["error_text"] == "stale_posting_reaper"
+    assert row["posting_started_at"] is None

--- a/tests/services/test_digests_weekly.py
+++ b/tests/services/test_digests_weekly.py
@@ -1005,3 +1005,207 @@ def test_validate_every_bullet_has_citation_passes_with_section_headers():
     _validate_every_bullet_has_citation(
         body, valid_citation_tokens={"[[mv:1]]", "[[mv:2]]"}
     )  # no raise
+
+
+# ── 8. FHR HIGH-1: provider exception under type='weekly' updates ledger ─────
+# ──    (NOT raises TypeError because `type` kwarg shadows builtin)            ─
+
+
+async def test_synthesize_digest_provider_exception_updates_ledger_weekly(
+    db_session,
+):
+    """FHR HIGH-1: ``synthesize_digest(type='weekly')`` whose provider raises
+    must update the placeholder ledger row with the provider error class name
+    and re-raise the provider exception — NOT ``TypeError: 'str' object is
+    not callable`` from ``type(exc).__name__`` where ``type`` is the kwarg.
+
+    The bug surfaced at lines ~1633 (kwarg ``type: Literal['daily','weekly']``
+    shadows the builtin) + ~1745 (``error=f"{type(exc).__name__}"`` in the
+    except branch). After fix, the exception path computes the class name
+    via ``exc.__class__.__name__`` (no shadowing concern).
+    """
+    from sqlalchemy import text as _text
+
+    from bot.db.repos.llm_usage_ledger import LedgerRepo
+    from bot.services.digest_context import DigestContext, DigestContextMessage
+    from bot.services.llm_gateway import synthesize_digest
+
+    chat_id = _next_chat_id()
+    _cm_id, mv_id = await _make_msg_and_version(
+        db_session,
+        chat_id=chat_id,
+        ts=datetime.now(timezone.utc) - timedelta(days=3),
+    )
+    await db_session.flush()
+
+    now = datetime.now(timezone.utc)
+    ctx = DigestContext(
+        type="daily",  # T8-03 widens later; routing reads explicit kwarg
+        window_start=now - timedelta(days=7),
+        window_end=now,
+        source_chat_id=chat_id,
+        cards=[],
+        messages=[
+            DigestContextMessage(
+                message_version_id=mv_id,
+                chat_message_id=_cm_id,
+                author_display="Alice",
+                text="weekly recap",
+                ts=now - timedelta(days=3),
+            )
+        ],
+    )
+
+    class _ConnectionError(RuntimeError):
+        """Synthetic provider failure — name distinct enough that we can
+        verify the ledger error_text carries it (and NOT 'TypeError')."""
+
+    class _FailingProvider:
+        async def call(self, *, prompt: str, model: str):
+            raise _ConnectionError("upstream unreachable")
+
+    cfg = _make_gateway_config()
+
+    with pytest.raises(_ConnectionError):
+        await synthesize_digest(
+            db_session,
+            context=ctx,
+            config=cfg,
+            ledger_repo=LedgerRepo(),
+            provider=_FailingProvider(),
+            type="weekly",
+        )
+    await db_session.flush()
+
+    # The placeholder ledger row MUST have been updated. Pull the most recent
+    # row in this test session.
+    row = (
+        await db_session.execute(
+            _text(
+                "SELECT id, error FROM llm_usage_ledger "
+                "ORDER BY id DESC LIMIT 1"
+            )
+        )
+    ).mappings().one_or_none()
+    assert row is not None, "placeholder ledger row missing"
+    # Must NOT be 'TypeError' (that's the bug signature) and MUST be the
+    # provider exception class name.
+    assert row["error"] == "_ConnectionError", (
+        f"expected ledger.error='_ConnectionError', got {row['error']!r}"
+    )
+
+
+async def test_synthesize_digest_provider_exception_updates_ledger_daily(
+    db_session,
+):
+    """FHR HIGH-1 regression-guard: same fix must keep type='daily' (default)
+    path correct — Phase 7 byte-for-byte preserved."""
+    from sqlalchemy import text as _text
+
+    from bot.db.repos.llm_usage_ledger import LedgerRepo
+    from bot.services.digest_context import DigestContext, DigestContextMessage
+    from bot.services.llm_gateway import synthesize_digest
+
+    chat_id = _next_chat_id()
+    _cm_id, mv_id = await _make_msg_and_version(
+        db_session,
+        chat_id=chat_id,
+        ts=datetime.now(timezone.utc) - timedelta(hours=6),
+    )
+    await db_session.flush()
+
+    now = datetime.now(timezone.utc)
+    ctx = DigestContext(
+        type="daily",
+        window_start=now - timedelta(days=1),
+        window_end=now,
+        source_chat_id=chat_id,
+        cards=[],
+        messages=[
+            DigestContextMessage(
+                message_version_id=mv_id,
+                chat_message_id=_cm_id,
+                author_display="Bob",
+                text="hi",
+                ts=now - timedelta(hours=6),
+            )
+        ],
+    )
+
+    class _DailyProviderError(RuntimeError):
+        pass
+
+    class _FailingProvider:
+        async def call(self, *, prompt: str, model: str):
+            raise _DailyProviderError("transient")
+
+    cfg = _make_gateway_config()
+
+    with pytest.raises(_DailyProviderError):
+        await synthesize_digest(
+            db_session,
+            context=ctx,
+            config=cfg,
+            ledger_repo=LedgerRepo(),
+            provider=_FailingProvider(),
+            type="daily",
+        )
+    await db_session.flush()
+
+    row = (
+        await db_session.execute(
+            _text(
+                "SELECT error FROM llm_usage_ledger ORDER BY id DESC LIMIT 1"
+            )
+        )
+    ).mappings().one_or_none()
+    assert row is not None
+    assert row["error"] == "_DailyProviderError"
+
+
+# ── 9. FHR HIGH-4: DigestConfig.to_context_config() forwards weekly fields ───
+
+
+def test_digest_config_to_context_config_forwards_weekly_fields():
+    """FHR HIGH-4: ``DigestConfig.to_context_config()`` must forward the
+    weekly-specific tunables (``weekly_min_cards_threshold``,
+    ``weekly_raw_message_top_n``, ``weekly_token_budget_input``) so operator
+    env-var overrides actually reach ``build_digest_context``.
+
+    Before the fix the helper only forwarded daily fields, so
+    ``_weekly_overrides`` in ``digest_context.py`` always read the dataclass
+    defaults — env overrides silently ignored.
+    """
+    cfg = _make_digest_config(
+        weekly_min_cards_threshold=11,
+        weekly_raw_message_top_n=77,
+        weekly_token_budget_input=32000,
+    )
+    ctx_cfg = cfg.to_context_config()
+    assert ctx_cfg.weekly_min_cards_threshold == 11
+    assert ctx_cfg.weekly_raw_message_top_n == 77
+    assert ctx_cfg.weekly_token_budget_input == 32000
+    # Daily fields still forwarded too.
+    assert ctx_cfg.min_cards_threshold == cfg.min_cards_threshold
+    assert ctx_cfg.raw_message_top_n == cfg.raw_message_top_n
+    assert ctx_cfg.token_budget_input == cfg.token_budget_input
+
+
+def test_load_digest_config_weekly_env_reaches_context_config(monkeypatch):
+    """End-to-end env-var → DigestConfig → DigestCtxConfig forwarding.
+
+    Sets DIGEST_WEEKLY_* env vars, loads config, asserts the to_context_config
+    bridge surfaces the same values. Verifies the operator-tuning path
+    (HIGH-4 root scenario) is no longer broken.
+    """
+    monkeypatch.setenv("DIGEST_WEEKLY_TOKEN_BUDGET", "32000")
+    monkeypatch.setenv("DIGEST_WEEKLY_MIN_CARDS_THRESHOLD", "15")
+    monkeypatch.setenv("DIGEST_WEEKLY_RAW_MESSAGE_TOP_N", "99")
+
+    from bot.services.digests import load_digest_config
+
+    cfg = load_digest_config()
+    ctx_cfg = cfg.to_context_config()
+    assert ctx_cfg.weekly_token_budget_input == 32000
+    assert ctx_cfg.weekly_min_cards_threshold == 15
+    assert ctx_cfg.weekly_raw_message_top_n == 99


### PR DESCRIPTION
## Summary

Final Holistic Review for Phase 8 (Claude `deep-product-reviewer` + Codex `codex:codex-rescue` deep-technical, independent) returned NEEDS_FIXES with 5 unique HIGH items (0 critical). All shipped in this PR.

## Fixes

| # | Sev | Reviewer | File | Issue → Resolution |
|---|-----|----------|------|--------------------|
| H1 | HIGH | Codex | `bot/services/llm_gateway.py:1745` | `synthesize_digest(type=...)` shadowed builtin `type`. `type(exc).__name__` raised TypeError, masking provider errors + skipping placeholder ledger update. Fix: `exc.__class__.__name__` (same pattern as T8-02 latent fix). |
| H2 | HIGH | Both | `bot/services/scheduler.py:376-450` | `digest_stale_posting_reaper_job` only caught `posting` rows; spec §5.G mandates also catching `approved_for_publish` > 5min. Without this, publisher crash between approve commit + posting transition leaves digest stuck forever. Fix: widened reaper UPDATE with CASE-driven `error_text` + OR-branched WHERE (`posting > 2min` OR `approved_for_publish > 5min` per spec). |
| H3 | HIGH | Codex | `bot/handlers/digest.py:323-422` | `--regenerate` SELECTed row state BEFORE acquiring advisory lock → 2 parallel regenerate could both pass pre-check then race. Fix: restructured to acquire lock FIRST, then read authoritative state, then audit-insert+DELETE+rerun. Race-loser cleanly refused. |
| H4 | HIGH | Claude | `bot/services/digests.py:84-99` | `DigestConfig.to_context_config()` only forwarded daily fields. Operator setting `DIGEST_WEEKLY_TOKEN_BUDGET=32000` etc. saw silent default fallback. Fix: forward all 3 weekly fields (`weekly_min_cards_threshold`, `weekly_raw_message_top_n`, `weekly_token_budget_input`). |
| H5 | HIGH | Claude | `bot/services/digest_renderer.py` + `bot/services/digest_publisher.py:313-321` | Renderer §5.I missing — weekly LLM produces `## Раздел: ...` headers per `digest_weekly_v0_1_0.py`, but renderer passed them through html_escape → published as literal `## Раздел: Объявления` text. Footer also single-day. Fix: new `digest_type` + `window_end_utc` kwargs, weekly section-header regex bolding (`<b>Раздел: ...</b>`), weekly footer "Еженедельный дайджест за DD.MM.YYYY – DD.MM.YYYY". Daily byte-for-byte preserved. |

## Tests added (TDD red-then-green, all verified RED before fix)

- H1: `test_synthesize_digest_provider_exception_updates_ledger_weekly` + daily regression
- H2: `test_reaper_reaps_stale_approved_for_publish` + freshness skip + Phase 7 posting regression
- H3: `test_digest_now_weekly_regenerate_race_state_changed_post_lock` + `test_digest_now_weekly_regenerate_row_deleted_under_lock`
- H4: `test_digest_config_to_context_config_forwards_weekly_fields` + env-end-to-end test
- H5: NEW `tests/services/test_digest_renderer_weekly.py` (5 tests — section header bolding, weekly footer, daily-unchanged-byte-for-byte regression, tag balance, daily-no-bolding)

## Verification

- **167 tests pass** in focused suite (`tests/services/test_digest*.py + tests/evals/test_digest_weekly_review_invariants.py`)
- **Phase 11 binding 12/12 green** (no regression on L8a/b + C7 + I6a/b.1/.2/.3/I6c + R5.a/b/c/d)
- **681 broader regression** pass (1 pre-existing unrelated failure: test_live_gateway_adapter BOT_TOKEN env isolation)
- **Daily flow byte-for-byte preserved** (verified via `assert out_old == out_explicit` in renderer test)
- Privacy lint exit 0, ruff exit 0

## Deviations from review packet (all defensible)

- H1 grep scope: only fixed the occurrence inside `synthesize_digest` (line 1745); other `type(exc).__name__` matches are in functions that don't shadow `type` (synthesize_answer, _synthesize_inner)
- H2 threshold: followed PHASE8_PLAN.md §5.G verbatim (2min posting / 5min approved) instead of packet's looser 5/5
- H3 test design: deterministic monkey-patched lock-injection instead of pytest-asyncio parallel scheduling — same observable assertions, more reliable
- H5 footer date: spec-mandated `(window_end_msk - timedelta(seconds=1))` for inclusive Sun-end label

## Out of scope (Phase 8.5 carryover)

MED items deferred (already documented in `PHASE8_ROLLOUT.md` carryover section per T8-08):
- M1 R5.a/.b binding test strength (handler-tests carry full assertion)
- M2 ApproveResult publisher-status forwarding (admin reply may mislead on skipped_no_destination)
- M3 `/digest_preview weekly` stale placeholder text
- M4 `bot/config.py` Phase 8 env var registration (cron HOUR/MINUTE_MSK use getattr fallback)
- M5 `digest_admin_notify` hardcoded "Phase 7 alert" label
- LOW: Digest ORM docstring stale, redactor SQL duplicates constant

## Test plan

- [x] 167 focused + 681 broader regression green
- [x] Phase 11 binding 12/12 green
- [x] Daily flow byte-for-byte preserved
- [x] Privacy lint + ruff clean
- [ ] CI green
- [ ] Merge — clears path for T8-08 closure docs (separate PR pending)