### PR TITLE
feat(p10.5-s1): privacy hardening — close 11.5-F + 9.5-F + 9.5-C carryovers

### DIFF
--- a/bot/services/forget_cascade.py
+++ b/bot/services/forget_cascade.py
@@ -1108,7 +1108,8 @@ async def _cascade_wiki_revisions(session: AsyncSession, event) -> int:
     """Mask ``wiki_revisions.body_markdown`` for revisions citing forgotten mvids.
 
     For every ``wiki_revisions`` row whose
-    ``source_message_version_ids_snapshot`` JSONB overlaps the affected mvids:
+    ``source_message_version_ids_snapshot`` JSONB overlaps the affected mvids
+    AND whose ``revision_status != 'forgotten_redacted'``:
 
     1. Set ``body_markdown = '[CONTENT_REDACTED: forget_event_id={n}]'``.
     2. Set ``revision_status = 'forgotten_redacted'``.
@@ -1117,6 +1118,12 @@ async def _cascade_wiki_revisions(session: AsyncSession, event) -> int:
     5. Set ``revision_sources_resolved_at = now()``.
 
     Returns count of wiki_revisions rows modified.
+
+    Idempotency (9.5-C): rows already in ``revision_status='forgotten_redacted'``
+    are skipped on re-run — their first-redaction provenance
+    (``redacted_by_forget_event_id``, ``redacted_at``, ``body_markdown``) is
+    preserved unchanged.  A second cascade pass for the same forget_event logs
+    ``already_redacted_skip`` and returns 0.
 
     Run-order invariant: MUST run AFTER ``wiki_pages`` and BEFORE ``card_sources``
     (see CASCADE_LAYER_ORDER). Running after ``wiki_pages`` ensures the page row
@@ -1128,6 +1135,10 @@ async def _cascade_wiki_revisions(session: AsyncSession, event) -> int:
     Privacy invariant: the redact string uses only ``forget_event_id`` (an
     integer) — never any user-readable body content.
     """
