### PR TITLE
fix(memory): make production import durable and ownership-safe

### DIFF
--- a/alembic/versions/088_unique_import_message_raw.py
+++ b/alembic/versions/088_unique_import_message_raw.py
@@ -1,0 +1,41 @@
+"""Enforce one canonical synthetic import raw row per source message.
+
+Revision ID: 088
+Revises: 087
+Create Date: 2026-07-15
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "088"
+down_revision: Union[str, Sequence[str], None] = "087"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_INDEX_NAME = "uq_telegram_updates_import_message_source"
+_PREDICATE = (
+    "update_id IS NULL "
+    "AND update_type = 'import_message' "
+    "AND chat_id IS NOT NULL "
+    "AND message_id IS NOT NULL"
+)
+
+
+def upgrade() -> None:
+    op.create_index(
+        _INDEX_NAME,
+        "telegram_updates",
+        ["update_type", "chat_id", "message_id"],
+        unique=True,
+        postgresql_where=sa.text(_PREDICATE),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(_INDEX_NAME, table_name="telegram_updates")

--- a/bot/db/models.py
+++ b/bot/db/models.py
@@ -923,8 +923,8 @@ class TelegramUpdate(Base):
     (T2-01 dry-run / T2-03 apply). Live updates carry a non-null ``update_id`` (Telegram
     guarantees uniqueness per bot), and the partial unique index
     ``ix_telegram_updates_update_id`` prevents duplicates on polling retries. Synthetic
-    import updates leave ``update_id`` NULL; the importer enforces its own idempotency
-    via ``raw_hash`` + ``ingestion_run_id``.
+    import updates leave ``update_id`` NULL; migration 088 enforces one canonical
+    ``import_message`` row per non-null ``(chat_id, message_id)`` source identity.
 
     No content is logged here; ``raw_json`` is the unmodified Telegram payload until the
     governance detector (T1-12) marks it offrecord, at which point ``is_redacted`` and
@@ -944,6 +944,17 @@ class TelegramUpdate(Base):
             "ix_telegram_updates_update_type_received_at",
             "update_type",
             "received_at",
+        ),
+        Index(
+            "uq_telegram_updates_import_message_source",
+            "update_type",
+            "chat_id",
+            "message_id",
+            unique=True,
+            postgresql_where=text(
+                "update_id IS NULL AND update_type = 'import_message' "
+                "AND chat_id IS NOT NULL AND message_id IS NOT NULL"
+            ),
         ),
         Index(
             "ix_telegram_updates_chat_id_message_id",

--- a/bot/db/repos/telegram_update.py
+++ b/bot/db/repos/telegram_update.py
@@ -13,6 +13,13 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from bot.db.models import TelegramUpdate
 
+_IMPORT_MESSAGE_INDEX_PREDICATE = (
+    "update_id IS NULL "
+    "AND update_type = 'import_message' "
+    "AND chat_id IS NOT NULL "
+    "AND message_id IS NOT NULL"
+)
+
 
 class TelegramUpdateRepo:
     @staticmethod
@@ -34,7 +41,9 @@ class TelegramUpdateRepo:
         duplicate insert (same ``update_id``) returns the existing row instead of raising.
         The conflict path is keyed by the partial unique index
         ``ix_telegram_updates_update_id`` (created in migration 005), so it fires only when
-        ``update_id`` is set — synthetic import rows (NULL ``update_id``) always insert.
+        ``update_id`` is set. Canonical ``import_message`` callers must use
+        :meth:`upsert_import_message`; this generic NULL-``update_id`` path does not
+        resolve source-identity conflicts.
 
         Flushes; does not commit. Caller controls the transaction lifecycle.
         """
@@ -74,7 +83,7 @@ class TelegramUpdateRepo:
             )
             return existing.scalar_one()
 
-        # No update_id (synthetic import) — always insert.
+        # No update_id (generic synthetic row) — direct insert.
         row = TelegramUpdate(
             update_type=update_type,
             raw_json=raw_json,
@@ -86,6 +95,46 @@ class TelegramUpdateRepo:
             redaction_reason=redaction_reason,
         )
         session.add(row)
+        await session.flush()
+        return row
+
+    @staticmethod
+    async def upsert_import_message(
+        session: AsyncSession,
+        *,
+        raw_json: dict,
+        chat_id: int,
+        message_id: int,
+        ingestion_run_id: int,
+    ) -> TelegramUpdate:
+        """Atomically create or refresh one canonical synthetic import raw row.
+
+        Conflict updates deliberately preserve the original ``ingestion_run_id``.
+        Moving ownership to a later duplicate run could make its rollback delete a
+        raw row referenced by a normalized message created by the original run.
+        """
+        insert_stmt = pg_insert(TelegramUpdate).values(
+            update_type="import_message",
+            update_id=None,
+            raw_json=raw_json,
+            raw_hash=None,
+            chat_id=chat_id,
+            message_id=message_id,
+            ingestion_run_id=ingestion_run_id,
+            is_redacted=False,
+            redaction_reason=None,
+        )
+        statement = insert_stmt.on_conflict_do_update(
+            index_elements=["update_type", "chat_id", "message_id"],
+            index_where=text(_IMPORT_MESSAGE_INDEX_PREDICATE),
+            set_={
+                "raw_json": insert_stmt.excluded.raw_json,
+                "raw_hash": None,
+                "is_redacted": False,
+                "redaction_reason": None,
+            },
+        ).returning(TelegramUpdate)
+        row = (await session.execute(statement)).scalar_one()
         await session.flush()
         return row
 

