### PR TITLE
feat(p10.5-s6): healing pipeline scope guard + close obsolete signals (FINAL sprint)

### DIFF
--- a/ops/healing/INVARIANTS.md
+++ b/ops/healing/INVARIANTS.md
@@ -1,5 +1,13 @@
 You are running in autonomous healing loop.
 
+**Scope guard (MUST read first):** If you cannot identify a concrete, real failure
+from the context bundle — a specific stack trace, log error, or live incident
+artifact pointing at a broken production behaviour — return a null verdict and
+exit immediately. Do not pick items from the backlog. Do not refactor. Do not
+"be helpful." Inventing work when no real failure is present is worse than doing
+nothing: it creates unsolicited PRs, wastes review bandwidth, and erodes trust in
+autonomous pipelines.
+
 Use superpowers:systematic-debugging skill mandatory before proposing or applying any fix.
 Use test-driven development for code changes: reproduce the failure with a red test, implement the smallest fix, then prove green tests.
 

--- a/ops/healing/orchestrator.py
+++ b/ops/healing/orchestrator.py
@@ -10,7 +10,38 @@ from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any, Literal
 
-Verdict = Literal["succeeded", "escalated"]
+Verdict = Literal["succeeded", "escalated", "no_action"]
+
+# Sources recognised as production monitors.  Payloads from any other source
+# are treated as unverified / synthetic and rejected by the scope guard.
+_TRUSTED_SOURCES: frozenset[str] = frozenset({"coolify", "sentry", "prod-monitor"})
+
+# Only these severity levels trigger autonomous healing.  Low / medium signals
+# must be investigated manually to avoid spurious pipeline activations.
+_ALLOWED_SEVERITIES: frozenset[str] = frozenset({"critical", "high"})
+
+
+def is_real_bug_signal(payload: dict) -> bool:
+    """Return True only when *payload* represents a genuine production incident.
+
+    Heuristics (ALL must pass):
+    - ``incident_id`` must be a non-empty, non-null value.
+    - ``severity`` must be one of {"critical", "high"}.
+    - ``source`` must be a trusted production log origin.
+    - Neither ``_synthetic`` nor ``test_payload`` flags may be truthy.
+
+    Any failure causes an immediate False return so that synthetic / test /
+    low-severity signals never reach the autonomous pipeline.
+    """
+    if not payload.get("incident_id"):
+        return False
+    if payload.get("severity") not in _ALLOWED_SEVERITIES:
+        return False
+    if payload.get("source") not in _TRUSTED_SOURCES:
+        return False
+    if payload.get("_synthetic") or payload.get("test_payload"):
+        return False
+    return True
 
 
 @dataclass(frozen=True)
@@ -229,6 +260,13 @@ def _run_real(signal_payload: str, config: HealingConfig) -> HealingResult:
                 time.sleep(config.cooldown_seconds)
                 continue
 
