### PR TITLE
test(p10.5-s2): Phase 11 binding suite hardening (#224 HIGH #1-#4)

### DIFF
--- a/tests/evals/test_citations.py
+++ b/tests/evals/test_citations.py
@@ -205,6 +205,14 @@ class TestCitationInvariants:
             f"qa_traces.evidence_ids={persisted.evidence_ids!r} does not match "
             f"bundle.evidence_ids={mv_ids!r}"
         )
+        # Verify the row shape written by the REAL handler helper: abstained=False
+        # for a non-empty bundle, and query text preserved verbatim.
+        assert persisted.abstained is False, (
+            "QaTrace.abstained must be False for a non-empty evidence bundle"
+        )
+        assert persisted.query_text == _CITATION_QUERY, (
+            f"QaTrace.query_text={persisted.query_text!r} does not match query sent to handler"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/evals/test_leakage.py
+++ b/tests/evals/test_leakage.py
@@ -314,14 +314,14 @@ async def _create_case(
         return SEED_CHAT_ID, "сигма", {created.version_id}
 
     if case_id == "L3b":
-        # L3b — tombstone by `message_hash:<content_hash>` key.
-        # Production search.py uses this branch when forget targets a content
-        # fingerprint rather than a specific (chat, message_id) tuple.
+        # L3b — tombstone by `message_hash:<content_hash>` key (#224 HIGH #1).
+        # Exercises the content-fingerprint forget path in search.py's NOT EXISTS
+        # subquery (branch: c.content_hash IS NOT NULL AND EXISTS forget_event
+        # WHERE tombstone_key = 'message_hash:<hash>').
         # Note: ChatMessage.content_hash is nullable and not auto-populated by
         # the current ingestion pipeline (message_persistence only stores it on
-        # MessageVersion). We mirror what tests/evals/conftest.py does and copy
-        # the v1 hash onto the chat_message row so the search.py
-        # `c.content_hash IS NOT NULL` branch is exercised.
+        # MessageVersion). We copy the v1 hash onto the chat_message row so the
+        # search.py `c.content_hash IS NOT NULL` branch is exercised.
         forget_event_repo = importlib.import_module("bot.db.repos.forget_event")
         created = await _persist_via_handler(
             session,
@@ -345,12 +345,20 @@ async def _create_case(
             authorized_by="system",
             tombstone_key=f"message_hash:{version.content_hash}",
         )
+        # Precondition: forget_event must carry target_type='message_hash'
+        assert event.target_type == "message_hash", (
+            f"L3b: expected target_type='message_hash', got {event.target_type!r}"
+        )
         await forget_event_repo.ForgetEventRepo.mark_status(session, event.id, status="processing")
         await forget_event_repo.ForgetEventRepo.mark_status(session, event.id, status="completed")
         return SEED_CHAT_ID, "тау", {created.version_id}
 
     if case_id == "L3c":
-        # L3c — tombstone by `user:<user_id>` key (full user-level forget).
+        # L3c — tombstone by `user:<user_id>` key (full user-level forget, #224 HIGH #1).
+        # Exercises the user-scope forget path in search.py's NOT EXISTS subquery
+        # (branch: EXISTS forget_event WHERE tombstone_key = 'user:<user_id>'
+        # matched against cm.user_id). Simulates a user invoking /forget_me so
+        # ALL their messages are excluded from /recall results.
         forget_event_repo = importlib.import_module("bot.db.repos.forget_event")
         user_id = 91_008
         created = await _persist_via_service(
@@ -367,6 +375,10 @@ async def _create_case(
             actor_user_id=None,
             authorized_by="system",
             tombstone_key=f"user:{user_id}",
+        )
+        # Precondition: forget_event must carry target_type='user'
+        assert event.target_type == "user", (
+            f"L3c: expected target_type='user', got {event.target_type!r}"
         )
         await forget_event_repo.ForgetEventRepo.mark_status(session, event.id, status="processing")
         await forget_event_repo.ForgetEventRepo.mark_status(session, event.id, status="completed")

--- a/tests/evals/test_leakage.py
+++ b/tests/evals/test_leakage.py
@@ -36,12 +36,15 @@ class PersistedMessage:
     user_id: int
 
 
-@pytest_asyncio.fixture(loop_scope="class")
+@pytest_asyncio.fixture(scope="function", loop_scope="class")
 async def leakage_session(eval_db_session: AsyncSession) -> AsyncIterator[AsyncSession]:
     # Per-case isolation: TRUNCATE before AND after each test invocation so
-    # L1-L5 (parametrized cases) do not see each other's content. Fixture
-    # itself stays class-scoped so the asyncpg connection / loop stays
-    # aligned with the conftest class-scope session.
+    # L1-L6 (parametrized cases) do not see each other's content.
+    # scope="function" is explicit: each parametrized case gets a fresh
+    # TRUNCATE-before / TRUNCATE-after cycle. loop_scope="class" aligns the
+    # asyncio event loop with the class-scoped eval_db_session / engine
+    # fixtures so the asyncpg connection stays bound to the same loop across
+    # all parametrized invocations in the class.
     await _clear_leakage_tables(eval_db_session)
     try:
         yield eval_db_session

--- a/tests/evals/test_refusal.py
+++ b/tests/evals/test_refusal.py
@@ -17,6 +17,11 @@ from tests.evals.conftest import SEED_CHAT_ID
 
 pytestmark = pytest.mark.asyncio(loop_scope="class")
 
+# Explicit non-community chat_ids used in R3b/R3c wrong-chat branch tests.
+# These must differ from SEED_CHAT_ID so the handler's community-id guard fires.
+NON_COMMUNITY_CHAT_ID_PRIVATE = -1099887766   # R3b: private chat wrong-chat path
+NON_COMMUNITY_CHAT_ID_GROUP = -1099887767    # R3c: supergroup wrong-chat + forbidden path
+
 CONTENT_TRUNCATE_SQL = text(
     "TRUNCATE TABLE qa_traces, message_versions, chat_messages, forget_events "
     "RESTART IDENTITY CASCADE"
@@ -290,7 +295,7 @@ class TestRefusal:
             "UserRepo.get must not be reached on wrong-chat branch"
         ))
         message = _message(
-            chat_id=SEED_CHAT_ID + 7777,  # non-community
+            chat_id=NON_COMMUNITY_CHAT_ID_PRIVATE,
             chat_type="private",
             user_id=1001,
             message_id=902,
@@ -322,7 +327,7 @@ class TestRefusal:
             "UserRepo.get must not be reached on wrong-chat branch"
         ))
         message = _message(
-            chat_id=SEED_CHAT_ID + 8888,
+            chat_id=NON_COMMUNITY_CHAT_ID_GROUP,
             chat_type="supergroup",
             user_id=1001,
             message_id=903,

--- a/tests/evals/test_refusal.py
+++ b/tests/evals/test_refusal.py
@@ -19,7 +19,7 @@ pytestmark = pytest.mark.asyncio(loop_scope="class")
 
 # Explicit non-community chat_ids used in R3b/R3c wrong-chat branch tests.
 # These must differ from SEED_CHAT_ID so the handler's community-id guard fires.
-NON_COMMUNITY_CHAT_ID_PRIVATE = -1099887766   # R3b: private chat wrong-chat path
+NON_COMMUNITY_CHAT_ID_PRIVATE = 1099887766    # R3b: private chat wrong-chat path (positive: Telegram private chat IDs > 0)
 NON_COMMUNITY_CHAT_ID_GROUP = -1099887767    # R3c: supergroup wrong-chat + forbidden path
 
 CONTENT_TRUNCATE_SQL = text(


### PR DESCRIPTION
## Summary

**Sprint 2 of 6** in Phase 10.5/11.5 carryover wave. 5 commits hardening existing Phase 11 binding tests for `#224 HIGH #1-#4`.

## Context — substantive close already shipped

The substantive close of #224 HIGH #1-#4 happened in commit `a4a288e` on 2026-05-11 ("test(p11): harden FHR HIGH findings"). On main at base:
- L3a `message:<chat_id>:<msg_id>` — present
- L3b `message_hash:<hash>` — present
- L3c `user:<user_id>` — present  
- C4 real handler `_write_trace` call — present
- R3 non-community chat IDs (`SEED_CHAT_ID + 7777/8888`) — present
- `leakage_session` `loop_scope='class'` — present

Sprint 2 adds **defense-in-depth hardening** on top:

## Commits

- `1e4ea1f` — test(s2-p11.5-b): explicit `assert event.target_type == "message_hash"` / `"user"` preconditions in L3b/L3c
- `089b33e` — test(s2-p11.5-c): C4 adds 2 assertions on persisted `QaTrace` (`abstained is False` + `query_text == _CITATION_QUERY`)
- `ec3ca58` — test(s2-p11.5-d): R3 named constants `NON_COMMUNITY_CHAT_ID_PRIVATE/_GROUP` replacing arithmetic offsets
- `62322e2` — refactor(s2-p11.5-e): explicit `scope="function"` + comment on `leakage_session`
- `1f500d7` — fix(s2-codex): `NON_COMMUNITY_CHAT_ID_PRIVATE` flipped to positive (Telegram convention)

## Phase 11 binding count

**84 → 84** (no new test cases; hardening of existing 84 cases).

## Unified Review

Round 1: Product **ACCEPTED** (verified all 4 items already on main, Sprint 2 = legitimate hardening) + Codex **REQUEST_CHANGES** (1 finding: `NON_COMMUNITY_CHAT_ID_PRIVATE` should be positive per Telegram convention).

Round 2 (after `1f500d7`): Codex **APPROVE**.

## Test plan
- [x] `pytest tests/evals/test_leakage.py -x -v` → 10 passed
- [x] `pytest tests/evals/test_citations.py -x -v` → 8 passed
- [x] `pytest tests/evals/test_refusal.py -x -v` → 6 passed
- [x] `bash scripts/lint_privacy_check.sh` → exit 0
- [ ] CI green required before merge

## #224 status

HIGH #1-#5 substantively closed (HIGH #5 by `4bf3089`/PR #243). Critical #4 (privacy allowlist narrowing + baseline-diff line-number bug) — **closed by Sprint 1 PR #336**. Issue #224 can be closed after this PR merges.

## Next sprint
Sprint 3 — Schema & cascade correctness (XOR migration 067 + edge_key_hash MERGE + Stale-page 410).

🤖 Generated with [Claude Code](https://claude.com/claude-code)