### PR TITLE
fix(ops): move healing venv out of /tmp + self-heal broken venv

### DIFF
--- a/.github/workflows/healing.yml
+++ b/.github/workflows/healing.yml
@@ -40,9 +40,20 @@ jobs:
       - name: Set up Python venv (system python; setup-python@v5 has no prebuilt for Ubuntu 25.10)
         run: |
           python3 --version
-          python3 -m venv /tmp/healing-venv
-          /tmp/healing-venv/bin/pip install --upgrade pip
-          echo "/tmp/healing-venv/bin" >> "$GITHUB_PATH"
+          # Venv must NOT live in /tmp: systemd-tmpfiles ages out files >10d by
+          # atime, deleting package .py sources while __pycache__/dist-info
+          # survive — pip then reports "already satisfied" but imports resolve
+          # to empty namespace packages (incident 2026-06-01: httpx lost
+          # Client/HTTPError and every healthcheck run failed).
+          VENV_DIR="$HOME/healing-venv"
+          if [ -x "$VENV_DIR/bin/python" ] && ! "$VENV_DIR/bin/python" -c "import httpx, psycopg; httpx.Client; httpx.HTTPError" >/dev/null 2>&1; then
+            echo "::warning::venv at $VENV_DIR is broken — dumping httpx state and recreating"
+            ls -la "$VENV_DIR"/lib/python*/site-packages/httpx/ 2>&1 || true
+            rm -rf "$VENV_DIR"
+          fi
+          python3 -m venv "$VENV_DIR"
+          "$VENV_DIR/bin/pip" install --upgrade pip
+          echo "$VENV_DIR/bin" >> "$GITHUB_PATH"
 
       - name: Install dependencies
         run: pip install -e ".[dev,healing]"

--- a/.github/workflows/healthcheck.yml
+++ b/.github/workflows/healthcheck.yml
@@ -27,9 +27,20 @@ jobs:
       - name: Set up Python venv (system python; setup-python@v5 has no prebuilt for Ubuntu 25.10)
         run: |
           python3 --version
-          python3 -m venv /tmp/healing-venv
-          /tmp/healing-venv/bin/pip install --upgrade pip
-          echo "/tmp/healing-venv/bin" >> "$GITHUB_PATH"
+          # Venv must NOT live in /tmp: systemd-tmpfiles ages out files >10d by
+          # atime, deleting package .py sources while __pycache__/dist-info
+          # survive — pip then reports "already satisfied" but imports resolve
+          # to empty namespace packages (incident 2026-06-01: httpx lost
+          # Client/HTTPError and every healthcheck run failed).
+          VENV_DIR="$HOME/healing-venv"
+          if [ -x "$VENV_DIR/bin/python" ] && ! "$VENV_DIR/bin/python" -c "import httpx, psycopg; httpx.Client; httpx.HTTPError" >/dev/null 2>&1; then
+            echo "::warning::venv at $VENV_DIR is broken — dumping httpx state and recreating"
+            ls -la "$VENV_DIR"/lib/python*/site-packages/httpx/ 2>&1 || true
+            rm -rf "$VENV_DIR"
+          fi
+          python3 -m venv "$VENV_DIR"
+          "$VENV_DIR/bin/pip" install --upgrade pip
+          echo "$VENV_DIR/bin" >> "$GITHUB_PATH"
 
       - name: Install dependencies
         run: pip install -e ".[dev,healing]"


### PR DESCRIPTION
## Problem

**Healing Healthcheck has failed on every run since 2026-06-01** (54 consecutive failures) — production was unmonitored for 9 days.

Root cause: the workflow venv lived at `/tmp/healing-venv`. Ubuntu's `systemd-tmpfiles` age-cleanup (10d atime threshold) silently deleted package `.py` sources (httpx et al.) while `__pycache__` and `.dist-info` survived (their atime is refreshed by pip's check and stat-based pyc validation doesn't touch sources). Result:

- pip: `Requirement already satisfied: httpx>=0.28 ... (0.28.1)` ✅
- runtime: `AttributeError: module 'httpx' has no attribute 'Client'` / `'HTTPError'` ❌ (empty namespace package)

Evidence: last green run [26733738002](https://github.com/Jekudy/vibeshkoder/actions/runs/26733738002) (Jun 1 03:35 UTC), first red [26751895875](https://github.com/Jekudy/vibeshkoder/actions/runs/26751895875) (Jun 1 11:23 UTC) — zero commits in between, same venv, same 'already satisfied', daily tmpfiles-clean window in between.

## Fix

- Venv moved to `$HOME/healing-venv` (persistent, not subject to /tmp aging) in both `healthcheck.yml` and `healing.yml` (only two users of the path).
- Sanity-import gate: if the venv exists but `import httpx, psycopg` + attribute check fails → dump httpx site-packages state (diagnostics) and recreate from scratch. Self-heals any future venv corruption.

## Verification plan

After merge: `gh workflow run healthcheck.yml` → expect green run + report appended to state branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)