### PR TITLE
feat(p10.5-s5): web polish — WEB_MEMBER_PASSWORD warning + R5 handler tightening

### DIFF
--- a/tests/evals/test_refusal.py
+++ b/tests/evals/test_refusal.py
@@ -1,11 +1,17 @@
-"""Phase 11 §5.3 — refusal / abstention cases for recall."""
+"""Phase 11 §5.3 — refusal / abstention cases for recall.
+
+R5.a/R5.b handler-layer tightening (8.5-C carryover):
+- R5.a: non-admin invokes /digest_approve → handler _is_admin gate → silent no-op
+  (no message.answer, no approve_digest service call).
+- R5.b: non-admin invokes /digest_reject → same silent no-op.
+"""
 
 from __future__ import annotations
 
 from datetime import datetime, timezone
 from types import SimpleNamespace
 from typing import Any
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from sqlalchemy import text
@@ -367,3 +373,79 @@ class TestRefusal:
         assert trace_create.call_args.kwargs["query"] == ""
         assert trace_create.call_args.kwargs["abstained"] is True
         assert session.mock_calls == []
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# R5.a / R5.b — handler-layer tightening (8.5-C carryover)
+#
+# These tests verify the handler's _is_admin gate at the Telegram routing
+# layer. The service-layer invariants (no DB mutation) are covered by
+# test_digest_weekly_review_invariants.py::test_R5a_* / test_R5b_*.
+#
+# Handler contract: non-admin caller → immediate return, no message.answer,
+# no service call. Matches the "silent no-op" precedent for /stats /
+# /admin_extract (PHASE8_PLAN.md §3).
+# ────────────────────────────────────────────────────────────────────────────
+
+
+def _non_admin_message(user_id: int = 9_999_999_999) -> SimpleNamespace:
+    """Build a minimal Telegram Message mock for a non-admin user."""
+    return SimpleNamespace(
+        from_user=SimpleNamespace(id=user_id),
+        answer=AsyncMock(),
+    )
+
+
+def _command_object(args: str = "1") -> SimpleNamespace:
+    """Build a minimal CommandObject mock."""
+    return SimpleNamespace(args=args)
+
+
+@pytest.mark.usefixtures("eval_app_env")
+class TestR5HandlerLayer:
+    """R5.a/R5.b: handler-layer admin gate for digest review commands."""
+
+    async def test_r5a_non_admin_digest_approve_handler_silent_no_op(self) -> None:
+        """R5.a handler-layer: non-admin calls cmd_digest_approve → silent return,
+        no message.answer, approve_digest service NOT called."""
+        handler = import_module("bot.handlers.digest")
+        message = _non_admin_message()
+        bot = AsyncMock()
+        session = AsyncMock()
+        command = _command_object("1")
+
+        # Ensure the non-admin user is not in ADMIN_IDS.
+        from bot.config import settings
+        assert message.from_user.id not in set(settings.ADMIN_IDS), (
+            "R5.a precondition: test user must NOT be in ADMIN_IDS"
+        )
+
+        with patch.object(handler, "approve_digest", new_callable=AsyncMock) as mock_svc:
+            await handler.cmd_digest_approve(message, bot, session, command)
+
+        # Silent no-op: no answer sent.
+        message.answer.assert_not_called()
+        # Service layer never reached.
+        mock_svc.assert_not_awaited()
+
+    async def test_r5b_non_admin_digest_reject_handler_silent_no_op(self) -> None:
+        """R5.b handler-layer: non-admin calls cmd_digest_reject → silent return,
+        no message.answer, reject_digest service NOT called."""
+        handler = import_module("bot.handlers.digest")
+        message = _non_admin_message()
+        session = AsyncMock()
+        command = _command_object("1 причина")
+
+        # Ensure the non-admin user is not in ADMIN_IDS.
+        from bot.config import settings
+        assert message.from_user.id not in set(settings.ADMIN_IDS), (
+            "R5.b precondition: test user must NOT be in ADMIN_IDS"
+        )
+
+        with patch.object(handler, "reject_digest", new_callable=AsyncMock) as mock_svc:
+            await handler.cmd_digest_reject(message, session, command)
+
+        # Silent no-op: no answer sent.
+        message.answer.assert_not_called()
+        # Service layer never reached.
+        mock_svc.assert_not_awaited()

