### PR TITLE
fix: harden memory and wiki automation acceptance

### DIFF
--- a/bot/handlers/chat_messages.py
+++ b/bot/handlers/chat_messages.py
@@ -32,11 +32,16 @@ async def save_chat_message(
     if message.from_user is None:
         return
 
-    # The bot's own digest/Q&A/wiki posts are output, never source memory.  Skipping
-    # before UserRepo/persistence prevents feedback loops while raw transport audit can
-    # still be retained by the upstream middleware.
+    # This bot's own digest/Q&A/wiki posts are output, never source memory. Other bots
+    # remain valid source authors. Skipping only the running bot before
+    # UserRepo/persistence prevents feedback loops while the upstream middleware still
+    # retains every delivered raw update.
     if message.from_user.is_bot:
-        return
+        runtime_bot = message.bot
+        if runtime_bot is None:
+            raise RuntimeError("bot-authored message requires an attached bot instance")
+        if message.from_user.id == runtime_bot.id:
+            return
 
     # Keep sender profile fresh for message attribution and admin lookups.
     await UserRepo.upsert(

--- a/bot/middlewares/normalized_memory_persistence.py
+++ b/bot/middlewares/normalized_memory_persistence.py
@@ -1,4 +1,4 @@
-"""Durably persist every human community message before router dispatch."""
+"""Durably persist every community source message before router dispatch."""
 
 from __future__ import annotations
 
@@ -15,13 +15,14 @@ from bot.services.message_persistence import persist_message_with_policy
 
 
 class NormalizedMemoryPersistenceMiddleware(BaseMiddleware):
-    """Archive human messages even when a higher-priority router consumes them.
+    """Archive source messages even when a higher-priority router consumes them.
 
     The archive transaction commits before the product handler runs.  A later
     command failure can therefore roll back its own side effects without
-    silently losing the source conversation.  Bot-authored output is excluded
-    from normalized/derived memory to prevent feedback loops; raw update
-    persistence remains the audit boundary for those updates.
+    silently losing the source conversation.  Only output authored by this
+    running bot is excluded from normalized/derived memory to prevent feedback
+    loops; other bots remain valid sources.  Raw update persistence remains the
+    audit boundary for every delivered update.
     """
 
     async def __call__(
@@ -35,8 +36,14 @@ class NormalizedMemoryPersistenceMiddleware(BaseMiddleware):
 
         message = event.message
         sender = message.from_user
-        if sender is None or sender.is_bot or message.chat.id != settings.COMMUNITY_CHAT_ID:
+        if sender is None or message.chat.id != settings.COMMUNITY_CHAT_ID:
             return await handler(event, data)
+        if sender.is_bot:
+            runtime_bot = message.bot
+            if runtime_bot is None:
+                raise RuntimeError("bot-authored message requires an attached bot instance")
+            if sender.id == runtime_bot.id:
+                return await handler(event, data)
 
         session = data.get("session")
         if session is None:

--- a/bot/services/llm_gateway.py
+++ b/bot/services/llm_gateway.py
@@ -181,6 +181,22 @@ class WikiGatewayContractError(WikiGatewayError):
     """The provider returned a malformed or unsupported wiki revision."""
 
 
+class WikiGatewayResponseContractError(WikiGatewayContractError):
+    """The provider response text failed strict wiki revision validation."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        topic_slug: str,
+        llm_usage_ledger_id: int,
+    ) -> None:
+        if not isinstance(topic_slug, str) or not topic_slug:
+            raise ValueError("topic_slug must be a non-empty string")
+        super().__init__(message, llm_usage_ledger_id=llm_usage_ledger_id)
+        self.topic_slug = topic_slug
+
+
 class WikiGatewayBudgetExceeded(WikiGatewayError):
     """Wiki compilation was refused by the shared LLM cost ceiling."""
 
@@ -1994,6 +2010,7 @@ def _unwrap_whole_response_json_fence(answer_text: str) -> str:
 def _validate_wiki_provider_response(
     answer_text: str,
     *,
+    topic_slug: str,
     allowed_card_ids: set[str],
     allowed_mvids: set[int],
     llm_usage_ledger_id: int,
@@ -2001,37 +2018,43 @@ def _validate_wiki_provider_response(
     try:
         payload = json.loads(_unwrap_whole_response_json_fence(answer_text))
     except json.JSONDecodeError as exc:
-        raise WikiGatewayContractError(
+        raise WikiGatewayResponseContractError(
             "wiki provider response is not valid JSON",
+            topic_slug=topic_slug,
             llm_usage_ledger_id=llm_usage_ledger_id,
         ) from exc
     if not isinstance(payload, dict) or set(payload) != {"title", "body_markdown"}:
-        raise WikiGatewayContractError(
+        raise WikiGatewayResponseContractError(
             "wiki provider response must use the exact object schema",
+            topic_slug=topic_slug,
             llm_usage_ledger_id=llm_usage_ledger_id,
         )
     title = payload["title"]
     body = payload["body_markdown"]
     if not isinstance(title, str) or not title.strip() or len(title.strip()) > 240:
-        raise WikiGatewayContractError(
+        raise WikiGatewayResponseContractError(
             "wiki provider title is invalid",
+            topic_slug=topic_slug,
             llm_usage_ledger_id=llm_usage_ledger_id,
         )
     if not isinstance(body, str) or not body.strip() or len(body) > MAX_WIKI_PRIOR_BODY_CHARS:
-        raise WikiGatewayContractError(
+        raise WikiGatewayResponseContractError(
             "wiki provider body_markdown is invalid",
+            topic_slug=topic_slug,
             llm_usage_ledger_id=llm_usage_ledger_id,
         )
 
     cited_cards, cited_mvids = _wiki_citation_sets(body)
     if not cited_cards and not cited_mvids:
-        raise WikiGatewayContractError(
+        raise WikiGatewayResponseContractError(
             "wiki provider body must contain at least one citation",
+            topic_slug=topic_slug,
             llm_usage_ledger_id=llm_usage_ledger_id,
         )
     if cited_cards - allowed_card_ids or cited_mvids - allowed_mvids:
-        raise WikiGatewayContractError(
+        raise WikiGatewayResponseContractError(
             "wiki provider returned an unsupported citation",
+            topic_slug=topic_slug,
             llm_usage_ledger_id=llm_usage_ledger_id,
         )
     return title.strip(), body.strip()
@@ -2432,6 +2455,7 @@ async def revise_wiki_topic(
     try:
         title, body = _validate_wiki_provider_response(
             provider_result.answer_text,
+            topic_slug=slug,
             allowed_card_ids=allowed_card_ids,
             allowed_mvids=allowed_mvids,
             llm_usage_ledger_id=ledger_id,
@@ -4244,6 +4268,7 @@ __all__ = [
     "WikiGatewayContractError",
     "WikiGatewayError",
     "WikiGatewayProviderError",
+    "WikiGatewayResponseContractError",
     "WikiGatewaySourceStaleError",
     "_cache_input_hash",
     "_normalize_query",

--- a/bot/services/scheduler.py
+++ b/bot/services/scheduler.py
@@ -27,6 +27,7 @@ from bot.services.invite_worker import process_invite_outbox
 from bot.services.llm_gateway import (
     LiveExtractCandidatesGateway,
     LiveWikiCompilerGateway,
+    WikiGatewayResponseContractError,
     load_gateway_config,
     resolve_provider,
 )
@@ -49,6 +50,7 @@ DEEPSEEK_EXTRACTION_MAX_TOKENS = 8_192
 DEEPSEEK_DIGEST_MAX_TOKENS = 4_096
 DEEPSEEK_WIKI_MAX_TOKENS = 8_192
 MAX_WIKI_TOPICS_PER_JOB = 256
+MAX_WIKI_RESPONSE_ATTEMPTS_PER_TOPIC = 2
 
 
 class WikiAutomationJobError(RuntimeError):
@@ -435,19 +437,58 @@ async def wiki_automation_job() -> None:
         )
         topics_seen = 0
         topics_compiled = 0
+        compile_attempts = 0
+        contract_retries = 0
         for _topic_number in range(MAX_WIKI_TOPICS_PER_JOB):
-            async with async_session() as session:
-                if not await FeatureFlagRepo.get(session, WIKI_COMPILER_FEATURE_FLAG):
-                    return
-                compile_result = await compile_changed_topics(
-                    session,
-                    actor_user_id=actor_user_id,
-                    gateway=wiki_gateway,
-                    publication_authorized=True,
-                    source_chat_id=settings.COMMUNITY_CHAT_ID,
-                    max_topics=1,
-                )
-                await session.commit()
+            retry_topic_slug: str | None = None
+            for attempt in range(1, MAX_WIKI_RESPONSE_ATTEMPTS_PER_TOPIC + 1):
+                try:
+                    async with async_session() as session:
+                        if not await FeatureFlagRepo.get(
+                            session,
+                            WIKI_COMPILER_FEATURE_FLAG,
+                        ):
+                            return
+                        compile_attempts += 1
+                        compile_kwargs = {
+                            "actor_user_id": actor_user_id,
+                            "gateway": wiki_gateway,
+                            "publication_authorized": True,
+                            "source_chat_id": settings.COMMUNITY_CHAT_ID,
+                            "max_topics": 1,
+                        }
+                        if retry_topic_slug is not None:
+                            compile_kwargs["target_topic_slug"] = retry_topic_slug
+                        compile_result = await compile_changed_topics(session, **compile_kwargs)
+                        await session.commit()
+                    break
+                except WikiGatewayResponseContractError as exc:
+                    if retry_topic_slug is not None and exc.topic_slug != retry_topic_slug:
+                        raise WikiAutomationJobError(
+                            "wiki response contract retry topic changed"
+                        ) from None
+                    retry_topic_slug = exc.topic_slug
+                    if attempt == MAX_WIKI_RESPONSE_ATTEMPTS_PER_TOPIC:
+                        logger.error(
+                            "wiki_automation_response_contract_exhausted",
+                            extra={
+                                "attempt": attempt,
+                                "max_attempts": MAX_WIKI_RESPONSE_ATTEMPTS_PER_TOPIC,
+                                "failed_ledger_id": exc.llm_usage_ledger_id,
+                            },
+                        )
+                        raise WikiAutomationJobError(
+                            "wiki response contract attempts exhausted"
+                        ) from None
+                    contract_retries += 1
+                    logger.warning(
+                        "wiki_automation_response_contract_retry",
+                        extra={
+                            "attempt": attempt,
+                            "max_attempts": MAX_WIKI_RESPONSE_ATTEMPTS_PER_TOPIC,
+                            "failed_ledger_id": exc.llm_usage_ledger_id,
+                        },
+                    )
             topics_seen = compile_result.topics_seen
             topics_compiled += compile_result.compiled_topics
             if compile_result.remaining_changed_topics == 0:
@@ -505,6 +546,8 @@ async def wiki_automation_job() -> None:
             extra={
                 "topics_seen": topics_seen,
                 "topics_compiled": topics_compiled,
+                "compile_attempts": compile_attempts,
+                "contract_retries": contract_retries,
                 "page_count": export_result.page_count,
                 "manifest_sha256": export_result.manifest_sha256,
                 "publish_status": publish_status,

--- a/bot/services/wiki_orchestrator.py
+++ b/bot/services/wiki_orchestrator.py
@@ -183,13 +183,18 @@ async def compile_changed_topics(
     publication_authorized: bool,
     source_chat_id: int,
     max_topics: int | None = None,
+    target_topic_slug: str | None = None,
 ) -> WikiOrchestrationResult:
-    """Compile every changed topic exactly once in the caller transaction."""
+    """Compile changed topics, optionally pinning one exact retry slug."""
     if publication_authorized is not True:
         raise WikiOrchestrationError("explicit publication authorization is required")
     _require_source_chat_id(source_chat_id)
     if max_topics is not None and (type(max_topics) is not int or not 1 <= max_topics <= 256):
         raise ValueError("max_topics must be an integer from 1 to 256")
+    if target_topic_slug is not None and (
+        not isinstance(target_topic_slug, str) or not target_topic_slug
+    ):
+        raise ValueError("target_topic_slug must be a non-empty string")
     await _require_actor(session, actor_user_id)
     if session.bind is not None and session.bind.dialect.name == "postgresql":
         await session.execute(
@@ -237,7 +242,12 @@ async def compile_changed_topics(
         )
     )
 
-    selected_topics = changed if max_topics is None else changed[:max_topics]
+    if target_topic_slug is None:
+        selected_topics = changed if max_topics is None else changed[:max_topics]
+    else:
+        selected_topics = [topic for topic in changed if topic.slug == target_topic_slug]
+        if not selected_topics:
+            raise WikiOrchestrationError("target topic is no longer changed and eligible")
     revisions: list[WikiCompilationResult] = []
     for topic in selected_topics:
         revisions.append(

--- a/bot/services/wiki_static_export.py
+++ b/bot/services/wiki_static_export.py
@@ -43,6 +43,8 @@ _SECRET_RE = re.compile(
     r")"
 )
 PUBLIC_GENERATION_MANIFEST_PATH = "generation-manifest.json"
+_NETWORK_REDACTION_MARKER = "[external reference removed]"
+_NON_WHITESPACE_TOKEN_RE = re.compile(r"\S+")
 _DANGEROUS_ELEMENT_RE = re.compile(
     r"<(script|style|iframe|form|object|embed|applet|base|link|meta)"
     r"(?:\s[^>]*)?>.*?</\1>",
@@ -244,14 +246,14 @@ def _validate_inputs(
             raise ValueError("page body and positive revision_seq are required")
         if not _CITATION_RE.search(page.body_markdown):
             raise ValueError("every exported page must contain at least one source citation")
-        _scan_user_content(page.title, forbidden_origins=forbidden_origins)
-        _scan_user_content(page.body_markdown, forbidden_origins=forbidden_origins)
+        public_title = _prepare_public_text(page.title, forbidden_origins=forbidden_origins)
+        public_body = _prepare_public_text(page.body_markdown, forbidden_origins=forbidden_origins)
         slugs.add(page.slug)
         normalized.append(
             StaticWikiPage(
                 slug=page.slug,
-                title=page.title.strip(),
-                body_markdown=page.body_markdown.strip(),
+                title=public_title.strip(),
+                body_markdown=public_body.strip(),
                 revision_seq=page.revision_seq,
             )
         )
@@ -264,6 +266,31 @@ def _scan_user_content(value: str, *, forbidden_origins: tuple[str, ...]) -> Non
         raise StaticExportSecurityError("network reference is forbidden in static export")
     if _SECRET_RE.search(value):
         raise StaticExportSecurityError("secret-like material is forbidden in static export")
+
+
+def _prepare_public_text(value: str, *, forbidden_origins: tuple[str, ...]) -> str:
+    """Redact network tokens after fail-closed checks on the private source."""
+    _assert_no_forbidden_origin(value, forbidden_origins=forbidden_origins)
+    if _SECRET_RE.search(value):
+        raise StaticExportSecurityError("secret-like material is forbidden in static export")
+    redacted = _redact_network_references(value)
+    _scan_user_content(redacted, forbidden_origins=forbidden_origins)
+    return redacted
+
+
+def _redact_network_references(value: str) -> str:
+    """Conservatively replace every whitespace-delimited token containing a network ref."""
+
+    def redact_token(match: re.Match[str]) -> str:
+        token = match.group(0)
+        if not _NETWORK_RE.search(token):
+            return token
+        citations = "".join(citation.group(0) for citation in _CITATION_RE.finditer(token))
+        return f"{_NETWORK_REDACTION_MARKER}{citations}"
+
+    # ponytail: redact the whole token; use Markdown-aware spans only if public copy
+    # quality requires it.
+    return _NON_WHITESPACE_TOKEN_RE.sub(redact_token, value)
 
 
 def _normalize_forbidden_origins(values: Iterable[str]) -> tuple[str, ...]:

--- a/tests/handlers/test_chat_messages_human_only.py
+++ b/tests/handlers/test_chat_messages_human_only.py
@@ -19,6 +19,8 @@ COMMUNITY_CHAT_ID = -1001234567890
 def _message(
     *,
     is_bot: bool,
+    sender_id: int = 777,
+    runtime_bot_id: int | None = None,
     text: str = "сообщение",
     with_photo: bool = False,
 ) -> SimpleNamespace:
@@ -26,12 +28,13 @@ def _message(
         message_id=701,
         chat=SimpleNamespace(id=COMMUNITY_CHAT_ID, type="supergroup"),
         from_user=SimpleNamespace(
-            id=777,
+            id=sender_id,
             username="shkoder" if is_bot else "member",
             first_name="Shkoder" if is_bot else "Member",
             last_name=None,
             is_bot=is_bot,
         ),
+        bot=SimpleNamespace(id=runtime_bot_id) if runtime_bot_id is not None else None,
         text=text,
         caption=None,
         date=datetime.now(timezone.utc),
@@ -74,7 +77,7 @@ async def test_catch_all_persists_human_message(monkeypatch) -> None:
     enqueue.assert_not_awaited()
 
 
-async def test_catch_all_skips_bot_authored_message_before_any_normalized_write(
+async def test_catch_all_skips_own_bot_message_before_any_normalized_write(
     monkeypatch,
 ) -> None:
     handler = import_module("bot.handlers.chat_messages")
@@ -86,13 +89,57 @@ async def test_catch_all_skips_bot_authored_message_before_any_normalized_write(
     monkeypatch.setattr(handler, "enqueue_photo_memory", enqueue)
 
     await handler.save_chat_message(
-        _message(is_bot=True, text="Дневной дайджест от Шкодера"),
+        _message(
+            is_bot=True,
+            sender_id=777,
+            runtime_bot_id=777,
+            text="Дневной дайджест от Шкодера",
+        ),
         AsyncMock(),
     )
 
     upsert.assert_not_awaited()
     persist.assert_not_awaited()
     enqueue.assert_not_awaited()
+
+
+async def test_catch_all_persists_other_bot_message(monkeypatch) -> None:
+    handler = import_module("bot.handlers.chat_messages")
+    upsert = AsyncMock()
+    persist = AsyncMock(
+        return_value=SimpleNamespace(
+            policy="normal",
+            is_offrecord_mark_created=False,
+            chat_message=SimpleNamespace(id=803),
+        )
+    )
+    monkeypatch.setattr(handler.UserRepo, "upsert", upsert)
+    monkeypatch.setattr(handler, "persist_message_with_policy", persist)
+    monkeypatch.setattr(handler, "enqueue_photo_memory", AsyncMock())
+
+    await handler.save_chat_message(
+        _message(is_bot=True, sender_id=888, runtime_bot_id=777),
+        AsyncMock(),
+    )
+
+    upsert.assert_awaited_once()
+    persist.assert_awaited_once()
+
+
+async def test_catch_all_bot_authored_message_without_runtime_bot_fails_fast(
+    monkeypatch,
+) -> None:
+    handler = import_module("bot.handlers.chat_messages")
+    persist = AsyncMock()
+    monkeypatch.setattr(handler, "persist_message_with_policy", persist)
+
+    with pytest.raises(RuntimeError, match="attached bot"):
+        await handler.save_chat_message(
+            _message(is_bot=True, sender_id=777),
+            AsyncMock(),
+        )
+
+    persist.assert_not_awaited()
 
 
 async def test_catch_all_queues_human_photo_after_normalized_persistence(

--- a/tests/middlewares/test_normalized_memory_persistence.py
+++ b/tests/middlewares/test_normalized_memory_persistence.py
@@ -13,15 +13,21 @@ pytestmark = pytest.mark.usefixtures("app_env")
 COMMUNITY_CHAT_ID = -1001234567890
 
 
-def _update(*, is_bot: bool = False, photo: bool = False) -> Update:
-    return Update(
+def _update(
+    *,
+    is_bot: bool = False,
+    sender_id: int = 701,
+    runtime_bot_id: int | None = None,
+    photo: bool = False,
+) -> Update:
+    update = Update(
         update_id=9001,
         message=Message(
             message_id=7001,
             date=datetime.now(timezone.utc),
             chat=Chat(id=COMMUNITY_CHAT_ID, type="supergroup"),
             from_user=User(
-                id=701,
+                id=sender_id,
                 is_bot=is_bot,
                 first_name="Shkoder" if is_bot else "Member",
                 username="shkoder_bot" if is_bot else "member",
@@ -41,6 +47,10 @@ def _update(*, is_bot: bool = False, photo: bool = False) -> Update:
             ),
         ),
     )
+    if runtime_bot_id is not None:
+        assert update.message is not None
+        update.message.as_(SimpleNamespace(id=runtime_bot_id))
+    return update
 
 
 async def test_persists_command_before_specific_handler_and_commits(monkeypatch):
@@ -101,7 +111,7 @@ async def test_queues_photo_even_when_later_handler_consumes_message(monkeypatch
     session.commit.assert_awaited_once()
 
 
-async def test_bot_output_is_not_written_to_normalized_memory(monkeypatch):
+async def test_own_bot_output_is_not_written_to_normalized_memory(monkeypatch):
     from bot.middlewares import normalized_memory_persistence as module
 
     upsert = AsyncMock()
@@ -115,7 +125,7 @@ async def test_bot_output_is_not_written_to_normalized_memory(monkeypatch):
 
     await module.NormalizedMemoryPersistenceMiddleware()(
         downstream,
-        _update(is_bot=True),
+        _update(is_bot=True, sender_id=701, runtime_bot_id=701),
         {"session": session},
     )
 
@@ -124,3 +134,42 @@ async def test_bot_output_is_not_written_to_normalized_memory(monkeypatch):
     enqueue.assert_not_awaited()
     session.commit.assert_not_awaited()
     downstream.assert_awaited_once()
+
+
+async def test_other_bot_output_is_written_to_normalized_memory(monkeypatch):
+    from bot.middlewares import normalized_memory_persistence as module
+
+    upsert = AsyncMock()
+    persist = AsyncMock(return_value=SimpleNamespace(chat_message=SimpleNamespace(id=993)))
+    downstream = AsyncMock()
+    session = AsyncMock()
+    monkeypatch.setattr(module.UserRepo, "upsert", upsert)
+    monkeypatch.setattr(module, "persist_message_with_policy", persist)
+    monkeypatch.setattr(module, "enqueue_photo_memory", AsyncMock())
+
+    await module.NormalizedMemoryPersistenceMiddleware()(
+        downstream,
+        _update(is_bot=True, sender_id=702, runtime_bot_id=701),
+        {"session": session},
+    )
+
+    upsert.assert_awaited_once()
+    persist.assert_awaited_once()
+    session.commit.assert_awaited_once()
+    downstream.assert_awaited_once()
+
+
+async def test_bot_authored_message_without_runtime_bot_fails_fast(monkeypatch):
+    from bot.middlewares import normalized_memory_persistence as module
+
+    persist = AsyncMock()
+    monkeypatch.setattr(module, "persist_message_with_policy", persist)
+
+    with pytest.raises(RuntimeError, match="attached bot"):
+        await module.NormalizedMemoryPersistenceMiddleware()(
+            AsyncMock(),
+            _update(is_bot=True, sender_id=701),
+            {"session": AsyncMock()},
+        )
+
+    persist.assert_not_awaited()

--- a/tests/services/test_llm_gateway_wiki.py
+++ b/tests/services/test_llm_gateway_wiki.py
@@ -291,6 +291,7 @@ def test_validate_wiki_provider_response_accepts_one_whole_json_fence(
 
     assert _validate_wiki_provider_response(
         f"```json{newline}{bare}{newline}```",
+        topic_slug="topic",
         allowed_card_ids=set(),
         allowed_mvids={123},
         llm_usage_ledger_id=7,
@@ -312,17 +313,51 @@ def test_validate_wiki_provider_response_rejects_non_exact_json_fences(
     answer_text: str,
 ) -> None:
     from bot.services.llm_gateway import (
-        WikiGatewayContractError,
+        WikiGatewayResponseContractError,
         _validate_wiki_provider_response,
     )
 
-    with pytest.raises(WikiGatewayContractError, match="not valid JSON"):
+    with pytest.raises(WikiGatewayResponseContractError, match="not valid JSON"):
         _validate_wiki_provider_response(
             answer_text,
+            topic_slug="topic",
             allowed_card_ids=set(),
             allowed_mvids={123},
             llm_usage_ledger_id=7,
         )
+
+
+@pytest.mark.parametrize(
+    "answer_text",
+    [
+        json.dumps({"title": "Topic", "body_markdown": "Fact [^mv:123].", "extra": True}),
+        json.dumps({"title": "", "body_markdown": "Fact [^mv:123]."}),
+        json.dumps({"title": "Topic", "body_markdown": ""}),
+        json.dumps({"title": "Topic", "body_markdown": "No citation."}),
+        json.dumps({"title": "Topic", "body_markdown": "Fact [^mv:999]."}),
+    ],
+)
+def test_wiki_response_validation_failures_use_narrow_retryable_subclass(
+    answer_text: str,
+) -> None:
+    from bot.services.llm_gateway import (
+        WikiGatewayContractError,
+        WikiGatewayResponseContractError,
+        _validate_wiki_provider_response,
+    )
+
+    with pytest.raises(WikiGatewayResponseContractError) as raised:
+        _validate_wiki_provider_response(
+            answer_text,
+            topic_slug="topic",
+            allowed_card_ids=set(),
+            allowed_mvids={123},
+            llm_usage_ledger_id=7,
+        )
+
+    assert isinstance(raised.value, WikiGatewayContractError)
+    assert raised.value.llm_usage_ledger_id == 7
+    assert raised.value.topic_slug == "topic"
 
 
 async def test_revise_wiki_topic_commits_priced_reservation_before_provider_finishes(
@@ -857,6 +892,7 @@ async def test_revise_wiki_topic_terminally_audits_malformed_provider_result(
         await caller_savepoint.rollback()
 
     ledger_id = raised.value.llm_usage_ledger_id
+    assert type(raised.value) is WikiGatewayContractError
     assert isinstance(ledger_id, int) and ledger_id > 0
     async with durable_ledger_factory() as fresh_session:
         row = (

--- a/tests/services/test_wiki_orchestrator.py
+++ b/tests/services/test_wiki_orchestrator.py
@@ -234,6 +234,50 @@ async def test_changed_topics_can_be_committed_one_at_a_time(db_session) -> None
     assert [call["slug"] for call in gateway.calls] == ["alpha", "beta"]
 
 
+async def test_targeted_changed_topic_compiles_that_slug_only(db_session) -> None:
+    from bot.services.wiki_orchestrator import compile_changed_topics
+
+    actor_id = await _make_user(db_session)
+    await _make_card(db_session, actor_id=actor_id, topic_slug="alpha", title="Alpha")
+    await _make_card(db_session, actor_id=actor_id, topic_slug="beta", title="Beta")
+    gateway = _Gateway()
+
+    targeted = await compile_changed_topics(
+        db_session,
+        actor_user_id=actor_id,
+        gateway=gateway,
+        publication_authorized=True,
+        source_chat_id=SOURCE_CHAT_ID,
+        max_topics=1,
+        target_topic_slug="beta",
+    )
+
+    assert targeted.compiled_topics == 1
+    assert targeted.remaining_changed_topics == 1
+    assert [call["slug"] for call in gateway.calls] == ["beta"]
+
+
+async def test_missing_targeted_topic_never_falls_back_to_another_slug(db_session) -> None:
+    from bot.services.wiki_orchestrator import WikiOrchestrationError, compile_changed_topics
+
+    actor_id = await _make_user(db_session)
+    await _make_card(db_session, actor_id=actor_id, topic_slug="alpha", title="Alpha")
+    gateway = _Gateway()
+
+    with pytest.raises(WikiOrchestrationError, match="no longer changed and eligible"):
+        await compile_changed_topics(
+            db_session,
+            actor_user_id=actor_id,
+            gateway=gateway,
+            publication_authorized=True,
+            source_chat_id=SOURCE_CHAT_ID,
+            max_topics=1,
+            target_topic_slug="missing",
+        )
+
+    assert gateway.calls == []
+
+
 async def test_static_export_acquires_and_uses_governed_snapshot_locks(
     db_session,
     tmp_path,

--- a/tests/services/test_wiki_static_export.py
+++ b/tests/services/test_wiki_static_export.py
@@ -73,6 +73,151 @@ def test_export_is_deterministic_for_same_pages(tmp_path) -> None:
     assert first.generation_dir == second.generation_dir
 
 
+def test_export_redacts_network_references_without_mutating_input(tmp_path) -> None:
+    marker = "[external reference removed]"
+    page = _page(
+        title="Docs https://title.example/path?q=one&x=two).",
+        body=(
+            "Plain https://body.example/a_(b)?q=one&x=two#part), "
+            "[External](https://link.example/private?q=one). "
+            "Also www.example.net/docs;param![^mv:42]."
+        ),
+    )
+    original = StaticWikiPage(**page.__dict__)
+
+    first = export_static_site(
+        [page],
+        publish_dir=tmp_path / "site",
+        site_title="Wiki",
+        publication_authorized=True,
+    )
+    second = export_static_site(
+        [page],
+        publish_dir=tmp_path / "site",
+        site_title="Wiki",
+        publication_authorized=True,
+    )
+
+    page_html = (first.generation_dir / "pages/memory/index.html").read_text(encoding="utf-8")
+    search_payload = json.loads(
+        (first.generation_dir / "search-index.json").read_text(encoding="utf-8")
+    )[0]
+    public_text = page_html + json.dumps(search_payload, ensure_ascii=False)
+    network_re = export_static_site.__globals__["_NETWORK_RE"]
+    assert marker in page_html
+    assert marker in search_payload["title"]
+    assert marker in search_payload["content"]
+    assert search_payload["source_refs"] == ["mv:42"]
+    assert search_payload["revision_seq"] == 3
+    assert not network_re.search(public_text)
+    assert "title.example" not in public_text
+    assert "body.example" not in public_text
+    assert "link.example" not in public_text
+    assert "www.example.net" not in public_text
+    assert "q=one" not in public_text
+    assert "x=two" not in public_text
+    assert "a_(b)" not in public_text
+    assert "docs;param" not in public_text
+    assert page == original
+    assert first.manifest_sha256 == second.manifest_sha256
+    assert first.generation_dir == second.generation_dir
+
+
+def test_network_redaction_preserves_adjacent_citations(tmp_path) -> None:
+    card_id = "123e4567-e89b-12d3-a456-426614174000"
+    page = _page(
+        body=(
+            "https://example.test/a?q=one#part).[^mv:42]. "
+            f"Middle www.example.test/b;[^card:{card_id}] after."
+        )
+    )
+
+    result = export_static_site(
+        [page],
+        publish_dir=tmp_path / "site",
+        site_title="Wiki",
+        publication_authorized=True,
+    )
+
+    search_payload = json.loads(
+        (result.generation_dir / "search-index.json").read_text(encoding="utf-8")
+    )[0]
+    assert "Middle " in search_payload["content"]
+    assert " after." in search_payload["content"]
+    assert search_payload["source_refs"] == ["mv:42", f"card:{card_id}"]
+    assert search_payload["content"].count("[external reference removed]") == 2
+    assert "example.test" not in search_payload["content"]
+
+
+def test_network_redaction_marker_is_safe_for_static_audit() -> None:
+    exporter_globals = export_static_site.__globals__
+    marker = exporter_globals["_NETWORK_REDACTION_MARKER"]
+
+    assert not exporter_globals["_NETWORK_RE"].search(marker)
+    assert not exporter_globals["_SECRET_RE"].search(marker)
+
+
+def test_export_rejects_secret_inside_network_url_before_redaction(tmp_path) -> None:
+    with pytest.raises(StaticExportSecurityError, match="secret-like"):
+        export_static_site(
+            [_page(body="https://example.test/?token=abcdefghijk [^mv:42].")],
+            publish_dir=tmp_path / "site",
+            site_title="Wiki",
+            publication_authorized=True,
+        )
+
+
+def test_export_rejects_forbidden_origin_inside_url_before_redaction(tmp_path) -> None:
+    with pytest.raises(StaticExportSecurityError, match="forbidden origin"):
+        export_static_site(
+            [_page(body="https://prod-vps.example.net/private [^mv:42].")],
+            publish_dir=tmp_path / "site",
+            site_title="Wiki",
+            publication_authorized=True,
+            forbidden_origins=["prod-vps.example.net"],
+        )
+
+
+def test_export_redacts_production_like_93_page_generation(tmp_path) -> None:
+    marker = "[external reference removed]"
+    pages = [
+        _page(
+            slug=f"page-{index:03d}",
+            title=f"Page {index:03d}",
+            body=(
+                f"Primary https://source-{index}.example/path?q={index}). "
+                + (f"Secondary www.extra-{index}.example/docs; " if index < 54 else "")
+                + f"[^mv:{index + 1}]."
+            ),
+        )
+        for index in range(93)
+    ]
+    originals = tuple(
+        (page.slug, page.title, page.body_markdown, page.revision_seq) for page in pages
+    )
+
+    result = export_static_site(
+        pages,
+        publish_dir=tmp_path / "site",
+        site_title="Wiki",
+        publication_authorized=True,
+    )
+
+    search_payload = json.loads(
+        (result.generation_dir / "search-index.json").read_text(encoding="utf-8")
+    )
+    public_content = " ".join(item["content"] for item in search_payload)
+    assert result.page_count == 93
+    assert len(search_payload) == 93
+    assert public_content.count(marker) == 147
+    assert not export_static_site.__globals__["_NETWORK_RE"].search(public_content)
+    assert (
+        tuple((page.slug, page.title, page.body_markdown, page.revision_seq) for page in pages)
+        == originals
+    )
+    assert audit_static_tree(result.generation_dir) == result.manifest_sha256
+
+
 @pytest.mark.parametrize("variant", ["title", "assets", "csp"])
 def test_public_generation_marker_covers_every_static_surface(
     tmp_path,
@@ -144,7 +289,7 @@ def test_export_escapes_titles_and_strips_active_html(tmp_path) -> None:
     assert "mv:42" in payload
 
 
-def test_security_failure_keeps_previous_atomic_generation(tmp_path) -> None:
+def test_forbidden_origin_failure_keeps_previous_atomic_generation(tmp_path) -> None:
     publish_dir = tmp_path / "site"
     first = export_static_site(
         [_page()],
@@ -154,12 +299,13 @@ def test_security_failure_keeps_previous_atomic_generation(tmp_path) -> None:
     )
     previous_target = publish_dir.resolve()
 
-    with pytest.raises(StaticExportSecurityError, match="network reference"):
+    with pytest.raises(StaticExportSecurityError, match="forbidden origin"):
         export_static_site(
             [_page(body="Never publish http://127.0.0.1:8080/private [^mv:42].")],
             publish_dir=publish_dir,
             site_title="Wiki",
             publication_authorized=True,
+            forbidden_origins=["127.0.0.1"],
         )
 
     assert publish_dir.resolve() == previous_target
@@ -194,35 +340,69 @@ def test_export_preserves_only_strict_internal_page_links(tmp_path) -> None:
     assert "/pages/rules/?debug=1" not in payload
     assert "/pages/rules/#private" not in payload
 
-    with pytest.raises(StaticExportSecurityError, match="network reference"):
-        export_static_site(
-            [_page(body="[External](https://example.com/private) [^mv:42].")],
-            publish_dir=tmp_path / "external-site",
-            site_title="Wiki",
-            publication_authorized=True,
-        )
+    external = export_static_site(
+        [_page(body="[External](https://example.com/private) [^mv:42].")],
+        publish_dir=tmp_path / "external-site",
+        site_title="Wiki",
+        publication_authorized=True,
+    )
+    external_payload = (external.publish_dir / "pages/memory/index.html").read_text(
+        encoding="utf-8"
+    )
+    assert "[external reference removed]" in external_payload
+    assert "example.com" not in external_payload
 
 
 @pytest.mark.parametrize(
-    ("body", "expected"),
+    "body",
     [
-        ("AKIA" + "ABCDEFGHIJKLMNOP [^mv:42].", "secret-like"),
-        ("ghp_" + "abcdefghijklmnopqrstuvwxyz123456 [^mv:42].", "secret-like"),
-        ("[::1] [^mv:42].", "network reference"),
-        ("169.254.169.254/latest/meta-data [^mv:42].", "network reference"),
-        ("host.docker.internal [^mv:42].", "network reference"),
+        "AKIA" + "ABCDEFGHIJKLMNOP [^mv:42].",
+        "ghp_" + "abcdefghijklmnopqrstuvwxyz123456 [^mv:42].",
     ],
 )
-def test_export_blocks_extended_secret_and_internal_host_patterns(
-    tmp_path, body: str, expected: str
-) -> None:
-    with pytest.raises(StaticExportSecurityError, match=expected):
+def test_export_blocks_extended_secret_patterns(tmp_path, body: str) -> None:
+    with pytest.raises(StaticExportSecurityError, match="secret-like"):
         export_static_site(
             [_page(body=body)],
             publish_dir=tmp_path / "site",
             site_title="Wiki",
             publication_authorized=True,
         )
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        "ftp://example.test/archive). [^mv:42].",
+        "ssh://example.test/private; [^mv:42].",
+        "postgresql://example.test/database?ssl=1 [^mv:42].",
+        "redis://example.test/cache#db [^mv:42].",
+        "mongodb+srv://example.test/data [^mv:42].",
+        "file:///etc/passwd [^mv:42].",
+        "www.example.test/docs [^mv:42].",
+        "localhost:8080/admin [^mv:42].",
+        "127.0.0.1/private [^mv:42].",
+        "10.0.0.1/private [^mv:42].",
+        "192.168.1.1/private [^mv:42].",
+        "172.31.255.254/private [^mv:42].",
+        "[::1]/admin [^mv:42].",
+        "2001:db8::1/path [^mv:42].",
+        "169.254.169.254/latest/meta-data [^mv:42].",
+        "host.docker.internal/private [^mv:42].",
+        "https://a.test,https://b.test [^mv:42].",
+    ],
+)
+def test_export_redacts_extended_network_patterns(tmp_path, body: str) -> None:
+    result = export_static_site(
+        [_page(body=body)],
+        publish_dir=tmp_path / "site",
+        site_title="Wiki",
+        publication_authorized=True,
+    )
+    payload = (result.publish_dir / "pages/memory/index.html").read_text(encoding="utf-8")
+
+    assert "[external reference removed]" in payload
+    assert not export_static_site.__globals__["_NETWORK_RE"].search(payload)
 
 
 def test_export_honors_caller_forbidden_origin_denylist(tmp_path) -> None:

--- a/tests/test_memory_runtime_wiring.py
+++ b/tests/test_memory_runtime_wiring.py
@@ -34,6 +34,44 @@ def _function_source(path: Path, function_name: str) -> str:
     raise AssertionError(f"function {function_name!r} not found in {path}")
 
 
+def _patch_wiki_compile_job(
+    monkeypatch,
+    scheduler_module,
+    *,
+    sessions: list[AsyncMock],
+    flag_values: list[bool],
+    compile_side_effect: object,
+    export_result: object | None = None,
+) -> tuple[AsyncMock, AsyncMock]:
+    session_iter = iter(sessions)
+
+    @asynccontextmanager
+    async def session_context():
+        yield next(session_iter)
+
+    monkeypatch.setattr(scheduler_module, "async_session", session_context)
+    monkeypatch.setattr(
+        "bot.db.repos.feature_flag.FeatureFlagRepo.get",
+        AsyncMock(side_effect=flag_values),
+    )
+    monkeypatch.setattr(scheduler_module, "_load_automation_actor_user_id", lambda: 42)
+    monkeypatch.setattr(scheduler_module, "_require_automation_actor", AsyncMock())
+    monkeypatch.setattr(
+        scheduler_module,
+        "load_gateway_config",
+        Mock(return_value=SimpleNamespace(provider="deepseek")),
+    )
+    monkeypatch.setattr(scheduler_module, "resolve_provider", Mock(return_value=object()))
+    compile_topics = AsyncMock(side_effect=compile_side_effect)
+    export = AsyncMock(return_value=export_result)
+    monkeypatch.setattr(
+        "bot.services.wiki_orchestrator.compile_changed_topics",
+        compile_topics,
+    )
+    monkeypatch.setattr("bot.services.wiki_orchestrator.export_static_wiki", export)
+    return compile_topics, export
+
+
 def test_memory_middlewares_are_registered_in_runtime_order() -> None:
     """DB must wrap raw, raw must wrap normalized, all before routers run."""
 
@@ -514,6 +552,170 @@ async def test_wiki_topics_commit_individually_and_provider_errors_are_sanitized
     sessions[2].commit.assert_not_awaited()
     assert "sentinel-secret" not in str(caught.value)
     assert "sentinel-secret" not in caplog.text
+
+
+async def test_wiki_response_contract_failure_retries_once_in_fresh_session(
+    monkeypatch,
+    tmp_path: Path,
+    caplog,
+) -> None:
+    scheduler_module = import_module("bot.services.scheduler")
+    gateway_module = import_module("bot.services.llm_gateway")
+    caplog.set_level("INFO", logger="bot.services.scheduler")
+    sessions = [AsyncMock(), AsyncMock(), AsyncMock(), AsyncMock()]
+    export_result = SimpleNamespace(
+        generation_dir=tmp_path / "generation",
+        manifest_sha256="c" * 64,
+        page_count=1,
+    )
+    compile_topics, export = _patch_wiki_compile_job(
+        monkeypatch,
+        scheduler_module,
+        sessions=sessions,
+        flag_values=[True, False, True, True, True, False],
+        compile_side_effect=[
+            gateway_module.WikiGatewayResponseContractError(
+                "sentinel-secret-provider-response",
+                llm_usage_ledger_id=101,
+                topic_slug="topic-a",
+            ),
+            SimpleNamespace(
+                topics_seen=1,
+                compiled_topics=1,
+                remaining_changed_topics=0,
+            ),
+        ],
+        export_result=export_result,
+    )
+    monkeypatch.setattr(
+        "bot.services.wiki_runtime.load_wiki_runtime_config",
+        Mock(
+            return_value=SimpleNamespace(
+                publish_dir=tmp_path / "current",
+                site_title="Shkoder Wiki",
+                forbidden_origins=("187.77.98.73",),
+            )
+        ),
+    )
+    publish = AsyncMock()
+    monkeypatch.setattr("bot.services.cloudflare_pages.publish_static_generation", publish)
+
+    await scheduler_module.wiki_automation_job()
+
+    assert compile_topics.await_count == 2
+    assert compile_topics.await_args_list[0].args[0] is sessions[1]
+    assert compile_topics.await_args_list[1].args[0] is sessions[2]
+    assert "target_topic_slug" not in compile_topics.await_args_list[0].kwargs
+    assert compile_topics.await_args_list[1].kwargs["target_topic_slug"] == "topic-a"
+    sessions[1].commit.assert_not_awaited()
+    sessions[2].commit.assert_awaited_once()
+    export.assert_awaited_once()
+    publish.assert_not_awaited()
+    assert "sentinel-secret" not in caplog.text
+    retry_record = next(
+        record
+        for record in caplog.records
+        if record.message == "wiki_automation_response_contract_retry"
+    )
+    assert (retry_record.attempt, retry_record.max_attempts, retry_record.failed_ledger_id) == (
+        1,
+        2,
+        101,
+    )
+    completed_record = next(
+        record for record in caplog.records if record.message == "wiki_automation_completed"
+    )
+    assert (completed_record.compile_attempts, completed_record.contract_retries) == (2, 1)
+
+
+async def test_wiki_response_contract_retry_exhaustion_is_sanitized_and_does_not_export(
+    monkeypatch,
+    caplog,
+) -> None:
+    scheduler_module = import_module("bot.services.scheduler")
+    gateway_module = import_module("bot.services.llm_gateway")
+    sessions = [AsyncMock(), AsyncMock(), AsyncMock()]
+    compile_topics, export = _patch_wiki_compile_job(
+        monkeypatch,
+        scheduler_module,
+        sessions=sessions,
+        flag_values=[True, False, True, True],
+        compile_side_effect=[
+            gateway_module.WikiGatewayResponseContractError(
+                "sentinel-secret-first",
+                llm_usage_ledger_id=201,
+                topic_slug="topic-a",
+            ),
+            gateway_module.WikiGatewayResponseContractError(
+                "sentinel-secret-second",
+                llm_usage_ledger_id=202,
+                topic_slug="topic-a",
+            ),
+        ],
+    )
+
+    with pytest.raises(
+        scheduler_module.WikiAutomationJobError,
+        match="wiki response contract attempts exhausted",
+    ) as caught:
+        await scheduler_module.wiki_automation_job()
+
+    assert compile_topics.await_count == 2
+    assert compile_topics.await_args_list[1].kwargs["target_topic_slug"] == "topic-a"
+    export.assert_not_awaited()
+    assert "sentinel-secret" not in str(caught.value)
+    assert "sentinel-secret" not in caplog.text
+    exhausted_record = next(
+        record
+        for record in caplog.records
+        if record.message == "wiki_automation_response_contract_exhausted"
+    )
+    assert (
+        exhausted_record.attempt,
+        exhausted_record.max_attempts,
+        exhausted_record.failed_ledger_id,
+    ) == (2, 2, 202)
+
+
+@pytest.mark.parametrize(
+    "error_name",
+    [
+        "WikiGatewayContractError",
+        "WikiGatewayProviderError",
+        "WikiGatewaySourceStaleError",
+        "WikiGatewayBudgetExceeded",
+        "RuntimeError",
+    ],
+)
+async def test_wiki_non_response_contract_errors_are_not_retried(
+    monkeypatch,
+    error_name: str,
+) -> None:
+    scheduler_module = import_module("bot.services.scheduler")
+    gateway_module = import_module("bot.services.llm_gateway")
+    sessions = [AsyncMock(), AsyncMock()]
+
+    error_cls = (
+        RuntimeError if error_name == "RuntimeError" else getattr(gateway_module, error_name)
+    )
+    error = (
+        error_cls("sentinel-secret", llm_usage_ledger_id=301)
+        if error_name != "RuntimeError"
+        else error_cls("sentinel-secret")
+    )
+    compile_topics, export = _patch_wiki_compile_job(
+        monkeypatch,
+        scheduler_module,
+        sessions=sessions,
+        flag_values=[True, False, True],
+        compile_side_effect=error,
+    )
+
+    with pytest.raises(scheduler_module.WikiAutomationJobError):
+        await scheduler_module.wiki_automation_job()
+
+    compile_topics.assert_awaited_once()
+    export.assert_not_awaited()
 
 
 def test_wiki_automation_is_registered_for_0930_moscow(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- keep every delivered raw update while excluding only Shkoder own bot ID from normalized memory
- preserve other bot-authored messages as memory sources and fail fast when runtime bot context is missing
- retry strict wiki response-contract failures once, in a fresh session, pinned to the same topic slug
- keep provider, source, budget, usage, and protocol failures fail-fast

## Verification
- 144 focused/import/raw/regression tests passed during implementation
- independent review found no remaining P0-P3 issues after same-topic pinning
- root rerun: 134 focused tests passed
- Ruff check/format, compileall, and git diff check passed

## Deployment
Bot image only. No migration, environment, or web deployment change.