### PR TITLE
feat(p10-w0d): Neo4j CI service + pytest fixture + graph_integration marker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,18 @@ jobs:
           --health-interval 5s
           --health-timeout 3s
           --health-retries 10
+      neo4j:
+        image: neo4j:5.20-community
+        env:
+          NEO4J_AUTH: neo4j/ci-test-password-min-32-chars-ok!
+        ports:
+          - 7687:7687
+          - 7474:7474
+        options: >-
+          --health-cmd "wget --spider --quiet http://localhost:7474 || exit 1"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 12
     env:
       BOT_TOKEN: 123456:test-token
       COMMUNITY_CHAT_ID: -1001234567890
@@ -41,6 +53,9 @@ jobs:
       WEB_PASSWORD: test-pass
       WEB_SESSION_SECRET: test-session-secret
       DEV_MODE: "true"
+      NEO4J_BOLT_URI: bolt://localhost:7687
+      NEO4J_AUTH_USER: neo4j
+      NEO4J_AUTH_PASSWORD: ci-test-password-min-32-chars-ok!
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -43,6 +43,18 @@ jobs:
           --health-interval 5s
           --health-timeout 3s
           --health-retries 10
+      neo4j:
+        image: neo4j:5.20-community
+        env:
+          NEO4J_AUTH: neo4j/ci-test-password-min-32-chars-ok!
+        ports:
+          - 7687:7687
+          - 7474:7474
+        options: >-
+          --health-cmd "wget --spider --quiet http://localhost:7474 || exit 1"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 12
     env:
       BOT_TOKEN: 123456:test-token
       COMMUNITY_CHAT_ID: -1001234567890
@@ -57,6 +69,9 @@ jobs:
       WEB_PASSWORD: test-pass
       WEB_SESSION_SECRET: test-session-secret
       DEV_MODE: "true"
+      NEO4J_BOLT_URI: bolt://localhost:7687
+      NEO4J_AUTH_USER: neo4j
+      NEO4J_AUTH_PASSWORD: ci-test-password-min-32-chars-ok!
     steps:
       - uses: actions/checkout@v4
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,12 +53,16 @@ services:
     volumes:
       - neo4j_data:/data
     environment:
-      NEO4J_AUTH: neo4j/${NEO4J_PASSWORD:-test_password_min_32_chars_for_neo4j_5}
+      # NEO4J_AUTH_PASSWORD is the canonical name (matches Settings.NEO4J_AUTH_PASSWORD in
+      # bot/config.py and the env var used by conftest.py neo4j_session fixture + CI workflows).
+      # The legacy NEO4J_PASSWORD is accepted as a fallback for backward compatibility.
+      NEO4J_AUTH: neo4j/${NEO4J_AUTH_PASSWORD:-${NEO4J_PASSWORD:-test_password_min_32_chars_for_neo4j_5}}
+      NEO4J_AUTH_USER: neo4j
       NEO4J_server_memory_heap_initial__size: 512m
       NEO4J_server_memory_heap_max__size: 512m
       NEO4J_server_memory_pagecache_size: 512m
     healthcheck:
