### PR TITLE
feat(p10-w0a): Phase 10 foundation — migration 060 + graph_common + repo

### DIFF
--- a/.superflow/charter.md
+++ b/.superflow/charter.md
@@ -33,7 +33,7 @@ WAVE 0 (3 PRs):
     bot/services/graph_source_eligibility.py: governance-aware source filter
     Reuses bot/services/governance.py forget_excludes predicate
     Pure code, no migrations. Imports from graph_common.py
-    Tests: positive (eligible source) + negative (forgotten/offrecord/nomem)
+    Tests: positive (eligible source) + negative (all 3 governance-excluded categories per governance.py contract)
   
   W0-D - feat/p10-w0d-neo4j-ci (NEW per duo iter 2)
     .github/workflows/evals.yml: Neo4j 5.x service block + healthcheck

--- a/.superflow/charter.md
+++ b/.superflow/charter.md
@@ -1,0 +1,125 @@
+# Phase 10 Execution Charter
+
+**Topic:** Phase 10 — Graph Projection / Neo4j (Graphiti-style)
+**Goal:** Close Phase 10 — all 8 remaining sprints (T10-02..T10-09) merged, Neo4j CI service running, dev mode verified, ready for production testing.
+**Authorized by:** PHASE10_PLAN.md ratified 2026-05-17 (2 BLOCKER + 9 HIGH + 4 MEDIUM addressed in revision passes). User /superflow invocation 2026-05-20.
+
+## Governance
+- **Mode:** standard
+- **Git workflow:** sprint_pr_queue (one PR per sprint, rebase merge, CI green before merge)
+- **Secondary provider:** codex (via `codex:codex-rescue` subagent — raw `codex` CLI broken in non-interactive shells per `~/.claude/rules/codex-routing.md`)
+- **Unified Review per PR:** Claude standard-product-reviewer + Codex deep-technical via codex-rescue
+- **Docs update gate per PR:** CLAUDE.md / llms.txt explicit check + per-PR rollout fragment
+- **`.par-evidence.json` required before push:** review verdicts + docs verdict
+- **NEVER `gh pr merge --admin`:** fix CI red first
+
+## Wave Plan
+
+```
+WAVE 0 (3 PRs):
+  W0-A (BLOCKING, sequential first) — feat/p10-w0a-foundation
+    Migration 060 (graph_projection_runs) per PHASE10_PLAN section 5.A
+    bot/services/graph_common.py: GraphNodeRef, GraphEdgeRef, RefusalError,
+      GraphProjectionPolicyError, ALLOWED_NODE_TYPES, ALLOWED_PREDICATES,
+      RESERVED ledger.call_type Literal values, repair_mode contract
+    bot/db/repos/graph_projection_run.py: create_run, update_run_stats,
+      finalize_run, list_recent_runs, get_active_run
+    docs/rollout-fragments/phase10/W0-A.md (per-PR rollout fragment)
+    Tests: unit tests for repo CRUD + dataclass freezing/validation
+  
+  After W0-A merged - dispatch in parallel:
+  
+  W0-B - feat/p10-w0b-eligibility (T10-02)
+    bot/services/graph_source_eligibility.py: governance-aware source filter
+    Reuses bot/services/governance.py forget_excludes predicate
+    Pure code, no migrations. Imports from graph_common.py
+    Tests: positive (eligible source) + negative (forgotten/offrecord/nomem)
+  
+  W0-D - feat/p10-w0d-neo4j-ci (NEW per duo iter 2)
+    .github/workflows/evals.yml: Neo4j 5.x service block + healthcheck
+    .github/workflows/ci.yml: optional Neo4j integration job
+    docker-compose-test.yml: Neo4j --profile graph for local
+    tests/conftest_neo4j.py: pytest fixture neo4j_session (cleaned per test)
+    Tests: verifies fixture connects + cleans state between tests
+
+WAVE 1 (2 PRs, sequential):
+  W1-C first - migrations 061-064 + repos
+    Migration 061: graph_provenance per section 5.A
+    Migration 062: graph_edges per section 5.A
+    Migration 063: graph_purge_pending per section 5.A
+    Migration 064: ledger.call_type ALTER + backfill
+    bot/db/repos/graph_provenance.py, graph_edge.py, graph_purge_pending.py
+  
+  W1-B after W1-C merged - T10-04 LLM extract
+    bot/services/llm_gateway.py: extract_graph_triples per section 5.B
+    Entity registry resolution INLINE (cards.id + users.id + UNKNOWN sentinel)
+    Real Neo4j binding tests via W0-D fixture
+
+WAVE 2 (2 PRs, parallel):
+  W2-B - T10-05 graph_projector modes
+    bot/services/graph_projector.py per section 5.C
+    pg_advisory_lock(GRAPH_REBUILD_LOCK) for full_rebuild — prevents race with
+      W2-C purge worker
+    Pre-condition: SELECT count from graph_purge_pending status='in_flight' = 0
+  
+  W2-C UNIFIED - T10-06 cascade + worker + readblock
+    bot/services/forget_cascade.py: _cascade_graph_provenance layer
+    bot/services/graph_purge_worker.py: drives Neo4j DETACH DELETE
+    bot/services/graph_purge_readblock.py: assert_no_pending_purge(node_keys)
+      (NO stub-in-main pattern — full impl in single PR per duo iter 2 critique)
+
+WAVE 2.5 (1 PR):
+  W2.5-D after W2-C merged - T10-07 graph_query
+    bot/services/graph_query.py per section 5.E
+    Role/visibility filters, parameterized Cypher, provenance-required output
+    Imports assert_no_pending_purge from W2-C
+
+WAVE 3 (2 PRs, parallel):
+  W3-E - T10-08 admin handlers + cron + ROLLOUT
+    bot/handlers/admin_graph.py: /graph_project_now (advisory lock) +
+      /graph_stats + /graph_query
+    bot/scheduler.py: graph_projection_nightly_job at 03:30 MSK
+    docs/memory-system/PHASE10_ROLLOUT.md: ASSEMBLED from
+      docs/rollout-fragments/phase10/*.md via concat script
+  
+  W3-F - T10-09 cross-component binding tests
+    tests/evals/test_graph_*.py: 5 cross-component scenarios
+    Phase 11 binding count: 60/60 -> 75-76/75-76
+```
+
+## Coordination Rules (anti-conflict)
+
+| Rule | Detail |
+|---|---|
+| Max parallel streams | 2 active per wave (3 only in W0 since helpers are tiny) |
+| Migration numbers | Reserved 060-064 (W0/W1) per canonical PHASE10_PLAN. No reordering. |
+| `bot/services/graph_query.py` ownership | Stream Query (W2.5-D) |
+| `bot/services/graph_purge_readblock.py` ownership | Stream Privacy (W2-C) |
+| `bot/services/forget_cascade.py` ownership | Stream Privacy (W2-C edits _cascade_graph_provenance) |
+| `bot/services/llm_gateway.py` ownership | Stream Projection (W1-B adds extract_graph_triples) |
+| Per-PR rollout fragments | `docs/rollout-fragments/phase10/<sprint-id>.md` — append-only, no merge conflict |
+| PR >24h stale | Mandatory rebase before review |
+| After merge | Rebase signal to other worktrees |
+| Race protection | `pg_advisory_lock(GRAPH_REBUILD_LOCK)` in W2-B + precondition check on pending purges |
+
+## Hard Constraints (must not violate)
+
+1. RFC-001:415 async cascade pattern — Postgres enqueue + separate worker + read-block fail-closed
+2. 3 feature flags default OFF: `memory.graph.projection.enabled`, `memory.graph.query.enabled`, `memory.graph.write_pending.paused`
+3. Cost ceilings separate from shared LLM_DAILY_USD_CEILING:
+   - `GRAPH_PROJECTION_DAILY_USD_CEILING` $2/day
+   - `GRAPH_PROJECTION_RUN_USD_CEILING` $0.50/run
+   - Max 200 sources/run
+4. replay-only `full_rebuild` (no LLM re-extraction)
+5. Ontology split: `knowledge_cards` -> CONCEPT nodes + LLM triples; `message_versions` -> provenance/event nodes only
+
+## Definition of Done (Phase 10 closure)
+
+1. All 9 PRs merged to main, CI green throughout
+2. Phase 11 binding tests: 60/60 -> 75-76/75-76
+3. Neo4j CI service runs in nightly `evals.yml`
+4. PHASE10_ROLLOUT.md complete and committed
+5. docker-compose --profile graph spins up cleanly in dev (manual verify)
+6. All 3 feature flags exist in `.env.example` with default OFF
+7. CLAUDE.md + ROADMAP.md + IMPLEMENTATION_STATUS.md updated to "Phase 10 CLOSED"
+8. Cleanup: stale worktrees removed (needs user permission)

