### PR TITLE
fix(memory): request DeepSeek JSON for wiki

### DIFF
--- a/bot/services/llm_gateway.py
+++ b/bot/services/llm_gateway.py
@@ -1131,6 +1131,7 @@ def resolve_provider(
     provider_name: str,
     *,
     deepseek_max_tokens: int | None = None,
+    deepseek_json_output: bool = False,
 ) -> LLMProvider:
     """Instantiate Anthropic or OpenAI provider per config.
 
@@ -1154,7 +1155,8 @@ def resolve_provider(
         return DeepSeekProvider(
             max_tokens=(
                 DEFAULT_DEEPSEEK_MAX_TOKENS if deepseek_max_tokens is None else deepseek_max_tokens
-            )
+            ),
+            json_output=deepseek_json_output,
         )
     raise ValueError(f"unknown provider: {provider_name}")
 

--- a/bot/services/llm_providers/deepseek.py
+++ b/bot/services/llm_providers/deepseek.py
@@ -31,12 +31,16 @@ class DeepSeekProvider:
         api_key: str | None = None,
         client: httpx.AsyncClient | None = None,
         max_tokens: int = DEFAULT_DEEPSEEK_MAX_TOKENS,
+        json_output: bool = False,
     ) -> None:
         if type(max_tokens) is not int or not 1 <= max_tokens <= MAX_DEEPSEEK_OUTPUT_TOKENS:
             raise ValueError(f"max_tokens must be between 1 and {MAX_DEEPSEEK_OUTPUT_TOKENS}")
+        if type(json_output) is not bool:
+            raise ValueError("json_output must be a boolean")
         self._api_key = api_key
         self._client = client
         self._max_tokens = max_tokens
+        self._json_output = json_output
 
     async def call(self, *, prompt: str, model: str) -> ProviderResult:
         api_key = self._api_key
@@ -54,17 +58,20 @@ class DeepSeekProvider:
             timeout=httpx.Timeout(60.0, connect=10.0),
         )
         started = time.monotonic()
+        request_payload: dict[str, Any] = {
+            "model": model,
+            "messages": [{"role": "user", "content": prompt}],
+            "thinking": {"type": "disabled"},
+            "max_tokens": self._max_tokens,
+            "stream": False,
+        }
+        if self._json_output:
+            request_payload["response_format"] = {"type": "json_object"}
         try:
             response = await client.post(
                 "/chat/completions",
                 headers={"Authorization": f"Bearer {api_key}"},
-                json={
-                    "model": model,
-                    "messages": [{"role": "user", "content": prompt}],
-                    "thinking": {"type": "disabled"},
-                    "max_tokens": self._max_tokens,
-                    "stream": False,
-                },
+                json=request_payload,
             )
         except httpx.TimeoutException as exc:
             raise ProviderTransientError("timeout", message="DeepSeek request timed out") from exc

--- a/bot/services/scheduler.py
+++ b/bot/services/scheduler.py
@@ -430,6 +430,7 @@ async def wiki_automation_job() -> None:
             provider=resolve_provider(
                 gateway_config.provider,
                 deepseek_max_tokens=DEEPSEEK_WIKI_MAX_TOKENS,
+                deepseek_json_output=True,
             ),
         )
         topics_seen = 0

--- a/tests/services/test_deepseek_provider.py
+++ b/tests/services/test_deepseek_provider.py
@@ -52,6 +52,41 @@ async def test_deepseek_provider_calls_v4_flash_non_thinking_and_reads_usage() -
 
 
 @pytest.mark.asyncio
+async def test_deepseek_provider_adds_json_output_only_when_enabled() -> None:
+    from bot.services.llm_providers.deepseek import DeepSeekProvider
+
+    captured: dict[str, object] = {}
+
+    def handle(request: httpx.Request) -> httpx.Response:
+        captured["payload"] = json.loads(request.content)
+        return httpx.Response(
+            200,
+            json={
+                "id": "ds-json-request-1",
+                "choices": [{"message": {"content": '{"title":"Topic","body_markdown":"Fact"}'}}],
+                "usage": {"prompt_tokens": 10, "completion_tokens": 8},
+            },
+        )
+
+    async with _client(httpx.MockTransport(handle)) as client:
+        provider = DeepSeekProvider(
+            api_key="test-key",
+            client=client,
+            json_output=True,
+        )
+        await provider.call(prompt="return json", model="deepseek-v4-flash")
+
+    assert captured["payload"] == {
+        "model": "deepseek-v4-flash",
+        "messages": [{"role": "user", "content": "return json"}],
+        "thinking": {"type": "disabled"},
+        "max_tokens": 512,
+        "stream": False,
+        "response_format": {"type": "json_object"},
+    }
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("status", "error_type", "subtype"),
     [
@@ -132,9 +167,27 @@ def test_deepseek_provider_accepts_bounded_task_specific_output_limit() -> None:
     assert provider._max_tokens == 8_192
 
 
+def test_deepseek_provider_resolver_forwards_json_output() -> None:
+    from bot.services.llm_gateway import resolve_provider
+    from bot.services.llm_providers.deepseek import DeepSeekProvider
+
+    provider = resolve_provider("deepseek", deepseek_json_output=True)
+
+    assert isinstance(provider, DeepSeekProvider)
+    assert provider._json_output is True
+
+
 @pytest.mark.parametrize("value", [0, -1, True, 384_001])
 def test_deepseek_provider_rejects_invalid_output_limit(value: object) -> None:
     from bot.services.llm_providers.deepseek import DeepSeekProvider
 
     with pytest.raises(ValueError):
         DeepSeekProvider(max_tokens=value)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("value", [None, 0, 1, "true"])
+def test_deepseek_provider_rejects_non_boolean_json_output(value: object) -> None:
+    from bot.services.llm_providers.deepseek import DeepSeekProvider
+
+    with pytest.raises(ValueError, match="json_output"):
+        DeepSeekProvider(json_output=value)  # type: ignore[arg-type]

--- a/tests/test_memory_runtime_wiring.py
+++ b/tests/test_memory_runtime_wiring.py
@@ -347,8 +347,9 @@ async def test_wiki_automation_runs_promote_compile_export_publish_pipeline(
         promote,
     )
     gateway_config_load = Mock(return_value=gateway_config)
+    provider_resolve = Mock(return_value=object())
     monkeypatch.setattr(scheduler_module, "load_gateway_config", gateway_config_load)
-    monkeypatch.setattr(scheduler_module, "resolve_provider", Mock(return_value=object()))
+    monkeypatch.setattr(scheduler_module, "resolve_provider", provider_resolve)
     monkeypatch.setattr("bot.services.wiki_orchestrator.compile_changed_topics", compile_topics)
     monkeypatch.setattr("bot.services.wiki_orchestrator.export_static_wiki", export)
     monkeypatch.setattr("bot.services.cloudflare_pages.publish_static_generation", publish)
@@ -356,6 +357,11 @@ async def test_wiki_automation_runs_promote_compile_export_publish_pipeline(
     await scheduler_module.wiki_automation_job()
 
     gateway_config_load.assert_called_once_with(prompt_template_version="wiki-revision-v0.1.0")
+    provider_resolve.assert_called_once_with(
+        "deepseek",
+        deepseek_max_tokens=scheduler_module.DEEPSEEK_WIKI_MAX_TOKENS,
+        deepseek_json_output=True,
+    )
     require_actor.assert_awaited_once_with(sessions[0], 42)
     promote.assert_awaited_once_with(sessions[0], actor_user_id=42, limit=100)
     sessions[0].commit.assert_awaited_once()


### PR DESCRIPTION
Summary:
- enable official DeepSeek JSON Output only for wiki compilation
- preserve the default DeepSeek request payload for extraction, QA, and digests
- keep exact wiki schema and citation validation fail-closed

Production evidence:
- 3 provider_contract_violation rows appeared within 63 wiki calls without JSON Output
- saved pages remain durable and static publishing remains disabled

Tests:
- TDD red confirmed unsupported json_output wiring
- 66 focused provider, scheduler, and wiki tests passed
- Ruff check, format check, and git diff check passed