--- a/bot/services/import_apply.py
+++ b/bot/services/import_apply.py
@@ -15,9 +15,9 @@ Pipeline per export message (chronological order, in-chunk):
                       are created with ``is_imported_only=True``.
     5. Reply resolver   — ``import_reply_resolver`` priority order (same_run > prior_run
                       > live > unresolved) (#98). Translates cm PK to message_id.
-    6. Synthetic raw    — Write a ``telegram_updates`` row with ``update_id=NULL`` and
-                      ``ingestion_run_id`` set. Audit row stays even when governance
-                      rejects the content.
+    6. Synthetic raw    — Atomically upsert one canonical ``telegram_updates`` row with
+                      ``update_id=NULL`` per source message. The first writer keeps
+                      ``ingestion_run_id`` ownership across duplicate runs.
     7. Persist          — ``persist_message_with_policy`` writes new rows; the explicit
                       import-only rehydrator restores rows hidden by retired policy.
     8. Edit history     — ``MessageVersionRepo.insert_version(imported_final=True)`` per
@@ -37,14 +37,14 @@ Hard invariants (verified by tests in tests/services/test_import_apply.py):
 - Idempotent: re-running on the same export produces zero net DB changes.
 - ``persist_message_with_policy`` is the sole creator of imported ``chat_messages``;
   exact-author repair may only redact an existing row.
-- Synthetic ``telegram_updates.update_id`` is always NULL; ``ingestion_run_id``
-  always matches the apply run.
+- Synthetic ``telegram_updates.update_id`` is always NULL; canonical source identity is
+  unique and conflict updates preserve the first owning ``ingestion_run_id``.
 - ``message_versions.imported_final=TRUE`` for every imported version row.
 
-Out of scope (next ticket — #104 logical rollback):
-- Rolling back an apply run via ``ingestion_run_id``.
-- The synthetic ``telegram_updates`` rows are deliberately tagged so #104 can
-  cascade DELETE them along with the run.
+Rollback ownership:
+- New imported ``chat_messages`` link to their synthetic raw row and roll back with it.
+- Existing normalized rows never adopt import raw ownership; rehydrated versions may link
+  to it and keep their row when the FK is cleared on rollback.
 """
 
 from __future__ import annotations
@@ -258,6 +258,13 @@ async def run_apply(
                 # swap the connection underneath the lock.
                 async with async_engine.connect() as connection:
                     async with acquire_advisory_lock(connection, ingestion_run_id):
+                        # pg_advisory_lock() autobegins a root transaction on this
+                        # explicit connection. End that transaction before binding the
+                        # worker session; otherwise its per-chunk commit only joins the
+                        # external transaction and the connection context rolls every
+                        # apparently successful chunk back on exit. Session-level
+                        # advisory locks survive COMMIT and remain held until unlock.
+                        await connection.commit()
                         async with AsyncSession(
                             bind=connection,
                             expire_on_commit=False,
@@ -453,6 +460,20 @@ async def _apply_one_message(
         or existing.current_version_is_redacted
     )
     if existing is not None and not needs_rehydrate:
+        await _upsert_synthetic_import_raw(
+            session,
+            raw_payload=_build_raw_payload(msg, chat_id=chat_id, msg_id=msg_id),
+            chat_id=chat_id,
+            message_id=msg_id,
+            ingestion_run_id=ingestion_run_id,
+        )
+        await _record_import_photo_if_needed(
+            session,
+            message_kind=_classify_td_kind(msg, warnings=None),
+            chat_message_id=existing.chat_message_id,
+            chat_id=chat_id,
+            message_id=msg_id,
+        )
         if existing.is_live:
             report.skipped_overlap_count += 1
         else:
@@ -516,16 +537,12 @@ async def _apply_one_message(
     # 6. Synthetic raw row — full canonical payload, tagged
     # with ingestion_run_id so #104 rollback can locate it. update_id MUST be NULL.
     raw_payload = _build_raw_payload(msg, chat_id=chat_id, msg_id=msg_id)
-    raw_row = await TelegramUpdateRepo.insert(
+    raw_row = await _upsert_synthetic_import_raw(
         session,
-        update_type=_IMPORT_UPDATE_TYPE,
-        update_id=None,  # synthetic — partial unique index is on update_id IS NOT NULL
-        raw_json=raw_payload,
-        raw_hash=None,
+        raw_payload=raw_payload,
         chat_id=chat_id,
         message_id=msg_id,
         ingestion_run_id=ingestion_run_id,
-        is_redacted=False,
     )
 
     # 7. Build the message duck.
@@ -542,12 +559,22 @@ async def _apply_one_message(
 
     # Close the read→insert race: a normal live row may appear after the initial
     # state lookup but before our synthetic raw insert.
-    if existing is None and await _check_live_overlap_pre_persist(
-        session,
-        chat_id=chat_id,
-        message_id=msg_id,
-        current_import_raw_update_id=raw_row.id,
-    ):
+    live_overlap_chat_message_id = None
+    if existing is None:
+        live_overlap_chat_message_id = await _check_live_overlap_pre_persist(
+            session,
+            chat_id=chat_id,
+            message_id=msg_id,
+            current_import_raw_update_id=raw_row.id,
+        )
+    if live_overlap_chat_message_id is not None:
+        await _record_import_photo_if_needed(
+            session,
+            message_kind=kind,
+            chat_message_id=live_overlap_chat_message_id,
+            chat_id=chat_id,
+            message_id=msg_id,
+        )
         report.skipped_overlap_count += 1
         return msg_id
 
@@ -574,20 +601,56 @@ async def _apply_one_message(
         )
         report.applied_count += 1
 
-    if kind == "photo":
-        from bot.services.image_memory import record_missing_import_photo
-
-        await record_missing_import_photo(
-            session,
-            chat_message_id=persist_result.chat_message.id,
-            chat_id=chat_id,
-            message_id=msg_id,
-        )
+    await _record_import_photo_if_needed(
+        session,
+        message_kind=kind,
+        chat_message_id=persist_result.chat_message.id,
+        chat_id=chat_id,
+        message_id=msg_id,
+    )
 
     return msg_id
 
 
-# ─── Internal helpers ─────────────────────────────────────────────────────────
+# ─── Internal helpers ────────────────────────────────────────
+
+
+async def _upsert_synthetic_import_raw(
+    session: AsyncSession,
+    *,
+    raw_payload: dict[str, Any],
+    chat_id: int,
+    message_id: int,
+    ingestion_run_id: int,
+) -> TelegramUpdate:
+    """Keep duplicate/overlap imports raw-first without taking normalized ownership."""
+    return await TelegramUpdateRepo.upsert_import_message(
+        session,
+        raw_json=raw_payload,
+        chat_id=chat_id,
+        message_id=message_id,
+        ingestion_run_id=ingestion_run_id,
+    )
+
+
+async def _record_import_photo_if_needed(
+    session: AsyncSession,
+    *,
+    message_kind: str,
+    chat_message_id: int,
+    chat_id: int,
+    message_id: int,
+) -> None:
+    if message_kind != "photo":
+        return
+    from bot.services.image_memory import record_missing_import_photo
+
+    await record_missing_import_photo(
+        session,
+        chat_message_id=chat_message_id,
+        chat_id=chat_id,
+        message_id=message_id,
+    )
 
 
 def _iter_export_messages(path: Path) -> Iterable[dict[str, Any]]:
@@ -882,7 +945,7 @@ async def _check_live_overlap_pre_persist(
     chat_id: int,
     message_id: int,
     current_import_raw_update_id: int,
-) -> bool:
+) -> int | None:
     stmt = (
         select(ChatMessage.id)
         .join(TelegramUpdate, TelegramUpdate.id == ChatMessage.raw_update_id)
@@ -894,7 +957,7 @@ async def _check_live_overlap_pre_persist(
         )
         .limit(1)
     )
-    return (await session.execute(stmt)).scalar_one_or_none() is not None
+    return (await session.execute(stmt)).scalar_one_or_none()
 
 
 async def _ensure_excluded_author_raw_only(
@@ -918,37 +981,26 @@ async def _ensure_excluded_author_raw_only(
                 TelegramUpdate.chat_id == chat_id,
                 TelegramUpdate.message_id == message_id,
                 TelegramUpdate.update_type == _IMPORT_UPDATE_TYPE,
+                TelegramUpdate.update_id.is_(None),
             )
             .order_by(TelegramUpdate.id)
             .limit(1)
             .with_for_update()
         )
     ).scalar_one_or_none()
-    changed = False
-    if raw_row is None:
-        await TelegramUpdateRepo.insert(
-            session,
-            update_type=_IMPORT_UPDATE_TYPE,
-            update_id=None,
-            raw_json=raw_payload,
-            raw_hash=None,
-            chat_id=chat_id,
-            message_id=message_id,
-            ingestion_run_id=ingestion_run_id,
-            is_redacted=False,
-        )
-        changed = True
-    elif (
+    changed = raw_row is None or (
         raw_row.raw_json != raw_payload
         or raw_row.raw_hash is not None
         or raw_row.is_redacted
         or raw_row.redaction_reason is not None
-    ):
-        raw_row.raw_json = copy.deepcopy(raw_payload)
-        raw_row.raw_hash = None
-        raw_row.is_redacted = False
-        raw_row.redaction_reason = None
-        changed = True
+    )
+    await _upsert_synthetic_import_raw(
+        session,
+        raw_payload=raw_payload,
+        chat_id=chat_id,
+        message_id=message_id,
+        ingestion_run_id=ingestion_run_id,
+    )
 
     normalized_row = (
         await session.execute(

--- a/bot/services/message_persistence.py
+++ b/bot/services/message_persistence.py
@@ -58,7 +58,8 @@ async def rehydrate_message_from_import(
 
     Phase 13 switched to complete human history.  This explicit import-only
     operation is intentionally allowed to undo the old sticky redaction ratchet;
-    normal live redeliveries still use :func:`persist_message_with_policy`.
+    normal live redeliveries still use :func:`persist_message_with_policy`. The
+    existing normalized row keeps its original raw-update ownership.
     """
     await advisory_lock_chat_message(session, message.chat.id, message.message_id)
     saved = (
@@ -110,7 +111,6 @@ async def rehydrate_message_from_import(
             caption=caption_value,
             date=captured_at,
             raw_json=raw_payload,
-            raw_update_id=raw_update_id,
             reply_to_message_id=normalized["reply_to_message_id"],
             message_thread_id=normalized["message_thread_id"],
             message_kind=normalized["message_kind"],

--- a/tests/db/test_digests_review_schema.py
+++ b/tests/db/test_digests_review_schema.py
@@ -155,7 +155,7 @@ async def test_alembic_head_is_latest(migrated_database_url: str) -> None:
     Migration 082: complete-history supersession and active-version uniqueness.
     """
     current = await _fetch_value(migrated_database_url, "SELECT version_num FROM alembic_version")
-    assert current == "087"
+    assert current == "088"
 
 
 async def test_080_message_media_and_ledger_call_types(

--- a/tests/db/test_fts_schema.py
+++ b/tests/db/test_fts_schema.py
@@ -197,7 +197,7 @@ async def test_alembic_upgrade_head_on_clean_db_green(migrated_database_url: str
     # + T12-07 (077 butler_undo_invocations table + status widened with 'undone').
     # + T12-07-fix C1 (078 butler_tool_invocations.inverse_op_payload column).
     # Assert the current head explicitly; revisit when future migrations land.
-    assert current == "087"
+    assert current == "088"
 
 
 async def test_insert_message_versions_generates_search_tsv_from_normalized_text(

--- a/tests/db/test_memory_reconciliation_schema.py
+++ b/tests/db/test_memory_reconciliation_schema.py
@@ -1,4 +1,4 @@
-"""Migration 087 acceptance tests for explicit paid-call reconciliation."""
+"""Migration 087-088 acceptance tests for memory rollout reconciliation."""
 
 from __future__ import annotations
 
@@ -453,3 +453,76 @@ async def test_087_downgrade_fails_closed_for_each_rollout_audit_surface(
     failed = _alembic(temp_database_url, "downgrade", "086", check=False)
     assert failed.returncode != 0
     assert "Cannot downgrade 087" in (failed.stdout + failed.stderr)
+
+
+async def test_088_canonical_import_raw_is_unique_across_runs(
+    temp_database_url: str,
+) -> None:
+    _alembic(temp_database_url, "upgrade", "088")
+    connection = await asyncpg.connect(**_kwargs(make_url(temp_database_url)))
+    try:
+        first_run = await connection.fetchval(
+            "INSERT INTO ingestion_runs (run_type, status) "
+            "VALUES ('import', 'completed') RETURNING id"
+        )
+        second_run = await connection.fetchval(
+            "INSERT INTO ingestion_runs (run_type, status) "
+            "VALUES ('import', 'completed') RETURNING id"
+        )
+        first_raw = await connection.fetchval(
+            """
+            INSERT INTO telegram_updates (
+                update_type, update_id, raw_json, chat_id, message_id, ingestion_run_id
+            ) VALUES ('import_message', NULL, '{}', -10088001, 88001, $1)
+            RETURNING id
+            """,
+            first_run,
+        )
+        duplicate = await connection.fetchval(
+            """
+            INSERT INTO telegram_updates (
+                update_type, update_id, raw_json, chat_id, message_id, ingestion_run_id
+            ) VALUES ('import_message', NULL, '{"new":true}', -10088001, 88001, $1)
+            ON CONFLICT (update_type, chat_id, message_id)
+            WHERE update_id IS NULL
+              AND update_type = 'import_message'
+              AND chat_id IS NOT NULL
+              AND message_id IS NOT NULL
+            DO NOTHING
+            RETURNING id
+            """,
+            second_run,
+        )
+        assert first_raw is not None
+        assert duplicate is None
+        assert (
+            await connection.fetchval(
+                """
+                SELECT count(*) FROM telegram_updates
+                WHERE update_type='import_message'
+                  AND update_id IS NULL
+                  AND chat_id=-10088001
+                  AND message_id=88001
+                """
+            )
+            == 1
+        )
+
+        await connection.execute(
+            """
+            INSERT INTO telegram_updates (update_type, update_id, chat_id, message_id)
+            VALUES ('message', 8800101, -10088001, 88001),
+                   ('message', 8800102, -10088001, 88001)
+            """
+        )
+        assert (
+            await connection.fetchval(
+                """
+                SELECT count(*) FROM telegram_updates
+                WHERE update_type='message' AND chat_id=-10088001 AND message_id=88001
+                """
+            )
+            == 2
+        )
+    finally:
+        await connection.close()

--- a/tests/db/test_telegram_update_repo.py
+++ b/tests/db/test_telegram_update_repo.py
@@ -79,9 +79,7 @@ async def test_insert_duplicate_update_id_returns_existing_no_duplicate(db_sessi
 
 
 async def test_insert_without_update_id_creates_independent_rows(db_session) -> None:
-    """Synthetic import updates (NULL update_id) bypass the partial unique index. Two
-    inserts produce two rows; the importer is responsible for its own dedup via raw_hash
-    + ingestion_run_id."""
+    """Different synthetic import source identities remain independent rows."""
     from bot.db.repos.telegram_update import TelegramUpdateRepo
 
     chat_id = _random_chat_id()

--- a/tests/services/test_import_apply.py
+++ b/tests/services/test_import_apply.py
@@ -456,7 +456,9 @@ async def test_apply_rehydrates_previously_redacted_message(db_session) -> None:
         await db_session.execute(
             sa_text(
                 "SELECT cm.memory_policy, cm.is_redacted, cm.text, "
-                "mv.is_redacted AS mv_is_redacted, mv.text AS mv_text "
+                "cm.raw_update_id, cm.current_version_id, "
+                "mv.is_redacted AS mv_is_redacted, mv.text AS mv_text, "
+                "mv.raw_update_id AS mv_raw_update_id "
                 "FROM chat_messages cm JOIN message_versions mv "
                 "ON mv.id = cm.current_version_id "
                 "WHERE cm.chat_id=:cid AND cm.message_id=1001"
@@ -469,6 +471,8 @@ async def test_apply_rehydrates_previously_redacted_message(db_session) -> None:
     assert restored.mv_is_redacted is False
     assert restored.text == "Hello everyone! Glad to be here."
     assert restored.mv_text == "Hello everyone! Glad to be here."
+    assert restored.raw_update_id is None
+    assert restored.mv_raw_update_id is not None
     versions = (
         await db_session.execute(
             sa_text(
@@ -511,6 +515,40 @@ async def test_apply_rehydrates_previously_redacted_message(db_session) -> None:
         include_cards=False,
     )
     assert any(hit.message_id == 1001 for hit in hits)
+
+    from bot.services.import_rollback import rollback_ingestion_run
+
+    rollback = await rollback_ingestion_run(db_session, run_id)
+    assert rollback.telegram_updates_deleted == 5
+    assert rollback.chat_messages_deleted == 4
+    assert rollback.message_versions_cascade_deleted == 4
+
+    preserved = (
+        await db_session.execute(
+            sa_text(
+                "SELECT cm.memory_policy, cm.is_redacted, cm.text, "
+                "cm.raw_update_id, cm.current_version_id, mv.raw_update_id AS mv_raw_update_id "
+                "FROM chat_messages cm JOIN message_versions mv "
+                "ON mv.id=cm.current_version_id WHERE cm.id=:chat_message_id"
+            ),
+            {"chat_message_id": hidden.id},
+        )
+    ).one()
+    assert preserved.memory_policy == "normal"
+    assert preserved.is_redacted is False
+    assert preserved.text == "Hello everyone! Glad to be here."
+    assert preserved.raw_update_id is None
+    assert preserved.current_version_id == restored.current_version_id
+    assert preserved.mv_raw_update_id is None
+
+    new_rows = await db_session.execute(
+        sa_text(
+            "SELECT COUNT(*) FROM chat_messages "
+            "WHERE chat_id=:chat_id AND message_id IN (1002, 1003, 1004, 1005)"
+        ),
+        {"chat_id": chat_id},
+    )
+    assert int(new_rows.scalar_one()) == 0
 
 
 # ─── Test 4: Governance gate ──────────────────────────────────────────────────
@@ -764,10 +802,11 @@ async def test_apply_sets_imported_final(db_session) -> None:
 
 async def test_apply_skips_version_when_live_row_wins_overlap_race(db_session) -> None:
     """If a live row appears after the duplicate gate but before persist, the import
-    synthetic raw row remains but imported_final version insertion is skipped."""
+    synthetic raw row remains, photo provenance is repaired, and imported_final
+    version insertion is skipped."""
     from bot.services.import_apply import run_apply
 
-    chat_id = -4004
+    chat_id = -1004004
     await db_session.execute(
         sa_text(
             """
@@ -827,8 +866,9 @@ async def test_apply_skips_version_when_live_row_wins_overlap_race(db_session) -
                 "date_unixtime": "1709287200",
                 "from": "Live Race User",
                 "from_id": "user900001",
-                "text": "import lost",
-                "text_entities": [{"type": "plain", "text": "import lost"}],
+                "text": "import photo caption",
+                "text_entities": [{"type": "plain", "text": "import photo caption"}],
+                "photo": "photos/missing_overlap.jpg",
             }
         ],
     }
@@ -880,6 +920,19 @@ async def test_apply_skips_version_when_live_row_wins_overlap_race(db_session) -
         {"rid": run_id},
     )
     assert int(synthetic_updates.scalar_one()) == 1
+
+    media = (
+        await db_session.execute(
+            sa_text(
+                "SELECT source_message_url, description_status, last_error_code "
+                "FROM message_media WHERE chat_message_id=:cmid"
+            ),
+            {"cmid": live_cm_id},
+        )
+    ).one()
+    assert media.source_message_url == "https://t.me/c/4004/9001"
+    assert media.description_status == "missing_source"
+    assert media.last_error_code == "historical_export_no_file"
 
 
 # ─── Test 7: Checkpoint / resume from mid-chunk failure ───────────────────────
@@ -965,6 +1018,89 @@ async def test_apply_advisory_lock_acquired(db_session) -> None:
     assert len(lock_connection_ids) == 1
     assert persist_connection_ids
     assert set(persist_connection_ids) == {lock_connection_ids[0]}
+
+
+async def test_engine_bound_advisory_apply_commits_chunks_for_fresh_connection(
+    postgres_engine,
+) -> None:
+    """Production engine-bound path must commit beyond the lock connection context."""
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+    from bot.services.import_apply import run_apply
+
+    chat_id = -1008812345678
+    run_id: int | None = None
+    try:
+        async with AsyncSession(bind=postgres_engine, expire_on_commit=False) as setup_session:
+            run_id = await _create_apply_run(
+                setup_session,
+                source_path=str(SMALL_CHAT),
+                chat_id=chat_id,
+                source_hash="engine_bound_commit_regression",
+            )
+            await setup_session.commit()
+
+        async with AsyncSession(bind=postgres_engine, expire_on_commit=False) as apply_session:
+            report = await run_apply(
+                apply_session,
+                ingestion_run_id=run_id,
+                resume_point=None,
+                chunking_config=_default_chunking(advisory_lock=True),
+            )
+        assert report.applied_count == 5
+        assert report.last_processed_export_msg_id == 1006
+
+        async with postgres_engine.connect() as observer:
+            persisted = (
+                await observer.execute(
+                    sa_text(
+                        """
+                        SELECT
+                            (SELECT COUNT(*) FROM telegram_updates
+                              WHERE ingestion_run_id=:run_id),
+                            (SELECT COUNT(*) FROM chat_messages
+                              WHERE chat_id=:chat_id),
+                            (SELECT COUNT(*) FROM message_media mm
+                              JOIN chat_messages cm ON cm.id=mm.chat_message_id
+                              WHERE cm.chat_id=:chat_id),
+                            (SELECT stats_json ->> 'last_processed_export_msg_id'
+                               FROM ingestion_runs WHERE id=:run_id)
+                        """
+                    ),
+                    {"run_id": run_id, "chat_id": chat_id},
+                )
+            ).one()
+        assert tuple(persisted[:3]) == (5, 5, 1)
+        assert persisted[3] == "1006"
+    finally:
+        if run_id is not None:
+            async with postgres_engine.begin() as cleanup:
+                await cleanup.execute(
+                    sa_text(
+                        "UPDATE chat_messages SET current_version_id=NULL WHERE chat_id=:chat_id"
+                    ),
+                    {"chat_id": chat_id},
+                )
+                await cleanup.execute(
+                    sa_text("DELETE FROM chat_messages WHERE chat_id=:chat_id"),
+                    {"chat_id": chat_id},
+                )
+                await cleanup.execute(
+                    sa_text("DELETE FROM telegram_updates WHERE chat_id=:chat_id"),
+                    {"chat_id": chat_id},
+                )
+                await cleanup.execute(
+                    sa_text("DELETE FROM ingestion_runs WHERE id=:run_id"),
+                    {"run_id": run_id},
+                )
+                await cleanup.execute(
+                    sa_text(
+                        "DELETE FROM users WHERE id IN (1000001, 1000002, 1000003) "
+                        "AND is_imported_only IS TRUE "
+                        "AND NOT EXISTS ("
+                        "SELECT 1 FROM chat_messages WHERE chat_messages.user_id=users.id)"
+                    )
+                )
 
 
 # ─── Test 9: Chunking — checkpoint advances per chunk ─────────────────────────

--- a/tests/services/test_import_chunking.py
+++ b/tests/services/test_import_chunking.py
@@ -214,8 +214,13 @@ def test_cli_chunk_size_zero_rejected() -> None:
     exit_code = None
     try:
         with (
-            patch("bot.db.repos.feature_flag.FeatureFlagRepo.get", new=AsyncMock(return_value=True)),
-            patch("bot.services.import_checkpoint.init_or_resume_run", new=AsyncMock(return_value=mock_decision)),
+            patch(
+                "bot.db.repos.feature_flag.FeatureFlagRepo.get", new=AsyncMock(return_value=True)
+            ),
+            patch(
+                "bot.services.import_checkpoint.init_or_resume_run",
+                new=AsyncMock(return_value=mock_decision),
+            ),
             patch("bot.db.engine.async_session", return_value=mock_session),
             patch.dict("sys.modules", {"bot.services.import_apply": fake_module}),
         ):
@@ -268,8 +273,13 @@ def test_cli_chunk_size_negative_rejected() -> None:
     exit_code = None
     try:
         with (
-            patch("bot.db.repos.feature_flag.FeatureFlagRepo.get", new=AsyncMock(return_value=True)),
-            patch("bot.services.import_checkpoint.init_or_resume_run", new=AsyncMock(return_value=mock_decision)),
+            patch(
+                "bot.db.repos.feature_flag.FeatureFlagRepo.get", new=AsyncMock(return_value=True)
+            ),
+            patch(
+                "bot.services.import_checkpoint.init_or_resume_run",
+                new=AsyncMock(return_value=mock_decision),
+            ),
             patch("bot.db.engine.async_session", return_value=mock_session),
             patch.dict("sys.modules", {"bot.services.import_apply": fake_module}),
         ):
@@ -321,8 +331,13 @@ def test_cli_chunk_size_excessive_rejected() -> None:
     exit_code = None
     try:
         with (
-            patch("bot.db.repos.feature_flag.FeatureFlagRepo.get", new=AsyncMock(return_value=True)),
-            patch("bot.services.import_checkpoint.init_or_resume_run", new=AsyncMock(return_value=mock_decision)),
+            patch(
+                "bot.db.repos.feature_flag.FeatureFlagRepo.get", new=AsyncMock(return_value=True)
+            ),
+            patch(
+                "bot.services.import_checkpoint.init_or_resume_run",
+                new=AsyncMock(return_value=mock_decision),
+            ),
             patch("bot.db.engine.async_session", return_value=mock_session),
             patch.dict("sys.modules", {"bot.services.import_apply": fake_module}),
         ):
@@ -387,8 +402,13 @@ def test_cli_chunk_size_overrides_invalid_env() -> None:
     exit_code = None
     try:
         with (
-            patch("bot.db.repos.feature_flag.FeatureFlagRepo.get", new=AsyncMock(return_value=True)),
-            patch("bot.services.import_checkpoint.init_or_resume_run", new=AsyncMock(return_value=mock_decision)),
+            patch(
+                "bot.db.repos.feature_flag.FeatureFlagRepo.get", new=AsyncMock(return_value=True)
+            ),
+            patch(
+                "bot.services.import_checkpoint.init_or_resume_run",
+                new=AsyncMock(return_value=mock_decision),
+            ),
             patch("bot.services.import_checkpoint.finalize_run", new=AsyncMock()),
             patch("bot.db.engine.async_session", return_value=mock_session),
             # env has invalid IMPORT_APPLY_CHUNK_SIZE but CLI provides valid --chunk-size
@@ -436,11 +456,10 @@ async def test_acquire_advisory_lock_happy_path(postgres_engine) -> None:
 
 
 async def test_acquire_advisory_lock_releases_on_exception(postgres_engine) -> None:
-    """Lock is released (pg_advisory_unlock) even when the body raises.
+    """Session lock survives COMMIT and is released when the body raises.
 
-    Verifies from a SEPARATE DB connection that the lock is truly released —
-    not merely re-acquirable from the same connection (stacked locks would
-    allow same-connection re-acquisition even if unlock was missed).
+    Both assertions use a SEPARATE DB connection so same-session stacked-lock
+    behavior cannot mask either an early release or a missed unlock.
     """
     from bot.services.import_chunking import _derive_lock_id, acquire_advisory_lock
     from sqlalchemy import text
@@ -452,13 +471,20 @@ async def test_acquire_advisory_lock_releases_on_exception(postgres_engine) -> N
     async with postgres_engine.connect() as conn1:
         with pytest.raises(RuntimeError, match="boom"):
             async with acquire_advisory_lock(conn1, ingestion_run_id):
+                # Production ends the implicit transaction opened by the lock
+                # SELECT before binding its worker session. Session-level locks
+                # must remain held across that transaction boundary.
+                await conn1.commit()
+                async with postgres_engine.connect() as observer:
+                    result = await observer.execute(
+                        text("SELECT pg_try_advisory_lock(:id)"), {"id": lock_id}
+                    )
+                    assert result.scalar() is False, "lock must survive COMMIT"
                 raise RuntimeError("boom")
 
     # Verify from a SEPARATE connection that the lock is released.
     async with postgres_engine.connect() as conn2:
-        result = await conn2.execute(
-            text("SELECT pg_try_advisory_lock(:id)"), {"id": lock_id}
-        )
+        result = await conn2.execute(text("SELECT pg_try_advisory_lock(:id)"), {"id": lock_id})
         assert result.scalar() is True, "lock should be releasable from another connection"
         # Cleanup: release the lock we just acquired on conn2.
         await conn2.execute(text("SELECT pg_advisory_unlock(:id)"), {"id": lock_id})
@@ -551,8 +577,13 @@ def test_cli_import_apply_passes_chunking_config_to_run_apply() -> None:
 
     try:
         with (
-            patch("bot.db.repos.feature_flag.FeatureFlagRepo.get", new=AsyncMock(return_value=True)),
-            patch("bot.services.import_checkpoint.init_or_resume_run", new=AsyncMock(return_value=mock_decision)),
+            patch(
+                "bot.db.repos.feature_flag.FeatureFlagRepo.get", new=AsyncMock(return_value=True)
+            ),
+            patch(
+                "bot.services.import_checkpoint.init_or_resume_run",
+                new=AsyncMock(return_value=mock_decision),
+            ),
             patch("bot.services.import_checkpoint.finalize_run", new=AsyncMock()),
             patch("bot.db.engine.async_session", return_value=mock_session),
             patch.dict("os.environ", {"IMPORT_APPLY_CHUNK_SIZE": "100"}),
@@ -575,7 +606,9 @@ def test_cli_import_apply_passes_chunking_config_to_run_apply() -> None:
     kwargs = call_kwargs.kwargs if call_kwargs.kwargs else {}
     # chunking_config should be a ChunkingConfig with chunk_size=100 (env override)
     chunking_config = kwargs.get("chunking_config")
-    assert chunking_config is not None, f"run_apply must receive chunking_config kwarg. Got kwargs: {kwargs}"
+    assert chunking_config is not None, (
+        f"run_apply must receive chunking_config kwarg. Got kwargs: {kwargs}"
+    )
     assert isinstance(chunking_config, ChunkingConfig)
     assert chunking_config.chunk_size == 100, (
         f"chunk_size should be 100 (from env IMPORT_APPLY_CHUNK_SIZE=100), "
@@ -626,8 +659,13 @@ def test_cli_import_apply_chunk_size_cli_arg_overrides_env() -> None:
 
     try:
         with (
-            patch("bot.db.repos.feature_flag.FeatureFlagRepo.get", new=AsyncMock(return_value=True)),
-            patch("bot.services.import_checkpoint.init_or_resume_run", new=AsyncMock(return_value=mock_decision)),
+            patch(
+                "bot.db.repos.feature_flag.FeatureFlagRepo.get", new=AsyncMock(return_value=True)
+            ),
+            patch(
+                "bot.services.import_checkpoint.init_or_resume_run",
+                new=AsyncMock(return_value=mock_decision),
+            ),
             patch("bot.services.import_checkpoint.finalize_run", new=AsyncMock()),
             patch("bot.db.engine.async_session", return_value=mock_session),
             patch.dict("os.environ", {"IMPORT_APPLY_CHUNK_SIZE": "300"}),
@@ -646,7 +684,9 @@ def test_cli_import_apply_chunk_size_cli_arg_overrides_env() -> None:
     call_kwargs = run_apply_mock.call_args
     kwargs = call_kwargs.kwargs if call_kwargs.kwargs else {}
     chunking_config = kwargs.get("chunking_config")
-    assert chunking_config is not None, f"run_apply must receive chunking_config kwarg. Got: {kwargs}"
+    assert chunking_config is not None, (
+        f"run_apply must receive chunking_config kwarg. Got: {kwargs}"
+    )
     assert isinstance(chunking_config, ChunkingConfig)
     assert chunking_config.chunk_size == 75, (
         f"--chunk-size 75 CLI arg must override env IMPORT_APPLY_CHUNK_SIZE=300. "

--- a/tests/services/test_import_html_apply.py
+++ b/tests/services/test_import_html_apply.py
@@ -124,6 +124,127 @@ async def test_html_apply_is_idempotent_and_persists_media_provenance(db_session
     assert int(count_result.scalar_one()) == 5
 
 
+async def test_html_reimport_repairs_missing_photo_media_without_duplicate_message(
+    db_session,
+) -> None:
+    from bot.services.import_apply import run_apply
+
+    first_run = await _create_run(db_session, "html_photo_repair_first")
+    first = await run_apply(
+        db_session,
+        ingestion_run_id=first_run,
+        resume_point=None,
+        chunking_config=_chunking(),
+        excluded_author_names=frozenset({"shkoder"}),
+    )
+    assert first.applied_count == 5
+
+    chat_message_id = int(
+        (
+            await db_session.execute(
+                sa_text("SELECT id FROM chat_messages WHERE chat_id=:chat_id AND message_id=102"),
+                {"chat_id": CHAT_ID},
+            )
+        ).scalar_one()
+    )
+    original_raw_update_id = int(
+        (
+            await db_session.execute(
+                sa_text("SELECT raw_update_id FROM chat_messages WHERE id=:chat_message_id"),
+                {"chat_message_id": chat_message_id},
+            )
+        ).scalar_one()
+    )
+    deleted = await db_session.execute(
+        sa_text("DELETE FROM message_media WHERE chat_message_id=:chat_message_id"),
+        {"chat_message_id": chat_message_id},
+    )
+    assert deleted.rowcount == 1
+    deleted_raw = await db_session.execute(
+        sa_text("DELETE FROM telegram_updates WHERE id=:raw_update_id"),
+        {"raw_update_id": original_raw_update_id},
+    )
+    assert deleted_raw.rowcount == 1
+
+    second_run = await _create_run(db_session, "html_photo_repair_second")
+    second = await run_apply(
+        db_session,
+        ingestion_run_id=second_run,
+        resume_point=None,
+        chunking_config=_chunking(),
+        excluded_author_names=frozenset({"shkoder"}),
+    )
+
+    assert second.applied_count == 0
+    assert second.skipped_duplicate_count == 5
+    chat_message_count = await db_session.execute(
+        sa_text("SELECT COUNT(*) FROM chat_messages WHERE chat_id=:chat_id AND message_id=102"),
+        {"chat_id": CHAT_ID},
+    )
+    assert int(chat_message_count.scalar_one()) == 1
+
+    media = (
+        await db_session.execute(
+            sa_text(
+                "SELECT chat_message_id, source_message_url, description_status, last_error_code "
+                "FROM message_media WHERE chat_message_id=:chat_message_id"
+            ),
+            {"chat_message_id": chat_message_id},
+        )
+    ).one()
+    assert media.chat_message_id == chat_message_id
+    assert media.source_message_url == "https://t.me/c/1234567890/102"
+    assert media.description_status == "missing_source"
+    assert media.last_error_code == "historical_export_no_file"
+
+    third_run = await _create_run(db_session, "html_photo_repair_third")
+    third = await run_apply(
+        db_session,
+        ingestion_run_id=third_run,
+        resume_point=None,
+        chunking_config=_chunking(),
+        excluded_author_names=frozenset({"shkoder"}),
+    )
+    assert third.applied_count == 0
+    assert third.skipped_duplicate_count == 5
+
+    raw_state = (
+        await db_session.execute(
+            sa_text(
+                "SELECT cm.raw_update_id, COUNT(tu.id) AS raw_count, "
+                "MIN(tu.ingestion_run_id) AS raw_run_id "
+                "FROM chat_messages cm "
+                "LEFT JOIN telegram_updates tu "
+                "ON tu.chat_id=cm.chat_id AND tu.message_id=cm.message_id "
+                "AND tu.update_type='import_message' AND tu.update_id IS NULL "
+                "WHERE cm.id=:chat_message_id "
+                "GROUP BY cm.raw_update_id"
+            ),
+            {"chat_message_id": chat_message_id},
+        )
+    ).one()
+    assert raw_state.raw_update_id is None
+    assert int(raw_state.raw_count) == 1
+    assert int(raw_state.raw_run_id) == second_run
+
+    from bot.services.import_rollback import rollback_ingestion_run
+
+    rollback = await rollback_ingestion_run(db_session, second_run)
+    assert rollback.telegram_updates_deleted == 1
+    assert rollback.chat_messages_deleted == 0
+    preserved = (
+        await db_session.execute(
+            sa_text(
+                "SELECT COUNT(*) FROM chat_messages cm "
+                "JOIN message_media mm ON mm.chat_message_id=cm.id "
+                "WHERE cm.id=:chat_message_id"
+            ),
+            {"chat_message_id": chat_message_id},
+        )
+    ).scalar_one()
+    assert int(preserved) == 1
+
+
 async def test_html_apply_excludes_exact_bot_author_but_keeps_raw_provenance(
     db_session,
 ) -> None:

--- a/tests/services/test_import_reply_resolver.py
+++ b/tests/services/test_import_reply_resolver.py
@@ -34,6 +34,7 @@ pytestmark = pytest.mark.usefixtures("app_env")
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def _rand_chat_id() -> int:
     """Negative chat id in the range Telegram uses for groups."""
     return -random.randint(100_000_000, 199_999_999)
@@ -232,8 +233,8 @@ async def test_prior_run_excludes_newer_runs(db_session) -> None:
     """prior_run must select strictly older runs (started_at < current_run.started_at).
 
     Setup: runs at t=1 (oldest), t=2 (current), t=3 (newest).
-    Message exists only in run-1 and run-3.
-    Resolving from run-2 should pick run-1 (older), NOT run-3 (newer).
+    Run-1 owns the canonical raw; run-3 refreshes it without taking ownership.
+    Resolving from run-2 must therefore select run-1 as the prior run.
 
     Uses explicit started_at values because PostgreSQL `now()` is transaction-stable —
     multiple inserts inside a single test transaction would otherwise share the same
@@ -273,9 +274,22 @@ async def test_prior_run_excludes_newer_runs(db_session) -> None:
     db_session.add_all([run1, run2, run3])
     await db_session.flush()
 
-    # Place the message in run1 and run3 (NOT in run2 which is "current")
-    _, cm_run1 = await _create_imported_message(db_session, chat_id, export_msg_id, run1.id, user_id)
-    _, cm_run3 = await _create_imported_message(db_session, chat_id, export_msg_id, run3.id, user_id)
+    # The canonical raw row is first created by run1. A later run3 refresh keeps
+    # run1 ownership instead of creating an ambiguous second source row.
+    raw_run1, cm_run1 = await _create_imported_message(
+        db_session, chat_id, export_msg_id, run1.id, user_id
+    )
+    from bot.db.repos.telegram_update import TelegramUpdateRepo
+
+    refreshed = await TelegramUpdateRepo.upsert_import_message(
+        db_session,
+        raw_json={"refreshed_by": "run3"},
+        chat_id=chat_id,
+        message_id=export_msg_id,
+        ingestion_run_id=run3.id,
+    )
+    assert refreshed.id == raw_run1.id
+    assert refreshed.ingestion_run_id == run1.id
 
     # Resolving from run2: prior should be run1 (older), not run3 (newer)
     result = await resolve_reply(
@@ -286,11 +300,7 @@ async def test_prior_run_excludes_newer_runs(db_session) -> None:
     )
 
     assert result.resolved_via == "prior_run"
-    # Must resolve to run1's chat_message, not run3's
-    assert result.chat_message_id == cm_run1.id, (
-        f"Expected cm_run1.id={cm_run1.id}, got {result.chat_message_id} "
-        f"(cm_run3.id={cm_run3.id} would indicate a newer run was selected)"
-    )
+    assert result.chat_message_id == cm_run1.id
 
 
 # ---------------------------------------------------------------------------
@@ -545,12 +555,22 @@ def test_aggregate_resolutions() -> None:
     )
 
     resolutions: dict = {
-        1: ReplyResolution(export_msg_id=1, chat_message_id=10, resolved_via="same_run", chain_depth=0),
-        2: ReplyResolution(export_msg_id=2, chat_message_id=20, resolved_via="same_run", chain_depth=0),
-        3: ReplyResolution(export_msg_id=3, chat_message_id=30, resolved_via="prior_run", chain_depth=1),
+        1: ReplyResolution(
+            export_msg_id=1, chat_message_id=10, resolved_via="same_run", chain_depth=0
+        ),
+        2: ReplyResolution(
+            export_msg_id=2, chat_message_id=20, resolved_via="same_run", chain_depth=0
+        ),
+        3: ReplyResolution(
+            export_msg_id=3, chat_message_id=30, resolved_via="prior_run", chain_depth=1
+        ),
         4: ReplyResolution(export_msg_id=4, chat_message_id=40, resolved_via="live", chain_depth=0),
-        5: ReplyResolution(export_msg_id=5, chat_message_id=None, resolved_via="unresolved", chain_depth=0),
-        6: ReplyResolution(export_msg_id=6, chat_message_id=None, resolved_via="unresolved", chain_depth=0),
+        5: ReplyResolution(
+            export_msg_id=5, chat_message_id=None, resolved_via="unresolved", chain_depth=0
+        ),
+        6: ReplyResolution(
+            export_msg_id=6, chat_message_id=None, resolved_via="unresolved", chain_depth=0
+        ),
     }
 
     stats = aggregate_resolutions(resolutions)


### PR DESCRIPTION
## Что исправлено

- сохраняем canonical raw и media для существующих overlap-сообщений
- не передаём ownership старых ChatMessage import-run-у, поэтому rollback их не удаляет
- migration 088 гарантирует один synthetic import raw на source message
- закрываем неявную external transaction после advisory lock, чтобы chunk commits реально сохранялись

## Проверка

- 112 focused tests passed, Ruff/format/diff clean
- независимый review: approve, P0/P1/P2 нет
- prod-copy migration 019 -> 088: 6300 сообщений сохранены, constraints valid
- prod-copy full import: 9403 raw, 9296 eligible normalized, 107 Shkoder raw-only, 660/660 photo media, 0 errors
- repeat import: applied 0, duplicates 9403, raw owner-runs 1, counts unchanged
