### PR TITLE
feat(p10-t10-06): graph cascade + purge worker + readblock + migration 063/065

### DIFF
--- a/alembic/versions/063_add_graph_purge_pending.py
+++ b/alembic/versions/063_add_graph_purge_pending.py
@@ -1,0 +1,114 @@
+"""add_graph_purge_pending
+
+Phase 10 / T10-06: async purge queue for Neo4j bolt DELETE.
+
+Written atomically in the same Postgres transaction as the Postgres-side cascade
+(forget_event commit). graph_purge_worker consumes rows, marks purged_at on
+success or failed_at+error on failure. graph_query.py checks this table before
+any Neo4j traversal: if any non-purged row exists for nodes in the result set →
+return abstained=True (fail-closed per RFC-001:415).
+
+Migration chain note: 062 → 064 → 063
+064 (add_llm_ledger_call_type) shipped in T10-03 before this sprint. Alembic
+supports non-contiguous revision IDs; this revision extends the 064 head.
+
+Revision ID: 063
+Revises: 064
+Create Date: 2026-05-20
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "063"
+down_revision: Union[str, Sequence[str], None] = "064"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_TABLE = "graph_purge_pending"
+
+
+def upgrade() -> None:
+    op.create_table(
+        _TABLE,
+        sa.Column("id", sa.BigInteger, primary_key=True, autoincrement=True),
+        sa.Column("forget_event_id", sa.BigInteger, nullable=False),
+        sa.Column("source_table", sa.Text, nullable=False),
+        sa.Column("source_pk", sa.Text, nullable=False),
+        # known at enqueue time if provenance row exists
+        sa.Column("graph_node_key", sa.Text, nullable=True),
+        sa.Column("graph_edge_key", sa.Text, nullable=True),
+        sa.Column(
+            "graph_provenance_id",
+            sa.BigInteger,
+            sa.ForeignKey("graph_provenance.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column(
+            "enqueued_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column("purged_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("failed_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("error", sa.Text, nullable=True),
+        sa.Column(
+            "retry_count",
+            sa.SmallInteger,
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+        sa.CheckConstraint(
+            "source_table IN ('message_versions', 'knowledge_cards', 'card_sources')",
+            name="ck_graph_purge_pending_source_table",
+        ),
+        sa.UniqueConstraint(
+            "forget_event_id",
+            "source_table",
+            "source_pk",
+            name="uq_graph_purge_pending_event_source",
+        ),
+    )
+
+    # Worker queue: fetch pending (non-purged, non-failed) rows ordered by enqueue time
+    op.create_index(
+        "ix_graph_purge_pending_queue",
+        _TABLE,
+        ["enqueued_at"],
+        postgresql_where=sa.text("purged_at IS NULL AND failed_at IS NULL"),
+    )
+
+    # Fail-closed check in graph_query.py: are there pending purge rows?
+    op.create_index(
+        "ix_graph_purge_pending_node_key",
+        _TABLE,
+        ["graph_node_key"],
+        postgresql_where=sa.text("purged_at IS NULL"),
+    )
+
+    # Support forget_event_id lookup
+    op.create_index(
+        "ix_graph_purge_pending_forget_event",
+        _TABLE,
+        ["forget_event_id"],
+    )
+
+    # Support source_table + source_pk lookup
+    op.create_index(
+        "ix_graph_purge_pending_source",
+        _TABLE,
+        ["source_table", "source_pk"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_graph_purge_pending_source", table_name=_TABLE)
+    op.drop_index("ix_graph_purge_pending_forget_event", table_name=_TABLE)
+    op.drop_index("ix_graph_purge_pending_node_key", table_name=_TABLE)
+    op.drop_index("ix_graph_purge_pending_queue", table_name=_TABLE)
+    op.drop_table(_TABLE)

--- a/alembic/versions/065_fix_graph_purge_pending_unique.py
+++ b/alembic/versions/065_fix_graph_purge_pending_unique.py
@@ -1,0 +1,57 @@
+"""fix_graph_purge_pending_unique
+
+CRITICAL-1 fix (T10-06): drop the (forget_event_id, source_table, source_pk) unique
+constraint on graph_purge_pending and replace with
+(forget_event_id, source_table, source_pk, graph_provenance_id).
+
+The old constraint collapsed multiple graph_provenance rows for the same
+(source_table, source_pk) into a single purge_pending row — only the first
+provenance row got a purge entry, leaving all other Neo4j nodes alive after
+the forget cascade. Invariant #9 violation.
+
+The new constraint allows one purge_pending row PER provenance row, so every
+Neo4j node derived from the source is purged atomically.
+
+Revision ID: 065
+Revises: 063
+Create Date: 2026-05-20
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "065"
+down_revision: Union[str, Sequence[str], None] = "063"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_TABLE = "graph_purge_pending"
+_OLD_CONSTRAINT = "uq_graph_purge_pending_event_source"
+_NEW_CONSTRAINT = "uq_graph_purge_pending_event_source_prov"
+
+
+def upgrade() -> None:
+    # Drop the old three-column unique constraint.
+    op.drop_constraint(_OLD_CONSTRAINT, _TABLE, type_="unique")
+
+    # Create the new four-column unique constraint including graph_provenance_id.
+    # NULL == NULL for uniqueness purposes in Postgres unique constraints uses
+    # NULLS DISTINCT (default); each NULL provenance_id is treated as distinct,
+    # which is what we want for rows with no provenance FK.
+    op.create_unique_constraint(
+        _NEW_CONSTRAINT,
+        _TABLE,
+        ["forget_event_id", "source_table", "source_pk", "graph_provenance_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(_NEW_CONSTRAINT, _TABLE, type_="unique")
+    op.create_unique_constraint(
+        _OLD_CONSTRAINT,
+        _TABLE,
+        ["forget_event_id", "source_table", "source_pk"],
+    )

--- a/bot/db/models.py
+++ b/bot/db/models.py
@@ -1724,3 +1724,71 @@ class GraphEdge(Base):
         DateTime(timezone=True), nullable=False, server_default=func.now()
     )
     purged_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+
+class GraphPurgePending(Base):
+    """Async purge queue for Neo4j bolt DELETE (T10-06 / alembic 063).
+
+    Written atomically in the same Postgres transaction as the Postgres-side forget
+    cascade. graph_purge_worker consumes rows and executes Neo4j DETACH DELETE via
+    bolt. graph_query.py checks this table before any traversal — fails closed
+    (abstained=True) while any non-purged row exists for query result nodes.
+
+    RFC-001:415 fail-closed invariant: purged_at IS NULL means the Neo4j purge has
+    NOT yet completed; graph queries must not return those nodes.
+
+    Migration 063.
+    """
+
+    __tablename__ = "graph_purge_pending"
+    __table_args__ = (
+        CheckConstraint(
+            "source_table IN ('message_versions', 'knowledge_cards', 'card_sources')",
+            name="ck_graph_purge_pending_source_table",
+        ),
+        # CRITICAL-1 fix (T10-06): include graph_provenance_id so multiple provenance rows
+        # for same (source_table, source_pk) each get their own purge_pending row.
+        # Previously: (forget_event_id, source_table, source_pk) — collapsed multi-provenance.
+        # Migration 065 drops old constraint and creates this one.
+        UniqueConstraint(
+            "forget_event_id",
+            "source_table",
+            "source_pk",
+            "graph_provenance_id",
+            name="uq_graph_purge_pending_event_source_prov",
+        ),
+        Index(
+            "ix_graph_purge_pending_queue",
+            "enqueued_at",
+            postgresql_where=text("purged_at IS NULL AND failed_at IS NULL"),
+        ),
+        Index(
+            "ix_graph_purge_pending_node_key",
+            "graph_node_key",
+            postgresql_where=text("purged_at IS NULL"),
+        ),
+        Index("ix_graph_purge_pending_forget_event", "forget_event_id"),
+        Index("ix_graph_purge_pending_source", "source_table", "source_pk"),
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    forget_event_id: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    source_table: Mapped[str] = mapped_column(Text, nullable=False)
+    source_pk: Mapped[str] = mapped_column(Text, nullable=False)
+    # known at enqueue time if provenance row exists
+    graph_node_key: Mapped[str | None] = mapped_column(Text, nullable=True)
+    graph_edge_key: Mapped[str | None] = mapped_column(Text, nullable=True)
+    graph_provenance_id: Mapped[int | None] = mapped_column(
+        BigInteger,
+        ForeignKey("graph_provenance.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    enqueued_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    purged_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    failed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    error: Mapped[str | None] = mapped_column(Text, nullable=True)
+    retry_count: Mapped[int] = mapped_column(
+        SmallInteger, nullable=False, server_default=text("0"), default=0
+    )

--- a/bot/db/repos/graph_provenance.py
+++ b/bot/db/repos/graph_provenance.py
@@ -116,8 +116,12 @@ async def create_provenance(
 async def mark_inactive(
     session: AsyncSession,
     provenance_id: int,
+    *,
+    purge_reason: str = "forget_cascade",
 ) -> None:
-    """Soft-delete a graph_provenance row by setting purged_at to now().
+    """Soft-delete a graph_provenance row by setting purged_at and purge_reason.
+
+    Spec §5.F step 2: SET purged_at = now(), purge_reason = 'forget_cascade'.
 
     Idempotent: if already purged, silently leaves the value as-is.
     Raises LookupError if the row does not exist.
@@ -130,7 +134,10 @@ async def mark_inactive(
         update(GraphProvenance)
         .where(GraphProvenance.id == provenance_id)
         .where(GraphProvenance.purged_at.is_(None))
-        .values(purged_at=datetime.now(tz=timezone.utc))
+        .values(
+            purged_at=datetime.now(tz=timezone.utc),
+            purge_reason=purge_reason,
+        )
     )
     result = await session.execute(stmt)
     if result.rowcount == 0:
@@ -149,7 +156,11 @@ async def mark_inactive(
         )
         return
     await session.flush()
-    _log.debug("graph_provenance: marked inactive id=%s", provenance_id)
+    _log.debug(
+        "graph_provenance: marked inactive id=%s purge_reason=%s",
+        provenance_id,
+        purge_reason,
+    )
 
 
 async def find_by_source(

--- a/bot/db/repos/graph_purge_pending.py
+++ b/bot/db/repos/graph_purge_pending.py
@@ -172,10 +172,9 @@ def sa_interval(minutes: int):
     """Return a SQLAlchemy interval expression for PostgreSQL."""
     from sqlalchemy import text
 
-    # nosemgrep: python.sqlalchemy.security.audit.avoid-sqlalchemy-text.avoid-sqlalchemy-text
     # `minutes` is coerced to int below — no user input can flow into the SQL string.
     minutes_int = int(minutes)
-    return text(f"INTERVAL '{minutes_int} minutes'")
+    return text(f"INTERVAL '{minutes_int} minutes'")  # nosemgrep: python.sqlalchemy.security.audit.avoid-sqlalchemy-text.avoid-sqlalchemy-text
 
 
 async def mark_purged(

--- a/bot/db/repos/graph_purge_pending.py
+++ b/bot/db/repos/graph_purge_pending.py
@@ -1,0 +1,283 @@
+"""Repository for ``graph_purge_pending`` (Phase 10 / T10-06).
+
+Flush-only — NEVER calls ``session.commit()`` or ``session.rollback()``.
+The caller owns the transaction lifecycle.
+
+Implements the async purge queue for Neo4j bolt DELETE rows per RFC-001:415.
+claim_batch uses SELECT ... FOR UPDATE SKIP LOCKED to prevent multi-worker
+double-claim.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Sequence
+
+from sqlalchemy import select, update
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from bot.db.models import GraphPurgePending
+
+_log = logging.getLogger(__name__)
+
+# Max retries before a row is moved to the DLQ (failed_at IS NOT NULL).
+MAX_RETRIES = 5
+
+# Stale claim timeout: rows stuck in the queue longer than this (purged_at IS NULL,
+# failed_at IS NULL, enqueued_at < now() - stale_minutes) are reset to retry on
+# the next claim_batch call. In practice these appear when a worker crashes mid-flight.
+STALE_CLAIM_MINUTES = 5
+
+
+async def enqueue(
+    session: AsyncSession,
+    *,
+    forget_event_id: int,
+    source_table: str,
+    source_pk: str,
+    graph_node_key: str | None = None,
+    graph_edge_key: str | None = None,
+    graph_provenance_id: int | None = None,
+) -> GraphPurgePending:
+    """Insert a new graph_purge_pending row.
+
+    Idempotent via ON CONFLICT DO NOTHING on
+    (forget_event_id, source_table, source_pk, graph_provenance_id).
+
+    CRITICAL-1 (T10-06): the unique key includes graph_provenance_id so that
+    multiple graph_provenance rows for the same (source_table, source_pk) each
+    receive their own purge_pending row. The old constraint
+    (forget_event_id, source_table, source_pk) collapsed all but the first row,
+    leaving the other Neo4j nodes alive after cascade.
+
+    Returns the row just inserted (or the existing row on conflict).
+
+    Flushes; caller commits.
+    """
+    _ALLOWED_SOURCE_TABLES = frozenset(
+        {"message_versions", "knowledge_cards", "card_sources"}
+    )
+    if source_table not in _ALLOWED_SOURCE_TABLES:
+        raise ValueError(
+            f"source_table {source_table!r} not allowed; "
+            f"must be one of {sorted(_ALLOWED_SOURCE_TABLES)}"
+        )
+
+    # Use PostgreSQL INSERT ... ON CONFLICT DO NOTHING for idempotency.
+    # On SQLite (tests), fall back to a plain INSERT (no ON CONFLICT syntax).
+    dialect_name = session.bind.dialect.name if session.bind is not None else "sqlite"
+
+    if dialect_name == "postgresql":
+        stmt = (
+            pg_insert(GraphPurgePending)
+            .values(
+                forget_event_id=forget_event_id,
+                source_table=source_table,
+                source_pk=source_pk,
+                graph_node_key=graph_node_key,
+                graph_edge_key=graph_edge_key,
+                graph_provenance_id=graph_provenance_id,
+            )
+            .on_conflict_do_nothing(
+                # CRITICAL-1 fix: include graph_provenance_id so each provenance row
+                # gets its own purge_pending entry (migration 065 constraint name).
+                constraint="uq_graph_purge_pending_event_source_prov"
+            )
+        )
+        await session.execute(stmt)
+        await session.flush()
+        # Re-fetch the row (either just inserted or existing on conflict).
+        row = await session.scalar(
+            select(GraphPurgePending).where(
+                GraphPurgePending.forget_event_id == forget_event_id,
+                GraphPurgePending.source_table == source_table,
+                GraphPurgePending.source_pk == source_pk,
+                GraphPurgePending.graph_provenance_id == graph_provenance_id
+                if graph_provenance_id is not None
+                else GraphPurgePending.graph_provenance_id.is_(None),
+            )
+        )
+        if row is None:
+            raise RuntimeError(
+                f"enqueue: row not found after INSERT ON CONFLICT DO NOTHING "
+                f"for forget_event_id={forget_event_id} source_table={source_table} "
+                f"source_pk={source_pk} graph_provenance_id={graph_provenance_id}"
+            )
+    else:
+        # SQLite path: plain insert.
+        row = GraphPurgePending(
+            forget_event_id=forget_event_id,
+            source_table=source_table,
+            source_pk=source_pk,
+            graph_node_key=graph_node_key,
+            graph_edge_key=graph_edge_key,
+            graph_provenance_id=graph_provenance_id,
+        )
+        session.add(row)
+        await session.flush()
+
+    _log.debug(
+        "graph_purge_pending: enqueued id=%s forget_event_id=%s source_table=%s source_pk=%s prov_id=%s",
+        row.id,
+        forget_event_id,
+        source_table,
+        source_pk,
+        graph_provenance_id,
+    )
+    return row
+
+
+async def claim_batch(
+    session: AsyncSession,
+    *,
+    batch_size: int = 20,
+) -> Sequence[GraphPurgePending]:
+    """Claim up to batch_size pending rows for processing.
+
+    Uses SELECT ... FOR UPDATE SKIP LOCKED on PostgreSQL to prevent
+    multi-worker double-claim. Returns pending rows (purged_at IS NULL,
+    failed_at IS NULL, ordered by enqueued_at ASC).
+
+    SQLite fallback (tests): plain SELECT without FOR UPDATE SKIP LOCKED.
+
+    Note on stale-row recovery: there is no separate ``claimed_at`` column in
+    this table (migration 063). FOR UPDATE SKIP LOCKED implicitly handles
+    worker crashes — locks are released on connection drop, so in-flight rows
+    become available to other workers on reconnect. No explicit stale-reset
+    UPDATE is needed.
+    """
+    dialect_name = session.bind.dialect.name if session.bind is not None else "sqlite"
+
+    stmt = (
+        select(GraphPurgePending)
+        .where(
+            GraphPurgePending.purged_at.is_(None),
+            GraphPurgePending.failed_at.is_(None),
+        )
+        .order_by(GraphPurgePending.enqueued_at.asc())
+        .limit(batch_size)
+    )
+    if dialect_name == "postgresql":
+        stmt = stmt.with_for_update(skip_locked=True)
+
+    result = await session.execute(stmt)
+    rows = list(result.scalars().all())
+    _log.debug("graph_purge_pending: claimed %d rows", len(rows))
+    return rows
+
+
+def sa_interval(minutes: int):
+    """Return a SQLAlchemy interval expression for PostgreSQL."""
+    from sqlalchemy import text
+
+    return text(f"INTERVAL '{minutes} minutes'")
+
+
+async def mark_purged(
+    session: AsyncSession,
+    row_id: int,
+) -> None:
+    """Mark a graph_purge_pending row as successfully purged.
+
+    Idempotent: if already purged, silently no-ops.
+    Raises LookupError if the row does not exist.
+
+    Flushes; caller commits.
+    """
+    stmt = (
+        update(GraphPurgePending)
+        .where(GraphPurgePending.id == row_id)
+        .where(GraphPurgePending.purged_at.is_(None))
+        .values(purged_at=datetime.now(tz=timezone.utc))
+    )
+    result = await session.execute(stmt)
+    if result.rowcount == 0:
+        exists = await session.scalar(
+            select(GraphPurgePending.id).where(GraphPurgePending.id == row_id)
+        )
+        if exists is None:
+            raise LookupError(
+                f"GraphPurgePending(id={row_id}) not found — cannot mark purged"
+            )
+        # Already purged — idempotent no-op.
+        _log.debug("graph_purge_pending: mark_purged id=%s already purged (noop)", row_id)
+        return
+    await session.flush()
+    _log.debug("graph_purge_pending: marked purged id=%s", row_id)
+
+
+async def mark_failed(
+    session: AsyncSession,
+    row_id: int,
+    *,
+    error_msg: str,
+) -> None:
+    """Mark a graph_purge_pending row as failed.
+
+    Increments retry_count. Sets failed_at only when retry_count reaches MAX_RETRIES.
+    Before MAX_RETRIES, the row stays in the pending queue for retry.
+
+    Raises LookupError if the row does not exist.
+
+    Flushes; caller commits.
+    """
+    row = await session.scalar(
+        select(GraphPurgePending).where(GraphPurgePending.id == row_id)
+    )
+    if row is None:
+        raise LookupError(
+            f"GraphPurgePending(id={row_id}) not found — cannot mark failed"
+        )
+
+    row.retry_count = (row.retry_count or 0) + 1
+    row.error = error_msg[:500]  # cap error message length
+
+    if row.retry_count >= MAX_RETRIES:
+        row.failed_at = datetime.now(tz=timezone.utc)
+        _log.error(
+            "graph_purge_pending: DLQ id=%s after %d retries error=%s",
+            row_id,
+            row.retry_count,
+            error_msg[:200],
+            extra={"graph_purge_dlq": True},
+        )
+    else:
+        _log.warning(
+            "graph_purge_pending: retry %d/%d id=%s error=%s",
+            row.retry_count,
+            MAX_RETRIES,
+            row_id,
+            error_msg[:200],
+        )
+
+    await session.flush()
+
+
+async def count_active(session: AsyncSession) -> dict[str, int]:
+    """Return counts of pending, failed (DLQ), and total rows.
+
+    Used by admin stats and health checks.
+    """
+    from sqlalchemy import func
+
+    pending_count = await session.scalar(
+        select(func.count()).select_from(GraphPurgePending).where(
+            GraphPurgePending.purged_at.is_(None),
+            GraphPurgePending.failed_at.is_(None),
+        )
+    )
+    failed_count = await session.scalar(
+        select(func.count()).select_from(GraphPurgePending).where(
+            GraphPurgePending.failed_at.is_not(None),
+        )
+    )
+    total_count = await session.scalar(
+        select(func.count()).select_from(GraphPurgePending)
+    )
+    return {
+        "pending": pending_count or 0,
+        "failed_dlq": failed_count or 0,
+        "total": total_count or 0,
+    }

--- a/bot/db/repos/graph_purge_pending.py
+++ b/bot/db/repos/graph_purge_pending.py
@@ -172,7 +172,10 @@ def sa_interval(minutes: int):
     """Return a SQLAlchemy interval expression for PostgreSQL."""
     from sqlalchemy import text
 
-    return text(f"INTERVAL '{minutes} minutes'")
+    # nosemgrep: python.sqlalchemy.security.audit.avoid-sqlalchemy-text.avoid-sqlalchemy-text
+    # `minutes` is coerced to int below — no user input can flow into the SQL string.
+    minutes_int = int(minutes)
+    return text(f"INTERVAL '{minutes_int} minutes'")
 
 
 async def mark_purged(

--- a/bot/services/forget_cascade.py
+++ b/bot/services/forget_cascade.py
@@ -168,6 +168,14 @@ CASCADE_LAYER_ORDER: tuple[str, ...] = (
     "message_links",
     "attachments",
     "fts_rows",
+    # Phase 10 / T10-06 layer:
+    # MUST run AFTER card_sources so card_source ids are still
+    # resolvable when we look up graph_provenance rows keyed by card.
+    # MUST run AFTER message_versions so the affected mvid set is
+    # fully resolved before the graph purge begins.
+    # Advisory-lock-guarded Postgres writes only in this layer;
+    # actual Neo4j bolt DELETE is delegated to graph_purge_worker (async).
+    "graph_nodes",
 )
 
 # Layers that apply only to specific target_types. Layers absent from this dict
@@ -195,6 +203,11 @@ _LAYER_APPLICABLE_TARGET_TYPES: dict[str, frozenset[str]] = {
     # (L9d: message_hash; L9e: user).
     "wiki_pages": frozenset({"message", "message_hash", "user"}),
     "wiki_revisions": frozenset({"message", "message_hash", "user"}),
+    # Phase 10 / T10-06 (PHASE10_PLAN.md §5.F): graph_nodes layer applies to
+    # all target_types that touch message_versions or knowledge_cards.
+    # Invariant #9: the layer MUST run even when memory.graph.projection.enabled
+    # is OFF — the flag gates new projections, not purge of already-projected content.
+    "graph_nodes": frozenset({"message", "message_hash", "user"}),
 }
 
 
@@ -1159,6 +1172,133 @@ async def _cascade_wiki_revisions(session: AsyncSession, event) -> int:
     return count
 
 
+# ─── Phase 10 / T10-06 cascade layer ─────────────────────────────────────────
+
+
+async def _cascade_graph_provenance(session: AsyncSession, event) -> int:
+    """Logical cascade for graph projections (T10-06 / PHASE10_PLAN.md §5.F).
+
+    1. Find all graph_provenance rows where (source_table, source_pk) matches
+       the forget_event target (via find_by_source). The lookup is by
+       source_message_version_id membership in the resolved affected_mvids set.
+    2. For each row: mark_inactive (soft-delete purged_at) + atomically enqueue a
+       graph_purge_pending row carrying graph_node_key + graph_edge_key.
+    3. graph_purge_pending rows drive the async Neo4j DETACH DELETE in a separate
+       worker (graph_purge_worker_tick). This layer does NO Neo4j bolt calls.
+    4. Fails closed: any DB write failure here means the entire forget cascade
+       FAILS for this event — does NOT swallow exceptions.
+
+    Invariant #9 binding: this layer is mandatory and runs even when
+    memory.graph.projection.enabled is OFF. The flag gates new projections,
+    not purge of already-projected content.
+
+    Returns the count of graph_purge_pending rows enqueued.
+    """
+    from bot.db.repos.graph_provenance import find_by_source, mark_inactive
+    from bot.db.repos.graph_purge_pending import enqueue as enqueue_purge
+
+    # Resolve affected message_version_ids (same helper as other layers).
+    mvids = await _resolve_affected_mvids(session, event)
+
+    if not mvids and event.target_type not in ("message", "message_hash", "user"):
+        return 0
+
+    # Build the set of (source_table, source_pk) pairs to query.
+    # Path 1: source_table='message_versions' — one pair per affected mvid.
+    source_pairs: list[tuple[str, str]] = []
+    for mvid in mvids:
+        source_pairs.append(("message_versions", str(mvid)))
+
+    # Path 2 (CRITICAL-2): source_table='knowledge_cards' — find cards whose
+    # graph_provenance rows must also be purged.
+    #
+    # Design note: this layer runs AFTER card_sources (per CASCADE_LAYER_ORDER).
+    # The card_sources layer has already deleted the card_sources rows and
+    # archived knowledge_cards whose all sources were forgotten. So we cannot
+    # query card_sources here (they are gone). Instead we look at:
+    #   graph_provenance WHERE source_table='knowledge_cards'
+    #     AND source_card_id IN (archived knowledge_cards)
+    #
+    # "Archived" cards are those set to card_status='archived' by the
+    # _cascade_card_sources_on_forget layer that ran before us. Purging all
+    # graph_provenance for archived cards is correct: an archived card's graph
+    # representation is stale and must not be served in queries.
+    if mvids:
+        from bot.db.models import KnowledgeCard, GraphProvenance as _GP
+        from sqlalchemy import select as _select
+
+        archived_card_subq = _select(KnowledgeCard.id).where(
+            KnowledgeCard.card_status == "archived"
+        )
+        archived_prov_rows = await session.execute(
+            _select(_GP.source_pk)
+            .where(_GP.source_table == "knowledge_cards")
+            .where(_GP.source_card_id.in_(archived_card_subq))
+            .where(_GP.purged_at.is_(None))
+        )
+        affected_card_ids = [str(r[0]) for r in archived_prov_rows.all()]
+        seen_card_ids: set[str] = set()
+        for card_id_str in affected_card_ids:
+            if card_id_str not in seen_card_ids:
+                seen_card_ids.add(card_id_str)
+                source_pairs.append(("knowledge_cards", card_id_str))
+
+    if not source_pairs:
+        return 0
+
+    enqueued_count = 0
+    for source_table, source_pk in source_pairs:
+        # find_by_source returns both active and already-purged rows.
+        provenance_rows = await find_by_source(
+            session, source_table=source_table, source_pk=source_pk
+        )
+        for prov in provenance_rows:
+            # Soft-delete the provenance row (idempotent if already purged).
+            # MEDIUM-8 fix: LookupError is re-raised as a cascade failure so the
+            # forget_event is NOT silently marked complete with missing purges.
+            await mark_inactive(session, prov.id)
+
+            # Enqueue purge_pending (idempotent per provenance row via
+            # ON CONFLICT DO NOTHING on the 4-column unique key).
+            await enqueue_purge(
+                session,
+                forget_event_id=int(event.id),
+                source_table=source_table,
+                source_pk=source_pk,
+                graph_node_key=prov.graph_node_key,
+                graph_edge_key=prov.graph_edge_key,
+                graph_provenance_id=prov.id,
+            )
+            enqueued_count += 1
+
+    # HIGH-4: soft-delete graph_edges rows for all provenance ids in this batch.
+    # Must run in the same transaction before the cascade layer completes.
+    if enqueued_count > 0:
+        from bot.db.models import GraphEdge
+        from sqlalchemy import update
+        from datetime import datetime, timezone
+
+        # Collect the provenance ids we just processed.
+        processed_prov_ids: list[int] = []
+        for source_table, source_pk in source_pairs:
+            prov_rows = await find_by_source(
+                session, source_table=source_table, source_pk=source_pk
+            )
+            for prov in prov_rows:
+                processed_prov_ids.append(prov.id)
+
+        if processed_prov_ids:
+            await session.execute(
+                update(GraphEdge)
+                .where(GraphEdge.graph_provenance_id.in_(processed_prov_ids))
+                .where(GraphEdge.purged_at.is_(None))
+                .values(purged_at=datetime.now(tz=timezone.utc))
+            )
+            await session.flush()
+
+    return enqueued_count
+
+
 # Map layer name → cascade function. Layers absent from this map are recorded as
 # skipped. When a future phase adds a layer's table, add its function here.
 _LAYER_FUNCS: dict[str, Any] = {
@@ -1176,6 +1316,8 @@ _LAYER_FUNCS: dict[str, Any] = {
     "wiki_revisions": _cascade_wiki_revisions,
     # T6-01 Phase 6 layer — PHASE6_PLAN.md §5.A.5.
     "card_sources": _cascade_card_sources_on_forget,
+    # T10-06 Phase 10 layer — PHASE10_PLAN.md §5.F. Runs AFTER card_sources.
+    "graph_nodes": _cascade_graph_provenance,
 }
 
 

--- a/bot/services/graph_purge_readblock.py
+++ b/bot/services/graph_purge_readblock.py
@@ -1,0 +1,106 @@
+"""Pending-purge read-block helpers for Phase 10 (T10-06).
+
+Implements the RFC-001:415 fail-closed read-block pattern for graph queries.
+Before any Neo4j traversal, callers MUST invoke these helpers to assert no
+pending purge rows exist for the candidate node keys.
+
+If any pending rows exist (purged_at IS NULL), raises RefusalError — the caller
+MUST return abstained=True rather than executing a Cypher query.
+
+This module is owned by Stream Privacy (T10-06).
+T10-05 (graph_query.py — future) will import assert_no_pending_purge.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from bot.db.models import GraphPurgePending
+from bot.services.graph_common import RefusalError
+
+_log = logging.getLogger(__name__)
+
+
+async def assert_no_pending_purge(
+    session: AsyncSession,
+    *,
+    node_keys: list[str],
+) -> None:
+    """Assert no pending purge rows exist for any of the given node_keys.
+
+    Queries graph_purge_pending for any row where graph_node_key is in the
+    given list AND purged_at IS NULL (pending or failed but not yet purged).
+
+    Raises RefusalError if any match — fails CLOSED per RFC-001:415.
+    Callers must return abstained=True when this raises.
+
+    node_keys: list of graph_node_key values from the candidate traversal result.
+
+    Invariant #9 binding: this check enforces the fail-closed window while the
+    async Neo4j purge is in progress. Even after failed_at is set on a row, the
+    row's purged_at is still NULL — so the read-block continues until the admin
+    manually clears the DLQ or a successful retry sets purged_at.
+    """
+    if not node_keys:
+        return
+
+    row = await session.scalar(
+        select(GraphPurgePending.id)
+        .where(
+            GraphPurgePending.graph_node_key.in_(node_keys),
+            GraphPurgePending.purged_at.is_(None),
+        )
+        .limit(1)
+    )
+    if row is not None:
+        _log.warning(
+            "graph_purge_readblock: pending purge row id=%s found for node_keys=%s — "
+            "returning abstained (RFC-001:415 fail-closed)",
+            row,
+            node_keys[:3],  # log first 3 only to avoid log flooding
+        )
+        raise RefusalError(
+            f"Pending graph purge exists for node_keys (first match id={row}). "
+            "Returning abstained=True per RFC-001:415 fail-closed contract."
+        )
+
+
+async def assert_no_pending_purge_for_source(
+    session: AsyncSession,
+    *,
+    source_table: str,
+    source_pk: str,
+) -> None:
+    """Assert no pending purge rows exist for the given (source_table, source_pk).
+
+    Sister helper for assert_no_pending_purge — queries by source identity
+    rather than graph_node_key. Useful when the caller knows the source row
+    but hasn't yet resolved its node_keys.
+
+    Raises RefusalError if any pending row matches — fails CLOSED per RFC-001:415.
+    """
+    row = await session.scalar(
+        select(GraphPurgePending.id)
+        .where(
+            GraphPurgePending.source_table == source_table,
+            GraphPurgePending.source_pk == source_pk,
+            GraphPurgePending.purged_at.is_(None),
+        )
+        .limit(1)
+    )
+    if row is not None:
+        _log.warning(
+            "graph_purge_readblock: pending purge row id=%s found for "
+            "source_table=%s source_pk=%s — returning abstained (RFC-001:415)",
+            row,
+            source_table,
+            source_pk,
+        )
+        raise RefusalError(
+            f"Pending graph purge exists for source_table={source_table!r} "
+            f"source_pk={source_pk!r} (first match id={row}). "
+            "Returning abstained=True per RFC-001:415 fail-closed contract."
+        )

--- a/bot/services/graph_purge_worker.py
+++ b/bot/services/graph_purge_worker.py
@@ -1,0 +1,160 @@
+"""Async purge worker for Neo4j bolt DELETE (T10-06 / Phase 10).
+
+Drives graph_purge_pending rows through Neo4j DETACH DELETE via bolt.
+Consumes rows claimed via claim_batch (SELECT ... FOR UPDATE SKIP LOCKED) and
+calls adapter.delete_provenance for each.
+
+On success: marks row purged_at = now().
+On failure: increments retry_count; sets failed_at after MAX_RETRIES (DLQ).
+Continues to next row on failure (does not abort the batch).
+
+Race safety:
+- claim_batch uses FOR UPDATE SKIP LOCKED — multi-worker safe.
+- Rows already purged (purged_at IS NOT NULL) are excluded by claim_batch.
+- Stale rows are idempotently retried.
+
+Feature flag: memory.graph.write_pending.paused (default OFF).
+When ON, the worker returns immediately without consuming any rows.
+Kill-switch for Neo4j downtime in production.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from bot.db.repos.graph_purge_pending import claim_batch, mark_failed, mark_purged
+
+_log = logging.getLogger(__name__)
+
+# Feature flag key for the kill-switch.
+GRAPH_PURGE_PAUSED_FLAG = "memory.graph.write_pending.paused"
+
+
+@dataclass
+class PurgeTickResult:
+    """Result of one graph_purge_worker_tick call."""
+
+    processed: int = 0
+    errors: int = 0
+    skipped_paused: bool = False
+    reprocessed: int = 0  # rows already purged (should never happen via claim_batch)
+
+
+async def graph_purge_worker_tick(
+    session: AsyncSession,
+    *,
+    adapter: Any,  # GraphAdapter protocol — imported lazily to avoid circular dep
+    batch_size: int = 20,
+) -> dict[str, Any]:
+    """Consume up to batch_size pending purge rows and issue Neo4j DELETE calls.
+
+    Returns a dict with keys: processed, errors, skipped_paused.
+
+    Feature flag kill-switch: if memory.graph.write_pending.paused is ON,
+    returns immediately with skipped_paused=True.
+
+    For each claimed row:
+      1. Call adapter.delete_provenance(str(row.graph_provenance_id or row.graph_node_key)).
+      2. On success: mark_purged.
+      3. On failure: mark_failed with error message; continue to next row.
+
+    Idempotent: rows already purged are not in the claim_batch result set
+    (purged_at IS NULL filter), so they are never reprocessed.
+    """
+    # Feature flag check — kill-switch for purge worker.
+    from bot.db.repos.feature_flag import FeatureFlagRepo
+
+    flag_paused = await FeatureFlagRepo.get(session, GRAPH_PURGE_PAUSED_FLAG)
+    if flag_paused:
+        _log.info(
+            "graph_purge_worker: flag %s is ON — skipping tick",
+            GRAPH_PURGE_PAUSED_FLAG,
+        )
+        return {"processed": 0, "errors": 0, "skipped_paused": True}
+
+    rows = await claim_batch(session, batch_size=batch_size)
+    processed = 0
+    errors = 0
+
+    for row in rows:
+        # Build the provenance identifier: prefer graph_provenance_id (numeric FK),
+        # fall back to graph_node_key (string identifier).
+        purge_key = (
+            str(row.graph_provenance_id)
+            if row.graph_provenance_id is not None
+            else row.graph_node_key or ""
+        )
+
+        try:
+            deleted_count = await adapter.delete_provenance(purge_key)
+
+            # CRITICAL-3 / HIGH-6: verify adapter actually deleted data.
+            # If delete_provenance returns 0 AND the provenance_id is non-NULL,
+            # this is unexpected — the Neo4j adapter may be drifting. Log a
+            # structured warning so ops can detect adapter drift.
+            # We still mark purged (idempotency assumption: 0 deletions may mean
+            # Neo4j never had this provenance or it was already purged by a prior
+            # tick). BUT only when provenance_id was NULL (fall-back path) or the
+            # return is truthy.  When provenance_id is non-NULL and count==0: log
+            # warning, do NOT mark purged — mark as failed so ops can investigate.
+            if deleted_count == 0 and row.graph_provenance_id is not None:
+                error_msg = (
+                    f"adapter.delete_provenance returned 0 deletions for non-NULL "
+                    f"graph_provenance_id={row.graph_provenance_id} (purge_key={purge_key!r}); "
+                    "Neo4j data may be missing or adapter is broken"
+                )
+                _log.warning(
+                    "graph_purge_worker: zero-delete id=%s purge_key=%s prov_id=%s — "
+                    "marking failed for manual review",
+                    row.id,
+                    purge_key,
+                    row.graph_provenance_id,
+                    extra={"graph_purge_zero_delete": True},
+                )
+                try:
+                    await mark_failed(session, row.id, error_msg=error_msg)
+                    await session.flush()
+                except Exception:
+                    _log.exception(
+                        "graph_purge_worker: could not mark_failed for id=%s", row.id
+                    )
+                errors += 1
+                continue
+
+            await mark_purged(session, row.id)
+            await session.flush()
+            processed += 1
+            _log.debug(
+                "graph_purge_worker: purged id=%s purge_key=%s deleted=%s",
+                row.id,
+                purge_key,
+                deleted_count,
+            )
+        except Exception as exc:
+            error_msg = str(exc)[:500]
+            _log.warning(
+                "graph_purge_worker: failed id=%s purge_key=%s error=%s",
+                row.id,
+                purge_key,
+                error_msg,
+            )
+            try:
+                await mark_failed(session, row.id, error_msg=error_msg)
+                await session.flush()
+            except Exception:
+                _log.exception(
+                    "graph_purge_worker: could not mark_failed for id=%s", row.id
+                )
+            errors += 1
+
+    _log.info(
+        "graph_purge_worker: tick processed=%d errors=%d batch_size=%d",
+        processed,
+        errors,
+        batch_size,
+    )
+    return {"processed": processed, "errors": errors, "skipped_paused": False}

--- a/docs/rollout-fragments/phase10/T10-06.md
+++ b/docs/rollout-fragments/phase10/T10-06.md
@@ -1,0 +1,88 @@
+# T10-06: Privacy-Critical Async Graph Purge Cascade
+
+**Status:** Implemented
+**Branch:** feat/p10-t10-06-cascade-purge
+**Date:** 2026-05-20
+**RFC:** RFC-001:415 conditional Neo4j approval (async purge, fail-closed)
+
+## Summary
+
+- Implements the privacy-critical async cascade layer that integrates Neo4j graph purge
+  into the existing forget cascade pipeline.
+- Postgres-side tombstones are written atomically (same transaction as cascade commit);
+  Neo4j bolt DELETE is driven asynchronously by `graph_purge_worker`.
+- Graph queries are gated by a read-block (`graph_purge_readblock.py`) that fails closed
+  (returns `abstained=True`) while any non-purged `graph_purge_pending` row exists.
+
+## Migration 063 Applied
+
+- **File:** `alembic/versions/063_add_graph_purge_pending.py`
+- **Chain:** 062 → 064 → 063 (non-contiguous due to T10-03 shipping 064 first)
+- **Table:** `graph_purge_pending` — async purge queue for Neo4j bolt DELETE
+- **Columns:** id, forget_event_id, source_table, source_pk, graph_node_key,
+  graph_edge_key, graph_provenance_id (FK nullable), enqueued_at, purged_at, failed_at,
+  error, retry_count
+- **Indexes:** worker queue (partial pending+non-failed), node_key (partial pending),
+  forget_event_id, source_table+source_pk
+- **ORM:** `GraphPurgePending` added to `bot/db/models.py`
+
+## New Services
+
+### `bot/services/graph_purge_readblock.py`
+- `assert_no_pending_purge(session, *, node_keys)` — raises `RefusalError` (RFC-001:415
+  fail-closed) if any node_key has a non-purged purge row.
+- `assert_no_pending_purge_for_source(session, *, source_table, source_pk)` — sister helper.
+- Imported by T10-05 (`graph_query.py`) before any Cypher traversal.
+
+### `bot/services/graph_purge_worker.py`
+- `graph_purge_worker_tick(session, *, adapter, batch_size=20)` — consumes pending rows
+  via `claim_batch` (SELECT FOR UPDATE SKIP LOCKED), calls `adapter.delete_provenance`,
+  marks rows purged or failed.
+- Returns dict: `{processed, errors, skipped_paused}`.
+- Feature flag kill-switch: `memory.graph.write_pending.paused` (default OFF).
+
+### `bot/db/repos/graph_purge_pending.py`
+- `enqueue` (idempotent via ON CONFLICT DO NOTHING)
+- `claim_batch` (FOR UPDATE SKIP LOCKED, batch_size configurable)
+- `mark_purged` (idempotent)
+- `mark_failed` (increments retry_count; sets failed_at at MAX_RETRIES=5 — DLQ)
+- `count_active` (pending/failed/total counts for admin stats)
+
+## `forget_cascade.py` Changes
+
+- New layer `"graph_nodes"` appended to `CASCADE_LAYER_ORDER` AFTER `"card_sources"`.
+- `_cascade_graph_provenance(session, event)` function:
+  - Resolves affected mvids via `_resolve_affected_mvids`.
+  - Queries `graph_provenance` by `(source_table='message_versions', source_pk=str(mvid))`.
+  - Soft-deletes provenance rows (`mark_inactive`).
+  - Enqueues `graph_purge_pending` rows atomically in the same cascade transaction.
+  - Returns count of enqueued rows (0 if no provenance rows found).
+- `_LAYER_APPLICABLE_TARGET_TYPES["graph_nodes"]` = `{"message", "message_hash", "user"}`.
+- Invariant #9: layer always runs when provenance rows exist, even if
+  `memory.graph.projection.enabled` is OFF.
+
+## Feature Flag
+
+- `memory.graph.write_pending.paused` (default OFF) — kill-switch for purge worker.
+  When ON, `graph_purge_worker_tick` returns immediately. Graph queries immediately
+  fail-closed on any pending-purge row.
+
+## Migration Chain
+
+```
+062 (graph_edges) → 064 (llm_ledger_call_type) → 063 (graph_purge_pending) [head]
+```
+
+Non-contiguous ordering: Alembic supports non-sequential revision IDs. The chain
+is linear (no branching) — 063 extends 064 as `down_revision="064"`.
+
+## Coordination Notes
+
+- Unblocks T10-05 (`graph_query.py`): import `assert_no_pending_purge` from
+  `bot.services.graph_purge_readblock` for the fail-closed check.
+- Parallel to T10-04 (`graph_projector.py`) — no shared files modified.
+
+## Docs Touched
+
+- `tests/db/test_fts_schema.py`: head assertion `"064"` → `"063"`
+- `tests/db/test_digests_review_schema.py`: head assertion `"064"` → `"063"`

--- a/tests/db/test_digests_review_schema.py
+++ b/tests/db/test_digests_review_schema.py
@@ -136,12 +136,14 @@ async def test_alembic_head_is_latest(migrated_database_url: str) -> None:
     FHR landed the legacy-grace nullable `wiki_page_id` migration; then to '060'
     when Phase 10 W0-A added graph_projection_runs; then to '062' when T10-02
     added graph_provenance (061) and graph_edges (062); then to '064' when T10-03
-    added llm_usage_ledger.call_type. The intent of this test is unchanged —
-    assert the head matches the latest shipped migration. Update the literal when
-    new migrations land.
+    added llm_usage_ledger.call_type; then to '063' when T10-06 added
+    graph_purge_pending (chain: 062→064→063); then to '065' when T10-06 CRITICAL-1
+    fix updated graph_purge_pending unique constraint to include graph_provenance_id.
+    The intent of this test is unchanged — assert the head matches the latest
+    shipped migration. Update the literal when new migrations land.
     """
     current = await _fetch_value(migrated_database_url, "SELECT version_num FROM alembic_version")
-    assert current == "064"
+    assert current == "065"
 
 
 # ─── Test: upgrade adds 4 review columns with correct types/nullability ──────

--- a/tests/db/test_fts_schema.py
+++ b/tests/db/test_fts_schema.py
@@ -186,9 +186,9 @@ async def test_alembic_upgrade_head_on_clean_db_green(migrated_database_url: str
     # + T9-01 (050-054 wiki schema) + Phase 9 FHR (055 legacy-grace nullable
     # wiki_page_id) + Phase 10 W0-A (060 graph_projection_runs) + T10-02
     # (061 graph_provenance, 062 graph_edges) + T10-03 (064 add_llm_ledger_call_type)
-    # advanced the head past 025.
+    # + T10-06 (063 graph_purge_pending) + T10-06 CRITICAL-1 fix (065) advanced the head past 025.
     # Assert the current head explicitly; revisit when future migrations land.
-    assert current == "064"
+    assert current == "065"
 
 
 async def test_insert_message_versions_generates_search_tsv_from_normalized_text(

--- a/tests/db/test_graph_purge_pending_repo.py
+++ b/tests/db/test_graph_purge_pending_repo.py
@@ -1,0 +1,325 @@
+"""Integration tests for bot/db/repos/graph_purge_pending.py (T10-06 / Phase 10).
+
+Uses temp_database_url pattern (same as test_graph_provenance_repo.py):
+creates an isolated temp Postgres DB, runs alembic upgrade head (includes 063),
+exercises the repo, then drops the DB.
+
+Tests are skipped (not failed) if Postgres is unreachable.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import uuid
+from collections.abc import AsyncIterator
+from pathlib import Path
+
+import asyncpg
+import pytest
+import pytest_asyncio
+from sqlalchemy.engine.url import URL, make_url
+
+from tests.conftest import DEFAULT_LOCAL_POSTGRES_URL
+
+pytestmark = pytest.mark.usefixtures("app_env")
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+# ─── Temp DB helpers ──────────────────────────────────────────────────────────
+
+
+def _base_test_url() -> URL:
+    raw_url = (
+        os.environ.get("TEST_DATABASE_URL")
+        or os.environ.get("DATABASE_URL")
+        or DEFAULT_LOCAL_POSTGRES_URL
+    )
+    return make_url(raw_url)
+
+
+def _asyncpg_kwargs(url: URL, *, database: str | None = None) -> dict:
+    return {
+        "user": url.username,
+        "password": url.password,
+        "host": url.host or "127.0.0.1",
+        "port": url.port or 5432,
+        "database": database or url.database,
+    }
+
+
+def _quote_identifier(identifier: str) -> str:
+    return '"' + identifier.replace('"', '""') + '"'
+
+
+async def _create_database(admin_url: URL, database_name: str) -> None:
+    conn = await asyncpg.connect(**_asyncpg_kwargs(admin_url, database="postgres"))
+    try:
+        await conn.execute(f"CREATE DATABASE {_quote_identifier(database_name)}")
+    finally:
+        await conn.close()
+
+
+async def _drop_database(admin_url: URL, database_name: str) -> None:
+    conn = await asyncpg.connect(**_asyncpg_kwargs(admin_url, database="postgres"))
+    try:
+        await conn.execute(
+            """
+            SELECT pg_terminate_backend(pid)
+            FROM pg_stat_activity
+            WHERE datname = $1 AND pid <> pg_backend_pid()
+            """,
+            database_name,
+        )
+        await conn.execute(f"DROP DATABASE IF EXISTS {_quote_identifier(database_name)}")
+    finally:
+        await conn.close()
+
+
+def _run_alembic(database_url: str, *args: str) -> subprocess.CompletedProcess:
+    env = os.environ.copy()
+    env["DATABASE_URL"] = database_url
+    return subprocess.run(
+        [sys.executable, "-m", "alembic", *args],
+        cwd=PROJECT_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=120,
+        check=True,
+    )
+
+
+# ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+
+@pytest_asyncio.fixture()
+async def purge_db_url() -> AsyncIterator[str]:
+    """Temp DB with alembic upgrade head (includes migrations 060-064, 063)."""
+    base_url = _base_test_url()
+    database_name = f"shkoder_purge_{uuid.uuid4().hex[:12]}"
+    try:
+        await _create_database(base_url, database_name)
+    except Exception as exc:
+        pytest.skip(f"cannot create temporary postgres database: {exc!s}")
+
+    db_url = base_url.set(database=database_name).render_as_string(hide_password=False)
+    try:
+        _run_alembic(db_url, "upgrade", "head")
+    except subprocess.CalledProcessError as exc:
+        await _drop_database(base_url, database_name)
+        pytest.skip(f"alembic upgrade head failed: {exc.stderr}")
+
+    try:
+        yield db_url
+    finally:
+        await _drop_database(base_url, database_name)
+
+
+@pytest_asyncio.fixture()
+async def purge_session(purge_db_url: str) -> AsyncIterator:
+    """AsyncSession on the migrated temp DB; each test fully isolated via rollback."""
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+    engine = create_async_engine(purge_db_url, echo=False)
+    try:
+        async with engine.connect() as conn:
+            outer = await conn.begin()
+            Session = async_sessionmaker(
+                bind=conn, class_=AsyncSession, expire_on_commit=False
+            )
+            async with Session() as session:
+                try:
+                    yield session
+                finally:
+                    if outer.is_active:
+                        await outer.rollback()
+    finally:
+        await engine.dispose()
+
+
+# ─── Tests ────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_enqueue_basic(purge_session):
+    """enqueue inserts a row and returns it with the expected fields."""
+    from bot.db.repos.graph_purge_pending import enqueue
+
+    row = await enqueue(
+        purge_session,
+        forget_event_id=1001,
+        source_table="message_versions",
+        source_pk="42",
+        graph_node_key="node:user:42",
+        graph_edge_key="edge:abc",
+    )
+
+    assert row.id is not None
+    assert row.forget_event_id == 1001
+    assert row.source_table == "message_versions"
+    assert row.source_pk == "42"
+    assert row.graph_node_key == "node:user:42"
+    assert row.graph_edge_key == "edge:abc"
+    assert row.purged_at is None
+    assert row.failed_at is None
+    assert row.retry_count == 0
+
+
+@pytest.mark.asyncio
+async def test_enqueue_idempotent(purge_session):
+    """enqueue with the same (forget_event_id, source_table, source_pk) is idempotent."""
+    from bot.db.repos.graph_purge_pending import enqueue
+
+    row1 = await enqueue(
+        purge_session,
+        forget_event_id=1002,
+        source_table="knowledge_cards",
+        source_pk="card-uuid-1",
+    )
+    row2 = await enqueue(
+        purge_session,
+        forget_event_id=1002,
+        source_table="knowledge_cards",
+        source_pk="card-uuid-1",
+    )
+    # Same row returned (same pk)
+    assert row1.id == row2.id
+
+
+@pytest.mark.asyncio
+async def test_claim_batch_skip_locked(purge_session):
+    """claim_batch returns pending rows in enqueued_at order."""
+    from bot.db.repos.graph_purge_pending import claim_batch, enqueue
+
+    await enqueue(
+        purge_session,
+        forget_event_id=2001,
+        source_table="message_versions",
+        source_pk="10",
+    )
+    await enqueue(
+        purge_session,
+        forget_event_id=2002,
+        source_table="message_versions",
+        source_pk="11",
+    )
+
+    batch = await claim_batch(purge_session, batch_size=10)
+    assert len(batch) == 2
+    # All returned rows must be pending (purged_at IS NULL, failed_at IS NULL)
+    for row in batch:
+        assert row.purged_at is None
+        assert row.failed_at is None
+
+
+@pytest.mark.asyncio
+async def test_mark_purged(purge_session):
+    """mark_purged sets purged_at; subsequent call is idempotent."""
+    from bot.db.repos.graph_purge_pending import enqueue, mark_purged
+
+    row = await enqueue(
+        purge_session,
+        forget_event_id=3001,
+        source_table="message_versions",
+        source_pk="20",
+    )
+    await mark_purged(purge_session, row.id)
+
+    # Re-fetch and check
+    from sqlalchemy import select
+    from bot.db.models import GraphPurgePending
+
+    refreshed = await purge_session.scalar(
+        select(GraphPurgePending).where(GraphPurgePending.id == row.id)
+    )
+    assert refreshed.purged_at is not None
+
+    # Idempotent second call must not raise
+    await mark_purged(purge_session, row.id)
+
+
+@pytest.mark.asyncio
+async def test_mark_failed_increments_retry(purge_session):
+    """mark_failed increments retry_count; sets failed_at only at MAX_RETRIES."""
+    import bot.db.repos.graph_purge_pending as gpp_module
+    from bot.db.repos.graph_purge_pending import enqueue, mark_failed
+
+    row = await enqueue(
+        purge_session,
+        forget_event_id=4001,
+        source_table="message_versions",
+        source_pk="30",
+    )
+
+    # First failure — not yet DLQ
+    await mark_failed(purge_session, row.id, error_msg="first error")
+
+    from sqlalchemy import select
+    from bot.db.models import GraphPurgePending
+
+    refreshed = await purge_session.scalar(
+        select(GraphPurgePending).where(GraphPurgePending.id == row.id)
+    )
+    assert refreshed.retry_count == 1
+    assert refreshed.failed_at is None  # not yet DLQ
+
+    # Fail until DLQ
+    for i in range(gpp_module.MAX_RETRIES - 1):
+        await mark_failed(purge_session, row.id, error_msg=f"error {i+2}")
+
+    refreshed = await purge_session.scalar(
+        select(GraphPurgePending).where(GraphPurgePending.id == row.id)
+    )
+    assert refreshed.retry_count == gpp_module.MAX_RETRIES
+    assert refreshed.failed_at is not None  # now DLQ
+
+
+@pytest.mark.asyncio
+async def test_count_active(purge_session):
+    """count_active returns correct pending/failed/total counts."""
+    from bot.db.repos.graph_purge_pending import count_active, enqueue, mark_purged
+
+    # Baseline counts before adding anything
+    counts_before = await count_active(purge_session)
+    pending_start = counts_before["pending"]
+    total_start = counts_before["total"]
+
+    row1 = await enqueue(
+        purge_session,
+        forget_event_id=5001,
+        source_table="message_versions",
+        source_pk="40",
+    )
+    await enqueue(
+        purge_session,
+        forget_event_id=5002,
+        source_table="message_versions",
+        source_pk="41",
+    )
+    await mark_purged(purge_session, row1.id)
+
+    counts = await count_active(purge_session)
+    # One still pending (row2), one purged (row1)
+    assert counts["pending"] == pending_start + 1
+    assert counts["total"] == total_start + 2
+
+
+@pytest.mark.asyncio
+async def test_claim_batch_excludes_purged(purge_session):
+    """claim_batch does not return rows that are already purged."""
+    from bot.db.repos.graph_purge_pending import claim_batch, enqueue, mark_purged
+
+    row = await enqueue(
+        purge_session,
+        forget_event_id=6001,
+        source_table="card_sources",
+        source_pk="cs-99",
+    )
+    await mark_purged(purge_session, row.id)
+
+    batch = await claim_batch(purge_session, batch_size=10)
+    row_ids = [r.id for r in batch]
+    assert row.id not in row_ids

--- a/tests/services/test_forget_cascade_graph_provenance.py
+++ b/tests/services/test_forget_cascade_graph_provenance.py
@@ -1,0 +1,422 @@
+"""Tests for forget_cascade._cascade_graph_provenance (T10-06 / Phase 10).
+
+Verifies:
+1. forget_event → _cascade_graph_provenance → marks graph_provenance rows inactive
+   AND enqueues graph_purge_pending rows in the same transaction.
+2. graph_nodes layer appears in CASCADE_LAYER_ORDER at the correct position.
+3. Full cascade with graph_nodes layer completes (status='completed' with graph_nodes).
+4. Layer records skipped when no graph_provenance rows exist for target.
+5. graph_nodes layer appears after card_sources in cascade_status on completion.
+"""
+
+from __future__ import annotations
+
+import itertools
+from datetime import datetime, timezone
+
+import pytest
+
+pytestmark = pytest.mark.usefixtures("app_env")
+
+_counter = itertools.count(start=9_000_000)
+
+
+def _next_id() -> int:
+    return next(_counter)
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────────────
+
+
+async def _make_user(db_session) -> int:
+    from bot.db.repos.user import UserRepo
+
+    uid = _next_id()
+    await UserRepo.upsert(
+        db_session,
+        telegram_id=uid,
+        username=f"u{uid}",
+        first_name="Test",
+        last_name=None,
+    )
+    return uid
+
+
+async def _make_message_with_version(db_session, *, text: str = "test") -> tuple[int, int, int, int]:
+    """Create a ChatMessage + v1 MessageVersion. Returns (cm_id, mv_id, chat_id, msg_id)."""
+    from bot.db.models import ChatMessage, MessageVersion
+
+    uid = await _make_user(db_session)
+    chat_id = -1_000_000_000_000 - _next_id()
+    msg_id = _next_id()
+    when = datetime.now(timezone.utc)
+
+    msg = ChatMessage(
+        message_id=msg_id,
+        chat_id=chat_id,
+        user_id=uid,
+        text=text,
+        date=when,
+        raw_json={"text": text},
+        memory_policy="normal",
+        is_redacted=False,
+    )
+    db_session.add(msg)
+    await db_session.flush()
+
+    ver = MessageVersion(
+        chat_message_id=msg.id,
+        version_seq=1,
+        text=text,
+        normalized_text=text,
+        entities_json={"entities": []},
+        content_hash=f"h-{_next_id()}",
+        is_redacted=False,
+    )
+    db_session.add(ver)
+    await db_session.flush()
+
+    msg.current_version_id = ver.id
+    await db_session.flush()
+    return msg.id, ver.id, chat_id, msg_id
+
+
+async def _make_projection_run(db_session) -> int:
+    from bot.db.repos.graph_projection_run import create_run
+
+    run = await create_run(db_session, mode="incremental", started_by="test")
+    await db_session.flush()
+    return run.id
+
+
+async def _make_provenance(
+    db_session,
+    *,
+    run_id: int,
+    source_table: str = "message_versions",
+    source_pk: str | None = None,
+    source_message_version_id: int | None = None,
+    source_card_id=None,
+    graph_node_key: str | None = None,
+    triple_hash: str | None = None,
+) -> int:
+    """Insert a graph_provenance row. Returns its id."""
+    from bot.db.repos.graph_provenance import create_provenance
+
+    pk = source_pk or str(_next_id())
+    prov = await create_provenance(
+        db_session,
+        projection_run_id=run_id,
+        source_table=source_table,
+        source_pk=pk,
+        source_message_version_id=source_message_version_id if source_table == "message_versions" else None,
+        source_card_id=source_card_id,
+        graph_node_key=graph_node_key or f"node:test:{_next_id()}",
+        triple_hash=triple_hash,
+    )
+    return prov.id
+
+
+async def _make_forget_event(db_session, *, target_type: str, target_id: str) -> int:
+    from bot.db.repos.forget_event import ForgetEventRepo
+
+    ev = await ForgetEventRepo.create(
+        db_session,
+        target_type=target_type,
+        target_id=target_id,
+        actor_user_id=None,
+        authorized_by="admin",
+        tombstone_key=f"{target_type}:{target_id}:test:{_next_id()}",
+    )
+    return ev.id
+
+
+# ─── Tests ────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_graph_nodes_in_cascade_layer_order(db_session):
+    """graph_nodes appears in CASCADE_LAYER_ORDER after card_sources."""
+    from bot.services.forget_cascade import CASCADE_LAYER_ORDER
+
+    layers = list(CASCADE_LAYER_ORDER)
+    assert "graph_nodes" in layers
+    card_sources_idx = layers.index("card_sources")
+    graph_nodes_idx = layers.index("graph_nodes")
+    assert graph_nodes_idx > card_sources_idx, (
+        "graph_nodes must appear after card_sources in CASCADE_LAYER_ORDER"
+    )
+
+
+@pytest.mark.asyncio
+async def test_cascade_graph_provenance_marks_inactive_and_enqueues(db_session):
+    """forget_event causes graph_provenance to be soft-deleted + purge_pending enqueued."""
+    from bot.services.forget_cascade import run_cascade_worker_once
+    from bot.db.models import GraphProvenance, GraphPurgePending
+    from sqlalchemy import select
+
+    cm_id, mv_id, chat_id, msg_id = await _make_message_with_version(db_session)
+    run_id = await _make_projection_run(db_session)
+    prov_id = await _make_provenance(
+        db_session,
+        run_id=run_id,
+        source_table="message_versions",
+        source_pk=str(mv_id),
+        source_message_version_id=mv_id,
+        graph_node_key=f"node:mv:{mv_id}",
+    )
+
+    await _make_forget_event(
+        db_session,
+        target_type="message",
+        target_id=str(cm_id),
+    )
+
+    await run_cascade_worker_once(db_session)
+
+    # graph_provenance row must be soft-deleted (purged_at IS NOT NULL)
+    prov = await db_session.scalar(
+        select(GraphProvenance).where(GraphProvenance.id == prov_id)
+    )
+    assert prov is not None
+    assert prov.purged_at is not None, "graph_provenance.purged_at must be set"
+
+    # graph_purge_pending row must be enqueued (purged_at IS NULL = waiting for worker)
+    purge_row = await db_session.scalar(
+        select(GraphPurgePending).where(
+            GraphPurgePending.source_table == "message_versions",
+            GraphPurgePending.source_pk == str(mv_id),
+        )
+    )
+    assert purge_row is not None, "graph_purge_pending row must be enqueued"
+    assert purge_row.purged_at is None  # not yet processed by graph_purge_worker
+
+
+@pytest.mark.asyncio
+async def test_cascade_graph_nodes_skipped_when_no_provenance(db_session):
+    """forget_event where target has no graph_provenance: layer records rows=0."""
+    from bot.services.forget_cascade import run_cascade_worker_once
+
+    cm_id, mv_id, chat_id, msg_id = await _make_message_with_version(db_session)
+    # No graph_provenance row created for this mv_id
+
+    event_id = await _make_forget_event(
+        db_session,
+        target_type="message",
+        target_id=str(cm_id),
+    )
+
+    await run_cascade_worker_once(db_session)
+
+    from sqlalchemy import select
+    from bot.db.models import ForgetEvent
+    ev = await db_session.scalar(
+        select(ForgetEvent).where(ForgetEvent.id == event_id)
+    )
+    assert ev.status == "completed"
+    cascade = ev.cascade_status
+    assert "graph_nodes" in cascade
+    assert cascade["graph_nodes"]["status"] == "completed"
+    assert cascade["graph_nodes"]["rows"] == 0
+
+
+@pytest.mark.asyncio
+async def test_full_cascade_includes_graph_nodes_completed(db_session):
+    """Full cascade run marks graph_nodes layer as completed in cascade_status."""
+    from bot.services.forget_cascade import run_cascade_worker_once
+
+    cm_id, mv_id, chat_id, msg_id = await _make_message_with_version(db_session)
+    run_id = await _make_projection_run(db_session)
+    await _make_provenance(
+        db_session,
+        run_id=run_id,
+        source_table="message_versions",
+        source_pk=str(mv_id),
+        source_message_version_id=mv_id,
+    )
+
+    event_id = await _make_forget_event(
+        db_session,
+        target_type="message",
+        target_id=str(cm_id),
+    )
+
+    stats = await run_cascade_worker_once(db_session)
+    assert stats["processed"] == 1
+    assert stats["failed"] == 0
+
+    from sqlalchemy import select
+    from bot.db.models import ForgetEvent
+    ev = await db_session.scalar(
+        select(ForgetEvent).where(ForgetEvent.id == event_id)
+    )
+    assert ev.status == "completed"
+    cascade = ev.cascade_status
+    assert cascade["graph_nodes"]["status"] == "completed"
+
+
+# ─── CRITICAL-1: multi-provenance row enqueue ────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_cascade_enqueues_purge_for_all_provenance_rows_of_source(db_session):
+    """CRITICAL-1: 3 graph_provenance rows for same source → 3 purge_pending rows."""
+    from bot.services.forget_cascade import run_cascade_worker_once
+    from bot.db.models import GraphPurgePending
+    from sqlalchemy import select, func
+
+    cm_id, mv_id, chat_id, msg_id = await _make_message_with_version(db_session)
+    run_id = await _make_projection_run(db_session)
+    source_pk = str(mv_id)
+
+    # Three graph_provenance rows for same (source_table, source_pk) — different triple_hash
+    for i in range(3):
+        await _make_provenance(
+            db_session,
+            run_id=run_id,
+            source_table="message_versions",
+            source_pk=source_pk,
+            source_message_version_id=mv_id,
+            graph_node_key=f"node:mv:{mv_id}:triple{i}",
+            triple_hash=f"hash_{mv_id}_{i}",
+        )
+
+    await _make_forget_event(
+        db_session,
+        target_type="message",
+        target_id=str(cm_id),
+    )
+
+    await run_cascade_worker_once(db_session)
+
+    # ALL 3 provenance rows must have a purge_pending row, not just 1
+    count = await db_session.scalar(
+        select(func.count()).select_from(GraphPurgePending).where(
+            GraphPurgePending.source_table == "message_versions",
+            GraphPurgePending.source_pk == source_pk,
+        )
+    )
+    assert count == 3, (
+        f"Expected 3 purge_pending rows for 3 provenance rows, got {count}"
+    )
+
+
+# ─── CRITICAL-2: knowledge_cards source path ─────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_cascade_enqueues_purge_for_archived_card_provenance(db_session):
+    """CRITICAL-2: card whose ALL sources are in affected_mvids gets knowledge_cards purge_pending."""
+    import uuid as _uuid
+    from bot.services.forget_cascade import run_cascade_worker_once
+    from bot.db.models import GraphPurgePending, KnowledgeCard, CardSource
+    from sqlalchemy import select
+
+    # One message with one version — will be the only source for the card
+    cm_id, mv_id, chat_id, msg_id = await _make_message_with_version(db_session, text="src msg")
+    run_id = await _make_projection_run(db_session)
+
+    # A knowledge card sourced from ONLY that one message version
+    card_id = _uuid.uuid4()
+    card = KnowledgeCard(
+        id=card_id,
+        title="Test Card",
+        body_markdown="body text",
+        card_status="draft",
+    )
+    db_session.add(card)
+    await db_session.flush()
+
+    src = CardSource(card_id=card_id, message_version_id=mv_id, position=0)
+    db_session.add(src)
+    await db_session.flush()
+
+    # graph_provenance for the knowledge_card itself
+    from bot.db.repos.graph_provenance import create_provenance
+    await create_provenance(
+        db_session,
+        projection_run_id=run_id,
+        source_table="knowledge_cards",
+        source_pk=str(card_id),
+        source_card_id=card_id,
+        graph_node_key=f"node:card:{card_id}",
+    )
+
+    # graph_provenance for the message_version
+    await _make_provenance(
+        db_session, run_id=run_id, source_table="message_versions",
+        source_pk=str(mv_id), source_message_version_id=mv_id,
+    )
+
+    # Forget the message — its mv_id is the ONLY source for the card,
+    # so all card sources are in affected_mvids.
+    await _make_forget_event(
+        db_session, target_type="message", target_id=str(cm_id)
+    )
+
+    await run_cascade_worker_once(db_session)
+
+    # Check that a purge_pending row was enqueued for the knowledge_cards provenance
+    card_purge = await db_session.scalar(
+        select(GraphPurgePending).where(
+            GraphPurgePending.source_table == "knowledge_cards",
+            GraphPurgePending.source_pk == str(card_id),
+        )
+    )
+    assert card_purge is not None, (
+        "purge_pending row must be enqueued for knowledge_cards provenance "
+        "when all card sources are in affected_mvids"
+    )
+
+
+# ─── HIGH-4: graph_edges.purged_at soft-delete ───────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_cascade_soft_deletes_graph_edges_in_same_transaction(db_session):
+    """HIGH-4: cascade must set purged_at on graph_edges rows for provenance."""
+    from bot.services.forget_cascade import run_cascade_worker_once
+    from bot.db.models import GraphEdge
+    from sqlalchemy import select
+
+    cm_id, mv_id, chat_id, msg_id = await _make_message_with_version(db_session)
+    run_id = await _make_projection_run(db_session)
+
+    # Create provenance
+    from bot.db.repos.graph_provenance import create_provenance
+    prov = await create_provenance(
+        db_session,
+        projection_run_id=run_id,
+        source_table="message_versions",
+        source_pk=str(mv_id),
+        source_message_version_id=mv_id,
+        graph_node_key=f"node:mv:{mv_id}",
+    )
+
+    # Create a graph_edge referencing this provenance
+    edge = GraphEdge(
+        graph_provenance_id=prov.id,
+        subject_node_key=f"node:mv:{mv_id}",
+        predicate="MENTIONS",
+        object_node_key="node:entity:test",
+        edge_key=f"edge:{mv_id}:MENTIONS:test",
+    )
+    db_session.add(edge)
+    await db_session.flush()
+
+    await _make_forget_event(
+        db_session,
+        target_type="message",
+        target_id=str(cm_id),
+    )
+
+    await run_cascade_worker_once(db_session)
+
+    # graph_edges.purged_at must be set
+    refreshed_edge = await db_session.scalar(
+        select(GraphEdge).where(GraphEdge.id == edge.id)
+    )
+    assert refreshed_edge is not None
+    assert refreshed_edge.purged_at is not None, (
+        "graph_edges.purged_at must be set by cascade (spec §5.F step 3)"
+    )

--- a/tests/services/test_graph_purge_readblock.py
+++ b/tests/services/test_graph_purge_readblock.py
@@ -1,0 +1,130 @@
+"""Tests for bot/services/graph_purge_readblock.py (T10-06 / Phase 10).
+
+Uses SQLite in-memory session (app_env fixture) to test the read-block helpers.
+Verifies RFC-001:415 fail-closed semantics:
+  - assert_no_pending_purge raises RefusalError when pending purge rows exist
+  - assert_no_pending_purge passes silently when no pending rows exist
+  - assert_no_pending_purge_for_source raises RefusalError on source match
+"""
+
+from __future__ import annotations
+
+import itertools
+from datetime import datetime, timezone
+
+import pytest
+
+pytestmark = pytest.mark.usefixtures("app_env")
+
+_counter = itertools.count(start=7_000_000)
+
+
+def _next_id() -> int:
+    return next(_counter)
+
+
+async def _insert_purge_pending(
+    db_session,
+    *,
+    forget_event_id: int,
+    source_table: str = "message_versions",
+    source_pk: str = "1",
+    graph_node_key: str | None = None,
+    purged_at=None,
+    failed_at=None,
+) -> None:
+    """Direct DB insert for test setup (bypasses repo to keep tests isolated)."""
+    from bot.db.models import GraphPurgePending
+
+    row = GraphPurgePending(
+        forget_event_id=forget_event_id,
+        source_table=source_table,
+        source_pk=source_pk,
+        graph_node_key=graph_node_key,
+        purged_at=purged_at,
+        failed_at=failed_at,
+    )
+    db_session.add(row)
+    await db_session.flush()
+
+
+@pytest.mark.asyncio
+async def test_assert_no_pending_purge_raises_when_node_pending(db_session):
+    """assert_no_pending_purge raises RefusalError when a node_key is pending."""
+    from bot.services.graph_purge_readblock import assert_no_pending_purge
+    from bot.services.graph_common import RefusalError
+
+    node_key = f"node:test:{_next_id()}"
+    forget_id = _next_id()
+    await _insert_purge_pending(
+        db_session,
+        forget_event_id=forget_id,
+        graph_node_key=node_key,
+    )
+
+    with pytest.raises(RefusalError):
+        await assert_no_pending_purge(db_session, node_keys=[node_key])
+
+
+@pytest.mark.asyncio
+async def test_assert_no_pending_purge_passes_when_no_rows(db_session):
+    """assert_no_pending_purge passes silently when no pending purge rows exist."""
+    from bot.services.graph_purge_readblock import assert_no_pending_purge
+
+    node_key = f"node:test:{_next_id()}"
+    # No rows inserted — should not raise
+    await assert_no_pending_purge(db_session, node_keys=[node_key])
+
+
+@pytest.mark.asyncio
+async def test_assert_no_pending_purge_passes_when_purged(db_session):
+    """assert_no_pending_purge passes when the row has purged_at set."""
+    from bot.services.graph_purge_readblock import assert_no_pending_purge
+
+    node_key = f"node:test:{_next_id()}"
+    forget_id = _next_id()
+    await _insert_purge_pending(
+        db_session,
+        forget_event_id=forget_id,
+        graph_node_key=node_key,
+        purged_at=datetime.now(timezone.utc),
+    )
+
+    # Already purged — should not raise
+    await assert_no_pending_purge(db_session, node_keys=[node_key])
+
+
+@pytest.mark.asyncio
+async def test_assert_no_pending_purge_for_source_raises(db_session):
+    """assert_no_pending_purge_for_source raises RefusalError when source matches."""
+    from bot.services.graph_purge_readblock import assert_no_pending_purge_for_source
+    from bot.services.graph_common import RefusalError
+
+    pk = str(_next_id())
+    forget_id = _next_id()
+    await _insert_purge_pending(
+        db_session,
+        forget_event_id=forget_id,
+        source_table="message_versions",
+        source_pk=pk,
+    )
+
+    with pytest.raises(RefusalError):
+        await assert_no_pending_purge_for_source(
+            db_session,
+            source_table="message_versions",
+            source_pk=pk,
+        )
+
+
+@pytest.mark.asyncio
+async def test_assert_no_pending_purge_for_source_passes_when_no_rows(db_session):
+    """assert_no_pending_purge_for_source passes when no pending rows for source."""
+    from bot.services.graph_purge_readblock import assert_no_pending_purge_for_source
+
+    pk = str(_next_id())
+    await assert_no_pending_purge_for_source(
+        db_session,
+        source_table="knowledge_cards",
+        source_pk=pk,
+    )

--- a/tests/services/test_graph_purge_worker.py
+++ b/tests/services/test_graph_purge_worker.py
@@ -1,0 +1,282 @@
+"""Tests for bot/services/graph_purge_worker.py (T10-06 / Phase 10).
+
+Tests graph_purge_worker_tick against a NetworkXAdapter (fake Neo4j),
+verifying state transitions in graph_purge_pending table.
+Uses db_session (shared postgres) fixture.
+"""
+
+from __future__ import annotations
+
+import itertools
+
+import pytest
+
+pytestmark = pytest.mark.usefixtures("app_env")
+
+_counter = itertools.count(start=8_000_000)
+
+
+def _next_id() -> int:
+    return next(_counter)
+
+
+async def _enqueue_row(
+    db_session,
+    *,
+    forget_event_id: int | None = None,
+    source_table: str = "message_versions",
+    source_pk: str | None = None,
+    graph_node_key: str | None = None,
+    graph_provenance_id: int | None = None,
+):
+    """Helper: enqueue a row via repo."""
+    from bot.db.repos.graph_purge_pending import enqueue
+
+    feid = forget_event_id or _next_id()
+    pk = source_pk or str(_next_id())
+    row = await enqueue(
+        db_session,
+        forget_event_id=feid,
+        source_table=source_table,
+        source_pk=pk,
+        graph_node_key=graph_node_key,
+        graph_provenance_id=graph_provenance_id,
+    )
+    return row
+
+
+@pytest.mark.asyncio
+async def test_worker_tick_processes_pending_row(db_session, graph_adapter_fake):
+    """worker tick picks up a pending row and marks it purged on success."""
+    from bot.services.graph_purge_worker import graph_purge_worker_tick
+    from bot.db.models import GraphPurgePending
+    from sqlalchemy import select
+
+    row = await _enqueue_row(db_session, graph_node_key="node:test:8000001")
+
+    result = await graph_purge_worker_tick(
+        db_session,
+        adapter=graph_adapter_fake,
+        batch_size=10,
+    )
+
+    assert result["processed"] >= 1
+
+    refreshed = await db_session.scalar(
+        select(GraphPurgePending).where(GraphPurgePending.id == row.id)
+    )
+    assert refreshed.purged_at is not None
+
+
+@pytest.mark.asyncio
+async def test_worker_tick_marks_failed_on_adapter_error(db_session):
+    """worker tick marks row as having retries on adapter failure."""
+    from bot.services.graph_purge_worker import graph_purge_worker_tick
+    from bot.db.models import GraphPurgePending
+    from sqlalchemy import select
+
+    class ErrorAdapter:
+        async def delete_provenance(self, provenance_id: str) -> int:
+            raise RuntimeError("neo4j is down")
+
+        async def close(self) -> None:
+            pass
+
+    row = await _enqueue_row(db_session, graph_node_key="node:test:failing")
+
+    result = await graph_purge_worker_tick(
+        db_session,
+        adapter=ErrorAdapter(),
+        batch_size=10,
+    )
+
+    # Error is captured but does not stop the worker
+    assert result["errors"] >= 1
+
+    refreshed = await db_session.scalar(
+        select(GraphPurgePending).where(GraphPurgePending.id == row.id)
+    )
+    # Not purged; retry_count incremented
+    assert refreshed.purged_at is None
+    assert refreshed.retry_count >= 1
+
+
+@pytest.mark.asyncio
+async def test_worker_tick_skips_purged_rows(db_session, graph_adapter_fake):
+    """worker tick does not reprocess already-purged rows."""
+    from bot.services.graph_purge_worker import graph_purge_worker_tick
+    from bot.db.repos.graph_purge_pending import mark_purged
+    from bot.db.models import GraphPurgePending
+    from sqlalchemy import select
+
+    row = await _enqueue_row(db_session, graph_node_key="node:test:already_done")
+    await mark_purged(db_session, row.id)
+
+    result = await graph_purge_worker_tick(
+        db_session,
+        adapter=graph_adapter_fake,
+        batch_size=10,
+    )
+
+    # The already-purged row must not be re-processed
+    refreshed = await db_session.scalar(
+        select(GraphPurgePending).where(GraphPurgePending.id == row.id)
+    )
+    # purged_at was set before tick; it should remain the same or be set once only
+    assert refreshed.purged_at is not None
+    # processed count does NOT include the already-purged row
+    assert result.get("reprocessed", 0) == 0
+
+
+@pytest.mark.asyncio
+async def test_worker_tick_returns_stats_dict(db_session, graph_adapter_fake):
+    """worker tick returns a dict with processed and errors keys."""
+    from bot.services.graph_purge_worker import graph_purge_worker_tick
+
+    result = await graph_purge_worker_tick(
+        db_session,
+        adapter=graph_adapter_fake,
+        batch_size=10,
+    )
+
+    assert "processed" in result
+    assert "errors" in result
+
+
+# ─── CRITICAL-3: worker false-purge when adapter returns 0 ───────────────────
+
+
+async def _make_provenance_for_worker(db_session) -> int:
+    """Create a minimal graph_provenance row for worker tests. Returns provenance id."""
+    from bot.db.models import ChatMessage, MessageVersion
+    from bot.db.repos.graph_provenance import create_provenance
+    from bot.db.repos.graph_projection_run import create_run
+    from datetime import datetime, timezone
+
+    uid = _next_id()
+    from bot.db.repos.user import UserRepo
+    await UserRepo.upsert(
+        db_session,
+        telegram_id=uid,
+        username=f"u{uid}",
+        first_name="Test",
+        last_name=None,
+    )
+    chat_id = -1_000_000_000_000 - _next_id()
+    msg_id = _next_id()
+    when = datetime.now(timezone.utc)
+
+    msg = ChatMessage(
+        message_id=msg_id, chat_id=chat_id, user_id=uid,
+        text="test", date=when, raw_json={"text": "test"},
+        memory_policy="normal", is_redacted=False,
+    )
+    db_session.add(msg)
+    await db_session.flush()
+
+    ver = MessageVersion(
+        chat_message_id=msg.id, version_seq=1, text="test",
+        normalized_text="test", entities_json={"entities": []},
+        content_hash=f"h-{_next_id()}", is_redacted=False,
+    )
+    db_session.add(ver)
+    await db_session.flush()
+    msg.current_version_id = ver.id
+    await db_session.flush()
+
+    run = await create_run(db_session, mode="incremental", started_by="test")
+    await db_session.flush()
+
+    prov = await create_provenance(
+        db_session,
+        projection_run_id=run.id,
+        source_table="message_versions",
+        source_pk=str(ver.id),
+        source_message_version_id=ver.id,
+        graph_node_key=f"node:mv:{ver.id}",
+    )
+    return prov.id
+
+
+@pytest.mark.asyncio
+async def test_worker_marks_failed_on_zero_row_delete_with_non_null_id(db_session):
+    """CRITICAL-3: when delete_provenance returns 0 AND provenance_id is non-NULL, worker must NOT mark purged."""
+    from bot.services.graph_purge_worker import graph_purge_worker_tick
+    from bot.db.models import GraphPurgePending
+    from sqlalchemy import select
+
+    class ZeroDeleteAdapter:
+        """Adapter that returns 0 (no rows deleted) but doesn't raise."""
+        async def delete_provenance(self, provenance_id: str) -> int:
+            return 0
+
+        async def close(self) -> None:
+            pass
+
+    # Create a real provenance row so the FK constraint is satisfied
+    prov_id = await _make_provenance_for_worker(db_session)
+
+    row = await _enqueue_row(
+        db_session,
+        graph_node_key="node:test:zero_delete",
+        graph_provenance_id=prov_id,  # non-NULL, valid FK
+    )
+
+    await graph_purge_worker_tick(
+        db_session,
+        adapter=ZeroDeleteAdapter(),
+        batch_size=10,
+    )
+
+    refreshed = await db_session.scalar(
+        select(GraphPurgePending).where(GraphPurgePending.id == row.id)
+    )
+
+    # Must NOT be marked purged — 0 deletions from adapter with non-null provenance_id
+    assert refreshed.purged_at is None, (
+        "Worker must NOT mark purged when adapter returns 0 for non-NULL provenance_id"
+    )
+
+
+# ─── MEDIUM-7: concurrent worker ticks no double claim ───────────────────────
+
+
+@pytest.mark.asyncio
+async def test_concurrent_worker_ticks_no_double_claim(db_session, graph_adapter_fake):
+    """MEDIUM-7: two sequential worker ticks must claim disjoint sets of rows."""
+    from bot.services.graph_purge_worker import graph_purge_worker_tick
+    from bot.db.repos.graph_purge_pending import enqueue
+
+    # Enqueue 2 distinct rows
+    rows = []
+    for i in range(2):
+        feid = _next_id()
+        pk = str(_next_id())
+        r = await enqueue(
+            db_session,
+            forget_event_id=feid,
+            source_table="message_versions",
+            source_pk=pk,
+            graph_node_key=f"node:test:concurrent:{i}",
+        )
+        rows.append(r.id)
+
+    # First tick: processes both rows (batch_size=10)
+    result1 = await graph_purge_worker_tick(
+        db_session, adapter=graph_adapter_fake, batch_size=10
+    )
+
+    # Second tick: no remaining pending rows
+    result2 = await graph_purge_worker_tick(
+        db_session, adapter=graph_adapter_fake, batch_size=10
+    )
+
+    # Combined processed count must equal number of rows inserted
+    total_processed = result1["processed"] + result2["processed"]
+    assert total_processed == len(rows), (
+        f"Expected {len(rows)} total processed across 2 ticks, got {total_processed}"
+    )
+    # Neither tick should have processed the same row twice
+    assert result2["processed"] == 0, (
+        "Second tick must find no rows (already processed by first tick)"
+    )


### PR DESCRIPTION
## Summary

Canonical Sprint **T10-06** — privacy-critical async cascade for graph projections per PHASE10_PLAN §5.A + §5.F. Closes Invariant #9 (durable tombstones) gap. Independent of T10-04 (projector), both Wave 2.

- Migration 063: `graph_purge_pending` table verbatim §5.A
- Migration 065: amends UniqueConstraint to 4-column `(forget_event_id, source_table, source_pk, graph_provenance_id)` — closes CRITICAL-1 multi-provenance collapse
- `_cascade_graph_provenance` with TWO paths:
  - Path 1: message_versions → find all matching graph_provenance rows → enqueue ONE purge_pending per provenance row
  - Path 2 (CRITICAL-2 fix): knowledge_cards archived by preceding cascade layer → find their graph_provenance rows → enqueue
  - `graph_edges` soft-deleted in same transaction (HIGH-4)
- `graph_purge_worker_tick`:
  - Zero-row-delete guard: `mark_failed` (not purged) when adapter returns 0 with non-NULL provenance_id (CRITICAL-3)
  - DLQ at MAX_RETRIES=5
  - Feature flag `memory.graph.write_pending.paused` kill switch
- `graph_purge_readblock.assert_no_pending_purge(...)` — raises RefusalError on overlap (consumed by T10-05 graph_query)

Migration chain: `062 → 064 → 063 → 065 (head)`

## Test plan

- [x] 27 tests in graph cascade/worker/readblock test files all green
- [x] Full suite: 1460 pass + 3 skip + 1 pre-existing BOT_TOKEN fail
- [x] `ruff check` clean
- [x] `lint_privacy_check.sh` clean
- [x] Migration chain verified `062 → 064 → 063 → 065`
- [x] Boundary: no edits to graph_projector, graph_query, graph_adapter, graph_common, llm_gateway, .github/workflows

Key new tests:
- `test_cascade_enqueues_purge_for_all_provenance_rows_of_source` (CRITICAL-1 binding)
- `test_cascade_enqueues_purge_for_archived_card_provenance` (CRITICAL-2 binding)
- `test_worker_marks_failed_on_zero_row_delete_with_non_null_id` (CRITICAL-3 binding)
- `test_cascade_soft_deletes_graph_edges_in_same_transaction` (HIGH-4)
- `test_concurrent_worker_ticks_no_double_claim`

## Unified Review

- **Claude product (standard-product-reviewer, opus):** round 1 NEEDS_FIXES (1 BLOCKER zero-commits + 1 BLOCKER missing card path; 3 concerns; 2 suggestions). Round 2 ACCEPTED.
- **Codex technical (codex:codex-rescue):** round 1 REQUEST_CHANGES (3 CRITICAL privacy: multi-provenance collapse, missing card path, false-purge marker; 3 HIGH: edges soft-delete, stale dead code, zero-delete guard; 2 MEDIUM). Round 2 APPROVE.
- All CRITICAL + HIGH fixed in one consolidated revision pass.

## Docs

- `docs/rollout-fragments/phase10/T10-06.md` — per-PR fragment
- CLAUDE.md / llms.txt / IMPLEMENTATION_STATUS.md UNCHANGED (deferred to Phase 10 closure)

## Phase 10.5 carryovers

- Scheduler entry for `graph_purge_worker_tick` deferred to T10-07 (admin handlers sprint will wire scheduler trigger or `/graph_purge_now` admin handler)

## Unblocked by this merge

- T10-05: `graph_query.py` imports `assert_no_pending_purge` for fail-closed read-block
- T10-07: admin handlers can call `/graph_purge_now` to manually drive worker tick
- T10-08: drift reconciliation uses graph_purge_pending counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)