--- a/alembic/versions/060_add_graph_projection_runs.py
+++ b/alembic/versions/060_add_graph_projection_runs.py
@@ -1,0 +1,104 @@
+"""add_graph_projection_runs
+
+Phase 10 / W0-A foundation: creates graph_projection_runs table.
+
+This table is the Postgres-side audit anchor for all Phase 10 Neo4j graph
+projection work. Every projector run (dry_run, incremental, full_rebuild,
+repair) creates one row here and updates it as the run progresses.
+
+Tables graph_provenance (061), graph_edges (062), and graph_purge_pending (063)
+all carry a FK to this table's id. Migration 064 adds call_type to
+llm_usage_ledger and references the reserved call_type values documented in
+bot/services/graph_common.py::RESERVED_LEDGER_CALL_TYPES.
+
+Revision ID: 060
+Revises: 055
+Create Date: 2026-05-20
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "060"
+down_revision: Union[str, Sequence[str], None] = "055"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_TABLE = "graph_projection_runs"
+_CK_MODE = "ck_graph_projection_runs_mode"
+_CK_STATUS = "ck_graph_projection_runs_status"
+_IX_STARTED_AT = "ix_graph_projection_runs_started_at"
+_IX_STATUS = "ix_graph_projection_runs_status"
+
+
+def upgrade() -> None:
+    op.create_table(
+        _TABLE,
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("mode", sa.Text(), nullable=False),
+        sa.Column("status", sa.Text(), nullable=False, server_default="running"),
+        sa.Column("source_cutoff_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("source_card_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("source_message_version_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("projected_node_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("projected_edge_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("skipped_policy_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("skipped_budget_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("llm_prompt_tokens", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("llm_completion_tokens", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column(
+            "estimated_cost_usd", sa.Numeric(precision=10, scale=6), nullable=False,
+            server_default="0"
+        ),
+        sa.Column(
+            "actual_cost_usd", sa.Numeric(precision=10, scale=6), nullable=False,
+            server_default="0"
+        ),
+        sa.Column(
+            "started_at", sa.DateTime(timezone=True), nullable=False,
+            server_default=sa.func.now()
+        ),
+        sa.Column("finished_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("error_code", sa.Text(), nullable=True),
+        sa.Column("error_context", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at", sa.DateTime(timezone=True), nullable=False,
+            server_default=sa.func.now()
+        ),
+        sa.Column("started_by", sa.Text(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+        sa.CheckConstraint(
+            "mode IN ('dry_run', 'incremental', 'full_rebuild', 'repair')",
+            name=_CK_MODE,
+        ),
+        sa.CheckConstraint(
+            "status IN ('running', 'completed', 'failed', 'cancelled', "
+            "'cost_exceeded', 'dry_run_complete')",
+            name=_CK_STATUS,
+        ),
+    )
+
+    # Index on started_at DESC for chronological listing queries
+    op.create_index(
+        _IX_STARTED_AT,
+        _TABLE,
+        [sa.text("started_at DESC")],
+    )
+
+    # Partial index: only index rows in monitoring-relevant states
+    op.create_index(
+        _IX_STATUS,
+        _TABLE,
+        ["status"],
+        postgresql_where=sa.text("status IN ('running', 'failed')"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(_IX_STATUS, table_name=_TABLE)
+    op.drop_index(_IX_STARTED_AT, table_name=_TABLE)
+    op.drop_table(_TABLE)

--- a/bot/db/models.py
+++ b/bot/db/models.py
@@ -1476,3 +1476,96 @@ class DigestRun(Base):
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=func.now()
     )
+
+
+# ─── Phase 10: graph projection runs (T10-W0-A / alembic 060) ─────────────────
+
+
+class GraphProjectionRun(Base):
+    """Audit row for one graph projection pass (W0-A / alembic 060).
+
+    One row per projector invocation (dry_run, incremental, full_rebuild, repair).
+    Tracks source counts, projected node/edge counts, skip counts, token usage,
+    cost estimates, and terminal status.
+
+    Status lifecycle: running → completed | failed | cancelled | cost_exceeded |
+                                dry_run_complete
+
+    Mode values: dry_run, incremental, full_rebuild, repair.
+
+    This table is the Postgres-side audit anchor for everything Neo4j-related.
+    graph_provenance (migration 061), graph_edges (062), and graph_purge_pending (063)
+    all reference this table's id.
+    """
+
+    __tablename__ = "graph_projection_runs"
+    __table_args__ = (
+        CheckConstraint(
+            "mode IN ('dry_run', 'incremental', 'full_rebuild', 'repair')",
+            name="ck_graph_projection_runs_mode",
+        ),
+        CheckConstraint(
+            "status IN ('running', 'completed', 'failed', 'cancelled', "
+            "'cost_exceeded', 'dry_run_complete')",
+            name="ck_graph_projection_runs_status",
+        ),
+        Index("ix_graph_projection_runs_started_at", text("started_at DESC")),
+        # Partial index: only index rows we need to look up for monitoring/operations
+        Index(
+            "ix_graph_projection_runs_status",
+            "status",
+            postgresql_where=text("status IN ('running', 'failed')"),
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    mode: Mapped[str] = mapped_column(Text, nullable=False)
+    status: Mapped[str] = mapped_column(
+        Text, nullable=False, default="running", server_default="running"
+    )
+    source_cutoff_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    source_card_count: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default=text("0")
+    )
+    source_message_version_count: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default=text("0")
+    )
+    projected_node_count: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default=text("0")
+    )
+    projected_edge_count: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default=text("0")
+    )
+    skipped_policy_count: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default=text("0")
+    )
+    skipped_budget_count: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default=text("0")
+    )
+    llm_prompt_tokens: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default=text("0")
+    )
+    llm_completion_tokens: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default=text("0")
+    )
+    estimated_cost_usd: Mapped[Decimal] = mapped_column(
+        Numeric(10, 6), nullable=False, default=Decimal("0"), server_default=text("0")
+    )
+    actual_cost_usd: Mapped[Decimal] = mapped_column(
+        Numeric(10, 6), nullable=False, default=Decimal("0"), server_default=text("0")
+    )
+    started_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    finished_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    error_code: Mapped[str | None] = mapped_column(Text, nullable=True)
+    error_context: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+
+    # started_by is stored as a free-text label (e.g. 'scheduler', 'admin:149820031')
+    # NOT a FK — the projector can be triggered without a users row (scheduler, CLI).
+    started_by: Mapped[str | None] = mapped_column(Text, nullable=True)

--- a/bot/db/repos/graph_projection_run.py
+++ b/bot/db/repos/graph_projection_run.py
@@ -1,0 +1,223 @@
+"""Repository for ``graph_projection_runs`` (Phase 10 / W0-A).
+
+Flush-only — NEVER calls ``session.commit()`` or ``session.rollback()``.
+The caller owns the transaction lifecycle.
+
+Stats update pattern: uses SQLAlchemy UPDATE statements to avoid stale
+read-modify-write cycles. The deep-merge for JSONB-style stats is done via
+column-level UPDATE (individual columns, not a JSONB column), so each call
+replaces only the explicitly supplied keys. Unknown keys are rejected with
+ValueError (not silently ignored) — this is intentional to surface stale
+callers early.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import Sequence
+
+from sqlalchemy import select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from bot.db.models import GraphProjectionRun
+from bot.services.graph_common import GraphProjectionMode, GraphProjectionRunStatus
+
+_log = logging.getLogger(__name__)
+
+# Terminal statuses per migration 060 CHECK constraint on status column.
+# Non-terminal is only 'running'. A run transitions running → terminal exactly once.
+TERMINAL_STATUSES: frozenset[str] = frozenset(
+    {"completed", "failed", "cancelled", "cost_exceeded", "dry_run_complete"}
+)
+NON_TERMINAL_STATUSES: frozenset[str] = frozenset({"running"})
+
+# Columns that update_run_stats is allowed to set. Enumerated from migration 060.
+# Semantics: SET-replace (not increment). Unknown keys are rejected. Empty patch is no-op.
+_UPDATABLE_STATS_COLS: frozenset[str] = frozenset({
+    "source_card_count",
+    "source_message_version_count",
+    "projected_node_count",
+    "projected_edge_count",
+    "skipped_policy_count",
+    "skipped_budget_count",
+    "llm_prompt_tokens",
+    "llm_completion_tokens",
+    "estimated_cost_usd",
+    "actual_cost_usd",
+    "source_cutoff_at",
+    "error_code",
+    "error_context",
+})
+
+
+async def create_run(
+    session: AsyncSession,
+    *,
+    mode: GraphProjectionMode,
+    started_by: str | None = None,
+) -> GraphProjectionRun:
+    """Insert a new graph_projection_runs row with status='running'.
+
+    mode: one of 'dry_run', 'incremental', 'full_rebuild', 'repair'.
+    started_by: free-text label for who triggered this run (e.g. 'scheduler',
+        'admin:149820031'). None for system-initiated runs.
+
+    Flushes; caller commits. NEVER commits internally.
+    """
+    run = GraphProjectionRun(
+        mode=mode,
+        status="running",
+        started_by=started_by,
+    )
+    session.add(run)
+    await session.flush()
+    _log.debug("graph_projection_runs: inserted run id=%s mode=%s", run.id, mode)
+    return run
+
+
+async def update_run_stats(
+    session: AsyncSession,
+    run_id: int,
+    *,
+    stats_patch: dict,
+) -> None:
+    """Update individual stat columns on a graph_projection_runs row.
+
+    Semantics:
+    - SET-replace (NOT increment): each supplied key overwrites the column value.
+    - Unknown keys rejected with ValueError (not silently ignored).
+    - Empty patch is a no-op (returns immediately without touching the row).
+
+    stats_patch keys must be a subset of the allowed columns defined by
+    _UPDATABLE_STATS_COLS (enumerated from migration 060).
+
+    Flushes; caller commits. NEVER commits internally.
+    """
+    unknown = set(stats_patch) - _UPDATABLE_STATS_COLS
+    if unknown:
+        raise ValueError(
+            f"update_run_stats received unknown keys: {sorted(unknown)}. "
+            f"Allowed: {sorted(_UPDATABLE_STATS_COLS)}"
+        )
+    if not stats_patch:
+        return
+
+    stmt = (
+        update(GraphProjectionRun)
+        .where(GraphProjectionRun.id == run_id)
+        .values(**stats_patch)
+    )
+    result = await session.execute(stmt)
+    if result.rowcount == 0:
+        raise LookupError(
+            f"GraphProjectionRun(id={run_id}) not found — cannot update stats"
+        )
+    await session.flush()
+    _log.debug(
+        "graph_projection_runs: updated stats run_id=%s keys=%s",
+        run_id, list(stats_patch.keys())
+    )
+
+
+async def finalize_run(
+    session: AsyncSession,
+    run_id: int,
+    *,
+    status: GraphProjectionRunStatus,
+    cost_usd: Decimal | None = None,
+) -> None:
+    """Set terminal status and finished_at on a graph_projection_runs row.
+
+    State-machine contract:
+    - status must be a terminal value (one of TERMINAL_STATUSES).
+    - Transitions only from 'running' → terminal (WHERE status='running').
+    - Idempotent for same terminal status: calling twice with the same terminal
+      status is a no-op (e.g., double-finalize on retry).
+    - Raises ValueError if attempting to transition to a DIFFERENT terminal status
+      (e.g., succeeded → failed).
+
+    cost_usd: if provided, updates actual_cost_usd.
+
+    Flushes; caller commits. NEVER commits internally.
+    """
+    if status not in TERMINAL_STATUSES:
+        raise ValueError(
+            f"finalize_run requires a terminal status; got {status!r}. "
+            f"Terminal statuses: {sorted(TERMINAL_STATUSES)}"
+        )
+
+    values: dict = {
+        "status": status,
+        "finished_at": datetime.now(tz=timezone.utc),
+    }
+    if cost_usd is not None:
+        values["actual_cost_usd"] = cost_usd
+
+    stmt = (
+        update(GraphProjectionRun)
+        .where(GraphProjectionRun.id == run_id)
+        .where(GraphProjectionRun.status == "running")
+        .values(**values)
+    )
+    result = await session.execute(stmt)
+    if result.rowcount == 0:
+        # Row may be already finalized — check for idempotency vs wrong transition
+        row_result = await session.execute(
+            select(GraphProjectionRun.status).where(GraphProjectionRun.id == run_id)
+        )
+        existing_status = row_result.scalar_one_or_none()
+        if existing_status is None:
+            raise LookupError(
+                f"GraphProjectionRun(id={run_id}) not found — cannot finalize"
+            )
+        if existing_status == status:
+            # Idempotent: same terminal status, no-op
+            _log.debug(
+                "graph_projection_runs: finalize_run id=%s already at status=%s (idempotent noop)",
+                run_id, status
+            )
+            return
+        raise ValueError(
+            f"Cannot finalize run {run_id}: already {existing_status!r}, "
+            f"requested {status!r}"
+        )
+    await session.flush()
+    _log.debug(
+        "graph_projection_runs: finalized run_id=%s status=%s", run_id, status
+    )
+
+
+async def list_recent_runs(
+    session: AsyncSession,
+    *,
+    limit: int = 20,
+) -> Sequence[GraphProjectionRun]:
+    """Return the most recent graph_projection_runs rows, descending by started_at.
+
+    limit: max rows to return (default 20).
+    """
+    stmt = (
+        select(GraphProjectionRun)
+        .order_by(GraphProjectionRun.started_at.desc(), GraphProjectionRun.id.desc())
+        .limit(limit)
+    )
+    result = await session.execute(stmt)
+    return result.scalars().all()
+
+
+async def get_active_run(session: AsyncSession) -> GraphProjectionRun | None:
+    """Return the currently running GraphProjectionRun (status='running'), or None.
+
+    If multiple 'running' rows exist (shouldn't happen — caller is responsible for
+    not starting overlapping runs), returns the most recently started one.
+    """
+    stmt = (
+        select(GraphProjectionRun)
+        .where(GraphProjectionRun.status == "running")
+        .order_by(GraphProjectionRun.started_at.desc(), GraphProjectionRun.id.desc())
+        .limit(1)
+    )
+    result = await session.execute(stmt)
+    return result.scalar_one_or_none()

