### PR TITLE
feat(p10-t10-02): migrations 061 (provenance) + 062 (edges) + repos

### DIFF
--- a/alembic/versions/061_add_graph_provenance.py
+++ b/alembic/versions/061_add_graph_provenance.py
@@ -1,0 +1,135 @@
+"""add_graph_provenance
+
+Phase 10 / T10-02: creates graph_provenance table.
+
+Maps each projected source (message_version or knowledge_card) to the Neo4j
+graph. Used by forget cascade (logical source_table/source_pk lookup) and by
+drift detection (active non-purged rows vs Neo4j node count).
+
+source_table / source_pk are intentionally NOT typed FK columns — they are
+logical application-code refs queried by _cascade_graph_provenance. The FK ON
+DELETE CASCADE on source_card_id / source_message_version_id is a safety net
+only. See PHASE10_PLAN.md §5.A for rationale.
+
+Revision ID: 061
+Revises: 060
+Create Date: 2026-05-20
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "061"
+down_revision: Union[str, Sequence[str], None] = "060"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_TABLE = "graph_provenance"
+_CK_SOURCE_TABLE = "ck_graph_provenance_source_table"
+_CK_HAS_SOURCE = "ck_graph_provenance_has_source"
+_CK_GRAPH_STORE = "ck_graph_provenance_graph_store"
+_IX_MVID = "ix_graph_provenance_mvid"
+_IX_CARD_ID = "ix_graph_provenance_card_id"
+_IX_ACTIVE = "ix_graph_provenance_active"
+_UQ_TRIPLE = "uq_graph_provenance_triple"
+
+
+def upgrade() -> None:
+    op.create_table(
+        _TABLE,
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("projection_run_id", sa.BigInteger(), nullable=False),
+        sa.Column("source_table", sa.Text(), nullable=False),
+        sa.Column("source_pk", sa.Text(), nullable=False),
+        sa.Column("source_message_version_id", sa.BigInteger(), nullable=True),
+        sa.Column("source_card_id", sa.Uuid(), nullable=True),
+        sa.Column("source_content_hash", sa.Text(), nullable=True),
+        sa.Column(
+            "graph_store", sa.Text(), nullable=False, server_default="neo4j"
+        ),
+        sa.Column("graph_node_key", sa.Text(), nullable=True),
+        sa.Column("graph_edge_key", sa.Text(), nullable=True),
+        sa.Column("triple_hash", sa.Text(), nullable=True),
+        sa.Column(
+            "governance_policy", sa.Text(), nullable=False, server_default="normal"
+        ),
+        sa.Column(
+            "created_at", sa.DateTime(timezone=True), nullable=False,
+            server_default=sa.func.now()
+        ),
+        sa.Column("purged_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("purge_reason", sa.Text(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+        sa.ForeignKeyConstraint(
+            ["projection_run_id"],
+            ["graph_projection_runs.id"],
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["source_message_version_id"],
+            ["message_versions.id"],
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["source_card_id"],
+            ["knowledge_cards.id"],
+            ondelete="CASCADE",
+        ),
+        sa.CheckConstraint(
+            "source_table IN ('message_versions', 'knowledge_cards')",
+            name=_CK_SOURCE_TABLE,
+        ),
+        sa.CheckConstraint(
+            "source_message_version_id IS NOT NULL OR source_card_id IS NOT NULL",
+            name=_CK_HAS_SOURCE,
+        ),
+        sa.CheckConstraint(
+            "graph_store IN ('neo4j', 'networkx_dev')",
+            name=_CK_GRAPH_STORE,
+        ),
+    )
+
+    # Cascade forget lookup: find all graph provenance rows for a given message_version
+    op.create_index(
+        _IX_MVID,
+        _TABLE,
+        ["source_message_version_id"],
+        postgresql_where=sa.text("source_message_version_id IS NOT NULL"),
+    )
+
+    # Cascade forget lookup: find all graph provenance rows for a given card
+    op.create_index(
+        _IX_CARD_ID,
+        _TABLE,
+        ["source_card_id"],
+        postgresql_where=sa.text("source_card_id IS NOT NULL"),
+    )
+
+    # Drift detection: active (non-purged) provenance rows
+    op.create_index(
+        _IX_ACTIVE,
+        _TABLE,
+        ["projection_run_id"],
+        postgresql_where=sa.text("purged_at IS NULL"),
+    )
+
+    # Idempotency: stable triple key within a projection run
+    op.create_index(
+        _UQ_TRIPLE,
+        _TABLE,
+        ["source_table", "source_pk", "triple_hash"],
+        unique=True,
+        postgresql_where=sa.text("purged_at IS NULL"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(_UQ_TRIPLE, table_name=_TABLE)
+    op.drop_index(_IX_ACTIVE, table_name=_TABLE)
+    op.drop_index(_IX_CARD_ID, table_name=_TABLE)
+    op.drop_index(_IX_MVID, table_name=_TABLE)
+    op.drop_table(_TABLE)

--- a/alembic/versions/062_add_graph_edges.py
+++ b/alembic/versions/062_add_graph_edges.py
@@ -1,0 +1,98 @@
+"""add_graph_edges
+
+Phase 10 / T10-02: creates graph_edges table.
+
+Postgres-side edge registry for idempotency, drift detection, and cascade
+lookup. Neo4j holds the traversable graph; this table proves every Neo4j edge
+has a Postgres-side provenance record.
+
+Predicate vocabulary is CHECK-constrained to ALLOWED_PREDICATES from
+bot/services/graph_common.py (same list).
+
+Revision ID: 062
+Revises: 061
+Create Date: 2026-05-20
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "062"
+down_revision: Union[str, Sequence[str], None] = "061"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_TABLE = "graph_edges"
+_CK_PREDICATE = "ck_graph_edges_predicate"
+_CK_CONFIDENCE = "ck_graph_edges_confidence"
+_IX_ACTIVE = "ix_graph_edges_active"
+_UQ_KEY = "uq_graph_edges_key"
+
+
+def upgrade() -> None:
+    op.create_table(
+        _TABLE,
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("graph_provenance_id", sa.BigInteger(), nullable=False),
+        sa.Column("subject_node_key", sa.Text(), nullable=False),
+        sa.Column("predicate", sa.Text(), nullable=False),
+        sa.Column("object_node_key", sa.Text(), nullable=False),
+        # stable MERGE key: SHA-256(subject+predicate+object)
+        sa.Column("edge_key", sa.Text(), nullable=False),
+        sa.Column(
+            "confidence_score",
+            sa.Numeric(precision=3, scale=2),
+            nullable=False,
+            server_default="0.50",
+        ),
+        sa.Column(
+            "created_at", sa.DateTime(timezone=True), nullable=False,
+            server_default=sa.func.now()
+        ),
+        sa.Column("purged_at", sa.DateTime(timezone=True), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+        sa.ForeignKeyConstraint(
+            ["graph_provenance_id"],
+            ["graph_provenance.id"],
+            ondelete="CASCADE",
+        ),
+        sa.CheckConstraint(
+            "predicate IN ("
+            "'MENTIONS', 'AUTHORED', 'KNOWS_ABOUT', 'ASKED', 'ANSWERED', "
+            "'DECIDED', 'RELATED_TO', 'SUPPORTS', 'DERIVED_FROM', "
+            "'PART_OF', 'CONTRADICTS', 'SUPERSEDES'"
+            ")",
+            name=_CK_PREDICATE,
+        ),
+        sa.CheckConstraint(
+            "confidence_score >= 0.00 AND confidence_score <= 1.00",
+            name=_CK_CONFIDENCE,
+        ),
+    )
+
+    # Drift detection: Neo4j edge count vs graph_edges count must match
+    op.create_index(
+        _IX_ACTIVE,
+        _TABLE,
+        ["graph_provenance_id"],
+        postgresql_where=sa.text("purged_at IS NULL"),
+    )
+
+    # Idempotent MERGE lookup: is this edge already projected?
+    op.create_index(
+        _UQ_KEY,
+        _TABLE,
+        ["edge_key"],
+        unique=True,
+        postgresql_where=sa.text("purged_at IS NULL"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(_UQ_KEY, table_name=_TABLE)
+    op.drop_index(_IX_ACTIVE, table_name=_TABLE)
+    op.drop_table(_TABLE)

--- a/bot/db/models.py
+++ b/bot/db/models.py
@@ -1569,3 +1569,152 @@ class GraphProjectionRun(Base):
     # started_by is stored as a free-text label (e.g. 'scheduler', 'admin:149820031')
     # NOT a FK — the projector can be triggered without a users row (scheduler, CLI).
     started_by: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+
+class GraphProvenance(Base):
+    """Source-to-graph mapping; one row per projected source triple.
+
+    Maps each projected source (message_version or knowledge_card) to the Neo4j
+    graph. Used by forget cascade (logical source_table/source_pk lookup) and by
+    drift detection (active non-purged rows vs Neo4j node count).
+
+    source_table / source_pk are logical application-code refs — NOT typed FK
+    columns. FK ON DELETE CASCADE on source_card_id / source_message_version_id
+    is a safety net only. See PHASE10_PLAN.md §5.A for rationale.
+
+    Migration 061.
+    """
+
+    __tablename__ = "graph_provenance"
+    __table_args__ = (
+        CheckConstraint(
+            "source_table IN ('message_versions', 'knowledge_cards')",
+            name="ck_graph_provenance_source_table",
+        ),
+        CheckConstraint(
+            "source_message_version_id IS NOT NULL OR source_card_id IS NOT NULL",
+            name="ck_graph_provenance_has_source",
+        ),
+        CheckConstraint(
+            "graph_store IN ('neo4j', 'networkx_dev')",
+            name="ck_graph_provenance_graph_store",
+        ),
+        # Cascade forget lookup: find all provenance rows for a given message_version
+        Index(
+            "ix_graph_provenance_mvid",
+            "source_message_version_id",
+            postgresql_where=text("source_message_version_id IS NOT NULL"),
+        ),
+        # Cascade forget lookup: find all provenance rows for a given card
+        Index(
+            "ix_graph_provenance_card_id",
+            "source_card_id",
+            postgresql_where=text("source_card_id IS NOT NULL"),
+        ),
+        # Drift detection: active (non-purged) provenance rows
+        Index(
+            "ix_graph_provenance_active",
+            "projection_run_id",
+            postgresql_where=text("purged_at IS NULL"),
+        ),
+        # Idempotency: stable triple key within a projection run
+        Index(
+            "uq_graph_provenance_triple",
+            "source_table",
+            "source_pk",
+            "triple_hash",
+            unique=True,
+            postgresql_where=text("purged_at IS NULL"),
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    projection_run_id: Mapped[int] = mapped_column(
+        BigInteger, ForeignKey("graph_projection_runs.id", ondelete="CASCADE"), nullable=False
+    )
+    source_table: Mapped[str] = mapped_column(Text, nullable=False)
+    source_pk: Mapped[str] = mapped_column(Text, nullable=False)
+    source_message_version_id: Mapped[int | None] = mapped_column(
+        BigInteger,
+        ForeignKey("message_versions.id", ondelete="CASCADE"),
+        nullable=True,
+    )
+    source_card_id: Mapped[_uuid_module.UUID | None] = mapped_column(
+        Uuid, ForeignKey("knowledge_cards.id", ondelete="CASCADE"), nullable=True
+    )
+    source_content_hash: Mapped[str | None] = mapped_column(Text, nullable=True)
+    graph_store: Mapped[str] = mapped_column(
+        Text, nullable=False, default="neo4j", server_default="neo4j"
+    )
+    graph_node_key: Mapped[str | None] = mapped_column(Text, nullable=True)
+    graph_edge_key: Mapped[str | None] = mapped_column(Text, nullable=True)
+    triple_hash: Mapped[str | None] = mapped_column(Text, nullable=True)
+    governance_policy: Mapped[str] = mapped_column(
+        Text, nullable=False, default="normal", server_default="normal"
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    purged_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    purge_reason: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+
+class GraphEdge(Base):
+    """Postgres-side edge registry for idempotency and drift detection.
+
+    Neo4j holds the traversable graph; this table proves every Neo4j edge has
+    a Postgres-side provenance record.
+
+    Predicate vocabulary is CHECK-constrained to ALLOWED_PREDICATES from
+    bot/services/graph_common.py.
+
+    Migration 062.
+    """
+
+    __tablename__ = "graph_edges"
+    __table_args__ = (
+        CheckConstraint(
+            "predicate IN ("
+            "'MENTIONS', 'AUTHORED', 'KNOWS_ABOUT', 'ASKED', 'ANSWERED', "
+            "'DECIDED', 'RELATED_TO', 'SUPPORTS', 'DERIVED_FROM', "
+            "'PART_OF', 'CONTRADICTS', 'SUPERSEDES'"
+            ")",
+            name="ck_graph_edges_predicate",
+        ),
+        CheckConstraint(
+            "confidence_score >= 0.00 AND confidence_score <= 1.00",
+            name="ck_graph_edges_confidence",
+        ),
+        # Drift detection: Neo4j edge count vs graph_edges count must match
+        Index(
+            "ix_graph_edges_active",
+            "graph_provenance_id",
+            postgresql_where=text("purged_at IS NULL"),
+        ),
+        # Idempotent MERGE lookup: is this edge already projected?
+        Index(
+            "uq_graph_edges_key",
+            "edge_key",
+            unique=True,
+            postgresql_where=text("purged_at IS NULL"),
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    graph_provenance_id: Mapped[int] = mapped_column(
+        BigInteger,
+        ForeignKey("graph_provenance.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    subject_node_key: Mapped[str] = mapped_column(Text, nullable=False)
+    predicate: Mapped[str] = mapped_column(Text, nullable=False)
+    object_node_key: Mapped[str] = mapped_column(Text, nullable=False)
+    # stable MERGE key: SHA-256(subject+predicate+object)
+    edge_key: Mapped[str] = mapped_column(Text, nullable=False)
+    confidence_score: Mapped[Decimal] = mapped_column(
+        Numeric(3, 2), nullable=False, default=Decimal("0.50"), server_default="0.50"
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    purged_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)

--- a/bot/db/repos/graph_edge.py
+++ b/bot/db/repos/graph_edge.py
@@ -1,0 +1,105 @@
+"""Repository for ``graph_edges`` (Phase 10 / T10-02).
+
+Flush-only — NEVER calls ``session.commit()`` or ``session.rollback()``.
+The caller owns the transaction lifecycle.
+
+Predicate vocabulary is enforced here (ValueError before flush) and at the DB
+layer (CHECK constraint). Confidence range [0.00, 1.00] is similarly dual-enforced.
+"""
+
+from __future__ import annotations
+
+import logging
+from decimal import Decimal
+from typing import Sequence
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from bot.db.models import GraphEdge
+from bot.services.graph_common import ALLOWED_PREDICATES
+
+_log = logging.getLogger(__name__)
+
+
+async def create_edge(
+    session: AsyncSession,
+    *,
+    graph_provenance_id: int,
+    subject_node_key: str,
+    predicate: str,
+    object_node_key: str,
+    edge_key: str,
+    confidence_score: Decimal = Decimal("0.50"),
+) -> GraphEdge:
+    """Insert a new graph_edges row.
+
+    predicate must be in ALLOWED_PREDICATES (from graph_common.py).
+    confidence_score must be in [0.00, 1.00].
+    Both constraints are checked before flush (ValueError) and enforced at DB level.
+
+    Flushes; caller commits. NEVER commits internally.
+    """
+    if predicate not in ALLOWED_PREDICATES:
+        raise ValueError(
+            f"predicate {predicate!r} is not in ALLOWED_PREDICATES: {ALLOWED_PREDICATES}"
+        )
+    if not (Decimal("0.00") <= confidence_score <= Decimal("1.00")):
+        raise ValueError(
+            f"confidence_score {confidence_score!r} is out of range [0.00, 1.00]"
+        )
+
+    row = GraphEdge(
+        graph_provenance_id=graph_provenance_id,
+        subject_node_key=subject_node_key,
+        predicate=predicate,
+        object_node_key=object_node_key,
+        edge_key=edge_key,
+        confidence_score=confidence_score,
+    )
+    session.add(row)
+    await session.flush()
+    _log.debug(
+        "graph_edges: inserted id=%s provenance_id=%s predicate=%s edge_key=%s",
+        row.id,
+        graph_provenance_id,
+        predicate,
+        edge_key,
+    )
+    return row
+
+
+async def find_by_provenance(
+    session: AsyncSession,
+    provenance_id: int,
+) -> Sequence[GraphEdge]:
+    """Return all graph_edges rows for the given graph_provenance_id.
+
+    Returns both active and purged rows. Ordered by id ASC for deterministic
+    enumeration.
+    """
+    stmt = (
+        select(GraphEdge)
+        .where(GraphEdge.graph_provenance_id == provenance_id)
+        .order_by(GraphEdge.id.asc())
+    )
+    result = await session.execute(stmt)
+    return result.scalars().all()
+
+
+async def count_for_drift_check(session: AsyncSession) -> int:
+    """Return the count of active (non-purged) graph_edges rows.
+
+    Used by T10-08 drift reconcile to compare Postgres edge count vs Neo4j edge count.
+    A mismatch indicates either a failed projection or a failed purge.
+    """
+    from sqlalchemy import func
+
+    stmt = (
+        select(func.count())
+        .select_from(GraphEdge)
+        .where(GraphEdge.purged_at.is_(None))
+    )
+    result = await session.execute(stmt)
+    count = result.scalar_one()
+    return int(count)

--- a/bot/db/repos/graph_provenance.py
+++ b/bot/db/repos/graph_provenance.py
@@ -1,0 +1,195 @@
+"""Repository for ``graph_provenance`` (Phase 10 / T10-02).
+
+Flush-only — NEVER calls ``session.commit()`` or ``session.rollback()``.
+The caller owns the transaction lifecycle.
+
+source_table / source_pk are logical refs (not typed FKs) queried by the forget
+cascade. source_table discriminates the source type; the matching FK column must
+be set and the OTHER FK column must be None. Code-level XOR enforcement here
+(DB CHECK is OR per §5.A spec). This ensures unambiguous forget cascade
+(queries by source_table+source_pk) and raises a clear ValueError before flush.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import datetime, timezone
+from typing import Sequence
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from bot.db.models import GraphProvenance
+
+_log = logging.getLogger(__name__)
+
+
+async def create_provenance(
+    session: AsyncSession,
+    *,
+    projection_run_id: int,
+    source_table: str,
+    source_pk: str,
+    source_card_id: uuid.UUID | None = None,
+    source_message_version_id: int | None = None,
+    triple_hash: str | None = None,
+    graph_store: str = "neo4j",
+    graph_node_key: str | None = None,
+    graph_edge_key: str | None = None,
+    source_content_hash: str | None = None,
+    governance_policy: str = "normal",
+) -> GraphProvenance:
+    """Insert a new graph_provenance row.
+
+    source_table discriminates the source type; the matching FK column must be
+    set, and the OTHER FK column must be None. Code-level XOR enforcement
+    (DB CHECK is OR per §5.A spec). Raises ValueError immediately (before flush)
+    on violation so the caller sees a clear error.
+
+    source_table must be one of 'message_versions' or 'knowledge_cards'.
+
+    Flushes; caller commits. NEVER commits internally.
+    """
+    _ALLOWED_SOURCE_TABLES = frozenset({"message_versions", "knowledge_cards"})
+    if source_table not in _ALLOWED_SOURCE_TABLES:
+        raise ValueError(
+            f"source_table {source_table!r} is not allowed. "
+            f"Must be one of: {sorted(_ALLOWED_SOURCE_TABLES)}"
+        )
+
+    # source_table discriminates the source type; the matching FK column must be
+    # set and the OTHER FK column must be None. Code-level XOR enforcement
+    # (DB CHECK is OR per §5.A spec). This prevents ambiguous rows that would
+    # break forget cascade (queries by source_table+source_pk).
+    if source_table == "message_versions" and source_card_id is not None:
+        raise ValueError(
+            "source_table='message_versions' requires source_message_version_id only; "
+            f"got source_card_id={source_card_id}"
+        )
+    if source_table == "knowledge_cards" and source_message_version_id is not None:
+        raise ValueError(
+            "source_table='knowledge_cards' requires source_card_id only; "
+            f"got source_message_version_id={source_message_version_id}"
+        )
+    if source_table == "message_versions" and source_message_version_id is None:
+        raise ValueError(
+            "source_table='message_versions' requires source_message_version_id to be set"
+        )
+    if source_table == "knowledge_cards" and source_card_id is None:
+        raise ValueError(
+            "source_table='knowledge_cards' requires source_card_id to be set"
+        )
+
+    # Defensive fallback: should not reach here after source_table-specific checks,
+    # but guard against future source_table values or refactoring gaps.
+    if source_card_id is None and source_message_version_id is None:
+        raise ValueError(
+            "create_provenance requires exactly one of source_card_id or "
+            "source_message_version_id to be non-NULL; both are None"
+        )
+
+    row = GraphProvenance(
+        projection_run_id=projection_run_id,
+        source_table=source_table,
+        source_pk=source_pk,
+        source_card_id=source_card_id,
+        source_message_version_id=source_message_version_id,
+        source_content_hash=source_content_hash,
+        graph_store=graph_store,
+        graph_node_key=graph_node_key,
+        graph_edge_key=graph_edge_key,
+        triple_hash=triple_hash,
+        governance_policy=governance_policy,
+    )
+    session.add(row)
+    await session.flush()
+    _log.debug(
+        "graph_provenance: inserted id=%s source_table=%s source_pk=%s",
+        row.id,
+        source_table,
+        source_pk,
+    )
+    return row
+
+
+async def mark_inactive(
+    session: AsyncSession,
+    provenance_id: int,
+) -> None:
+    """Soft-delete a graph_provenance row by setting purged_at to now().
+
+    Idempotent: if already purged, silently leaves the value as-is.
+    Raises LookupError if the row does not exist.
+
+    Flushes; caller commits. NEVER commits internally.
+    """
+    from sqlalchemy import update
+
+    stmt = (
+        update(GraphProvenance)
+        .where(GraphProvenance.id == provenance_id)
+        .where(GraphProvenance.purged_at.is_(None))
+        .values(purged_at=datetime.now(tz=timezone.utc))
+    )
+    result = await session.execute(stmt)
+    if result.rowcount == 0:
+        # Check if row exists at all (already purged = idempotent, missing = error)
+        exists_result = await session.execute(
+            select(GraphProvenance.id).where(GraphProvenance.id == provenance_id)
+        )
+        if exists_result.scalar_one_or_none() is None:
+            raise LookupError(
+                f"GraphProvenance(id={provenance_id}) not found — cannot mark inactive"
+            )
+        # Row exists but purged_at is already set: idempotent no-op
+        _log.debug(
+            "graph_provenance: mark_inactive id=%s already purged (idempotent noop)",
+            provenance_id,
+        )
+        return
+    await session.flush()
+    _log.debug("graph_provenance: marked inactive id=%s", provenance_id)
+
+
+async def find_by_source(
+    session: AsyncSession,
+    *,
+    source_table: str,
+    source_pk: str,
+) -> Sequence[GraphProvenance]:
+    """Return all graph_provenance rows for the given source (active + purged).
+
+    Used by forget cascade to find all provenance rows to soft-delete before
+    enqueueing graph_purge_pending. Returns both active and already-purged rows
+    so the caller can decide.
+
+    Ordered by id ASC for deterministic enumeration.
+    """
+    stmt = (
+        select(GraphProvenance)
+        .where(GraphProvenance.source_table == source_table)
+        .where(GraphProvenance.source_pk == source_pk)
+        .order_by(GraphProvenance.id.asc())
+    )
+    result = await session.execute(stmt)
+    return result.scalars().all()
+
+
+async def find_active(
+    session: AsyncSession,
+    *,
+    projection_run_id: int | None = None,
+) -> Sequence[GraphProvenance]:
+    """Return active (non-purged) graph_provenance rows.
+
+    projection_run_id: if provided, filter to rows from that run only.
+
+    Ordered by id ASC for deterministic enumeration.
+    """
+    stmt = select(GraphProvenance).where(GraphProvenance.purged_at.is_(None))
+    if projection_run_id is not None:
+        stmt = stmt.where(GraphProvenance.projection_run_id == projection_run_id)
+    stmt = stmt.order_by(GraphProvenance.id.asc())
+    result = await session.execute(stmt)
+    return result.scalars().all()

--- a/docs/rollout-fragments/phase10/T10-02-rest.md
+++ b/docs/rollout-fragments/phase10/T10-02-rest.md
@@ -1,0 +1,79 @@
+# T10-02-rest Rollout Fragment
+
+## Summary
+
+Adds migrations 061 (graph_provenance) and 062 (graph_edges), their ORM
+models, and repository layers. These tables complete the Postgres-side graph
+registry needed by Phase 10 Neo4j projection and forget cascade.
+
+## Migrations Applied
+
+| Revision | File | Tables Created |
+|----------|------|----------------|
+| 061 | alembic/versions/061_add_graph_provenance.py | graph_provenance |
+| 062 | alembic/versions/062_add_graph_edges.py | graph_edges |
+
+Migration chain: 055 -> 060 -> 061 -> 062 (head)
+
+## Tables Created
+
+### graph_provenance (migration 061)
+
+Maps each projected source (message_version or knowledge_card) to the Neo4j
+graph. One row per projected triple.
+
+- source_table / source_pk: logical refs for forget cascade lookups (NOT typed FKs)
+- FK ON DELETE CASCADE on source_card_id / source_message_version_id: safety net only
+- CHECK constraints: source_table IN (...), has_source (OR, not XOR), graph_store IN (...)
+- Indexes: ix_mvid (partial), ix_card_id (partial), ix_active (partial WHERE purged_at IS NULL),
+  uq_triple (unique partial WHERE purged_at IS NULL)
+
+### graph_edges (migration 062)
+
+Postgres-side edge registry for idempotency and drift detection.
+
+- FK to graph_provenance.id with ON DELETE CASCADE
+- predicate CHECK constraint: must be in ALLOWED_PREDICATES (12 values)
+- confidence_score CHECK: [0.00, 1.00]
+- Indexes: ix_active (partial WHERE purged_at IS NULL), uq_key (unique partial)
+
+## New Files
+
+| File | Purpose |
+|------|---------|
+| alembic/versions/061_add_graph_provenance.py | Migration: graph_provenance |
+| alembic/versions/062_add_graph_edges.py | Migration: graph_edges |
+| bot/db/repos/graph_provenance.py | Repo: create, mark_inactive, find_by_source, find_active |
+| bot/db/repos/graph_edge.py | Repo: create_edge, find_by_provenance, count_for_drift_check |
+| tests/db/test_graph_provenance_repo.py | Integration tests for graph_provenance repo |
+| tests/db/test_graph_edge_repo.py | Integration tests for graph_edge repo |
+
+## Modified Files
+
+| File | Change |
+|------|--------|
+| bot/db/models.py | Added GraphProvenance and GraphEdge ORM models |
+| tests/db/test_digests_review_schema.py | Updated alembic head assertion from "060" to "062" |
+
+## Coordination Notes
+
+- Unblocks T10-03 (extract_graph_triples in llm_gateway.py writes to graph_provenance)
+- Unblocks T10-06 (forget_cascade._cascade_graph_provenance queries graph_provenance
+  by source_table/source_pk and soft-deletes via mark_inactive; enqueues graph_purge_pending)
+- T10-08 drift reconcile uses count_for_drift_check(session) to compare Postgres edge
+  count vs Neo4j edge count
+
+## Scope NOT in This PR
+
+- Migration 063 (graph_purge_pending): T10-06 territory
+- Migration 064 (llm_usage_ledger.call_type): T10-03 territory
+- bot/services/graph_adapter.py: T10-01 territory
+- bot/services/forget_cascade.py _cascade_graph_provenance: T10-06 territory
+
+## Phase 10.5 Carryovers
+
+- Tighten `ck_graph_provenance_has_source` from OR to XOR (spec §5.A amendment). Code-level validation in `create_provenance` enforces source_table↔FK consistency (FIX-1 in W0-A review pass), but the DB-level CHECK remains OR per current spec verbatim. Track for Phase 10.5 if XOR enforcement at DB layer is desired.
+
+## Docs Touched
+
+- docs/rollout-fragments/phase10/T10-02-rest.md (this file, new)

--- a/tests/db/test_digests_review_schema.py
+++ b/tests/db/test_digests_review_schema.py
@@ -134,12 +134,13 @@ async def test_alembic_head_is_latest(migrated_database_url: str) -> None:
     Previously asserted '038' (Phase 8 weekly review-gate); rolled forward to
     '054' when T9-01 added wiki migrations 050-054; then to '055' when Phase 9
     FHR landed the legacy-grace nullable `wiki_page_id` migration; then to '060'
-    when Phase 10 W0-A added graph_projection_runs. The intent of this test is
+    when Phase 10 W0-A added graph_projection_runs; then to '062' when T10-02
+    added graph_provenance (061) and graph_edges (062). The intent of this test is
     unchanged — assert the head matches the latest shipped migration. Update the
     literal when new migrations land.
     """
     current = await _fetch_value(migrated_database_url, "SELECT version_num FROM alembic_version")
-    assert current == "060"
+    assert current == "062"
 
 
 # ─── Test: upgrade adds 4 review columns with correct types/nullability ──────

--- a/tests/db/test_fts_schema.py
+++ b/tests/db/test_fts_schema.py
@@ -184,10 +184,10 @@ async def test_alembic_upgrade_head_on_clean_db_green(migrated_database_url: str
     # T6-01 (030-034) + T6-02 (035 operator_user_id) + Phase 6.5 M-2 (036
     # gateway_error) + T7-01 (037 digests) + T8-01 (038 review-gate states)
     # + T9-01 (050-054 wiki schema) + Phase 9 FHR (055 legacy-grace nullable
-    # wiki_page_id) + Phase 10 W0-A (060 graph_projection_runs) advanced the
-    # head past 025. Assert the current head explicitly; revisit when future
-    # migrations land.
-    assert current == "060"
+    # wiki_page_id) + Phase 10 W0-A (060 graph_projection_runs) + T10-02
+    # (061 graph_provenance, 062 graph_edges) advanced the head past 025.
+    # Assert the current head explicitly; revisit when future migrations land.
+    assert current == "062"
 
 
 async def test_insert_message_versions_generates_search_tsv_from_normalized_text(

--- a/tests/db/test_graph_edge_repo.py
+++ b/tests/db/test_graph_edge_repo.py
@@ -1,0 +1,418 @@
+"""Integration tests for bot/db/repos/graph_edge.py (T10-02 / Phase 10).
+
+Uses temp_database_url pattern: creates an isolated temp Postgres DB, runs
+alembic upgrade head (includes 061 + 062), exercises the repo, then drops the DB.
+
+Tests are skipped (not failed) if Postgres is unreachable.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import uuid
+from collections.abc import AsyncIterator
+from datetime import datetime, timezone
+from decimal import Decimal
+from pathlib import Path
+
+import asyncpg
+import pytest
+import pytest_asyncio
+from sqlalchemy.engine.url import URL, make_url
+
+from tests.conftest import DEFAULT_LOCAL_POSTGRES_URL
+
+pytestmark = pytest.mark.usefixtures("app_env")
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+# ─── Temp DB helpers ──────────────────────────────────────────────────────────
+
+
+def _base_test_url() -> URL:
+    raw_url = (
+        os.environ.get("TEST_DATABASE_URL")
+        or os.environ.get("DATABASE_URL")
+        or DEFAULT_LOCAL_POSTGRES_URL
+    )
+    return make_url(raw_url)
+
+
+def _asyncpg_kwargs(url: URL, *, database: str | None = None) -> dict[str, object]:
+    return {
+        "user": url.username,
+        "password": url.password,
+        "host": url.host or "127.0.0.1",
+        "port": url.port or 5432,
+        "database": database or url.database,
+    }
+
+
+def _quote_identifier(identifier: str) -> str:
+    return '"' + identifier.replace('"', '""') + '"'
+
+
+async def _create_database(admin_url: URL, database_name: str) -> None:
+    conn = await asyncpg.connect(**_asyncpg_kwargs(admin_url, database="postgres"))
+    try:
+        await conn.execute(f"CREATE DATABASE {_quote_identifier(database_name)}")
+    finally:
+        await conn.close()
+
+
+async def _drop_database(admin_url: URL, database_name: str) -> None:
+    conn = await asyncpg.connect(**_asyncpg_kwargs(admin_url, database="postgres"))
+    try:
+        await conn.execute(
+            """
+            SELECT pg_terminate_backend(pid)
+            FROM pg_stat_activity
+            WHERE datname = $1 AND pid <> pg_backend_pid()
+            """,
+            database_name,
+        )
+        await conn.execute(f"DROP DATABASE IF EXISTS {_quote_identifier(database_name)}")
+    finally:
+        await conn.close()
+
+
+def _run_alembic(database_url: str, *args: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["DATABASE_URL"] = database_url
+    return subprocess.run(
+        [sys.executable, "-m", "alembic", *args],
+        cwd=PROJECT_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=120,
+        check=True,
+    )
+
+
+@pytest_asyncio.fixture()
+async def edge_db_url() -> AsyncIterator[str]:
+    """Temp DB with alembic upgrade head (includes migrations 060, 061, 062)."""
+    base_url = _base_test_url()
+    database_name = f"shkoder_graph_edge_{uuid.uuid4().hex[:12]}"
+    try:
+        await _create_database(base_url, database_name)
+    except Exception as exc:
+        pytest.skip(f"cannot create temporary postgres database: {exc!s}")
+
+    db_url = base_url.set(database=database_name).render_as_string(hide_password=False)
+    try:
+        _run_alembic(db_url, "upgrade", "head")
+    except subprocess.CalledProcessError as exc:
+        await _drop_database(base_url, database_name)
+        pytest.skip(f"alembic upgrade head failed: {exc.stderr}")
+
+    try:
+        yield db_url
+    finally:
+        await _drop_database(base_url, database_name)
+
+
+@pytest_asyncio.fixture()
+async def edge_session(edge_db_url: str) -> AsyncIterator:
+    """AsyncSession on the migrated temp DB; each test fully isolated via rollback."""
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+    engine = create_async_engine(edge_db_url, echo=False)
+    try:
+        async with engine.connect() as conn:
+            outer = await conn.begin()
+            Session = async_sessionmaker(
+                bind=conn, class_=AsyncSession, expire_on_commit=False
+            )
+            async with Session() as session:
+                try:
+                    yield session
+                finally:
+                    if outer.is_active:
+                        await outer.rollback()
+    finally:
+        await engine.dispose()
+
+
+# ─── helpers ──────────────────────────────────────────────────────────────────
+
+
+async def _make_run(session) -> int:
+    from bot.db.repos.graph_projection_run import create_run
+
+    run = await create_run(session, mode="incremental", started_by="test")
+    await session.flush()
+    return run.id
+
+
+async def _make_knowledge_card(session) -> uuid.UUID:
+    from sqlalchemy import text
+
+    card_id = uuid.uuid4()
+    await session.execute(
+        text(
+            "INSERT INTO knowledge_cards (id, title, body_markdown, card_status) "
+            "VALUES (:id, 'Test Card', 'content', 'draft')"
+        ),
+        {"id": str(card_id)},
+    )
+    return card_id
+
+
+async def _make_provenance(session, *, run_id: int) -> int:
+    """Insert minimal graph_provenance row using knowledge_card path."""
+    from bot.db.repos.graph_provenance import create_provenance
+
+    card_id = await _make_knowledge_card(session)
+    row = await create_provenance(
+        session,
+        projection_run_id=run_id,
+        source_table="knowledge_cards",
+        source_pk=str(card_id),
+        source_card_id=card_id,
+    )
+    return row.id
+
+
+def _edge_key() -> str:
+    """Generate a unique stable edge key."""
+    return uuid.uuid4().hex
+
+
+# ─── create_edge ─────────────────────────────────────────────────────────────
+
+
+async def test_create_edge_with_valid_predicate(edge_session) -> None:
+    """create_edge inserts a row for a valid predicate."""
+    from bot.db.repos.graph_edge import create_edge
+
+    run_id = await _make_run(edge_session)
+    prov_id = await _make_provenance(edge_session, run_id=run_id)
+
+    edge = await create_edge(
+        edge_session,
+        graph_provenance_id=prov_id,
+        subject_node_key="user:123",
+        predicate="MENTIONS",
+        object_node_key="topic:python",
+        edge_key=_edge_key(),
+        confidence_score=Decimal("0.85"),
+    )
+
+    assert edge.id is not None
+    assert edge.graph_provenance_id == prov_id
+    assert edge.predicate == "MENTIONS"
+    assert edge.subject_node_key == "user:123"
+    assert edge.object_node_key == "topic:python"
+    assert edge.confidence_score == Decimal("0.85")
+    assert edge.purged_at is None
+
+
+async def test_create_edge_rejects_invalid_predicate(edge_session) -> None:
+    """create_edge raises ValueError for an unknown predicate."""
+    from bot.db.repos.graph_edge import create_edge
+
+    run_id = await _make_run(edge_session)
+    prov_id = await _make_provenance(edge_session, run_id=run_id)
+
+    with pytest.raises(ValueError, match="ALLOWED_PREDICATES"):
+        await create_edge(
+            edge_session,
+            graph_provenance_id=prov_id,
+            subject_node_key="user:1",
+            predicate="INVALID_PREDICATE",
+            object_node_key="topic:foo",
+            edge_key=_edge_key(),
+        )
+
+
+async def test_create_edge_rejects_invalid_confidence_above_one(edge_session) -> None:
+    """create_edge raises ValueError for confidence_score > 1.0."""
+    from bot.db.repos.graph_edge import create_edge
+
+    run_id = await _make_run(edge_session)
+    prov_id = await _make_provenance(edge_session, run_id=run_id)
+
+    with pytest.raises(ValueError, match="out of range"):
+        await create_edge(
+            edge_session,
+            graph_provenance_id=prov_id,
+            subject_node_key="user:1",
+            predicate="MENTIONS",
+            object_node_key="topic:foo",
+            edge_key=_edge_key(),
+            confidence_score=Decimal("1.01"),
+        )
+
+
+async def test_create_edge_rejects_invalid_confidence_below_zero(edge_session) -> None:
+    """create_edge raises ValueError for confidence_score < 0.0."""
+    from bot.db.repos.graph_edge import create_edge
+
+    run_id = await _make_run(edge_session)
+    prov_id = await _make_provenance(edge_session, run_id=run_id)
+
+    with pytest.raises(ValueError, match="out of range"):
+        await create_edge(
+            edge_session,
+            graph_provenance_id=prov_id,
+            subject_node_key="user:1",
+            predicate="MENTIONS",
+            object_node_key="topic:foo",
+            edge_key=_edge_key(),
+            confidence_score=Decimal("-0.01"),
+        )
+
+
+# ─── FK integrity ────────────────────────────────────────────────────────────
+
+
+async def test_create_edge_rejects_dangling_provenance_fk(edge_session) -> None:
+    """create_edge raises IntegrityError when graph_provenance_id points to
+    a non-existent provenance row (FK constraint violation)."""
+    from sqlalchemy.exc import IntegrityError
+
+    from bot.db.repos.graph_edge import create_edge
+
+    with pytest.raises(IntegrityError):
+        await create_edge(
+            edge_session,
+            graph_provenance_id=99999999,
+            subject_node_key="user:1",
+            predicate="MENTIONS",
+            object_node_key="topic:foo",
+            edge_key=_edge_key(),
+        )
+
+
+async def test_create_edge_rejects_duplicate_edge_key(edge_session) -> None:
+    """Two active edges with the same edge_key violate uq_graph_edges_key
+    (unique partial index WHERE purged_at IS NULL)."""
+    from sqlalchemy.exc import IntegrityError
+
+    from bot.db.repos.graph_edge import create_edge
+
+    run_id = await _make_run(edge_session)
+    prov_id = await _make_provenance(edge_session, run_id=run_id)
+    shared_key = _edge_key()
+
+    await create_edge(
+        edge_session,
+        graph_provenance_id=prov_id,
+        subject_node_key="user:1",
+        predicate="MENTIONS",
+        object_node_key="topic:a",
+        edge_key=shared_key,
+    )
+
+    with pytest.raises(IntegrityError):
+        await create_edge(
+            edge_session,
+            graph_provenance_id=prov_id,
+            subject_node_key="user:2",
+            predicate="AUTHORED",
+            object_node_key="card:b",
+            edge_key=shared_key,
+        )
+
+
+# ─── find_by_provenance ───────────────────────────────────────────────────────
+
+
+async def test_find_by_provenance_returns_all_edges(edge_session) -> None:
+    """find_by_provenance returns all edges (active and purged) for a provenance row."""
+    from bot.db.repos.graph_edge import create_edge, find_by_provenance
+
+    run_id = await _make_run(edge_session)
+    prov_id = await _make_provenance(edge_session, run_id=run_id)
+
+    edge1 = await create_edge(
+        edge_session,
+        graph_provenance_id=prov_id,
+        subject_node_key="user:1",
+        predicate="MENTIONS",
+        object_node_key="topic:a",
+        edge_key=_edge_key(),
+    )
+    edge2 = await create_edge(
+        edge_session,
+        graph_provenance_id=prov_id,
+        subject_node_key="user:1",
+        predicate="AUTHORED",
+        object_node_key="card:x",
+        edge_key=_edge_key(),
+    )
+
+    # Also create an edge on a DIFFERENT provenance to verify filtering
+    prov_id2 = await _make_provenance(edge_session, run_id=run_id)
+    await create_edge(
+        edge_session,
+        graph_provenance_id=prov_id2,
+        subject_node_key="user:2",
+        predicate="KNOWS_ABOUT",
+        object_node_key="topic:b",
+        edge_key=_edge_key(),
+    )
+
+    edges = await find_by_provenance(edge_session, prov_id)
+    edge_ids = {e.id for e in edges}
+    assert edge1.id in edge_ids
+    assert edge2.id in edge_ids
+    assert len(edges) == 2  # only edges for prov_id, not prov_id2
+
+
+# ─── count_for_drift_check ────────────────────────────────────────────────────
+
+
+async def test_count_for_drift_check_matches_neo4j(edge_session) -> None:
+    """count_for_drift_check returns count of active (non-purged) graph_edges rows.
+
+    T10-08 drift reconcile will compare this count against Neo4j's edge count.
+    This test uses placeholder logic — actual Neo4j count comparison is T10-08.
+    """
+    from sqlalchemy import update
+
+    from bot.db.models import GraphEdge
+    from bot.db.repos.graph_edge import count_for_drift_check, create_edge
+
+    initial_count = await count_for_drift_check(edge_session)
+
+    run_id = await _make_run(edge_session)
+    prov_id = await _make_provenance(edge_session, run_id=run_id)
+
+    edge1 = await create_edge(
+        edge_session,
+        graph_provenance_id=prov_id,
+        subject_node_key="user:1",
+        predicate="MENTIONS",
+        object_node_key="topic:a",
+        edge_key=_edge_key(),
+    )
+    await create_edge(
+        edge_session,
+        graph_provenance_id=prov_id,
+        subject_node_key="user:1",
+        predicate="AUTHORED",
+        object_node_key="card:x",
+        edge_key=_edge_key(),
+    )
+    await edge_session.flush()
+
+    count_after_insert = await count_for_drift_check(edge_session)
+    assert count_after_insert == initial_count + 2
+
+    # Soft-delete one edge (simulate purge)
+    await edge_session.execute(
+        update(GraphEdge)
+        .where(GraphEdge.id == edge1.id)
+        .values(purged_at=datetime.now(tz=timezone.utc))
+    )
+    await edge_session.flush()
+
+    count_after_purge = await count_for_drift_check(edge_session)
+    # purged edge is excluded; second edge still active
+    assert count_after_purge == initial_count + 1

--- a/tests/db/test_graph_provenance_repo.py
+++ b/tests/db/test_graph_provenance_repo.py
@@ -1,0 +1,477 @@
+"""Integration tests for bot/db/repos/graph_provenance.py (T10-02 / Phase 10).
+
+Uses temp_database_url pattern (same as test_graph_projection_run_repo.py):
+creates an isolated temp Postgres DB, runs alembic upgrade head (includes 061),
+exercises the repo, then drops the DB.
+
+Tests are skipped (not failed) if Postgres is unreachable.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import uuid
+from collections.abc import AsyncIterator
+from pathlib import Path
+
+import asyncpg
+import pytest
+import pytest_asyncio
+from sqlalchemy.engine.url import URL, make_url
+
+from tests.conftest import DEFAULT_LOCAL_POSTGRES_URL
+
+pytestmark = pytest.mark.usefixtures("app_env")
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+# ─── Temp DB helpers ──────────────────────────────────────────────────────────
+
+
+def _base_test_url() -> URL:
+    raw_url = (
+        os.environ.get("TEST_DATABASE_URL")
+        or os.environ.get("DATABASE_URL")
+        or DEFAULT_LOCAL_POSTGRES_URL
+    )
+    return make_url(raw_url)
+
+
+def _asyncpg_kwargs(url: URL, *, database: str | None = None) -> dict[str, object]:
+    return {
+        "user": url.username,
+        "password": url.password,
+        "host": url.host or "127.0.0.1",
+        "port": url.port or 5432,
+        "database": database or url.database,
+    }
+
+
+def _quote_identifier(identifier: str) -> str:
+    return '"' + identifier.replace('"', '""') + '"'
+
+
+async def _create_database(admin_url: URL, database_name: str) -> None:
+    conn = await asyncpg.connect(**_asyncpg_kwargs(admin_url, database="postgres"))
+    try:
+        await conn.execute(f"CREATE DATABASE {_quote_identifier(database_name)}")
+    finally:
+        await conn.close()
+
+
+async def _drop_database(admin_url: URL, database_name: str) -> None:
+    conn = await asyncpg.connect(**_asyncpg_kwargs(admin_url, database="postgres"))
+    try:
+        await conn.execute(
+            """
+            SELECT pg_terminate_backend(pid)
+            FROM pg_stat_activity
+            WHERE datname = $1 AND pid <> pg_backend_pid()
+            """,
+            database_name,
+        )
+        await conn.execute(f"DROP DATABASE IF EXISTS {_quote_identifier(database_name)}")
+    finally:
+        await conn.close()
+
+
+def _run_alembic(database_url: str, *args: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["DATABASE_URL"] = database_url
+    return subprocess.run(
+        [sys.executable, "-m", "alembic", *args],
+        cwd=PROJECT_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=120,
+        check=True,
+    )
+
+
+@pytest_asyncio.fixture()
+async def provenance_db_url() -> AsyncIterator[str]:
+    """Temp DB with alembic upgrade head (includes migrations 060, 061, 062)."""
+    base_url = _base_test_url()
+    database_name = f"shkoder_provenance_{uuid.uuid4().hex[:12]}"
+    try:
+        await _create_database(base_url, database_name)
+    except Exception as exc:
+        pytest.skip(f"cannot create temporary postgres database: {exc!s}")
+
+    db_url = base_url.set(database=database_name).render_as_string(hide_password=False)
+    try:
+        _run_alembic(db_url, "upgrade", "head")
+    except subprocess.CalledProcessError as exc:
+        await _drop_database(base_url, database_name)
+        pytest.skip(f"alembic upgrade head failed: {exc.stderr}")
+
+    try:
+        yield db_url
+    finally:
+        await _drop_database(base_url, database_name)
+
+
+@pytest_asyncio.fixture()
+async def prov_session(provenance_db_url: str) -> AsyncIterator:
+    """AsyncSession on the migrated temp DB; each test fully isolated via rollback."""
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+    engine = create_async_engine(provenance_db_url, echo=False)
+    try:
+        async with engine.connect() as conn:
+            outer = await conn.begin()
+            Session = async_sessionmaker(
+                bind=conn, class_=AsyncSession, expire_on_commit=False
+            )
+            async with Session() as session:
+                try:
+                    yield session
+                finally:
+                    if outer.is_active:
+                        await outer.rollback()
+    finally:
+        await engine.dispose()
+
+
+# ─── helpers ──────────────────────────────────────────────────────────────────
+
+
+async def _make_run(session) -> int:
+    """Insert a graph_projection_runs row and return its id."""
+    from bot.db.repos.graph_projection_run import create_run
+
+    run = await create_run(session, mode="incremental", started_by="test")
+    await session.flush()
+    return run.id
+
+
+async def _make_message_version(session) -> int:
+    """Insert minimal message_versions row and return its id.
+
+    Users.id IS the telegram user id (BigInteger PK). ChatMessages requires
+    message_id, chat_id, user_id, date. MessageVersions requires
+    chat_message_id, version_seq.
+    """
+    from datetime import datetime, timezone
+
+    from sqlalchemy import text
+
+    user_id = abs(hash(uuid.uuid4().hex)) % (10**9)
+    # users.id is the PK = telegram_id; no separate telegram_id column
+    await session.execute(
+        text(
+            "INSERT INTO users (id, first_name) VALUES (:id, :fname) "
+            "ON CONFLICT (id) DO NOTHING"
+        ),
+        {"id": user_id, "fname": "Test"},
+    )
+
+    msg_telegram_id = abs(hash(uuid.uuid4().hex)) % (10**9)
+    result = await session.execute(
+        text(
+            "INSERT INTO chat_messages (message_id, chat_id, user_id, date) "
+            "VALUES (:mid, :cid, :uid, :d) RETURNING id"
+        ),
+        {
+            "mid": msg_telegram_id,
+            "cid": -1001234567890,
+            "uid": user_id,
+            "d": datetime.now(tz=timezone.utc),
+        },
+    )
+    chat_msg_id = result.scalar_one()
+
+    result = await session.execute(
+        text(
+            "INSERT INTO message_versions (chat_message_id, version_seq, text, content_hash) "
+            "VALUES (:mid, 1, 'hello', :ch) RETURNING id"
+        ),
+        {"mid": chat_msg_id, "ch": uuid.uuid4().hex},
+    )
+    return result.scalar_one()
+
+
+async def _make_knowledge_card(session) -> uuid.UUID:
+    """Insert minimal knowledge_cards row and return its id.
+
+    knowledge_cards requires title + body_markdown (body_tsv is Computed).
+    card_status defaults to 'draft'.
+    """
+    from sqlalchemy import text
+
+    card_id = uuid.uuid4()
+    await session.execute(
+        text(
+            "INSERT INTO knowledge_cards (id, title, body_markdown, card_status) "
+            "VALUES (:id, 'Test Card', 'content', 'draft')"
+        ),
+        {"id": str(card_id)},
+    )
+    return card_id
+
+
+# ─── create_provenance ────────────────────────────────────────────────────────
+
+
+async def test_create_provenance_with_card_source(prov_session) -> None:
+    """create_provenance inserts a row with source_card_id path."""
+    from bot.db.repos.graph_provenance import create_provenance
+
+    run_id = await _make_run(prov_session)
+    card_id = await _make_knowledge_card(prov_session)
+
+    row = await create_provenance(
+        prov_session,
+        projection_run_id=run_id,
+        source_table="knowledge_cards",
+        source_pk=str(card_id),
+        source_card_id=card_id,
+        triple_hash="abc123",
+    )
+
+    assert row.id is not None
+    assert row.projection_run_id == run_id
+    assert row.source_table == "knowledge_cards"
+    assert row.source_pk == str(card_id)
+    assert row.source_card_id == card_id
+    assert row.source_message_version_id is None
+    assert row.triple_hash == "abc123"
+    assert row.purged_at is None
+    assert row.graph_store == "neo4j"
+
+
+async def test_create_provenance_with_message_version_source(prov_session) -> None:
+    """create_provenance inserts a row with source_message_version_id path."""
+    from bot.db.repos.graph_provenance import create_provenance
+
+    run_id = await _make_run(prov_session)
+    mv_id = await _make_message_version(prov_session)
+
+    row = await create_provenance(
+        prov_session,
+        projection_run_id=run_id,
+        source_table="message_versions",
+        source_pk=str(mv_id),
+        source_message_version_id=mv_id,
+        triple_hash="def456",
+    )
+
+    assert row.id is not None
+    assert row.source_message_version_id == mv_id
+    assert row.source_card_id is None
+    assert row.source_table == "message_versions"
+
+
+async def test_create_provenance_rejects_source_table_fk_mismatch(prov_session) -> None:
+    """create_provenance raises ValueError when source_table='message_versions' but
+    source_card_id is populated instead of source_message_version_id."""
+    from bot.db.repos.graph_provenance import create_provenance
+
+    run_id = await _make_run(prov_session)
+    card_id = await _make_knowledge_card(prov_session)
+
+    with pytest.raises(ValueError, match="source_table='message_versions' requires source_message_version_id only"):
+        await create_provenance(
+            prov_session,
+            projection_run_id=run_id,
+            source_table="message_versions",
+            source_pk=str(card_id),
+            source_card_id=card_id,
+            source_message_version_id=None,
+        )
+
+
+async def test_create_provenance_rejects_source_table_missing_fk(prov_session) -> None:
+    """create_provenance raises ValueError when source_table='message_versions' but
+    source_message_version_id is None (missing required FK)."""
+    from bot.db.repos.graph_provenance import create_provenance
+
+    run_id = await _make_run(prov_session)
+
+    with pytest.raises(ValueError, match="source_table='message_versions' requires source_message_version_id to be set"):
+        await create_provenance(
+            prov_session,
+            projection_run_id=run_id,
+            source_table="message_versions",
+            source_pk="99",
+            source_card_id=None,
+            source_message_version_id=None,
+        )
+
+
+async def test_create_provenance_rejects_duplicate_active_triple(prov_session) -> None:
+    """Two active rows with the same (source_table, source_pk, triple_hash) violate
+    the unique partial index uq_graph_provenance_triple (WHERE purged_at IS NULL)."""
+    from sqlalchemy.exc import IntegrityError
+
+    from bot.db.repos.graph_provenance import create_provenance
+
+    run_id = await _make_run(prov_session)
+    mv_id = await _make_message_version(prov_session)
+
+    await create_provenance(
+        prov_session,
+        projection_run_id=run_id,
+        source_table="message_versions",
+        source_pk=str(mv_id),
+        source_message_version_id=mv_id,
+        triple_hash="hash_abc123",
+    )
+
+    with pytest.raises(IntegrityError):
+        await create_provenance(
+            prov_session,
+            projection_run_id=run_id,
+            source_table="message_versions",
+            source_pk=str(mv_id),
+            source_message_version_id=mv_id,
+            triple_hash="hash_abc123",
+        )
+
+
+async def test_create_provenance_rejects_dangling_projection_run_id(prov_session) -> None:
+    """create_provenance with a non-existent projection_run_id raises IntegrityError
+    (FK constraint on graph_provenance.projection_run_id)."""
+    from sqlalchemy.exc import IntegrityError
+
+    from bot.db.repos.graph_provenance import create_provenance
+
+    mv_id = await _make_message_version(prov_session)
+
+    with pytest.raises(IntegrityError):
+        await create_provenance(
+            prov_session,
+            projection_run_id=99999999,
+            source_table="message_versions",
+            source_pk=str(mv_id),
+            source_message_version_id=mv_id,
+        )
+
+
+async def test_create_provenance_rejects_no_source(prov_session) -> None:
+    """create_provenance raises ValueError when both source FKs are NULL.
+
+    With source_table='message_versions' and both FKs None, the source_table-
+    specific check fires first ('requires source_message_version_id to be set').
+    """
+    from bot.db.repos.graph_provenance import create_provenance
+
+    run_id = await _make_run(prov_session)
+
+    with pytest.raises(ValueError, match="source_message_version_id"):
+        await create_provenance(
+            prov_session,
+            projection_run_id=run_id,
+            source_table="message_versions",
+            source_pk="42",
+            source_card_id=None,
+            source_message_version_id=None,
+        )
+
+
+# ─── mark_inactive ────────────────────────────────────────────────────────────
+
+
+async def test_mark_inactive_soft_deletes(prov_session) -> None:
+    """mark_inactive sets purged_at to a non-NULL timestamp."""
+    from bot.db.repos.graph_provenance import create_provenance, mark_inactive
+
+    run_id = await _make_run(prov_session)
+    mv_id = await _make_message_version(prov_session)
+
+    row = await create_provenance(
+        prov_session,
+        projection_run_id=run_id,
+        source_table="message_versions",
+        source_pk=str(mv_id),
+        source_message_version_id=mv_id,
+    )
+    assert row.purged_at is None
+
+    await mark_inactive(prov_session, row.id)
+    await prov_session.flush()
+    await prov_session.refresh(row)
+
+    assert row.purged_at is not None
+
+
+# ─── find_by_source ───────────────────────────────────────────────────────────
+
+
+async def test_find_by_source_returns_matching(prov_session) -> None:
+    """find_by_source returns rows matching both card and message_version sources."""
+    from bot.db.repos.graph_provenance import create_provenance, find_by_source
+
+    run_id = await _make_run(prov_session)
+    mv_id = await _make_message_version(prov_session)
+    card_id = await _make_knowledge_card(prov_session)
+
+    row_mv = await create_provenance(
+        prov_session,
+        projection_run_id=run_id,
+        source_table="message_versions",
+        source_pk=str(mv_id),
+        source_message_version_id=mv_id,
+    )
+    row_card = await create_provenance(
+        prov_session,
+        projection_run_id=run_id,
+        source_table="knowledge_cards",
+        source_pk=str(card_id),
+        source_card_id=card_id,
+    )
+
+    rows_mv = await find_by_source(
+        prov_session, source_table="message_versions", source_pk=str(mv_id)
+    )
+    assert len(rows_mv) == 1
+    assert rows_mv[0].id == row_mv.id
+
+    rows_card = await find_by_source(
+        prov_session, source_table="knowledge_cards", source_pk=str(card_id)
+    )
+    assert len(rows_card) == 1
+    assert rows_card[0].id == row_card.id
+
+
+# ─── find_active ──────────────────────────────────────────────────────────────
+
+
+async def test_find_active_filters_inactive(prov_session) -> None:
+    """find_active excludes rows with purged_at set."""
+    from bot.db.repos.graph_provenance import (
+        create_provenance,
+        find_active,
+        mark_inactive,
+    )
+
+    run_id = await _make_run(prov_session)
+    mv_id1 = await _make_message_version(prov_session)
+    mv_id2 = await _make_message_version(prov_session)
+
+    row_active = await create_provenance(
+        prov_session,
+        projection_run_id=run_id,
+        source_table="message_versions",
+        source_pk=str(mv_id1),
+        source_message_version_id=mv_id1,
+    )
+    row_inactive = await create_provenance(
+        prov_session,
+        projection_run_id=run_id,
+        source_table="message_versions",
+        source_pk=str(mv_id2),
+        source_message_version_id=mv_id2,
+    )
+
+    await mark_inactive(prov_session, row_inactive.id)
+    await prov_session.flush()
+
+    active_rows = await find_active(prov_session)
+    active_ids = {r.id for r in active_rows}
+    assert row_active.id in active_ids
+    assert row_inactive.id not in active_ids


### PR DESCRIPTION
## Summary

Sprint **T10-02-rest** of Phase 10 — second slice of canonical T10-02 (per PHASE10_PLAN §1044). Migration 060 shipped in W0-A; this PR ships 061 + 062. Migration 063 (purge_pending) ships in T10-06; migration 064 (ledger.call_type) ships in T10-03.

- `alembic/versions/061_add_graph_provenance.py` — verbatim §5.A schema
- `alembic/versions/062_add_graph_edges.py` — verbatim §5.A schema, FK CASCADE to provenance
- `bot/db/models.py` — `GraphProvenance` + `GraphEdge` ORM (Index metadata matches migration DESC ordering, no drift)
- `bot/db/repos/graph_provenance.py` — code-level `source_table↔FK` consistency (XOR), `find_by_source` for forget cascade lookup, `mark_inactive` soft delete
- `bot/db/repos/graph_edge.py` — `create_edge`, `find_by_provenance`, `count_for_drift_check`

## Test plan

- [x] `pytest tests/db/test_graph_provenance_repo.py tests/db/test_graph_edge_repo.py -v` — 18/18 pass (happy paths, CHECK violations, FK IntegrityError, source_table mismatch, duplicate active triple, partial-unique edge_key collision)
- [x] Full suite: 1409 pass + 1 skipped + 1 pre-existing BOT_TOKEN failure (unrelated)
- [x] `ruff check` — green
- [x] `alembic history`: `060 → 061 → 062` chain confirmed
- [x] Head assertions rolled `060 → 062` in `test_digests_review_schema.py` and `test_fts_schema.py` (CI keeping)
- [x] Boundary respected — no edits outside W0-A/W0-D-already-merged + new scope

## Unified Review

- **Claude product (standard-product-reviewer, opus):** ACCEPTED. OR-vs-XOR concern resolved at code level; DB-level CHECK tightening deferred as Phase 10.5 carryover.
- **Codex technical (codex:codex-rescue):** round 1 REQUEST_CHANGES (1 CRITICAL staging-observation, 2 MEDIUM source_table validation + missing tests, 1 LOW edge FK tests). Fixed in single revision pass. APPROVE.

## Docs

- `docs/rollout-fragments/phase10/T10-02-rest.md` — per-PR fragment with Phase 10.5 carryover note
- `CLAUDE.md` / `llms.txt` / `IMPLEMENTATION_STATUS.md` UNCHANGED (deferred to Phase 10 closure / W3-E)

## Phase 10.5 carryover

- Tighten `ck_graph_provenance_has_source` from OR to XOR at DB layer (spec amendment). Code-level validation in `create_provenance` enforces XOR via `source_table` discriminator; DB CHECK remains OR per current spec verbatim.

## Unblocked by this merge

- T10-03: `llm_gateway.extract_graph_triples` writes `graph_provenance` + `graph_edges`
- T10-06: forget cascade `_cascade_graph_provenance` queries by `source_table` + `source_pk`
- T10-08: `count_for_drift_check` foundation for drift reconcile

Independent of W0-D (Neo4j CI, also in flight as #325).

🤖 Generated with [Claude Code](https://claude.com/claude-code)