+    import logging
+
+    _log = logging.getLogger(__name__)
+
     if event.target_id is None:
         raise ValueError(
             f"forget_event target_type={event.target_type!r} requires non-None target_id"
@@ -1153,7 +1164,8 @@ async def _cascade_wiki_revisions(session: AsyncSession, event) -> int:
             "    redacted_at = now(), "
             "    redacted_by_forget_event_id = :event_id, "
             "    revision_sources_resolved_at = now() "
-            "WHERE source_message_version_ids_snapshot @> ANY("
+            "WHERE revision_status != 'forgotten_redacted' "
+            "  AND source_message_version_ids_snapshot @> ANY("
             "    SELECT jsonb_build_array(v::bigint) "
             "    FROM unnest(CAST(:mvids AS bigint[])) AS v"
             ")"
@@ -1169,6 +1181,12 @@ async def _cascade_wiki_revisions(session: AsyncSession, event) -> int:
     count = result.rowcount or 0
     if count:
         await session.flush()
+    else:
+        _log.debug(
+            "already_redacted_skip: _cascade_wiki_revisions found 0 rows to redact "
+            "(all matching revisions already forgotten_redacted) for forget_event_id=%s",
+            event.id,
+        )
     return count
 
 

--- a/scripts/lint_privacy_check.sh
+++ b/scripts/lint_privacy_check.sh
@@ -104,6 +104,12 @@ is_allowed_path() {
   [[ "$path" == "tests/evals/test_wiki_refusal.py" ]] && return 0
   [[ "$path" == "tests/evals/test_wiki_no_graph.py" ]] && return 0
 
+  # 9.5-F Cache-Control binding test — module-level docstring explains WHY the
+  # no-store header is required by referencing the privacy cascade contract.
+  # Same rationale as other eval test allowlist entries above — the file
+  # enforces the privacy-cache policy by name.
+  [[ "$path" == "tests/evals/test_wiki_cache_control.py" ]] && return 0
+
   # T10-04 graph_projector integration test — verifies governance pre-filter
   # excludes governance-restricted cards from projection. Names canonical
   # privacy literals in fixture SQL and assertion messages because the test

--- a/tests/evals/_llm_guard.py
+++ b/tests/evals/_llm_guard.py
@@ -16,22 +16,34 @@ from typing import Any
 from urllib.parse import urlparse
 
 # ---------------------------------------------------------------------------
-# LLM hostname block-list (mirrors LLM_PROVIDER_HOSTNAMES in
-# tests/evals/test_no_llm_imports.py — keep in sync).
+# LLM hostname block-list — single source of truth.
+#
+# LLM_PROVIDER_HOSTNAMES is the canonical frozenset used by:
+#   - the runtime httpx guard (LLM_GUARD_HOSTNAMES alias below)
+#   - the static AST/text scan in tests/evals/test_no_llm_imports.py
+#     (imported directly as LLM_PROVIDER_HOSTNAMES)
+#
+# Adding a new LLM provider? Add it here only — both guards pick it up.
 # ---------------------------------------------------------------------------
 
-LLM_GUARD_HOSTNAMES: frozenset[str] = frozenset(
+LLM_PROVIDER_HOSTNAMES: frozenset[str] = frozenset(
     [
         "api.anthropic.com",
         "api.openai.com",
+        "generativelanguage.googleapis.com",
+        "api.together.xyz",
+        "api.groq.com",
+        "api.mistral.ai",
         "api.cohere.ai",
         "api.cohere.com",
-        "api.mistral.ai",
-        "generativelanguage.googleapis.com",
         "api.replicate.com",
         "api-inference.huggingface.co",
     ]
 )
+
+# Alias kept for backwards-compat with existing callers that import
+# LLM_GUARD_HOSTNAMES directly.
+LLM_GUARD_HOSTNAMES: frozenset[str] = LLM_PROVIDER_HOSTNAMES
 
 
 class LLMNetworkCallDetected(AssertionError):

--- a/tests/evals/test_no_llm_imports.py
+++ b/tests/evals/test_no_llm_imports.py
@@ -193,6 +193,83 @@ def test_i4_no_llm_provider_url_outside_gateway() -> None:
     )
 
 
+def test_no_llm_provider_urls_outside_gateway() -> None:
+    """I4b: LLM provider URLs must not appear in bot/, web/, or ops/ outside the
+    allow-listed gateway files.
+
+    Extends test_i4_no_llm_provider_url_outside_gateway (bot/-only) to cover
+    web/ and ops/ as well, since a direct httpx call in a web route or ops script
+    would bypass the invariant-#2 contract just as much as one in bot/.
+
+    Additional hostnames covered: api.together.xyz, api.groq.com, api.replicate.com,
+    api.cohere.ai, api.mistral.ai, api.groq.com (already in LLM_PROVIDER_HOSTNAMES).
+
+    Honeypot assertion: tests/fixtures/honeypot_llm_url.py contains a known
+    LLM hostname in a comment; when that file is included in the scan paths
+    it MUST be detected — proving the guard is live and not a no-op.
+    """
+    scan_roots = [
+        root
+        for root in [
+            REPO_ROOT / "bot",
+            REPO_ROOT / "web",
+            REPO_ROOT / "ops",
+        ]
+        if root.is_dir()
+    ]
+
+    # Expanded hostname set: task I4b adds provider domains not in the original I4.
+    extended_hostnames: frozenset[str] = frozenset(
+        set(LLM_PROVIDER_HOSTNAMES)
+        | {
+            "api.together.xyz",
+            "api.groq.com",
+            "api.replicate.com",
+            "api.cohere.com",
+            "api.mistral.ai",
+            "api-inference.huggingface.co",
+        }
+    )
+
+    allowed_url_files: frozenset[str] = frozenset(
+        [
+            "bot/services/llm_gateway.py",
+            "bot/services/llm_providers/anthropic.py",
+            "bot/services/llm_providers/openai.py",
+        ]
+    )
+
+    violations: list[str] = []
+    for root in scan_roots:
+        for path in _collect_python_files(root):
+            rel = _relative_to_repo(path)
+            if rel in allowed_url_files:
+                continue
+            for line_no, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+                for host in extended_hostnames:
+                    if host in line:
+                        violations.append(f"{rel}:{line_no}: hostname {host!r}")
+                        break
+
+    assert not violations, (
+        "invariant 2 URL-level violation (I4b) — LLM provider hostname in "
+        "bot/, web/, or ops/ outside the allow-list:\n" + "\n".join(violations)
+    )
+
+    # Honeypot: verify the guard would catch the known-bad fixture.
+    honeypot_path = REPO_ROOT / "tests" / "fixtures" / "honeypot_llm_url.py"
+    assert honeypot_path.is_file(), (
+        f"honeypot fixture missing at {honeypot_path} — "
+        "create tests/fixtures/honeypot_llm_url.py with '# api.openai.com'"
+    )
+    honeypot_text = honeypot_path.read_text(encoding="utf-8")
+    honeypot_caught = any(host in honeypot_text for host in extended_hostnames)
+    assert honeypot_caught, (
+        "honeypot fixture does not contain any known LLM hostname — "
+        "the guard would silently pass even a URL-leaking file"
+    )
+
+
 def test_i3_allow_list_contract_documented() -> None:
     """I3: allow-list contains exactly the Phase 5 provider boundary files.
 

--- a/tests/evals/test_no_llm_imports.py
+++ b/tests/evals/test_no_llm_imports.py
@@ -16,9 +16,9 @@ from pathlib import Path
 
 import pytest
 
-# Single source of truth: LLM_GUARD_HOSTNAMES in tests/evals/_llm_guard.py.
-# Imported here to avoid drift between the runtime guard and the AST check.
-from tests.evals._llm_guard import LLM_GUARD_HOSTNAMES as _LLM_GUARD_HOSTNAMES
+# Single source of truth: LLM_PROVIDER_HOSTNAMES in tests/evals/_llm_guard.py.
+# Imported directly to avoid drift between the runtime guard and the AST check.
+from tests.evals._llm_guard import LLM_PROVIDER_HOSTNAMES
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 BOT_ROOT = REPO_ROOT / "bot"
@@ -52,8 +52,10 @@ ALLOWED_LLM_IMPORT_FILES: frozenset[str] = frozenset(
 # I4 — URL-level guard. The provider SDK imports above (anthropic / openai)
 # are not the only way to call an LLM endpoint: a direct httpx / requests /
 # aiohttp call to a provider hostname would bypass the invariant-#2 contract
-# while passing the import-graph check. This domain list catches that.
-LLM_PROVIDER_HOSTNAMES: tuple[str, ...] = tuple(sorted(_LLM_GUARD_HOSTNAMES))
+# while passing the import-graph check. LLM_PROVIDER_HOSTNAMES (imported from
+# _llm_guard) is the single source of truth — both the runtime httpx guard
+# and this static scan use the same set, so they cannot drift.
+_LLM_PROVIDER_HOSTNAMES_TUPLE: tuple[str, ...] = tuple(sorted(LLM_PROVIDER_HOSTNAMES))
 
 
 def _relative_to_repo(path: Path) -> str:
@@ -193,6 +195,31 @@ def test_i4_no_llm_provider_url_outside_gateway() -> None:
     )
 
 
+def _scan_files_for_hostnames(
+    paths: list[Path],
+    hostnames: frozenset[str],
+) -> list[tuple[Path, str]]:
+    """Scan *paths* for lines containing any of *hostnames*.
+
+    Returns a list of (path, hostname) pairs — one entry per file/host
+    match (at most one per file line, first hostname match wins).  Both
+    the production assertion and the honeypot assertion call this helper
+    directly, so a broken scanner fails both assertions simultaneously.
+    """
+    matches: list[tuple[Path, str]] = []
+    for path in paths:
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (UnicodeDecodeError, OSError):
+            continue
+        for line in text.splitlines():
+            for host in hostnames:
+                if host in line:
+                    matches.append((path, host))
+                    break
+    return matches
+
+
 def test_no_llm_provider_urls_outside_gateway() -> None:
     """I4b: LLM provider URLs must not appear in bot/, web/, or ops/ outside the
     allow-listed gateway files.
@@ -201,12 +228,14 @@ def test_no_llm_provider_urls_outside_gateway() -> None:
     web/ and ops/ as well, since a direct httpx call in a web route or ops script
     would bypass the invariant-#2 contract just as much as one in bot/.
 
-    Additional hostnames covered: api.together.xyz, api.groq.com, api.replicate.com,
-    api.cohere.ai, api.mistral.ai, api.groq.com (already in LLM_PROVIDER_HOSTNAMES).
+    Hostname set is LLM_PROVIDER_HOSTNAMES from _llm_guard.py — the single
+    source of truth for both the runtime httpx guard and this static scan.
+    Previously extra hostnames (api.together.xyz, api.groq.com, etc.) were
+    defined inline; they are now part of LLM_PROVIDER_HOSTNAMES in _llm_guard.py.
 
     Honeypot assertion: tests/fixtures/honeypot_llm_url.py contains a known
-    LLM hostname in a comment; when that file is included in the scan paths
-    it MUST be detected — proving the guard is live and not a no-op.
+    LLM hostname; the honeypot is scanned with the SAME _scan_files_for_hostnames
+    helper as the production scan — so a broken scanner fails BOTH assertions.
     """
     scan_roots = [
         root
@@ -218,19 +247,6 @@ def test_no_llm_provider_urls_outside_gateway() -> None:
         if root.is_dir()
     ]
 
-    # Expanded hostname set: task I4b adds provider domains not in the original I4.
-    extended_hostnames: frozenset[str] = frozenset(
-        set(LLM_PROVIDER_HOSTNAMES)
-        | {
-            "api.together.xyz",
-            "api.groq.com",
-            "api.replicate.com",
-            "api.cohere.com",
-            "api.mistral.ai",
-            "api-inference.huggingface.co",
-        }
-    )
-
     allowed_url_files: frozenset[str] = frozenset(
         [
             "bot/services/llm_gateway.py",
@@ -239,34 +255,36 @@ def test_no_llm_provider_urls_outside_gateway() -> None:
         ]
     )
 
-    violations: list[str] = []
+    # Production scan: collect all python files, excluding allow-listed gateway files.
+    production_paths: list[Path] = []
     for root in scan_roots:
         for path in _collect_python_files(root):
-            rel = _relative_to_repo(path)
-            if rel in allowed_url_files:
-                continue
-            for line_no, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
-                for host in extended_hostnames:
-                    if host in line:
-                        violations.append(f"{rel}:{line_no}: hostname {host!r}")
-                        break
+            if _relative_to_repo(path) not in allowed_url_files:
+                production_paths.append(path)
 
+    prod_matches = _scan_files_for_hostnames(production_paths, LLM_PROVIDER_HOSTNAMES)
+
+    violations = [
+        f"{_relative_to_repo(path)}:hostname {host!r}"
+        for path, host in prod_matches
+    ]
     assert not violations, (
         "invariant 2 URL-level violation (I4b) — LLM provider hostname in "
         "bot/, web/, or ops/ outside the allow-list:\n" + "\n".join(violations)
     )
 
-    # Honeypot: verify the guard would catch the known-bad fixture.
+    # Honeypot: the SAME helper must detect the known-bad fixture.
     honeypot_path = REPO_ROOT / "tests" / "fixtures" / "honeypot_llm_url.py"
     assert honeypot_path.is_file(), (
         f"honeypot fixture missing at {honeypot_path} — "
         "create tests/fixtures/honeypot_llm_url.py with '# api.openai.com'"
     )
-    honeypot_text = honeypot_path.read_text(encoding="utf-8")
-    honeypot_caught = any(host in honeypot_text for host in extended_hostnames)
-    assert honeypot_caught, (
-        "honeypot fixture does not contain any known LLM hostname — "
-        "the guard would silently pass even a URL-leaking file"
+    honeypot_matches = _scan_files_for_hostnames(
+        [honeypot_path], LLM_PROVIDER_HOSTNAMES
+    )
+    assert len(honeypot_matches) >= 1, (
+        "honeypot fixture was not detected by _scan_files_for_hostnames — "
+        "the scanner is broken or the fixture no longer contains a known LLM hostname"
     )
 
 

--- a/tests/evals/test_wiki_cache_control.py
+++ b/tests/evals/test_wiki_cache_control.py
@@ -1,0 +1,149 @@
+"""Phase 11 binding test — 9.5-F: Cache-Control: no-store on member /wiki/{slug}.
+
+Member-facing wiki pages (GET /wiki/{slug}) must carry no-store cache headers
+on every response (200, 404, 410). If a page becomes forgotten or redacted after
+a browser visit, stale cached content must not persist.
+
+Covered:
+  - 200 (page found, governance OK)           → Cache-Control contains no-store, no-cache, private
+  - 404 (page not found)                       → Cache-Control contains no-store
+  - 410 (page archived by governance)          → Cache-Control contains no-store
+  - Pragma: no-cache + Expires: 0              → present on successful 200
+
+Run: pytest tests/evals/test_wiki_cache_control.py -x -v
+Does NOT require a live database — all DB helpers are monkeypatched.
+"""
+
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+
+import pytest
+
+from tests.conftest import import_module
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def _make_client(session_cookie: str | None = None):
+    web_app = import_module("web.app")
+    from fastapi.testclient import TestClient
+    client = TestClient(web_app.create_app(), raise_server_exceptions=False)
+    if session_cookie:
+        client.cookies.set("session", session_cookie)
+    return client
+
+
+def _member_cookie() -> str:
+    web_auth = import_module("web.auth")
+    return web_auth.create_session_cookie(role="member")
+
+
+def _make_page_row(
+    *,
+    page_id: uuid.UUID | None = None,
+    slug: str = "test-slug",
+    title: str = "Test Page",
+    body_markdown: str = "Hello",
+    page_status: str = "reviewed",
+    public_enabled: bool = False,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=page_id or uuid.uuid4(),
+        slug=slug,
+        title=title,
+        body_markdown=body_markdown,
+        page_status=page_status,
+        public_enabled=public_enabled,
+    )
+
+
+async def _async_true():
+    return True
+
+
+async def _async_none():
+    return None
+
+
+async def _async_list(items):
+    return items
+
+
+async def _async_page(page):
+    return page
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def wiki_app_env(app_env):
+    """Reuse the shared app_env fixture."""
+    yield
+
+
+# ── Test: member /wiki/{slug} 200 has no-store, no-cache, private ─────────────
+
+
+def test_member_wiki_has_no_store_header(monkeypatch) -> None:
+    """GET /wiki/{slug} with valid member session → 200 with Cache-Control: no-store."""
+    page_id = uuid.uuid4()
+    page = _make_page_row(page_id=page_id, slug="test-slug", page_status="reviewed")
+
+    async def _fake_render(session, *, page_id, role, body_markdown):
+        from bot.services.wiki_renderer import WikiRenderResult
+        return WikiRenderResult(html_body="<p>Hello</p>", page_archived=False)
+
+    wiki_routes = import_module("web.routes.wiki")
+    monkeypatch.setattr(wiki_routes, "_wiki_enabled", lambda session: _async_true())
+    monkeypatch.setattr(wiki_routes, "_get_page_by_slug", lambda session, slug: _async_page(page))
+    monkeypatch.setattr(wiki_routes, "render_wiki_page", _fake_render)
+    monkeypatch.setattr(wiki_routes, "_get_page_sources", lambda session, page_id: _async_list([]))
+
+    client = _make_client(session_cookie=_member_cookie())
+    response = client.get("/wiki/test-slug", follow_redirects=False)
+
+    assert response.status_code == 200
+    cc = response.headers.get("Cache-Control", "")
+    assert "no-store" in cc, f"expected 'no-store' in Cache-Control, got: {cc!r}"
+    assert "no-cache" in cc, f"expected 'no-cache' in Cache-Control, got: {cc!r}"
+    assert "private" in cc, f"expected 'private' in Cache-Control, got: {cc!r}"
+
+
+def test_member_wiki_404_has_no_store_header(monkeypatch) -> None:
+    """GET /wiki/{slug} when page not found → 404 with Cache-Control: no-store."""
+    wiki_routes = import_module("web.routes.wiki")
+    monkeypatch.setattr(wiki_routes, "_wiki_enabled", lambda session: _async_true())
+    monkeypatch.setattr(wiki_routes, "_get_page_by_slug", lambda session, slug: _async_none())
+
+    client = _make_client(session_cookie=_member_cookie())
+    response = client.get("/wiki/missing-slug", follow_redirects=False)
+
+    assert response.status_code == 404
+    cc = response.headers.get("Cache-Control", "")
+    assert "no-store" in cc, f"expected 'no-store' in Cache-Control on 404, got: {cc!r}"
+
+
+def test_member_wiki_410_has_no_store_header(monkeypatch) -> None:
+    """GET /wiki/{slug} when governance archives page → 410 with Cache-Control: no-store."""
+    page_id = uuid.uuid4()
+    page = _make_page_row(page_id=page_id, slug="archived-slug", page_status="reviewed")
+
+    async def _fake_render_archived(session, *, page_id, role, body_markdown):
+        from bot.services.wiki_renderer import WikiRenderResult
+        return WikiRenderResult(html_body="", page_archived=True)
+
+    wiki_routes = import_module("web.routes.wiki")
+    monkeypatch.setattr(wiki_routes, "_wiki_enabled", lambda session: _async_true())
+    monkeypatch.setattr(wiki_routes, "_get_page_by_slug", lambda session, slug: _async_page(page))
+    monkeypatch.setattr(wiki_routes, "render_wiki_page", _fake_render_archived)
+
+    client = _make_client(session_cookie=_member_cookie())
+    response = client.get("/wiki/archived-slug", follow_redirects=False)
+
+    assert response.status_code == 410
+    cc = response.headers.get("Cache-Control", "")
+    assert "no-store" in cc, f"expected 'no-store' in Cache-Control on 410, got: {cc!r}"

--- a/tests/evals/test_wiki_cache_control.py
+++ b/tests/evals/test_wiki_cache_control.py
@@ -147,3 +147,120 @@ def test_member_wiki_410_has_no_store_header(monkeypatch) -> None:
     assert response.status_code == 410
     cc = response.headers.get("Cache-Control", "")
     assert "no-store" in cc, f"expected 'no-store' in Cache-Control on 410, got: {cc!r}"
+
+
+# ── Helper: full cache-control contract assertion ─────────────────────────────
+
+
+def _assert_full_cache_control_contract(response) -> None:
+    """Assert the complete cache-control contract on a wiki response.
+
+    Checks: Cache-Control contains no-store, no-cache, must-revalidate, private;
+    Pragma: no-cache; Expires: 0.  A regression in any single directive fails
+    the test immediately, not just 'no-store'.
+    """
+    cc = response.headers.get("Cache-Control", "")
+    assert "no-store" in cc, f"expected 'no-store' in Cache-Control, got: {cc!r}"
+    assert "no-cache" in cc, f"expected 'no-cache' in Cache-Control, got: {cc!r}"
+    assert "must-revalidate" in cc, f"expected 'must-revalidate' in Cache-Control, got: {cc!r}"
+    assert "private" in cc, f"expected 'private' in Cache-Control, got: {cc!r}"
+    pragma = response.headers.get("Pragma", "")
+    assert pragma == "no-cache", f"expected Pragma: no-cache, got: {pragma!r}"
+    expires = response.headers.get("Expires", "")
+    assert expires == "0", f"expected Expires: 0, got: {expires!r}"
+
+
+# ── Full contract tests for all response paths ────────────────────────────────
+
+
+def test_member_wiki_200_has_full_cache_control_contract(monkeypatch) -> None:
+    """GET /wiki/{slug} 200 → full cache-control contract (no-store, no-cache,
+    must-revalidate, private, Pragma: no-cache, Expires: 0)."""
+    page_id = uuid.uuid4()
+    page = _make_page_row(page_id=page_id, slug="test-slug", page_status="reviewed")
+
+    async def _fake_render(session, *, page_id, role, body_markdown):
+        from bot.services.wiki_renderer import WikiRenderResult
+        return WikiRenderResult(html_body="<p>Hello</p>", page_archived=False)
+
+    wiki_routes = import_module("web.routes.wiki")
+    monkeypatch.setattr(wiki_routes, "_wiki_enabled", lambda session: _async_true())
+    monkeypatch.setattr(wiki_routes, "_get_page_by_slug", lambda session, slug: _async_page(page))
+    monkeypatch.setattr(wiki_routes, "render_wiki_page", _fake_render)
+    monkeypatch.setattr(wiki_routes, "_get_page_sources", lambda session, page_id: _async_list([]))
+
+    client = _make_client(session_cookie=_member_cookie())
+    response = client.get("/wiki/test-slug", follow_redirects=False)
+
+    assert response.status_code == 200
+    _assert_full_cache_control_contract(response)
+
+
+def test_member_wiki_404_has_full_cache_control_contract(monkeypatch) -> None:
+    """GET /wiki/{slug} 404 → full cache-control contract."""
+    wiki_routes = import_module("web.routes.wiki")
+    monkeypatch.setattr(wiki_routes, "_wiki_enabled", lambda session: _async_true())
+    monkeypatch.setattr(wiki_routes, "_get_page_by_slug", lambda session, slug: _async_none())
+
+    client = _make_client(session_cookie=_member_cookie())
+    response = client.get("/wiki/missing-slug", follow_redirects=False)
+
+    assert response.status_code == 404
+    _assert_full_cache_control_contract(response)
+
+
+def test_member_wiki_410_has_full_cache_control_contract(monkeypatch) -> None:
+    """GET /wiki/{slug} 410 (archived) → full cache-control contract."""
+    page_id = uuid.uuid4()
+    page = _make_page_row(page_id=page_id, slug="archived-slug", page_status="reviewed")
+
+    async def _fake_render_archived(session, *, page_id, role, body_markdown):
+        from bot.services.wiki_renderer import WikiRenderResult
+        return WikiRenderResult(html_body="", page_archived=True)
+
+    wiki_routes = import_module("web.routes.wiki")
+    monkeypatch.setattr(wiki_routes, "_wiki_enabled", lambda session: _async_true())
+    monkeypatch.setattr(wiki_routes, "_get_page_by_slug", lambda session, slug: _async_page(page))
+    monkeypatch.setattr(wiki_routes, "render_wiki_page", _fake_render_archived)
+
+    client = _make_client(session_cookie=_member_cookie())
+    response = client.get("/wiki/archived-slug", follow_redirects=False)
+
+    assert response.status_code == 410
+    _assert_full_cache_control_contract(response)
+
+
+def test_member_wiki_403_has_full_cache_control_contract(monkeypatch) -> None:
+    """GET /wiki/{slug} with authenticated-but-wrong-role session → 403 with full cache-control contract.
+
+    Product MED (9.5-F): 403 insufficient_role response must carry
+    Cache-Control: no-store, no-cache, must-revalidate, private + Pragma/Expires
+    so that proxy caches cannot serve a stale 403 to a newly authorised member.
+
+    A cookie with role='guest' passes auth middleware (authenticated=True) but
+    fails _require_member_or_admin (role not in {'admin', 'member'}) → 403.
+    """
+    web_auth = import_module("web.auth")
+    guest_cookie = web_auth.create_session_cookie(role="guest")
+    client = _make_client(session_cookie=guest_cookie)
+    response = client.get("/wiki/any-slug", follow_redirects=False)
+
+    assert response.status_code == 403
+    _assert_full_cache_control_contract(response)
+
+
+def test_member_wiki_503_has_full_cache_control_contract(monkeypatch) -> None:
+    """GET /wiki/{slug} when wiki feature flag is off → 503 with full cache-control contract.
+
+    Product MED (9.5-F): 503 wiki_disabled response must carry
+    Cache-Control: no-store, no-cache, must-revalidate, private + Pragma/Expires
+    so that CDN caches do not lock users out after the flag is flipped on.
+    """
+    wiki_routes = import_module("web.routes.wiki")
+    monkeypatch.setattr(wiki_routes, "_wiki_enabled", lambda session: _async_none())
+
+    client = _make_client(session_cookie=_member_cookie())
+    response = client.get("/wiki/any-slug", follow_redirects=False)
+
+    assert response.status_code == 503
+    _assert_full_cache_control_contract(response)

--- a/tests/fixtures/honeypot_llm_url.py
+++ b/tests/fixtures/honeypot_llm_url.py
@@ -1,0 +1,12 @@
+"""Honeypot fixture for test_no_llm_provider_urls_outside_gateway.
+
+This file intentionally contains an LLM provider URL in a comment so the
+url-guard test can verify that the detection mechanism works correctly.
+
+When the scan path is extended to include tests/fixtures/, this file must
+appear in the detected-violations list.
+
+Honeypot marker: # api.openai.com
+"""
+
+# This module contains NO runnable code — it is a static fixture only.

--- a/tests/services/test_wiki_cascade.py
+++ b/tests/services/test_wiki_cascade.py
@@ -705,6 +705,90 @@ async def test_cascade_wiki_revisions_metadata_fields(db_session) -> None:
     assert row["revision_sources_resolved_at"] is not None
 
 
+# ── 9.5-C: _cascade_wiki_revisions idempotency guard ─────────────────────────
+
+
+async def test_cascade_wiki_revisions_idempotent_second_run_is_noop(db_session) -> None:
+    """9.5-C: Running _cascade_wiki_revisions twice for the same forget_event
+    on an already-redacted revision must be a no-op on the second run.
+
+    Contract:
+    - First run: body_markdown is masked, revision_status='forgotten_redacted'.
+    - Second run (same forget_event): row is SKIPPED (already_redacted_skip),
+      body_markdown and redacted_by_forget_event_id are NOT overwritten.
+    - Return value of second run: 0 rows modified.
+    """
+    from bot.services.forget_cascade import _cascade_wiki_revisions
+    from sqlalchemy import text
+
+    uid = await _make_user(db_session)
+    cm = await _make_chat_message(db_session, user_id=uid)
+    mv_id = await _make_message_version(db_session, chat_message_id=cm.id)
+
+    page_id = await _make_wiki_page(db_session, page_status="reviewed")
+    await _link_mv(db_session, page_id=page_id, message_version_id=mv_id)
+
+    rev_id = uuid.uuid4()
+    await session_execute_insert_revision(
+        db_session,
+        rev_id=rev_id,
+        page_id=page_id,
+        mv_ids=[mv_id],
+        body_markdown="original body before forget",
+    )
+
+    event_id = await _make_forget_event_row(
+        db_session,
+        tombstone_key=f"message:{cm.chat_id}:{cm.message_id}",
+        target_type="message",
+        target_id=str(cm.id),
+    )
+    event = _FakeEvent(
+        id=event_id,
+        target_type="message",
+        target_id=str(cm.id),
+        tombstone_key=f"message:{cm.chat_id}:{cm.message_id}",
+    )
+
+    # First run — should redact
+    count1 = await _cascade_wiki_revisions(db_session, event)
+    assert count1 == 1
+
+    row_after_first = (
+        await db_session.execute(
+            text(
+                "SELECT body_markdown, revision_status, redacted_by_forget_event_id "
+                "FROM wiki_revisions WHERE id = :id"
+            ),
+            {"id": str(rev_id)},
+        )
+    ).mappings().one()
+    assert row_after_first["revision_status"] == "forgotten_redacted"
+    first_body = row_after_first["body_markdown"]
+    assert first_body == f"[CONTENT_REDACTED: forget_event_id={event_id}]"
+
+    # Second run — must be no-op (idempotency guard)
+    count2 = await _cascade_wiki_revisions(db_session, event)
+    assert count2 == 0, (
+        f"Second cascade run returned {count2} rows modified; "
+        "expected 0 — already-redacted revisions must be skipped"
+    )
+
+    row_after_second = (
+        await db_session.execute(
+            text(
+                "SELECT body_markdown, revision_status, redacted_by_forget_event_id "
+                "FROM wiki_revisions WHERE id = :id"
+            ),
+            {"id": str(rev_id)},
+        )
+    ).mappings().one()
+    # Provenance must be unchanged
+    assert row_after_second["revision_status"] == "forgotten_redacted"
+    assert row_after_second["body_markdown"] == first_body
+    assert row_after_second["redacted_by_forget_event_id"] == event_id
+
+
 # ── AC#13: cascade order index assertions ─────────────────────────────────────
 
 

--- a/web/routes/wiki.py
+++ b/web/routes/wiki.py
@@ -59,6 +59,17 @@ WIKI_FEATURE_FLAG = "memory.wiki.enabled"
 
 _NO_STORE = "no-store, max-age=0, must-revalidate"
 
+# Member-facing authenticated routes (GET /wiki/{slug}) require stronger
+# cache directives: no-store to prevent storage, no-cache to force
+# revalidation, private to block shared caches, must-revalidate per HTTP
+# spec. Pragma and Expires are legacy headers for HTTP/1.0 compliance.
+_MEMBER_NO_STORE = "no-store, no-cache, must-revalidate, private"
+_MEMBER_CACHE_HEADERS = {
+    "Cache-Control": _MEMBER_NO_STORE,
+    "Pragma": "no-cache",
+    "Expires": "0",
+}
+
 # ── Allowed roles for member routes ─────────────────────────────────────────
 
 _MEMBER_ROLES = {"admin", "member"}
@@ -310,7 +321,12 @@ async def wiki_public_page(slug: str, request: Request) -> Response:
 
 @router.get("/{slug}")
 async def wiki_page(slug: str, request: Request) -> Response:
-    """Single page view with governance revalidation. Member or admin only."""
+    """Single page view with governance revalidation. Member or admin only.
+
+    Cache-Control (9.5-F): every response (200, 404, 410) carries
+    ``Cache-Control: no-store, no-cache, must-revalidate, private`` so that
+    stale browser/CDN caches cannot serve forgotten or redacted content.
+    """
     role = _require_member_or_admin(request)
     if role is None:
         return JSONResponse(
@@ -329,7 +345,7 @@ async def wiki_page(slug: str, request: Request) -> Response:
         page = await _get_page_by_slug(session, slug)
 
         if page is None:
-            return Response(status_code=404)
+            return Response(status_code=404, headers=_MEMBER_CACHE_HEADERS)
 
         page_id = uuid.UUID(str(page.id))
 
@@ -342,11 +358,11 @@ async def wiki_page(slug: str, request: Request) -> Response:
         )
 
         if render_result.page_archived:
-            return Response(status_code=410)
+            return Response(status_code=410, headers=_MEMBER_CACHE_HEADERS)
 
         sources = await _get_page_sources(session, page_id)
 
-    return TEMPLATES.TemplateResponse(
+    template_response = TEMPLATES.TemplateResponse(
         request=request,
         name="wiki/page.html",
         context={
@@ -358,6 +374,9 @@ async def wiki_page(slug: str, request: Request) -> Response:
             "user": getattr(request.state, "user", {}),
         },
     )
+    for header, value in _MEMBER_CACHE_HEADERS.items():
+        template_response.headers[header] = value
+    return template_response
 
 
 # ── /robots.txt — wiki variant (AC#9 HIGH F) ─────────────────────────────────

--- a/web/routes/wiki.py
+++ b/web/routes/wiki.py
@@ -323,7 +323,7 @@ async def wiki_public_page(slug: str, request: Request) -> Response:
 async def wiki_page(slug: str, request: Request) -> Response:
     """Single page view with governance revalidation. Member or admin only.
 
-    Cache-Control (9.5-F): every response (200, 404, 410) carries
+    Cache-Control (9.5-F): every response (200, 403, 404, 410, 503) carries
     ``Cache-Control: no-store, no-cache, must-revalidate, private`` so that
     stale browser/CDN caches cannot serve forgotten or redacted content.
     """
@@ -331,6 +331,7 @@ async def wiki_page(slug: str, request: Request) -> Response:
     if role is None:
         return JSONResponse(
             status_code=403,
+            headers=_MEMBER_CACHE_HEADERS,
             content={"detail": "insufficient_role", "required": "member"},
         )
 
@@ -338,7 +339,7 @@ async def wiki_page(slug: str, request: Request) -> Response:
         if not await _wiki_enabled(session):
             return JSONResponse(
                 status_code=503,
-                headers={"Retry-After": "3600"},
+                headers={**_MEMBER_CACHE_HEADERS, "Retry-After": "60"},
                 content={"detail": "wiki_disabled"},
             )
 


### PR DESCRIPTION
## Summary

**Sprint 1 of 6** in Phase 10.5/11.5 carryover wave. Closes 3 privacy/cascade items via 4 commits.

## Closed carryovers

- **11.5-F** (#224 HIGH #5) — httpx-level no-LLM URL guard for `bot/`, `web/`, `ops/` scan tree with extended hostname coverage (`api.together.xyz`, `api.groq.com`, plus existing). Single source of truth `LLM_PROVIDER_HOSTNAMES` in `tests/evals/_llm_guard.py` shared by runtime guard + static scan; honeypot fixture exercises the same scanner code path.
- **9.5-F** — `Cache-Control: no-store, no-cache, must-revalidate, private` + `Pragma: no-cache` + `Expires: 0` on every member `/wiki/{slug}` response path (200, 403, 404, 410, 503). Retry-After on 503 also tuned to 60s.
- **9.5-C** — `_cascade_wiki_revisions` idempotency guard: WHERE `revision_status != 'forgotten_redacted'` preserves the first-redaction provenance when a second cascade fires for the same revision.

11.5-A (privacy lint baseline-diff bug) was already closed on main (commit `66066b6`, May 2026) — skipped correctly by implementer.

## Phase 11 binding tests

**77 → 84 (+7)**:
- 1 × URL guard (`test_no_llm_provider_urls_outside_gateway`)
- 5 × cache-control contract on all five status code paths (200/403/404/410/503)
- 1 × cascade idempotency (`test_cascade_wiki_revisions_idempotent_second_run_is_noop`, DB-backed, skipped locally without postgres)

## Unified Review

Round 1: Product **NEEDS_FIXES** (Cache-Control gap on 403/503) + Codex **REQUEST_CHANGES** (3 findings — hostname split, honeypot path, partial header contract assertions).

Round 2 (after fix commit `002adda`): Product **ACCEPTED**, Codex **APPROVE**.

`.par-evidence.json`:
- claude_product: ACCEPTED
- technical_review: APPROVE
- docs_update: UNCHANGED (wave-style — closure block lands after wave completion)
- docs_review: PASS
- review_rounds: 2

## Files

```
bot/services/forget_cascade.py           — idempotency guard
web/routes/wiki.py                       — _MEMBER_CACHE_HEADERS on all 5 paths
tests/evals/_llm_guard.py                — LLM_PROVIDER_HOSTNAMES canonical
tests/evals/test_no_llm_imports.py       — URL scan + helper
tests/evals/test_wiki_cache_control.py   — 8 cache-control binding tests (NEW)
tests/fixtures/honeypot_llm_url.py       — honeypot (NEW)
tests/services/test_wiki_cascade.py      — idempotency binding test
scripts/lint_privacy_check.sh            — allowlist
```

## Test plan
- [x] `bash scripts/lint_privacy_check.sh` → exit 0
- [x] `pytest tests/evals/test_no_llm_imports.py -x -v` → 5 passed
- [x] `pytest tests/evals/test_wiki_cache_control.py -x -v` → 8 passed
- [x] `pytest tests/services/test_wiki_cascade.py -x -v` → 7 passed, 12 skipped (DB-backed)
- [x] `pytest tests/web/test_wiki_routes.py -x -v` → 19 passed
- [ ] CI green required before merge

## Next sprint
Sprint 2 — Phase 11 binding suite hardening (L3a/b + C4 + R3 + leakage_session refactor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)