--- a/bot/services/graph_common.py
+++ b/bot/services/graph_common.py
@@ -1,0 +1,195 @@
+"""Shared types and constants for Phase 10 graph projection.
+
+Ownership model:
+  - graph_common (this file): shared constants, dataclasses, error types, Protocol stubs
+  - llm_gateway.py (W1-B): extract_graph_triples implementation
+  - graph_projector.py (W2-B): projection modes (dry_run, incremental, full_rebuild, repair)
+  - cascade_worker.py (W2-C): forget cascade + Neo4j purge worker
+  - graph_query.py (W2.5-D): read-side traversal with read-block
+
+References: PHASE10_PLAN.md §5.A (schema) and §5.B (extract_graph_triples contract).
+
+RESERVED_LEDGER_CALL_TYPES contract:
+  The single reserved value for llm_usage_ledger.call_type is 'graph_projection'.
+  This matches PHASE10_PLAN.md §5.B step 4 exactly. Discrimination between
+  dry_run / incremental / full_rebuild / repair modes is done via the
+  graph_projection_runs.mode column (CHECK-constrained), NOT via call_type
+  subdivision. Migration 064 (owned by W1-C) reserves this single string.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal, Protocol, runtime_checkable
+
+
+# ─── Allowed ontology values ─────────────────────────────────────────────────
+
+# Verbatim from PHASE10_PLAN.md §5.B prompt template.
+# These are the only node types the LLM extractor may emit; any other value
+# is invalid and causes the triple to be dropped (refuse-on-unknown rule).
+ALLOWED_NODE_TYPES: tuple[str, ...] = (
+    "Person",
+    "Topic",
+    "Project",
+    "Decision",
+    "Question",
+    "Answer",
+    "Event",
+    "KnowledgeCard",
+    "Source",
+)
+
+# Verbatim from PHASE10_PLAN.md §5.B prompt template.
+# Predicate vocabulary; enforced by GraphEdgeRef.__post_init__ and by
+# graph_edges.ck_graph_edges_predicate DB CHECK (migration 062).
+ALLOWED_PREDICATES: tuple[str, ...] = (
+    "MENTIONS",
+    "AUTHORED",
+    "KNOWS_ABOUT",
+    "ASKED",
+    "ANSWERED",
+    "DECIDED",
+    "RELATED_TO",
+    "SUPPORTS",
+    "DERIVED_FROM",
+    "PART_OF",
+    "CONTRADICTS",
+    "SUPERSEDES",
+)
+
+# Reserved llm_usage_ledger.call_type values for Phase 10.
+# Migration 064 (owned by W1-C) will ALTER TABLE llm_usage_ledger to add the
+# call_type column. Per PHASE10_PLAN.md §5.B step 4, there is exactly ONE
+# reserved value: 'graph_projection'. Mode discrimination (dry_run vs incremental
+# vs full_rebuild vs repair) is handled via graph_projection_runs.mode column
+# (CHECK-constrained), NOT via call_type subdivision.
+RESERVED_LEDGER_CALL_TYPES: tuple[str, ...] = (
+    "graph_projection",  # per PHASE10_PLAN §5.B step 4
+                         # discrimination of dry/incremental/full/repair modes
+                         # is via graph_projection_runs.mode column (CHECK-constrained),
+                         # NOT via ledger.call_type subdivision. This is the reserved
+                         # value contract for migration 064 in W1-C.
+)
+
+
+# ─── Literal type aliases ────────────────────────────────────────────────────
+
+# Exact CHECK constraint values from migration 060 (graph_projection_runs).
+GraphProjectionMode = Literal["dry_run", "incremental", "full_rebuild", "repair"]
+GraphProjectionRunStatus = Literal[
+    "running", "completed", "failed", "cancelled", "cost_exceeded", "dry_run_complete"
+]
+
+
+# ─── Dataclasses ─────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class GraphNodeRef:
+    """Typed reference to a Neo4j node identified by node_key.
+
+    node_key: stable Postgres-derived identifier (e.g. "user:12345", "card:uuid")
+    node_type: must be one of ALLOWED_NODE_TYPES
+    """
+
+    node_key: str
+    node_type: str
+
+    def __post_init__(self) -> None:
+        if self.node_type not in ALLOWED_NODE_TYPES:
+            raise ValueError(
+                f"node_type {self.node_type!r} is not in ALLOWED_NODE_TYPES: {ALLOWED_NODE_TYPES}"
+            )
+
+
+@dataclass(frozen=True)
+class GraphEdgeRef:
+    """Typed reference to a Neo4j relationship (edge) identified by edge_key.
+
+    edge_key: stable SHA-256 key (subject+predicate+object)
+    source_key: node_key of the subject node
+    target_key: node_key of the object node
+    predicate: must be one of ALLOWED_PREDICATES
+    """
+
+    edge_key: str
+    source_key: str
+    target_key: str
+    predicate: str
+
+    def __post_init__(self) -> None:
+        if self.predicate not in ALLOWED_PREDICATES:
+            raise ValueError(
+                f"predicate {self.predicate!r} is not in ALLOWED_PREDICATES: {ALLOWED_PREDICATES}"
+            )
+
+
+# ─── Error hierarchy ─────────────────────────────────────────────────────────
+
+
+class RefusalError(Exception):
+    """Base error for graph query and projection refusals.
+
+    Raised when Phase 10 components must abort an operation due to a
+    governance or budget constraint. Subclasses carry specific semantics
+    used by the projector, cascade worker, and read-block.
+
+    Used by future read-block in W2-C (assert_no_pending_purge) and by
+    extract_graph_triples in W1-B (governance pre-call assertion).
+    """
+
+
+class GraphProjectionPolicyError(RefusalError):
+    """Raised by extract_graph_triples when governance_policy != 'normal'.
+
+    Per PHASE10_PLAN.md §5.B: the pre-call assertion is fail-closed —
+    never extract over non-normal content. Caller must catch this, mark
+    the source as skipped_policy_count, and proceed to the next source.
+    """
+
+
+class GraphProjectionBudgetError(RefusalError):
+    """Raised by the graph projector when a cost ceiling is exceeded.
+
+    Two ceilings apply:
+    - GRAPH_PROJECTION_RUN_USD_CEILING ($0.50/run)
+    - GRAPH_PROJECTION_DAILY_USD_CEILING ($2/day)
+
+    When either ceiling is hit, the projector stops processing further
+    sources and raises this error; the run is marked 'cost_exceeded'.
+    """
+
+
+# ─── Protocols ───────────────────────────────────────────────────────────────
+
+
+@runtime_checkable
+class RepairModeContract(Protocol):
+    """API surface for repair_mode invocation.
+
+    Declares the interface that the W2-B graph_projector will provide to
+    the W2-C cascade worker. The cascade worker calls request_repair when
+    a Postgres forget event requires a targeted Neo4j node re-projection
+    rather than a full purge (e.g. shared-node provenance cleanup).
+
+    Implementations are owned by W2-B (graph_projector.py). This Protocol
+    is defined here so W2-C (cascade_worker.py) can type-annotate its
+    injected projector reference without importing from graph_projector
+    and creating a circular dependency.
+    """
+
+    async def request_repair(
+        self,
+        *,
+        source_table: str,
+        source_pk: str,
+        reason: str,
+    ) -> None:
+        """Request a targeted repair projection for a specific source row.
+
+        source_table: 'message_versions' or 'knowledge_cards'
+        source_pk: PK value of the row requiring repair (str form)
+        reason: human-readable reason for the repair (e.g. 'forget_cascade')
+        """
+        ...

--- a/docs/memory-system/PHASE10_PLAN.md
+++ b/docs/memory-system/PHASE10_PLAN.md
@@ -216,6 +216,15 @@ CREATE INDEX ix_graph_projection_runs_status
     WHERE status IN ('running', 'failed');
 ```
 
+**W0-A implementation note (added 2026-05-20):** Migration 060 implementation also
+adds a `started_by TEXT NULL` column for admin/scheduler audit trail (admin handler
+records admin telegram_id as text; scheduler records `'scheduler'` literal).
+This column is NOT in the canonical spec table above but is required by the
+`create_run(*, started_by: str | None)` signature in §5.C and §5.G/H consumers.
+See `docs/rollout-fragments/phase10/W0-A.md` for rationale.
+
+<!-- updated-by-w0a:2026-05-20 -->
+
 **Migration 061: `graph_provenance`**
 
 ```sql

--- a/docs/rollout-fragments/phase10/W0-A.md
+++ b/docs/rollout-fragments/phase10/W0-A.md
@@ -1,0 +1,104 @@
+# Rollout Fragment: W0-A (Phase 10 Foundation)
+
+## Summary
+
+Sprint W0-A establishes the Postgres-side foundation for Phase 10 graph projection:
+
+- Migration 060: `graph_projection_runs` table — audit anchor for every projector run
+- ORM model `GraphProjectionRun` in `bot/db/models.py`
+- Repo `bot/db/repos/graph_projection_run.py` — CRUD for projection runs
+- `bot/services/graph_common.py` — shared constants, dataclasses, error hierarchy, Protocol
+
+No feature flags are toggled in this sprint. All Phase 10 feature flags default OFF and are
+defined in later sprints (W1-B / W3-E introduce the three env-var feature flags).
+
+## Env Vars
+
+None added in this sprint.
+
+## Migration Applied
+
+| Migration | Table | Action |
+|-----------|-------|--------|
+| 060 | `graph_projection_runs` | CREATE TABLE |
+
+down_revision = 055 (chain: 055 -> 060)
+
+## Tables Created
+
+### `graph_projection_runs`
+
+One row per graph projector invocation. Columns:
+
+| Column | Type | Notes |
+|--------|------|-------|
+| id | BIGSERIAL PK | |
+| mode | TEXT NOT NULL | CHECK: dry_run / incremental / full_rebuild / repair |
+| status | TEXT NOT NULL | CHECK: running / completed / failed / cancelled / cost_exceeded / dry_run_complete |
+| source_cutoff_at | TIMESTAMPTZ | nullable — set when incremental watermark is known |
+| source_card_count | INTEGER | count of knowledge_cards sources processed |
+| source_message_version_count | INTEGER | count of message_versions sources processed |
+| projected_node_count | INTEGER | Neo4j nodes written |
+| projected_edge_count | INTEGER | Neo4j edges written |
+| skipped_policy_count | INTEGER | sources skipped due to governance policy |
+| skipped_budget_count | INTEGER | sources skipped due to cost ceiling |
+| llm_prompt_tokens | INTEGER | aggregated prompt tokens across all LLM calls in run |
+| llm_completion_tokens | INTEGER | aggregated completion tokens |
+| estimated_cost_usd | NUMERIC(10,6) | pre-run cost estimate |
+| actual_cost_usd | NUMERIC(10,6) | post-run actual cost from ledger |
+| started_at | TIMESTAMPTZ NOT NULL | server default now() |
+| finished_at | TIMESTAMPTZ | null while running; set by finalize_run |
+| error_code | TEXT | structured error code on failure |
+| error_context | TEXT | human-readable error detail |
+| started_by | TEXT | free-text label (e.g. 'scheduler', 'admin:149820031') |
+| created_at | TIMESTAMPTZ NOT NULL | server default now() |
+
+Indexes:
+- `ix_graph_projection_runs_started_at` on `started_at DESC`
+- `ix_graph_projection_runs_status` on `status` WHERE status IN ('running', 'failed')
+
+## Coordination Notes for Next Streams
+
+**Unblocked after W0-A merge:**
+
+- W0-B (`feat/p10-w0b-eligibility`): `graph_source_eligibility.py` imports from
+  `bot/services/graph_common.py` (ALLOWED_NODE_TYPES, RefusalError). Can start
+  immediately after merge.
+
+- W0-D (`feat/p10-w0d-neo4j-ci`): Neo4j CI service, docker-compose profile, and
+  `conftest_neo4j.py` fixture. No dependencies on W0-A schema — can start in parallel
+  after W0-A merge.
+
+**Sequential after W0-A (Wave 1):**
+
+- W1-C must add migrations 061-064 sequentially after 060. The `down_revision` chain is:
+  - 061 (graph_provenance) references `graph_projection_runs.id` via FK
+  - 062 (graph_edges) references `graph_provenance.id` via FK
+  - 063 (graph_purge_pending) references `graph_provenance.id` via FK
+  - 064 (llm_usage_ledger.call_type) — independent ALTER; no FK to above tables
+
+- W1-B (extract_graph_triples) waits for W1-C migrations and can reference
+  `RESERVED_LEDGER_CALL_TYPES` from `graph_common.py` for the `call_type` values.
+
+**Reserved ledger.call_type values (documented in graph_common.py):**
+
+Migration 064 (W1-C) will add `call_type VARCHAR(32) NOT NULL DEFAULT 'unknown'` to
+`llm_usage_ledger`. Per PHASE10_PLAN §5.B step 4, all Phase 10 graph projection LLM
+calls use a SINGLE canonical call_type value:
+
+- `graph_projection` — every `extract_graph_triples` LLM call across all projector modes
+
+Mode discrimination (dry_run / incremental / full_rebuild / repair) is captured by the
+`graph_projection_runs.mode` column (CHECK-constrained), NOT by ledger.call_type
+subdivision. The §5.A daily-cost ceiling SQL filters `WHERE call_type = 'graph_projection'`
+unchanged.
+
+See `bot/services/graph_common.py::RESERVED_LEDGER_CALL_TYPES` for the authoritative
+single-value tuple.
+
+## Docs Touched
+
+- `CLAUDE.md` — UNCHANGED (W0-A is infrastructure-only; Phase 10 progress is tracked in IMPLEMENTATION_STATUS.md and will roll into CLAUDE.md "Memory System Cycle" only at Phase 10 closure)
+- `llms.txt` — N/A (file does not exist in repo)
+- `docs/memory-system/PHASE10_PLAN.md` — UPDATED §5.A with `started_by` implementation note (MEDIUM-1 fix)
+- `docs/memory-system/IMPLEMENTATION_STATUS.md` — not yet updated; will be added at W3-E closure assembly

--- a/tests/db/test_digests_review_schema.py
+++ b/tests/db/test_digests_review_schema.py
@@ -125,20 +125,21 @@ async def migrated_database_url(temp_database_url: str) -> AsyncIterator[str]:
     yield temp_database_url
 
 
-# ─── Test: head is now 055 (Phase 9 FHR legacy-grace nullable) ────────────────
+# ─── Test: alembic head is the latest migration ────────────────────────────────
 
 
-async def test_alembic_head_is_055(migrated_database_url: str) -> None:
-    """After upgrade head, alembic_version reports 055 (latest Phase 9 migration).
+async def test_alembic_head_is_latest(migrated_database_url: str) -> None:
+    """After upgrade head, alembic_version reports the latest migration.
 
     Previously asserted '038' (Phase 8 weekly review-gate); rolled forward to
     '054' when T9-01 added wiki migrations 050-054; then to '055' when Phase 9
-    FHR landed the legacy-grace nullable `wiki_page_id` migration. The intent
-    of this test is unchanged — assert the head matches the latest shipped
-    migration. Update the literal when new migrations land.
+    FHR landed the legacy-grace nullable `wiki_page_id` migration; then to '060'
+    when Phase 10 W0-A added graph_projection_runs. The intent of this test is
+    unchanged — assert the head matches the latest shipped migration. Update the
+    literal when new migrations land.
     """
     current = await _fetch_value(migrated_database_url, "SELECT version_num FROM alembic_version")