-      test: ["CMD-SHELL", "cypher-shell -u neo4j -p $${NEO4J_PASSWORD:-test_password_min_32_chars_for_neo4j_5} 'RETURN 1' || exit 1"]
+      test: ["CMD-SHELL", "cypher-shell -u neo4j -p $${NEO4J_AUTH_PASSWORD:-$${NEO4J_PASSWORD:-test_password_min_32_chars_for_neo4j_5}} 'RETURN 1' || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 5

--- a/docs/rollout-fragments/phase10/W0-D.md
+++ b/docs/rollout-fragments/phase10/W0-D.md
@@ -1,0 +1,84 @@
+# W0-D: Neo4j CI Service Infrastructure
+
+## Summary
+
+Adds Neo4j as a GitHub Actions service container (evals.yml + ci.yml), registers the
+`graph_integration` pytest marker, adds a `neo4j_session` fixture with auto-skip when
+`NEO4J_BOLT_URI` is absent, and provides smoke tests. Neo4j is already present in
+docker-compose.yml under `profiles: [graph]` — updated to align env var naming (see Coordination Notes).
+
+## Neo4j Image
+
+`neo4j:5.20-community` — stable Neo4j 5.x Community Edition tag.
+
+## Env Vars Introduced
+
+| Variable | Value in CI | Where set |
+|---|---|---|
+| `NEO4J_BOLT_URI` | `bolt://localhost:7687` | GitHub Actions `env:` block in ci.yml and evals.yml |
+| `NEO4J_AUTH_USER` | `neo4j` | Same |
+| `NEO4J_AUTH_PASSWORD` | `ci-test-password-min-32-chars-ok!` | Same (32 chars; matches Neo4j 5 default policy) |
+
+For local dev, these are set automatically by `docker-compose.dev.yml neo4j-dev` service or
+`docker-compose.yml --profile graph neo4j` service. The fixture auto-skips if `NEO4J_BOLT_URI`
+is not exported.
+
+## New Pytest Marker
+
+`graph_integration` — marks tests that require a live Neo4j bolt endpoint. Tests skip
+automatically if `NEO4J_BOLT_URI` is not set. Registered in `[tool.pytest.ini_options]` in
+`pyproject.toml`.
+
+## New Fixture
+
+`neo4j_session` in `tests/conftest.py` — async Neo4j session that cleans all nodes/edges
+before each test (`MATCH (n) DETACH DELETE n`). Closes driver on teardown.
+
+Safety guard: the fixture validates the `NEO4J_BOLT_URI` host against an allowlist
+(`localhost`, `127.0.0.1`, `neo4j`, `neo4j-test`) and calls `pytest.fail()` if the host is
+outside the list, preventing accidental wipes of staging/production data.
+
+## Smoke Tests
+
+`tests/integration/test_neo4j_fixture.py`:
+- `test_neo4j_fixture_connects_and_returns_data` — MERGE + read a TestNode
+- `test_neo4j_fixture_cleans_between_tests` — verify DB is empty at test start
+
+Both tests are `@pytest.mark.graph_integration` and SKIP locally without Neo4j.
+
+## Coordination Notes
+
+### Env var naming alignment
+
+`NEO4J_AUTH_PASSWORD` is the canonical variable name — it matches `Settings.NEO4J_AUTH_PASSWORD`
+in `bot/config.py` and is used directly by `conftest.py` `neo4j_session` and the CI workflow
+`env:` blocks.
+
+`docker-compose.yml` resolves the password as
+`${NEO4J_AUTH_PASSWORD:-${NEO4J_PASSWORD:-<default>}}` — it prefers the canonical name and
+falls back to `NEO4J_PASSWORD` for backward compatibility with pre-W0-D setups.
+
+This sprint unblocks:
+- T10-03 (LLM extract) binding tests that write/read Neo4j
+- W2-B (graph_projector) integration tests
+- W2-C (purge worker) integration tests
+- W2.5-D (graph_query) integration tests
+- T10-09 cross-component binding tests in tests/evals/
+
+## Files Changed
+
+| File | Change |
+|---|---|
+| `.github/workflows/evals.yml` | Add neo4j service + NEO4J_* env vars; fix password to 32 chars |
+| `.github/workflows/ci.yml` | Add neo4j service + NEO4J_* env vars; fix password to 32 chars |
+| `docker-compose.yml` | Align NEO4J_AUTH to prefer NEO4J_AUTH_PASSWORD (canonical); add NEO4J_AUTH_USER |
+| `tests/conftest.py` | Add neo4j_session fixture with host allowlist guard |
+| `pyproject.toml` | Register graph_integration marker |
+| `tests/integration/test_neo4j_fixture.py` | New smoke tests |
+| `docs/rollout-fragments/phase10/W0-D.md` | This file |
+
+## Docs Touched
+
+- CLAUDE.md: UNCHANGED
+- llms.txt: N/A (no new public API surface)
+- IMPLEMENTATION_STATUS: deferred to W3-E per plan

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ pythonpath = ["."]
 asyncio_mode = "auto"
 markers = [
     "graph_unit: unit tests for graph adapter using NetworkXAdapter (no real Neo4j required)",
+    "graph_integration: integration tests that require a live Neo4j instance (NEO4J_BOLT_URI must be set)",
 ]
 
 [tool.ruff]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -118,6 +118,55 @@ def graph_adapter_fake() -> NetworkXAdapter:
     return NetworkXAdapter()
 
 
+_NEO4J_SAFE_HOSTS = {"localhost", "127.0.0.1", "neo4j", "neo4j-test"}
+
+
+def _neo4j_host_from_uri(uri: str) -> str:
+    """Extract the host portion from a bolt URI (e.g. bolt://localhost:7687 → localhost)."""
+    from urllib.parse import urlparse
+
+    return urlparse(uri).hostname or ""
+
+
+@pytest_asyncio.fixture()
+async def neo4j_session():
+    """Provides a cleaned Neo4j async session for tests marked @pytest.mark.graph_integration.
+
+    Connects to the bolt URI in NEO4J_BOLT_URI (CI Neo4j service or local compose).
+    Cleans all nodes/relationships BEFORE yielding so each test starts with an empty DB.
+    Closes the session and driver after the test.
+
+    Skipped automatically if NEO4J_BOLT_URI is not set in env (allows local dev without Neo4j).
+
+    Safety guard: refuses to wipe the DB if the URI host is not in the local allowlist
+    {localhost, 127.0.0.1, neo4j, neo4j-test}. This prevents accidentally wiping data when
+    NEO4J_BOLT_URI is mistakenly pointed at a staging or production instance.
+    """
+    bolt_uri = os.environ.get("NEO4J_BOLT_URI")
+    if not bolt_uri:
+        pytest.skip("NEO4J_BOLT_URI not set — skipping graph_integration test")
+
+    host = _neo4j_host_from_uri(bolt_uri)
+    if host not in _NEO4J_SAFE_HOSTS:
+        pytest.fail(
+            f"neo4j_session fixture refuses to wipe non-local Neo4j (host={host!r}). "
+            "Set NEO4J_BOLT_URI to localhost or a *-test instance for tests."
+        )
+
+    from neo4j import AsyncGraphDatabase  # type: ignore[import]
+
+    user = os.environ.get("NEO4J_AUTH_USER", "neo4j")
+    password = os.environ.get("NEO4J_AUTH_PASSWORD", "")
+    driver = AsyncGraphDatabase.driver(bolt_uri, auth=(user, password))
+    try:
+        async with driver.session(database="neo4j") as session:
+            # Clean before test so each test starts with an empty graph
+            await session.run("MATCH (n) DETACH DELETE n")
+            yield session
+    finally:
+        await driver.close()
+
+
 @pytest_asyncio.fixture()
 async def db_session(postgres_engine) -> AsyncIterator:
     """Yield an AsyncSession bound to the test postgres.

--- a/tests/integration/test_neo4j_fixture.py
+++ b/tests/integration/test_neo4j_fixture.py
@@ -1,0 +1,43 @@
+"""Smoke tests for the neo4j_session fixture (W0-D).
+
+Tests are marked @pytest.mark.graph_integration and are SKIPPED when
+NEO4J_BOLT_URI is not set (local dev without Neo4j). In CI the service is
+present and NEO4J_BOLT_URI is set, so tests RUN.
+
+Two behavioral tests:
+  1. Fixture connects and returns data — MERGE + READ a node.
+  2. Fixture cleans between tests — second test sees an empty DB.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.graph_integration
+@pytest.mark.asyncio
+async def test_neo4j_fixture_connects_and_returns_data(neo4j_session) -> None:
+    """Fixture connects to Neo4j, runs MERGE, and reads the node back."""
+    await neo4j_session.run(
+        "MERGE (n:TestNode {key: $key}) SET n.value = $value",
+        key="smoke-1",
+        value="hello",
+    )
+    result = await neo4j_session.run(
+        "MATCH (n:TestNode {key: $key}) RETURN n.value AS v",
+        key="smoke-1",
+    )
+    record = await result.single()
+    assert record is not None
+    assert record["v"] == "hello"
+
+
+@pytest.mark.graph_integration
+@pytest.mark.asyncio
+async def test_neo4j_fixture_cleans_between_tests(neo4j_session) -> None:
+    """DB is empty at start of each test — node from previous test must not exist."""
+    result = await neo4j_session.run("MATCH (n) RETURN count(n) AS cnt")
+    record = await result.single()
+    assert record is not None
+    # DB should be empty — cleanup ran before this test
+    assert record["cnt"] == 0


### PR DESCRIPTION
## Summary

Sprint **W0-D** of Phase 10 (Graph Projection / Neo4j) — independent infrastructure sprint. Adds Neo4j 5.20-community service to CI workflows so Phase 10 graph-touching binding tests can run automatically:

- `.github/workflows/evals.yml` + `.github/workflows/ci.yml` — `neo4j:5.20-community` service alongside postgres
- `tests/conftest.py` — async `neo4j_session` fixture with host allowlist guard
- `pyproject.toml` — `graph_integration` pytest marker
- `docker-compose.yml` — env var alignment (`${NEO4J_AUTH_PASSWORD:-${NEO4J_PASSWORD:-…}}` fallback chain)

## Test plan

- [x] `tests/integration/test_neo4j_fixture.py` — 2 smoke tests, SKIPPED locally when `NEO4J_BOLT_URI` unset
- [x] Skip-path verified: `pytest tests/integration/test_neo4j_fixture.py` → 2 skipped
- [x] YAML validation: evals.yml + ci.yml + docker-compose.yml all parse clean
- [x] `ruff check` — all clean
- [x] Coordination boundaries respected — no edits to `bot/`, `alembic/`, only workflow + test infra

## Unified Review

- **Claude product (standard-product-reviewer, opus):** ACCEPTED. Concern noted as Phase 10.5 carryover.
- **Codex technical (codex:codex-rescue):** round 1 REQUEST_CHANGES (1 HIGH staging-observation, 1 MEDIUM env-name mismatch, 1 LOW password length). Fixed in single revision pass. CI password padded to 33 chars; fixture host allowlist guard added; docker-compose env var alignment closes dev↔CI naming gap.

## Docs

- `docs/rollout-fragments/phase10/W0-D.md` — per-PR fragment (concat into PHASE10_ROLLOUT.md at W3-E)
- `CLAUDE.md` UNCHANGED (Phase 10 progress rolls in at closure)
- `llms.txt` N/A (does not exist)
- `IMPLEMENTATION_STATUS.md` UNCHANGED (deferred to W3-E)

## Phase 10.5 carryover

- Fuller wipe-protection (e.g. require explicit `NEO4J_TEST_DB=true` env flag) — current minimal allowlist refuses non-local hosts only.

## Unblocked by this merge

- T10-03 LLM extract Neo4j binding tests
- W2-B graph_projector tests
- W2-C purge worker tests
- W2.5-D graph_query tests
- T10-09 cross-component scenarios

Independent of T10-02-rest (migrations 061+062, also in flight as separate PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)