--- a/tests/web/test_auth_role.py
+++ b/tests/web/test_auth_role.py
@@ -10,10 +10,12 @@ Scenarios:
 7. WEB_PASSWORD alias: only WEB_PASSWORD set → accepted as admin + DeprecationWarning on startup
 8. ConfigurationError raised when WEB_ADMIN_PASSWORD == WEB_MEMBER_PASSWORD
 9. Backward compat: existing single-password test path still works
+10. 9.5-E: create_app() warns when WEB_MEMBER_PASSWORD is absent (wiki member login unavailable)
 """
 
 from __future__ import annotations
 
+import logging
 import warnings
 
 import pytest
@@ -330,3 +332,43 @@ def test_backward_compat_existing_session_cookie(app_env) -> None:
     payload = _decode_cookie(cookie)
     assert payload.get("role") == "admin"
     assert payload.get("authenticated") is True
+
+
+# ── Test 10: 9.5-E — WEB_MEMBER_PASSWORD startup warning ─────────────────────
+
+
+def test_create_app_warns_when_member_password_absent(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """9.5-E: create_app() emits a WARNING via the 'web.app' logger when
+    WEB_MEMBER_PASSWORD is not set.
+
+    Wiki member login is unavailable without WEB_MEMBER_PASSWORD; admin
+    enabling memory.wiki.enabled would get 500s instead of a clear error.
+    The startup warning surfaces the misconfiguration early.
+    """
+    monkeypatch.setenv("BOT_TOKEN", "123456:test-token")
+    monkeypatch.setenv("COMMUNITY_CHAT_ID", "-1001234567890")
+    monkeypatch.setenv("ADMIN_IDS", "[149820031]")
+    monkeypatch.setenv("WEB_ADMIN_PASSWORD", "admin-password-12")
+    monkeypatch.setenv("WEB_SESSION_SECRET", "test-session-secret")
+    monkeypatch.setenv("DEV_MODE", "true")
+    # Explicitly clear WEB_MEMBER_PASSWORD and WEB_PASSWORD to exercise the no-member-pw path.
+    monkeypatch.delenv("WEB_MEMBER_PASSWORD", raising=False)
+    monkeypatch.delenv("WEB_PASSWORD", raising=False)
+    from tests.conftest import _clear_modules
+    _clear_modules()
+
+    with caplog.at_level(logging.WARNING, logger="web.app"):
+        web_app = import_module("web.app")
+        web_app.create_app()
+
+    warning_messages = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+    member_pw_warnings = [m for m in warning_messages if "WEB_MEMBER_PASSWORD" in str(m)]
+    assert member_pw_warnings, (
+        "9.5-E: expected WARNING about WEB_MEMBER_PASSWORD being empty/missing, "
+        f"got log records: {warning_messages}"
+    )
+
+    _clear_modules()

--- a/web/app.py
+++ b/web/app.py
@@ -12,6 +12,24 @@ from web.auth import get_user_from_cookie, create_session_cookie, _cookie_finger
 
 logger = logging.getLogger(__name__)
 
+
+def _check_member_password_config() -> None:
+    """9.5-E: Warn at startup if WEB_MEMBER_PASSWORD is absent.
+
+    Wiki member login is unavailable without WEB_MEMBER_PASSWORD. Admins who
+    enable memory.wiki.enabled without setting this env var will get 500s
+    instead of a clear error. This check surfaces the misconfiguration early.
+    """
+    from web.config import settings as _settings
+
+    member_pw = _settings.WEB_MEMBER_PASSWORD
+    if not member_pw:
+        logger.warning(
+            "WEB_MEMBER_PASSWORD is empty/missing. "
+            "Wiki member login will be unavailable. "
+            "Set WEB_MEMBER_PASSWORD in env to enable member access."
+        )
+
 _WEB_DIR = Path(__file__).resolve().parent
 
 TEMPLATES = Jinja2Templates(directory=str(_WEB_DIR / "templates"))
@@ -35,6 +53,8 @@ def _is_admin_only_path(path: str) -> bool:
 
 
 def create_app() -> FastAPI:
+    _check_member_password_config()
+
     app = FastAPI(title="Vibe Gatekeeper Admin")
 
     # Mount static files


### PR DESCRIPTION
## Summary

**Sprint 5 of 6** in Phase 10.5/11.5 carryover wave. Small web/UX polish — 2 commits.

## Closed carryovers

### 9.5-E — `WEB_MEMBER_PASSWORD` startup warning
- `web/app.py::_check_member_password_config()` called from `create_app()`. Emits `WARNING` via `web.app` logger when `settings.WEB_MEMBER_PASSWORD` is None/empty.
- Test in `tests/web/test_auth_role.py` (caplog fixture, TDD red→green).
- Note: warning fires unconditionally (wiki flag lives in DB, not env — checking flag at app-create time would require async session). Erring on the side of louder safety.

### 8.5-C — R5.a/R5.b handler-layer refusal assertions tightened
- `TestR5HandlerLayer` class added to `tests/evals/test_refusal.py`.
- Both tests mock services (`approve_digest`/`reject_digest`), invoke `cmd_digest_approve`/`cmd_digest_reject` with non-admin `user_id`, assert:
  - `message.answer.assert_not_called()` — silent no-op contract
  - `mock_svc.assert_not_awaited()` — service never reached
- Locks in established project convention from PHASE8_PLAN §3.

## Not implemented (scope-correct)

### 9.5-A — L9a OR → AND assertion polish — **DEFERRED** (real gap discovered)
Implementer found that splitting `assert (mv_id in suppressed_citations) or page_archived` into AND form exposes a real gap: `wiki_renderer.py:270-276` early-returns when `page_archived=True` without populating `suppressed_citations`. The OR-form masks this by passing via the second disjunct. Privacy invariant is still upheld (page_archived blocks the entire render path), but a contract decision is needed: (1) populate `suppressed_citations` before early-return, OR (2) explicitly document archived pages return empty list and tighten L9a with branch-specific assertions. Tracked as follow-up.

### 8.5-A — Weekly renderer bolding + footer — **ALREADY ON MAIN**
Implemented earlier in Phase 7 T7-05 (PR with `770da3a`) + Phase 8 FHR. `_WEEKLY_SECTION_HEADER_RE` regex emits `<b>Раздел: \1</b>`; weekly footer in `digest_renderer.py:184`. 5 existing tests passing. No commit needed.

## Phase 11 binding tests

**89 → 89** (polish only — no new binding cases).

## Unified Review

Single round: Product **ACCEPTED** (with `suggestion`-severity note on log noise) + Codex **APPROVE** (with INFO-tier observation on same).

`.par-evidence.json`:
- claude_product: ACCEPTED
- technical_review: APPROVE
- docs_update: UNCHANGED
- docs_review: PASS
- review_rounds: 1

## Files

```
web/app.py                       (_check_member_password_config + call)
tests/web/test_auth_role.py      (+caplog test 10)
tests/evals/test_refusal.py      (TestR5HandlerLayer)
```

## Test plan
- [x] `ruff check --no-cache .` → All checks passed
- [x] `bash scripts/lint_privacy_check.sh` → exit 0
- [x] `pytest tests/web/` → 43 passed
- [x] `pytest tests/evals/test_leakage.py tests/evals/test_refusal.py` → 18 passed
- [x] `pytest tests/services/test_digest_renderer_weekly.py tests/services/test_digests_weekly.py` → 30 passed
- [ ] CI green required before merge

## Next sprint
Sprint 6 (FINAL) — Healing pipeline scope guard (#282) + close #228 + #315 as obsolete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)