### PR TITLE
fix(memory): accept strict wiki JSON fences

### DIFF
--- a/bot/services/llm_gateway.py
+++ b/bot/services/llm_gateway.py
@@ -1977,6 +1977,18 @@ def _build_wiki_revision_prompt(
     return prompt
 
 
+_WHOLE_RESPONSE_JSON_FENCE_RE = re.compile(
+    r"\A```json\r?\n(?P<payload>.*?)\r?\n```\Z",
+    re.DOTALL,
+)
+
+
+def _unwrap_whole_response_json_fence(answer_text: str) -> str:
+    """Return bare JSON or the payload of one exact lowercase json fence."""
+    fenced = _WHOLE_RESPONSE_JSON_FENCE_RE.fullmatch(answer_text.strip())
+    return fenced.group("payload") if fenced is not None else answer_text
+
+
 def _validate_wiki_provider_response(
     answer_text: str,
     *,
@@ -1985,7 +1997,7 @@ def _validate_wiki_provider_response(
     llm_usage_ledger_id: int,
 ) -> tuple[str, str]:
     try:
-        payload = json.loads(answer_text)
+        payload = json.loads(_unwrap_whole_response_json_fence(answer_text))
     except json.JSONDecodeError as exc:
         raise WikiGatewayContractError(
             "wiki provider response is not valid JSON",
@@ -2517,12 +2529,6 @@ def _build_extraction_prompt(
     )
 
 
-_EXTRACTION_JSON_FENCE_RE = re.compile(
-    r"\A```json\r?\n(?P<payload>.*?)\r?\n```\Z",
-    re.DOTALL,
-)
-
-
 def _parse_extraction_response(answer_text: str) -> list[dict[str, Any]]:
     """Parse the provider response into a list of candidate dicts.
 
@@ -2534,11 +2540,8 @@ def _parse_extraction_response(answer_text: str) -> list[dict[str, Any]]:
     keeps the SAVEPOINT in ``run_extraction_pass`` clean and lets the
     audit layer record ``error="no_valid_candidates"`` on the ledger row.
     """
-    stripped = answer_text.strip()
-    fenced = _EXTRACTION_JSON_FENCE_RE.fullmatch(stripped)
-    payload = fenced.group("payload") if fenced is not None else answer_text
     try:
-        parsed = json.loads(payload)
+        parsed = json.loads(_unwrap_whole_response_json_fence(answer_text))
     except (json.JSONDecodeError, ValueError):
         return []
     if not isinstance(parsed, list):

--- a/tests/services/test_llm_gateway_wiki.py
+++ b/tests/services/test_llm_gateway_wiki.py
@@ -277,6 +277,54 @@ async def test_revise_wiki_topic_uses_bounded_untrusted_prompt_and_audits_succes
     )
 
 
+@pytest.mark.parametrize("newline", ["\n", "\r\n"])
+def test_validate_wiki_provider_response_accepts_one_whole_json_fence(
+    newline: str,
+) -> None:
+    from bot.services.llm_gateway import _validate_wiki_provider_response
+
+    body = "Supported fact [^mv:123]."
+    bare = json.dumps(
+        {"title": "Topic", "body_markdown": body},
+        ensure_ascii=False,
+    )
+
+    assert _validate_wiki_provider_response(
+        f"```json{newline}{bare}{newline}```",
+        allowed_card_ids=set(),
+        allowed_mvids={123},
+        llm_usage_ledger_id=7,
+    ) == ("Topic", body)
+
+
+@pytest.mark.parametrize(
+    "answer_text",
+    [
+        'prefix\n```json\n{"title":"Topic","body_markdown":"Fact [^mv:123]."}\n```',
+        '```json\n{"title":"Topic","body_markdown":"Fact [^mv:123]."}\n```\nsuffix',
+        '```\n{"title":"Topic","body_markdown":"Fact [^mv:123]."}\n```',
+        '```JSON\n{"title":"Topic","body_markdown":"Fact [^mv:123]."}\n```',
+        '```json\n{"title":"Topic","body_markdown":"Fact [^mv:123]."}\n```\n'
+        '```json\n{"title":"Other","body_markdown":"Other [^mv:123]."}\n```',
+    ],
+)
+def test_validate_wiki_provider_response_rejects_non_exact_json_fences(
+    answer_text: str,
+) -> None:
+    from bot.services.llm_gateway import (
+        WikiGatewayContractError,
+        _validate_wiki_provider_response,
+    )
+
+    with pytest.raises(WikiGatewayContractError, match="not valid JSON"):
+        _validate_wiki_provider_response(
+            answer_text,
+            allowed_card_ids=set(),
+            allowed_mvids={123},
+            llm_usage_ledger_id=7,
+        )
+
+
 async def test_revise_wiki_topic_commits_priced_reservation_before_provider_finishes(
     db_session,
     durable_ledger_factory,


### PR DESCRIPTION
Summary:
- accept bare JSON or one exact whole-response lowercase json fence for wiki compilation
- reuse the same strict unwrapping contract for extraction
- reject prose, suffixes, generic or uppercase fences, and multiple payloads

Tests:
- 57 focused gateway tests passed
- Ruff check, format check, and git diff check passed