-    assert current == "055"
+    assert current == "060"
 
 
 # ─── Test: upgrade adds 4 review columns with correct types/nullability ──────

--- a/tests/db/test_fts_schema.py
+++ b/tests/db/test_fts_schema.py
@@ -184,9 +184,10 @@ async def test_alembic_upgrade_head_on_clean_db_green(migrated_database_url: str
     # T6-01 (030-034) + T6-02 (035 operator_user_id) + Phase 6.5 M-2 (036
     # gateway_error) + T7-01 (037 digests) + T8-01 (038 review-gate states)
     # + T9-01 (050-054 wiki schema) + Phase 9 FHR (055 legacy-grace nullable
-    # wiki_page_id) advanced the head past 025. Assert the current head
-    # explicitly; revisit when future migrations land.
-    assert current == "055"
+    # wiki_page_id) + Phase 10 W0-A (060 graph_projection_runs) advanced the
+    # head past 025. Assert the current head explicitly; revisit when future
+    # migrations land.
+    assert current == "060"
 
 
 async def test_insert_message_versions_generates_search_tsv_from_normalized_text(

--- a/tests/db/test_graph_projection_run_repo.py
+++ b/tests/db/test_graph_projection_run_repo.py
@@ -1,0 +1,406 @@
+"""Integration tests for bot/db/repos/graph_projection_run.py (W0-A / Phase 10).
+
+Uses the temp_database_url pattern (like test_fts_schema.py): creates an isolated
+temporary Postgres database, runs alembic upgrade head (which includes migration 060),
+tests the repo CRUD, then drops the database.
+
+Tests are skipped (not failed) if postgres is unreachable.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import uuid
+from collections.abc import AsyncIterator
+from datetime import datetime, timezone
+from decimal import Decimal
+from pathlib import Path
+
+import asyncpg
+import pytest
+import pytest_asyncio
+from sqlalchemy.engine.url import URL, make_url
+
+from tests.conftest import DEFAULT_LOCAL_POSTGRES_URL
+
+pytestmark = pytest.mark.usefixtures("app_env")
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+# ─── Temp DB helpers (same pattern as test_fts_schema.py) ─────────────────────
+
+
+def _base_test_url() -> URL:
+    raw_url = (
+        os.environ.get("TEST_DATABASE_URL")
+        or os.environ.get("DATABASE_URL")
+        or DEFAULT_LOCAL_POSTGRES_URL
+    )
+    return make_url(raw_url)
+
+
+def _asyncpg_kwargs(url: URL, *, database: str | None = None) -> dict[str, object]:
+    return {
+        "user": url.username,
+        "password": url.password,
+        "host": url.host or "127.0.0.1",
+        "port": url.port or 5432,
+        "database": database or url.database,
+    }
+
+
+def _quote_identifier(identifier: str) -> str:
+    return '"' + identifier.replace('"', '""') + '"'
+
+
+async def _create_database(admin_url: URL, database_name: str) -> None:
+    conn = await asyncpg.connect(**_asyncpg_kwargs(admin_url, database="postgres"))
+    try:
+        await conn.execute(f"CREATE DATABASE {_quote_identifier(database_name)}")
+    finally:
+        await conn.close()
+
+
+async def _drop_database(admin_url: URL, database_name: str) -> None:
+    conn = await asyncpg.connect(**_asyncpg_kwargs(admin_url, database="postgres"))
+    try:
+        await conn.execute(
+            """
+            SELECT pg_terminate_backend(pid)
+            FROM pg_stat_activity
+            WHERE datname = $1 AND pid <> pg_backend_pid()
+            """,
+            database_name,
+        )
+        await conn.execute(f"DROP DATABASE IF EXISTS {_quote_identifier(database_name)}")
+    finally:
+        await conn.close()
+
+
+def _run_alembic(database_url: str, *args: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["DATABASE_URL"] = database_url
+    return subprocess.run(
+        [sys.executable, "-m", "alembic", *args],
+        cwd=PROJECT_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=120,
+        check=True,
+    )
+
+
+@pytest_asyncio.fixture()
+async def graph_run_db_url() -> AsyncIterator[str]:
+    """Temp DB with alembic upgrade head (includes migration 060)."""
+    base_url = _base_test_url()
+    database_name = f"shkoder_graph_run_{uuid.uuid4().hex[:12]}"
+    try:
+        await _create_database(base_url, database_name)
+    except Exception as exc:
+        pytest.skip(f"cannot create temporary postgres database: {exc!s}")
+
+    db_url = base_url.set(database=database_name).render_as_string(hide_password=False)
+    try:
+        _run_alembic(db_url, "upgrade", "head")
+    except subprocess.CalledProcessError as exc:
+        await _drop_database(base_url, database_name)
+        pytest.skip(f"alembic upgrade head failed: {exc.stderr}")
+
+    try:
+        yield db_url
+    finally:
+        await _drop_database(base_url, database_name)
+
+
+@pytest_asyncio.fixture()
+async def graph_session(graph_run_db_url: str) -> AsyncIterator:
+    """AsyncSession connected to the migrated temp DB; each test fully isolated."""
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+    engine = create_async_engine(graph_run_db_url, echo=False)
+    try:
+        async with engine.connect() as conn:
+            outer = await conn.begin()
+            Session = async_sessionmaker(
+                bind=conn, class_=AsyncSession, expire_on_commit=False
+            )
+            async with Session() as session:
+                try:
+                    yield session
+                finally:
+                    if outer.is_active:
+                        await outer.rollback()
+    finally:
+        await engine.dispose()
+
+
+# ─── create_run ───────────────────────────────────────────────────────────────
+
+
+async def test_create_run_returns_row_with_started_at(graph_session) -> None:
+    from bot.db.models import GraphProjectionRun
+    from bot.db.repos.graph_projection_run import create_run
+    from sqlalchemy import select
+
+    run = await create_run(graph_session, mode="dry_run", started_by="scheduler")
+
+    assert run.id is not None
+    assert run.mode == "dry_run"
+    assert run.status == "running"
+    assert run.started_at is not None
+    assert run.started_by == "scheduler"
+    assert run.finished_at is None
+
+    # Verify persisted in DB
+    fetched = await graph_session.execute(
+        select(GraphProjectionRun).where(GraphProjectionRun.id == run.id)
+    )
+    row = fetched.scalar_one()
+    assert row.mode == "dry_run"
+    assert row.status == "running"
+
+
+async def test_create_run_accepts_none_started_by(graph_session) -> None:
+    from bot.db.repos.graph_projection_run import create_run
+
+    run = await create_run(graph_session, mode="incremental", started_by=None)
+
+    assert run.started_by is None
+    assert run.mode == "incremental"
+
+
+# ─── update_run_stats ─────────────────────────────────────────────────────────
+
+
+async def test_update_run_stats_deep_merges_jsonb(graph_session) -> None:
+    """update_run_stats preserves existing column values when patching a subset."""
+    from bot.db.repos.graph_projection_run import create_run, update_run_stats
+
+    run = await create_run(graph_session, mode="incremental", started_by="admin:1")
+
+    # First patch: set initial counts
+    await update_run_stats(
+        graph_session, run.id, stats_patch={"projected_node_count": 5, "llm_prompt_tokens": 100}
+    )
+    await graph_session.flush()
+
+    # Fetch and verify first patch applied
+    await graph_session.refresh(run)
+    assert run.projected_node_count == 5
+    assert run.llm_prompt_tokens == 100
+
+    # Second patch: update nodes without touching tokens
+    await update_run_stats(
+        graph_session, run.id,
+        stats_patch={"projected_node_count": 10, "projected_edge_count": 3}
+    )
+    await graph_session.flush()
+
+    await graph_session.refresh(run)
+    assert run.projected_node_count == 10
+    assert run.projected_edge_count == 3
+    # Deep-merge semantics: llm_prompt_tokens not in second patch → stays at 100
+    assert run.llm_prompt_tokens == 100
+
+
+# ─── finalize_run ─────────────────────────────────────────────────────────────
+
+
+async def test_finalize_run_sets_status_and_completed_at(graph_session) -> None:
+    from bot.db.repos.graph_projection_run import create_run, finalize_run
+
+    run = await create_run(graph_session, mode="full_rebuild", started_by=None)
+    assert run.finished_at is None
+    assert run.status == "running"
+
+    await finalize_run(graph_session, run.id, status="completed", cost_usd=Decimal("0.042000"))
+    await graph_session.flush()
+
+    await graph_session.refresh(run)
+    assert run.status == "completed"
+    assert run.finished_at is not None
+    assert run.actual_cost_usd == Decimal("0.042000")
+    # finished_at should be close to now
+    delta = (datetime.now(tz=timezone.utc) - run.finished_at).total_seconds()
+    assert abs(delta) < 60
+
+
+async def test_finalize_run_without_cost_leaves_cost_at_zero(graph_session) -> None:
+    from bot.db.repos.graph_projection_run import create_run, finalize_run
+
+    run = await create_run(graph_session, mode="dry_run", started_by=None)
+    await finalize_run(graph_session, run.id, status="dry_run_complete")
+    await graph_session.flush()
+
+    await graph_session.refresh(run)
+    assert run.status == "dry_run_complete"
+    assert run.actual_cost_usd == Decimal("0")
+
+
+# ─── get_active_run ───────────────────────────────────────────────────────────
+
+
+async def test_get_active_run_returns_only_running(graph_session) -> None:
+    from bot.db.repos.graph_projection_run import create_run, finalize_run, get_active_run
+
+    # No running run initially
+    active = await get_active_run(graph_session)
+    assert active is None
+
+    # Create a running run
+    run = await create_run(graph_session, mode="incremental", started_by=None)
+    await graph_session.flush()
+
+    active = await get_active_run(graph_session)
+    assert active is not None
+    assert active.id == run.id
+    assert active.status == "running"
+
+    # Finalize it — should no longer be active
+    await finalize_run(graph_session, run.id, status="completed")
+    await graph_session.flush()
+
+    active = await get_active_run(graph_session)
+    assert active is None
+
+
+# ─── list_recent_runs ─────────────────────────────────────────────────────────
+
+
+async def test_list_recent_runs_ordered_desc_by_started_at(graph_session) -> None:
+    from bot.db.repos.graph_projection_run import create_run, list_recent_runs
+
+    # Create 3 runs in order
+    run1 = await create_run(graph_session, mode="dry_run", started_by=None)
+    run2 = await create_run(graph_session, mode="incremental", started_by=None)
+    run3 = await create_run(graph_session, mode="full_rebuild", started_by=None)
+    await graph_session.flush()
+
+    runs = await list_recent_runs(graph_session, limit=10)
+
+    # Should return at least our 3 runs
+    ids_returned = [r.id for r in runs]
+    assert run1.id in ids_returned
+    assert run2.id in ids_returned
+    assert run3.id in ids_returned
+
+    # Most recent first (DESC order by started_at then id)
+    our_runs = [r for r in runs if r.id in {run1.id, run2.id, run3.id}]
+    our_ids = [r.id for r in our_runs]
+    # run3 was created last → higher id → should appear before run2 and run1
+    assert our_ids.index(run3.id) < our_ids.index(run2.id)
+    assert our_ids.index(run2.id) < our_ids.index(run1.id)
+
+
+async def test_list_recent_runs_respects_limit(graph_session) -> None:
+    from bot.db.repos.graph_projection_run import create_run, list_recent_runs
+
+    for _ in range(5):
+        await create_run(graph_session, mode="dry_run", started_by=None)
+    await graph_session.flush()
+
+    runs = await list_recent_runs(graph_session, limit=3)
+    assert len(runs) <= 3
+
+
+# ─── HIGH-3: finalize_run state-machine guard ─────────────────────────────────
+
+
+async def test_finalize_run_rejects_non_terminal_status(graph_session) -> None:
+    """finalize_run raises ValueError when called with a non-terminal status."""
+    from bot.db.repos.graph_projection_run import create_run, finalize_run
+
+    run = await create_run(graph_session, mode="dry_run", started_by=None)
+    await graph_session.flush()
+
+    with pytest.raises(ValueError, match="requires a terminal status"):
+        await finalize_run(graph_session, run.id, status="running")  # type: ignore[arg-type]
+
+
+async def test_finalize_run_idempotent_for_same_terminal(graph_session) -> None:
+    """finalize_run is a no-op when called twice with the same terminal status."""
+    from bot.db.repos.graph_projection_run import create_run, finalize_run
+
+    run = await create_run(graph_session, mode="incremental", started_by=None)
+    await graph_session.flush()
+
+    await finalize_run(graph_session, run.id, status="completed")
+    await graph_session.flush()
+
+    # Second call with same status must not raise
+    await finalize_run(graph_session, run.id, status="completed")
+
+
+async def test_finalize_run_rejects_terminal_to_different_terminal(graph_session) -> None:
+    """finalize_run raises ValueError when attempting succeeded → failed transition."""
+    from bot.db.repos.graph_projection_run import create_run, finalize_run
+
+    run = await create_run(graph_session, mode="full_rebuild", started_by=None)
+    await graph_session.flush()
+
+    await finalize_run(graph_session, run.id, status="completed")
+    await graph_session.flush()
+
+    with pytest.raises(ValueError, match="already"):
+        await finalize_run(graph_session, run.id, status="failed")
+
+
+# ─── HIGH-4: update_run_stats rejects unknown keys ────────────────────────────
+
+
+async def test_update_run_stats_rejects_unknown_keys(graph_session) -> None:
+    """update_run_stats raises ValueError for unknown column names."""
+    from bot.db.repos.graph_projection_run import create_run, update_run_stats
+
+    run = await create_run(graph_session, mode="dry_run", started_by=None)
+    await graph_session.flush()
+
+    with pytest.raises(ValueError, match="unknown keys"):
+        await update_run_stats(graph_session, run.id, stats_patch={"bogus_col": 1})
+
+
+async def test_update_run_stats_empty_patch_is_noop(graph_session) -> None:
+    """update_run_stats with empty dict does not touch the row."""
+    from bot.db.repos.graph_projection_run import create_run, update_run_stats
+
+    run = await create_run(graph_session, mode="dry_run", started_by=None)
+    await graph_session.flush()
+
+    # Empty patch must not raise and must not modify the row
+    await update_run_stats(graph_session, run.id, stats_patch={})
+    await graph_session.refresh(run)
+    assert run.projected_node_count == 0  # untouched
+
+
+# ─── MEDIUM-3: get_active_run deterministic ordering ─────────────────────────
+
+
+async def test_get_active_run_deterministic_on_tied_started_at(graph_session) -> None:
+    """When two running rows share started_at, get_active_run returns the higher id."""
+    from sqlalchemy import update as sa_update
+
+    from bot.db.models import GraphProjectionRun
+    from bot.db.repos.graph_projection_run import create_run, get_active_run
+
+    run1 = await create_run(graph_session, mode="dry_run", started_by=None)
+    run2 = await create_run(graph_session, mode="incremental", started_by=None)
+    await graph_session.flush()
+
+    # Force both rows to the same started_at to simulate a tied timestamp
+    tied_ts = run1.started_at
+    await graph_session.execute(
+        sa_update(GraphProjectionRun)
+        .where(GraphProjectionRun.id.in_([run1.id, run2.id]))
+        .values(started_at=tied_ts)
+    )
+    await graph_session.flush()
+
+    active = await get_active_run(graph_session)
+    assert active is not None
+    # Higher id should win on tied started_at (ORDER BY started_at DESC, id DESC)
+    assert active.id == max(run1.id, run2.id)

--- a/tests/unit/test_graph_common.py
+++ b/tests/unit/test_graph_common.py
@@ -1,0 +1,160 @@
+"""Unit tests for bot/services/graph_common.py (W0-A / Phase 10).
+
+Tests verify:
+- ALLOWED_NODE_TYPES, ALLOWED_PREDICATES, RESERVED_LEDGER_CALL_TYPES constants
+- GraphNodeRef validates node_type membership
+- GraphEdgeRef validates predicate membership
+- RefusalError hierarchy (GraphProjectionPolicyError, GraphProjectionBudgetError)
+- RepairModeContract Protocol exists
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+# ─── Constants ───────────────────────────────────────────────────────────────
+
+
+def test_graph_common_constants_present() -> None:
+    from bot.services.graph_common import (
+        ALLOWED_NODE_TYPES,
+        ALLOWED_PREDICATES,
+        RESERVED_LEDGER_CALL_TYPES,
+        GraphProjectionMode,
+        GraphProjectionRunStatus,
+        RepairModeContract,
+    )
+
+    # ALLOWED_NODE_TYPES: 9 types per §5.B prompt template
+    assert len(ALLOWED_NODE_TYPES) == 9
+    assert "Person" in ALLOWED_NODE_TYPES
+    assert "KnowledgeCard" in ALLOWED_NODE_TYPES
+    assert "Source" in ALLOWED_NODE_TYPES
+
+    # ALLOWED_PREDICATES: 12 predicates per §5.B
+    assert len(ALLOWED_PREDICATES) == 12
+    assert "MENTIONS" in ALLOWED_PREDICATES
+    assert "SUPERSEDES" in ALLOWED_PREDICATES
+
+    # RESERVED_LEDGER_CALL_TYPES: exactly one value per PHASE10_PLAN §5.B step 4
+    assert RESERVED_LEDGER_CALL_TYPES == ("graph_projection",), RESERVED_LEDGER_CALL_TYPES
+
+    # GraphProjectionMode: exactly the 4 CHECK constraint values from migration 060
+    assert GraphProjectionMode.__args__ == ("dry_run", "incremental", "full_rebuild", "repair")
+
+    # GraphProjectionRunStatus: exactly the 6 CHECK constraint values from migration 060
+    assert GraphProjectionRunStatus.__args__ == (
+        "running", "completed", "failed", "cancelled", "cost_exceeded", "dry_run_complete"
+    )
+
+    # RepairModeContract is importable
+    assert RepairModeContract is not None
+
+
+# ─── GraphNodeRef validation ──────────────────────────────────────────────────
+
+
+def test_graph_node_ref_validates_node_type() -> None:
+    from bot.services.graph_common import GraphNodeRef
+
+    # Valid construction
+    ref = GraphNodeRef(node_key="key:abc", node_type="Person")
+    assert ref.node_key == "key:abc"
+    assert ref.node_type == "Person"
+
+    # Invalid node_type raises ValueError
+    with pytest.raises(ValueError, match="node_type"):
+        GraphNodeRef(node_key="key:abc", node_type="InvalidType")
+
+
+def test_graph_node_ref_is_frozen() -> None:
+    from bot.services.graph_common import GraphNodeRef
+
+    ref = GraphNodeRef(node_key="key:abc", node_type="Topic")
+    with pytest.raises(Exception):
+        ref.node_key = "different"  # type: ignore[misc]
+
+
+# ─── GraphEdgeRef validation ──────────────────────────────────────────────────
+
+
+def test_graph_edge_ref_validates_predicate() -> None:
+    from bot.services.graph_common import GraphEdgeRef
+
+    # Valid construction
+    edge = GraphEdgeRef(
+        edge_key="edge:abc",
+        source_key="src:1",
+        target_key="tgt:2",
+        predicate="MENTIONS",
+    )
+    assert edge.predicate == "MENTIONS"
+
+    # Invalid predicate raises ValueError
+    with pytest.raises(ValueError, match="predicate"):
+        GraphEdgeRef(
+            edge_key="edge:abc",
+            source_key="src:1",
+            target_key="tgt:2",
+            predicate="INVALID_PREDICATE",
+        )
+
+
+def test_graph_edge_ref_is_frozen() -> None:
+    from bot.services.graph_common import GraphEdgeRef
+
+    edge = GraphEdgeRef(
+        edge_key="edge:abc",
+        source_key="src:1",
+        target_key="tgt:2",
+        predicate="RELATED_TO",
+    )
+    with pytest.raises(Exception):
+        edge.predicate = "MENTIONS"  # type: ignore[misc]
+
+
+# ─── Error hierarchy ──────────────────────────────────────────────────────────
+
+
+def test_refusal_error_hierarchy() -> None:
+    from bot.services.graph_common import (
+        GraphProjectionBudgetError,
+        GraphProjectionPolicyError,
+        RefusalError,
+    )
+
+    # GraphProjectionPolicyError is-a RefusalError
+    policy_err = GraphProjectionPolicyError("governance_policy != normal")
+    assert isinstance(policy_err, RefusalError)
+    assert isinstance(policy_err, Exception)
+
+    # GraphProjectionBudgetError is-a RefusalError
+    budget_err = GraphProjectionBudgetError("cost ceiling exceeded")
+    assert isinstance(budget_err, RefusalError)
+    assert isinstance(budget_err, Exception)
+
+    # They are distinct types
+    assert not isinstance(policy_err, GraphProjectionBudgetError)
+    assert not isinstance(budget_err, GraphProjectionPolicyError)
+
+
+# ─── RepairModeContract Protocol ─────────────────────────────────────────────
+
+
+def test_repair_mode_contract_protocol_shape() -> None:
+    """RepairModeContract declares the repair_mode API surface."""
+    import inspect
+
+    from bot.services.graph_common import RepairModeContract
+
+    # Protocol should have request_repair as an abstract method
+    assert hasattr(RepairModeContract, "request_repair")
+    method = RepairModeContract.request_repair
+    sig = inspect.signature(method)
+    params = list(sig.parameters.keys())
+    # Should have self + keyword params
+    assert "self" in params
+    assert "source_table" in params
+    assert "source_pk" in params
+    assert "reason" in params


### PR DESCRIPTION
## Summary

Sprint **W0-A** of Phase 10 (Graph Projection / Neo4j) — BLOCKING foundation gate. Unlocks parallel W0-B (T10-02 source eligibility helpers) and W0-D (Neo4j CI service) after merge.

- Migration 060 `graph_projection_runs` per `PHASE10_PLAN.md §5.A` (verbatim, plus `started_by TEXT NULL` for admin/scheduler audit — documented in §5.A implementation note)
- `bot/services/graph_common.py` — shared types/constants. `RESERVED_LEDGER_CALL_TYPES=('graph_projection',)` single value per §5.B step 4 (mode discrimination via `graph_projection_runs.mode`, not call_type subdivision)
- `bot/db/repos/graph_projection_run.py` — async repo with state-machine guard on `finalize_run`, unknown-key rejection on `update_run_stats`, deterministic ordering `(started_at DESC, id DESC)`, flush-only (caller owns transaction)
- `bot/db/models.py` — `GraphProjectionRun` ORM. Index metadata `text("started_at DESC")` matches migration (no drift)
- Per-PR rollout fragment `docs/rollout-fragments/phase10/W0-A.md` (assembled into `PHASE10_ROLLOUT.md` at W3-E)
- `.superflow/charter.md` — Phase 10 wave plan + coordination rules (from duo dialogue 3 iterations)

## Test plan

- [x] `pytest tests/unit/test_graph_common.py` — 7/7 pass (constants, dataclass freezing/validation, error hierarchy, Protocol shape)
- [x] `pytest tests/db/test_graph_projection_run_repo.py` — 14/14 pass (CRUD + state-machine guards + unknown-key rejection + tied-timestamp determinism + idempotency)
- [x] Full suite: 1391/1391 pass (1 pre-existing failure `test_live_gateway_adapter_satisfies_protocol_and_delegates` requires `BOT_TOKEN`, unrelated)
- [x] `ruff check` — all clean
- [x] `alembic history` — `055 -> 060 (head)` confirmed
- [x] Coordination boundaries respected — no edits to `cascade_worker.py`, `forget_cascade.py`, `llm_gateway.py`, `graph_query.py`, `graph_projector.py`, `graph_purge_worker.py`, `graph_purge_readblock.py`, `graph_adapter.py`, `.github/workflows/*` (all owned by other Phase 10 streams)

## Unified Review

- **Claude product (standard-product-reviewer, opus):** round 1 NEEDS_FIXES (2 HIGH RESERVED_LEDGER_CALL_TYPES + 2 MEDIUM + 2 LOW). Round 2 **ACCEPTED**.
- **Codex technical (codex:codex-rescue):** round 1 REQUEST_CHANGES (2 HIGH state-machine+unknown-keys + 2 MEDIUM ordering+index-drift + 1 LOW test-name). Round 2 **APPROVE**.
- All 11 findings closed in one consolidated revision pass.

## Docs

- `docs/memory-system/PHASE10_PLAN.md` §5.A — added W0-A implementation note for `started_by` column
- `docs/rollout-fragments/phase10/W0-A.md` — per-PR fragment (concat into `PHASE10_ROLLOUT.md` at W3-E)
- `CLAUDE.md` UNCHANGED (Phase 10 progress rolls into CLAUDE.md only at Phase 10 closure)
- `llms.txt` N/A (does not exist in repo)
- `IMPLEMENTATION_STATUS.md` UNCHANGED in this PR (will be updated at Phase 10 closure)

## Next streams (unblocked by this merge)

- **W0-B** (parallel) — T10-02 source eligibility + governance pre-filter helpers
- **W0-D** (parallel) — Neo4j CI service block + docker-compose-test + pytest fixture

Then sequential Wave 1: W1-C (migrations 061-064) → W1-B (T10-04 LLM extract).

🤖 Generated with [Claude Code](https://claude.com/claude-code)