+            # TODO: choose dispatch mode based on environment.
+            # When running inside a Claude Code session, replace this block with
+            #   Agent(subagent_type="codex:codex-rescue", ...)
+            # per ~/.claude/rules/codex-routing.md — raw `codex exec` is broken on
+            # ChatGPT accounts and requires the codex plugin runtime for correct auth.
+            # Until that dispatch mechanism is wired, the step falls through if codex
+            # is not on PATH (see issue #282 Option C / Option A tracking).
             codex = subprocess.run(
                 [
                     "codex",
@@ -299,6 +337,29 @@ def run_healing(
     if os.environ.get("HEALING_DRY_RUN") == "true":
         scenario = os.environ.get("HEALING_DRY_RUN_SCENARIO", "success")
         return _dry_run_result(scenario, config)
+
+    try:
+        payload = json.loads(signal_payload)
+    except (json.JSONDecodeError, ValueError):
+        payload = {}
+
+    if not is_real_bug_signal(payload):
+        sys.stderr.write(
+            "[ops.healing.orchestrator] Scope guard: signal rejected as synthetic / "
+            "unverified. No PR will be opened. Inspect payload fields: "
+            f"incident_id={payload.get('incident_id')!r}, "
+            f"severity={payload.get('severity')!r}, "
+            f"source={payload.get('source')!r}\n"
+        )
+        sys.stderr.flush()
+        return HealingResult(
+            verdict="no_action",
+            attempts=0,
+            rolled_back=False,
+            escalated=False,
+            events=["scope_guard:reject"],
+        )
+
     return _run_real(signal_payload, config)
 
 

--- a/ops/healing/orchestrator.py
+++ b/ops/healing/orchestrator.py
@@ -3,45 +3,74 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
+import shutil
 import subprocess
 import sys
 import time
+from collections.abc import Mapping
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any, Literal
 
 Verdict = Literal["succeeded", "escalated", "no_action"]
 
-# Sources recognised as production monitors.  Payloads from any other source
-# are treated as unverified / synthetic and rejected by the scope guard.
-_TRUSTED_SOURCES: frozenset[str] = frozenset({"coolify", "sentry", "prod-monitor"})
+# Substring markers in a check's ``reason`` field that identify operator-triggered
+# synthetic / dry-run payloads.  Matched case-insensitively.
+_SYNTHETIC_REASON_MARKERS = re.compile(
+    r"\b(synthetic|test|verification|manual|dry[\s_-]?run)\b",
+    re.IGNORECASE,
+)
 
-# Only these severity levels trigger autonomous healing.  Low / medium signals
-# must be investigated manually to avoid spurious pipeline activations.
-_ALLOWED_SEVERITIES: frozenset[str] = frozenset({"critical", "high"})
+# Component names from CheckReport.to_dict() that are included in the is_red
+# calculation.  db_roundtrip is intentionally excluded — the GitHub Actions
+# self-hosted runner has no route to Coolify's internal Docker bridge, so the
+# check is continuously RED without reflecting actual DB health.  See
+# CheckReport.is_red in ops/healing/healthcheck.py for the authoritative comment.
+_HEALING_TARGETS: tuple[str, ...] = ("coolify_status", "telegram_pending")
 
 
-def is_real_bug_signal(payload: dict) -> bool:
-    """Return True only when *payload* represents a genuine production incident.
+def is_real_bug_signal(payload: object) -> bool:
+    """Return True if *payload* represents a genuine production failure worth healing.
 
-    Heuristics (ALL must pass):
-    - ``incident_id`` must be a non-empty, non-null value.
-    - ``severity`` must be one of {"critical", "high"}.
-    - ``source`` must be a trusted production log origin.
-    - Neither ``_synthetic`` nor ``test_payload`` flags may be truthy.
+    Accepts the ``CheckReport.to_dict()`` payload shape produced by
+    ``ops/healing/healthcheck.py``.  Rejects:
 
-    Any failure causes an immediate False return so that synthetic / test /
-    low-severity signals never reach the autonomous pipeline.
+    - Non-mapping inputs (None, list, str, scalar) — malformed JSON guard.
+    - Operator-triggered dry-runs: ``_synthetic=True`` or ``test_payload=True``
+      at the top level.
+    - Payloads with no red check among the healing targets (coolify_status,
+      telegram_pending).
+    - Red checks whose ``reason`` field matches the synthetic/test/verification
+      marker pattern — catches payloads where db_roundtrip.reason='synthetic'
+      would otherwise slip through (2026-05-13 regression payload).
+
+    db_roundtrip is explicitly excluded from healing targets even if red,
+    mirroring the ``CheckReport.is_red`` property in healthcheck.py.
     """
-    if not payload.get("incident_id"):
+    if not isinstance(payload, Mapping):
         return False
-    if payload.get("severity") not in _ALLOWED_SEVERITIES:
+
+    # Explicit synthetic flags from operator-triggered or test runs
+    if payload.get("_synthetic") is True or payload.get("test_payload") is True:
         return False
-    if payload.get("source") not in _TRUSTED_SOURCES:
-        return False
-    if payload.get("_synthetic") or payload.get("test_payload"):
-        return False
-    return True
+
+    # Find red checks among healing targets, skipping synthetic-reason entries
+    red_components: list[str] = []
+    for name in _HEALING_TARGETS:
+        check = payload.get(name)
+        if not isinstance(check, Mapping):
+            continue
+        if check.get("status") != "red":
+            continue
+        reason = str(check.get("reason", ""))
+        if _SYNTHETIC_REASON_MARKERS.search(reason):
+            # Reason field indicates a synthetic/test trigger — skip this check
+            # even though its status is red.
+            continue
+        red_components.append(name)
+
+    return len(red_components) > 0
 
 
 @dataclass(frozen=True)
@@ -267,25 +296,37 @@ def _run_real(signal_payload: str, config: HealingConfig) -> HealingResult:
             # ChatGPT accounts and requires the codex plugin runtime for correct auth.
             # Until that dispatch mechanism is wired, the step falls through if codex
             # is not on PATH (see issue #282 Option C / Option A tracking).
-            codex = subprocess.run(
-                [
-                    "codex",
-                    "exec",
-                    "review",
-                    "--base",
-                    "main",
-                    "-m",
-                    "gpt-5.5",
-                    "-c",
-                    "model_reasoning_effort=high",
-                    "--ephemeral",
-                ],
-                text=True,
-                capture_output=True,
-                check=False,
-            )
-            _write_text(config.work_dir / f"codex-{attempt}.log", codex.stdout + codex.stderr)
-            if codex.returncode != 0 or "APPROVE" not in codex.stdout:
+            codex_path = shutil.which("codex")
+            if codex_path is None:
+                sys.stderr.write(
+                    "[ops.healing.orchestrator] codex not found on PATH — skipping "
+                    "secondary review; merge gating falls back to Claude-only review. "
+                    "See issue #282.\n"
+                )
+                sys.stderr.flush()
+                codex_approved = True  # fall through to Claude-only merge
+            else:
+                codex = subprocess.run(
+                    [
+                        codex_path,
+                        "exec",
+                        "review",
+                        "--base",
+                        "main",
+                        "-m",
+                        "gpt-5.5",
+                        "-c",
+                        "model_reasoning_effort=high",
+                        "--ephemeral",
+                    ],
+                    text=True,
+                    capture_output=True,
+                    check=False,
+                )
+                _write_text(config.work_dir / f"codex-{attempt}.log", codex.stdout + codex.stderr)
+                codex_approved = codex.returncode == 0 and "APPROVE" in codex.stdout
+
+            if not codex_approved:
                 events.append("codex:reject")
                 time.sleep(config.cooldown_seconds)
                 continue
@@ -344,12 +385,16 @@ def run_healing(
         payload = {}
 
     if not is_real_bug_signal(payload):
+        # Log the CheckReport fields that are relevant for debugging scope-guard
+        # decisions: coolify_status and telegram_pending statuses plus operator flags.
+        coolify = payload.get("coolify_status") if isinstance(payload, Mapping) else None
+        telegram = payload.get("telegram_pending") if isinstance(payload, Mapping) else None
         sys.stderr.write(
             "[ops.healing.orchestrator] Scope guard: signal rejected as synthetic / "
             "unverified. No PR will be opened. Inspect payload fields: "
-            f"incident_id={payload.get('incident_id')!r}, "
-            f"severity={payload.get('severity')!r}, "
-            f"source={payload.get('source')!r}\n"
+            f"coolify_status={coolify!r}, "
+            f"telegram_pending={telegram!r}, "
+            f"_synthetic={payload.get('_synthetic') if isinstance(payload, Mapping) else None!r}\n"
         )
         sys.stderr.flush()
         return HealingResult(
@@ -369,7 +414,10 @@ def main() -> int:
     args = parser.parse_args()
     result = run_healing(args.signal_payload)
     print(json.dumps(result.to_dict(), indent=2, sort_keys=True))
-    return 0 if result.verdict == "succeeded" else 1
+    # no_action = correct abstain decision (guard rejected a synthetic/non-red payload),
+    # not a failure.  Only escalated verdict signals an unresolved production incident.
+    EXIT_OK = {"succeeded", "no_action"}
+    return 0 if result.verdict in EXIT_OK else 1
 
 
 if __name__ == "__main__":

--- a/tests/healing/test_orchestrator.py
+++ b/tests/healing/test_orchestrator.py
@@ -1,15 +1,19 @@
-"""Tests for ops.healing.orchestrator._run.
+"""Tests for ops.healing.orchestrator._run and scope guard.
 
 Sprint 1A: ensure child failures surface stdout/stderr to parent stderr so
 GitHub Actions logs capture the real error, not just `exit status 1`.
+
+Sprint S6: synthetic-signal scope guard — is_real_bug_signal() must reject
+synthetic / low-severity / untrusted-source payloads before any PR is opened.
 """
 
+import json
 import subprocess
 import sys
 
 import pytest
 
-from ops.healing.orchestrator import _run
+from ops.healing.orchestrator import _run, is_real_bug_signal, run_healing, HealingConfig
 
 
 def test_run_surfaces_child_stderr_on_failure(capsys: pytest.CaptureFixture[str]) -> None:
@@ -47,3 +51,89 @@ def test_run_success_does_not_emit_to_stderr(capsys: pytest.CaptureFixture[str])
     assert result.returncode == 0
     assert result.stdout == "ok\n"
     assert "[ops.healing._run]" not in captured.err
+
+
+# ---------------------------------------------------------------------------
+# Sprint S6: is_real_bug_signal scope guard tests
+# ---------------------------------------------------------------------------
+
+def _make_real_payload(**overrides: object) -> dict:
+    base: dict = {
+        "incident_id": "INC-1234",
+        "severity": "high",
+        "source": "sentry",
+        "reason": "500 errors spike on /api/recall",
+    }
+    base.update(overrides)
+    return base
+
+
+def test_scope_guard_accepts_real_signal() -> None:
+    payload = _make_real_payload()
+    assert is_real_bug_signal(payload) is True
+
+
+def test_scope_guard_accepts_critical_severity() -> None:
+    payload = _make_real_payload(severity="critical")
+    assert is_real_bug_signal(payload) is True
+
+
+def test_scope_guard_rejects_missing_incident_id() -> None:
+    payload = _make_real_payload()
+    del payload["incident_id"]
+    assert is_real_bug_signal(payload) is False
+
+
+def test_scope_guard_rejects_null_incident_id() -> None:
+    payload = _make_real_payload(incident_id=None)
+    assert is_real_bug_signal(payload) is False
+
+
+def test_scope_guard_rejects_low_severity() -> None:
+    payload = _make_real_payload(severity="low")
+    assert is_real_bug_signal(payload) is False
+
+
+def test_scope_guard_rejects_medium_severity() -> None:
+    payload = _make_real_payload(severity="medium")
+    assert is_real_bug_signal(payload) is False
+
+
+def test_scope_guard_rejects_unknown_source() -> None:
+    payload = _make_real_payload(source="local-test-runner")
+    assert is_real_bug_signal(payload) is False
+
+
+def test_scope_guard_rejects_synthetic_flag() -> None:
+    payload = _make_real_payload(_synthetic=True)
+    assert is_real_bug_signal(payload) is False
+
+
+def test_scope_guard_rejects_test_payload_flag() -> None:
+    payload = _make_real_payload(test_payload=True)
+    assert is_real_bug_signal(payload) is False
+
+
+def test_scope_guard_accepts_coolify_source() -> None:
+    payload = _make_real_payload(source="coolify")
+    assert is_real_bug_signal(payload) is True
+
+
+def test_scope_guard_accepts_prod_monitor_source() -> None:
+    payload = _make_real_payload(source="prod-monitor")
+    assert is_real_bug_signal(payload) is True
+
+
+def test_run_healing_returns_no_action_on_synthetic_signal(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When signal is synthetic, run_healing must return no_action verdict without opening any PRs."""
+    monkeypatch.delenv("HEALING_DRY_RUN", raising=False)
+    synthetic_payload = json.dumps({
+        "incident_id": None,
+        "severity": "low",
+        "source": "local-test-runner",
+        "reason": "synthetic verification run",
+        "_synthetic": True,
+    })
+    result = run_healing(synthetic_payload, HealingConfig())
+    assert result.verdict == "no_action"
+    assert result.escalated is False

--- a/tests/healing/test_orchestrator.py
+++ b/tests/healing/test_orchestrator.py
@@ -5,6 +5,10 @@ GitHub Actions logs capture the real error, not just `exit status 1`.
 
 Sprint S6: synthetic-signal scope guard — is_real_bug_signal() must reject
 synthetic / low-severity / untrusted-source payloads before any PR is opened.
+
+Sprint S6 review (Fix 1-6): guard rewritten around CheckReport.to_dict() shape;
+regression test with actual 2026-05-13 payload; malformed-input safety;
+integration test for real-signal path; no_action exit code; codex-on-PATH guard.
 """
 
 import json
@@ -13,7 +17,13 @@ import sys
 
 import pytest
 
-from ops.healing.orchestrator import _run, is_real_bug_signal, run_healing, HealingConfig
+from ops.healing.orchestrator import (
+    HealingConfig,
+    HealingResult,
+    _run,
+    is_real_bug_signal,
+    run_healing,
+)
 
 
 def test_run_surfaces_child_stderr_on_failure(capsys: pytest.CaptureFixture[str]) -> None:
@@ -54,86 +64,263 @@ def test_run_success_does_not_emit_to_stderr(capsys: pytest.CaptureFixture[str])
 
 
 # ---------------------------------------------------------------------------
-# Sprint S6: is_real_bug_signal scope guard tests
+# Sprint S6: is_real_bug_signal scope guard tests (CheckReport schema)
+# Guard was rewritten in the S6 review to match CheckReport.to_dict() shape.
 # ---------------------------------------------------------------------------
 
-def _make_real_payload(**overrides: object) -> dict:
+def _make_checkreport_payload(**overrides: object) -> dict:
+    """Build a minimal valid CheckReport.to_dict() payload with coolify_status=red."""
     base: dict = {
-        "incident_id": "INC-1234",
-        "severity": "high",
-        "source": "sentry",
-        "reason": "500 errors spike on /api/recall",
+        "coolify_status": {"status": "red", "reason": "container exited with code 137"},
+        "telegram_pending": {"status": "green", "reason": "ok"},
+        "db_roundtrip": {"status": "green", "reason": "ok"},
+        "is_red": True,
+        "generated_at": "2026-05-22T10:00:00+00:00",
     }
     base.update(overrides)
     return base
 
 
 def test_scope_guard_accepts_real_signal() -> None:
-    payload = _make_real_payload()
+    """A valid CheckReport with coolify_status=red must be accepted."""
+    payload = _make_checkreport_payload()
     assert is_real_bug_signal(payload) is True
 
 
-def test_scope_guard_accepts_critical_severity() -> None:
-    payload = _make_real_payload(severity="critical")
+def test_scope_guard_accepts_telegram_red() -> None:
+    """A valid CheckReport with telegram_pending=red must be accepted."""
+    payload = _make_checkreport_payload(
+        coolify_status={"status": "green", "reason": "ok"},
+        telegram_pending={"status": "red", "reason": "no updates in 10m"},
+    )
     assert is_real_bug_signal(payload) is True
 
 
-def test_scope_guard_rejects_missing_incident_id() -> None:
-    payload = _make_real_payload()
-    del payload["incident_id"]
+def test_scope_guard_rejects_all_green() -> None:
+    """All-green CheckReport must be rejected — no real failure."""
+    payload = _make_checkreport_payload(
+        coolify_status={"status": "green", "reason": "ok"},
+        telegram_pending={"status": "green", "reason": "ok"},
+        is_red=False,
+    )
     assert is_real_bug_signal(payload) is False
 
 
-def test_scope_guard_rejects_null_incident_id() -> None:
-    payload = _make_real_payload(incident_id=None)
-    assert is_real_bug_signal(payload) is False
-
-
-def test_scope_guard_rejects_low_severity() -> None:
-    payload = _make_real_payload(severity="low")
-    assert is_real_bug_signal(payload) is False
-
-
-def test_scope_guard_rejects_medium_severity() -> None:
-    payload = _make_real_payload(severity="medium")
-    assert is_real_bug_signal(payload) is False
-
-
-def test_scope_guard_rejects_unknown_source() -> None:
-    payload = _make_real_payload(source="local-test-runner")
+def test_scope_guard_rejects_only_db_red() -> None:
+    """db_roundtrip=red alone must not trigger healing (excluded per healthcheck.py)."""
+    payload = _make_checkreport_payload(
+        coolify_status={"status": "green", "reason": "ok"},
+        telegram_pending={"status": "green", "reason": "ok"},
+        db_roundtrip={"status": "red", "reason": "connection refused"},
+        is_red=False,
+    )
     assert is_real_bug_signal(payload) is False
 
 
 def test_scope_guard_rejects_synthetic_flag() -> None:
-    payload = _make_real_payload(_synthetic=True)
+    """_synthetic=True at top level must reject even with red coolify_status."""
+    payload = _make_checkreport_payload(_synthetic=True)
     assert is_real_bug_signal(payload) is False
 
 
 def test_scope_guard_rejects_test_payload_flag() -> None:
-    payload = _make_real_payload(test_payload=True)
+    """test_payload=True at top level must reject even with red coolify_status."""
+    payload = _make_checkreport_payload(test_payload=True)
     assert is_real_bug_signal(payload) is False
 
 
-def test_scope_guard_accepts_coolify_source() -> None:
-    payload = _make_real_payload(source="coolify")
-    assert is_real_bug_signal(payload) is True
+def test_scope_guard_rejects_synthetic_reason_in_red_check() -> None:
+    """Red check with reason='synthetic ...' must be rejected."""
+    payload = _make_checkreport_payload(
+        coolify_status={"status": "red", "reason": "synthetic probe"},
+    )
+    assert is_real_bug_signal(payload) is False
 
 
-def test_scope_guard_accepts_prod_monitor_source() -> None:
-    payload = _make_real_payload(source="prod-monitor")
-    assert is_real_bug_signal(payload) is True
+def test_scope_guard_rejects_test_reason_in_red_check() -> None:
+    """Red check with reason='test ...' must be rejected."""
+    payload = _make_checkreport_payload(
+        coolify_status={"status": "red", "reason": "test run only"},
+    )
+    assert is_real_bug_signal(payload) is False
+
+
+def test_scope_guard_rejects_empty_payload() -> None:
+    """Empty mapping (no healing targets) must be rejected."""
+    assert is_real_bug_signal({}) is False
 
 
 def test_run_healing_returns_no_action_on_synthetic_signal(monkeypatch: pytest.MonkeyPatch) -> None:
     """When signal is synthetic, run_healing must return no_action verdict without opening any PRs."""
     monkeypatch.delenv("HEALING_DRY_RUN", raising=False)
     synthetic_payload = json.dumps({
-        "incident_id": None,
-        "severity": "low",
-        "source": "local-test-runner",
-        "reason": "synthetic verification run",
         "_synthetic": True,
+        "coolify_status": {"status": "red", "reason": "container stopped"},
+        "telegram_pending": {"status": "green", "reason": "ok"},
+        "db_roundtrip": {"status": "green", "reason": "ok"},
+        "is_red": True,
+        "generated_at": "2026-05-22T10:00:00+00:00",
     })
     result = run_healing(synthetic_payload, HealingConfig())
     assert result.verdict == "no_action"
     assert result.escalated is False
+
+
+# ---------------------------------------------------------------------------
+# Sprint S6 review: Fix 1 — CheckReport schema guard
+# ---------------------------------------------------------------------------
+
+def test_scope_guard_accepts_checkreport_coolify_red() -> None:
+    """CheckReport payload with coolify_status=red must be accepted."""
+    payload = {
+        "coolify_status": {"status": "red", "reason": "container exited with code 137"},
+        "telegram_pending": {"status": "green", "reason": "ok"},
+        "db_roundtrip": {"status": "green", "reason": "ok"},
+        "is_red": True,
+        "generated_at": "2026-05-22T10:00:00+00:00",
+    }
+    assert is_real_bug_signal(payload) is True
+
+
+def test_scope_guard_accepts_checkreport_telegram_red() -> None:
+    """CheckReport payload with telegram_pending=red must be accepted."""
+    payload = {
+        "coolify_status": {"status": "green", "reason": "ok"},
+        "telegram_pending": {"status": "red", "reason": "no updates received in 10m"},
+        "db_roundtrip": {"status": "green", "reason": "ok"},
+        "is_red": True,
+        "generated_at": "2026-05-22T10:00:00+00:00",
+    }
+    assert is_real_bug_signal(payload) is True
+
+
+def test_scope_guard_rejects_only_db_roundtrip_red() -> None:
+    """db_roundtrip=red alone must not trigger healing (excluded per healthcheck.py policy)."""
+    payload = {
+        "coolify_status": {"status": "green", "reason": "ok"},
+        "telegram_pending": {"status": "green", "reason": "ok"},
+        "db_roundtrip": {"status": "red", "reason": "connection refused"},
+        "is_red": False,
+        "generated_at": "2026-05-22T10:00:00+00:00",
+    }
+    assert is_real_bug_signal(payload) is False
+
+
+def test_scope_guard_rejects_all_green_checkreport() -> None:
+    """All-green CheckReport must not trigger healing."""
+    payload = {
+        "coolify_status": {"status": "green", "reason": "ok"},
+        "telegram_pending": {"status": "green", "reason": "ok"},
+        "db_roundtrip": {"status": "green", "reason": "ok"},
+        "is_red": False,
+        "generated_at": "2026-05-22T10:00:00+00:00",
+    }
+    assert is_real_bug_signal(payload) is False
+
+
+# ---------------------------------------------------------------------------
+# Sprint S6 review: Fix 2 — Regression test with actual 2026-05-13 payload
+# ---------------------------------------------------------------------------
+
+def test_is_real_bug_signal_rejects_2026_05_13_synthetic_payload() -> None:
+    """Regression: actual payload from healing run 25813274803 that triggered PR #281
+    must be rejected — db_roundtrip reason='synthetic' is the trigger."""
+    payload = {
+        "coolify_status": {"status": "green", "reason": "ok"},
+        "db_roundtrip": {"status": "red", "reason": "synthetic"},
+        "telegram_pending": {"status": "green", "reason": "ok"},
+        "is_red": True,
+        "generated_at": "2026-05-13T16:50:00+00:00",
+    }
+    assert is_real_bug_signal(payload) is False
+
+
+# ---------------------------------------------------------------------------
+# Sprint S6 review: Fix 3 — Malformed JSON safety
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("bad_input", [None, "string", [], 42, True])
+def test_is_real_bug_signal_rejects_non_mapping(bad_input: object) -> None:
+    """Malformed JSON (null, list, scalar) must not crash and must return False."""
+    assert is_real_bug_signal(bad_input) is False
+
+
+# ---------------------------------------------------------------------------
+# Sprint S6 review: Fix 4 — Integration test: real payload reaches _run_real
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_run_healing_calls_real_path_on_real_signal(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When guard accepts a CheckReport payload, _run_real must be invoked."""
+    monkeypatch.delenv("HEALING_DRY_RUN", raising=False)
+    real_payload = {
+        "coolify_status": {"status": "red", "reason": "container exited with code 137"},
+        "telegram_pending": {"status": "green", "reason": "ok"},
+        "db_roundtrip": {"status": "green", "reason": "ok"},
+        "is_red": True,
+        "generated_at": "2026-05-22T10:00:00+00:00",
+    }
+    sentinel = HealingResult(
+        verdict="succeeded",
+        attempts=1,
+        rolled_back=False,
+        escalated=False,
+        events=["test:sentinel"],
+    )
+    called: list = []
+
+    def fake_run_real(signal_payload: str, config: HealingConfig) -> HealingResult:
+        called.append((signal_payload, config))
+        return sentinel
+
+    monkeypatch.setattr("ops.healing.orchestrator._run_real", fake_run_real)
+    result = run_healing(json.dumps(real_payload), HealingConfig())
+    assert result is sentinel
+    assert called, "_run_real should be invoked for real signals"
+
+
+# ---------------------------------------------------------------------------
+# Sprint S6 review: Fix 5 — no_action verdict exits 0
+# ---------------------------------------------------------------------------
+
+def test_run_healing_no_action_verdict_on_synthetic_checkreport(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Synthetic CheckReport payload with _synthetic=True must return no_action."""
+    monkeypatch.delenv("HEALING_DRY_RUN", raising=False)
+    payload = {
+        "_synthetic": True,
+        "coolify_status": {"status": "red", "reason": "container stopped"},
+        "telegram_pending": {"status": "green", "reason": "ok"},
+        "db_roundtrip": {"status": "green", "reason": "ok"},
+        "is_red": True,
+        "generated_at": "2026-05-22T10:00:00+00:00",
+    }
+    result = run_healing(json.dumps(payload), HealingConfig())
+    assert result.verdict == "no_action"
+
+
+# ---------------------------------------------------------------------------
+# Sprint S6 review: synthetic reason marker in red check
+# ---------------------------------------------------------------------------
+
+def test_scope_guard_rejects_synthetic_reason_in_red_component() -> None:
+    """Red check with reason matching 'synthetic' marker must be rejected."""
+    payload = {
+        "coolify_status": {"status": "red", "reason": "synthetic test run"},
+        "telegram_pending": {"status": "green", "reason": "ok"},
+        "db_roundtrip": {"status": "green", "reason": "ok"},
+        "is_red": True,
+        "generated_at": "2026-05-22T10:00:00+00:00",
+    }
+    assert is_real_bug_signal(payload) is False
+
+
+def test_scope_guard_rejects_verification_reason_in_red_component() -> None:
+    """Red check with reason matching 'verification' marker must be rejected."""
+    payload = {
+        "coolify_status": {"status": "green", "reason": "ok"},
+        "telegram_pending": {"status": "red", "reason": "manual verification run"},
+        "db_roundtrip": {"status": "green", "reason": "ok"},
+        "is_red": True,
+        "generated_at": "2026-05-22T10:00:00+00:00",
+    }
+    assert is_real_bug_signal(payload) is False


### PR DESCRIPTION
## Summary

**Sprint 6 of 6** — FINAL sprint of Phase 10.5/11.5 carryover wave. 2 commits.

Closes #282 (healing orchestrator scope guard). Closes #228 + #315 (already closed as obsolete in this sprint).

## Closed carryovers

### #282 — Healing orchestrator synthetic-signal scope guard

**Root cause of incident 2026-05-13 (PR #281):** Healing pipeline accepted synthetic `CheckReport` payload where `db_roundtrip.reason='synthetic'` triggered autonomous PR creation (T6-08 web cards page). The pipeline had no scope guard.

**Implementation:** `ops/healing/orchestrator.py::is_real_bug_signal(payload: object) -> bool`:
- `isinstance(payload, Mapping)` safety — rejects `None`, `str`, `list`, scalars without `AttributeError`
- Reads ACTUAL `CheckReport.to_dict()` shape (`coolify_status`, `telegram_pending`, `db_roundtrip`, `is_red`, `reason`)
- Excludes `db_roundtrip` from healing targets per `healthcheck.py:42-54` policy
- Rejects `_synthetic=True` / `test_payload=True` operator-triggered flags
- Rejects red checks whose `reason` matches `\b(synthetic|test|verification|manual|dry[\s_-]?run)\b` (case-insensitive)

`run_healing()` calls guard before `_run_real()`. Rejection → `HealingResult(verdict="no_action", events=...)` without invoking Claude session or Codex CLI.

**Issue #282 Option C** (codex-on-PATH guard): `shutil.which("codex")` check before `subprocess.run(["codex", ...])`. Missing codex → log warning + Claude-only review path (no `FileNotFoundError`).

**Exit code contract:** `EXIT_OK = {"succeeded", "no_action"}` — abstain decision = exit 0, not failure. Workflow runs no longer marked red for correct abstentions.

### #228 + #315 — closed as obsolete

Already closed manually in this sprint via `gh issue close` (Phase 5 Wave 2 / orchestrator-B coordination signals long obsolete).

## Critical regression test

`test_is_real_bug_signal_rejects_2026_05_13_synthetic_payload` replays the **literal payload** from healing run 25813274803:

```json
{
  "coolify_status": {"status": "green", "reason": "ok"},
  "db_roundtrip": {"status": "red", "reason": "synthetic"},
  "telegram_pending": {"status": "green", "reason": "ok"},
  "is_red": true,
  "generated_at": "2026-05-13T16:50:00+00:00"
}
```

Asserts `is_real_bug_signal(payload) is False`. PR #281-class incident cannot recur.

## Unified Review

Round 1: Product **NEEDS_FIXES (2 BLOCKERS — schema mismatch + fake regression test)** + Codex **REQUEST_CHANGES (2 HIGH — same schema + malformed JSON; 1 MED — integration test)**.

Round 2 (after `88cc795`): Product **ACCEPTED** + Codex **APPROVE**. All 6 findings addressed.

`.par-evidence.json`:
- claude_product: ACCEPTED
- technical_review: APPROVE
- docs_update: UNCHANGED
- docs_review: PASS
- review_rounds: 2

## Files

```
ops/healing/orchestrator.py        (is_real_bug_signal + no_action verdict + Option C codex guard)
ops/healing/INVARIANTS.md          (abstain rule)
tests/healing/test_orchestrator.py (28 tests: 12 guard unit + parametrized non-Mapping + 2026-05-13 replay + integration sentinel)
```

## Test plan
- [x] `pytest tests/healing/` → 28 passed in 0.14s
- [x] Full healing suite (ex. test_healthcheck.py psycopg requirement) → 58 passed
- [x] `ruff check --no-cache .` → All checks passed
- [x] `bash scripts/lint_privacy_check.sh` → exit 0
- [ ] CI green required before merge

## Wave summary (post-merge → FHR)

After this PR merges, the Phase 10.5/11.5 carryover wave (6 sprints / 6 PRs) is complete:

| Sprint | PR | Theme | Commits | Phase 11 |
|---|---|---|---|---|
| 1 | #336 | Privacy hardening | 4 | 77→84 |
| 2 | #337 | P11 binding suite hardening | 5 | 84→84 |
| 3 | #338 | Schema & cascade correctness | 9 (inc. 3 CI fixes) | 84→88 |
| 4 | #339 | DRY refactor | 7 (inc. 2 CI fixes) | 88→89 |
| 5 | #340 | Web polish | 2 | 89→89 |
| 6 | this | Healing scope guard | 2 | 89→89 |

Final Holistic Review (per /superflow Rule 9 — ≥4 sprints in sprint_pr_queue mode + governance=standard) launches after merge.

Closes #282
Closes #228
Closes #315

🤖 Generated with [Claude Code](https://claude.com/claude-code)