### PR TITLE
fix(memory): bind wiki prompt contract

### DIFF
--- a/bot/services/scheduler.py
+++ b/bot/services/scheduler.py
@@ -414,13 +414,16 @@ async def wiki_automation_job() -> None:
         # Heavy static-site dependencies stay behind the master feature flag.
         # A flag-off production process can therefore remain a strict no-op.
         from bot.services.cloudflare_pages import publish_static_generation
+        from bot.services.wiki_compiler import WIKI_PROMPT_TEMPLATE_VERSION
         from bot.services.wiki_orchestrator import (
             compile_changed_topics,
             export_static_wiki,
         )
         from bot.services.wiki_runtime import load_wiki_runtime_config
 
-        gateway_config = load_gateway_config()
+        gateway_config = load_gateway_config(
+            prompt_template_version=WIKI_PROMPT_TEMPLATE_VERSION,
+        )
         wiki_gateway = LiveWikiCompilerGateway(
             config=gateway_config,
             ledger_repo=LedgerRepo(),

--- a/bot/services/wiki_compiler.py
+++ b/bot/services/wiki_compiler.py
@@ -43,7 +43,7 @@ _CITATION_RE = re.compile(
 )
 _MAX_TITLE_LENGTH = 240
 _MAX_BODY_LENGTH = 100_000
-_PROMPT_VERSION = "wiki-revision-v0.1.0"
+WIKI_PROMPT_TEMPLATE_VERSION = "wiki-revision-v0.1.0"
 
 _MESSAGE_SOURCES_SQL = """
 SELECT
@@ -362,7 +362,7 @@ async def compile_topic_page(
         prior_revision_seq=base.revision_seq if base else 0,
         source_cards=cards,
         source_messages=messages,
-        prompt_template_version=_PROMPT_VERSION,
+        prompt_template_version=WIKI_PROMPT_TEMPLATE_VERSION,
         source_chat_id=source_chat_id,
     )
     title, body, ledger_id, cited_cards, cited_mvids = _validate_draft(
@@ -722,6 +722,7 @@ def _slug_lock_id(slug: str) -> int:
 
 
 __all__ = [
+    "WIKI_PROMPT_TEMPLATE_VERSION",
     "WikiCompilationResult",
     "WikiCompilerContractError",
     "WikiCompilerError",

--- a/tests/test_memory_runtime_wiring.py
+++ b/tests/test_memory_runtime_wiring.py
@@ -346,7 +346,8 @@ async def test_wiki_automation_runs_promote_compile_export_publish_pipeline(
         "bot.services.candidate_promotion.promote_pending_candidates",
         promote,
     )
-    monkeypatch.setattr(scheduler_module, "load_gateway_config", Mock(return_value=gateway_config))
+    gateway_config_load = Mock(return_value=gateway_config)
+    monkeypatch.setattr(scheduler_module, "load_gateway_config", gateway_config_load)
     monkeypatch.setattr(scheduler_module, "resolve_provider", Mock(return_value=object()))
     monkeypatch.setattr("bot.services.wiki_orchestrator.compile_changed_topics", compile_topics)
     monkeypatch.setattr("bot.services.wiki_orchestrator.export_static_wiki", export)
@@ -354,6 +355,7 @@ async def test_wiki_automation_runs_promote_compile_export_publish_pipeline(
 
     await scheduler_module.wiki_automation_job()
 
+    gateway_config_load.assert_called_once_with(prompt_template_version="wiki-revision-v0.1.0")
     require_actor.assert_awaited_once_with(sessions[0], 42)
     promote.assert_awaited_once_with(sessions[0], actor_user_id=42, limit=100)
     sessions[0].commit.assert_awaited_once()


### PR DESCRIPTION
## Что исправлено

- wiki automation загружает LLM config с канонической версией wiki prompt
- compiler и runtime используют одну экспортированную константу
- regression-тест фиксирует production wiring contract

## Проверки

- 74 targeted tests passed
- Ruff check/format clean
- git diff --check clean
- independent review: APPROVE, P0-P3 нет

Production symptom: compile job отказал fail-closed до первого LLM/ledger вызова из-за prompt-template mismatch.