### PR TITLE
fix: isolate static publisher workspace

### DIFF
--- a/bot/services/cloudflare_pages.py
+++ b/bot/services/cloudflare_pages.py
@@ -12,12 +12,14 @@ import hashlib
 import ipaddress
 import os
 import re
+import shutil
 import subprocess
 import uuid
 from collections.abc import Awaitable, Callable, Iterable, Mapping
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 from pathlib import Path
+from tempfile import TemporaryDirectory
 from typing import Literal, Protocol, TypeAlias
 from urllib.parse import urlsplit
 
@@ -202,8 +204,9 @@ async def publish_static_generation(
 
     A session-level advisory lock serializes deployments to the same project and
     branch.  Historical success is only an optimization hint: the current live
-    generation marker must still match before an upload can be skipped.  The tree
-    audit is the final operation before spawning the pinned Wrangler process.
+    generation marker must still match before an upload can be skipped.  Both
+    canonical and disposable deploy trees are audited before spawning Wrangler;
+    the disposable tree is audited again before smoke verification.
     """
 
     if not _MANIFEST_RE.fullmatch(expected_manifest_sha256):
@@ -211,6 +214,7 @@ async def publish_static_generation(
     resolved_config = config or load_cloudflare_pages_config()
     resolved_engine = db_engine or _default_engine()
     resolved_smoke_check = smoke_check or _public_smoke_check
+    resolved_forbidden_origins = tuple(forbidden_origins)
     identity = {
         "manifest_sha256": expected_manifest_sha256,
         "project": resolved_config.project,
@@ -239,7 +243,7 @@ async def publish_static_generation(
             try:
                 actual_manifest_sha256 = audit_static_tree(
                     resolved_generation,
-                    forbidden_origins=forbidden_origins,
+                    forbidden_origins=resolved_forbidden_origins,
                 )
             except (StaticExportError, OSError) as exc:
                 audit_id = await _begin_attempt(connection, identity)
@@ -274,6 +278,7 @@ async def publish_static_generation(
 
             audit_id = await _begin_attempt(connection, identity)
             process: _Process | None = None
+            wrangler_workdir: TemporaryDirectory[str] | None = None
             try:
                 try:
                     _validate_pinned_runtime()
@@ -286,12 +291,26 @@ async def publish_static_generation(
                     )
                     raise CloudflarePagesPublishError("runtime_missing", audit_id) from None
 
+                await _audit_attempt_tree(
+                    connection,
+                    audit_id=audit_id,
+                    root=resolved_generation,
+                    expected_manifest_sha256=expected_manifest_sha256,
+                    forbidden_origins=resolved_forbidden_origins,
+                )
+
                 try:
-                    actual_manifest_sha256 = audit_static_tree(
-                        resolved_generation,
-                        forbidden_origins=forbidden_origins,
+                    wrangler_workdir = TemporaryDirectory(
+                        prefix=".wrangler-",
+                        dir=resolved_generation.parent,
                     )
-                except (StaticExportError, OSError) as exc:
+                    wrangler_cwd = Path(wrangler_workdir.name).resolve(strict=True)
+                    deploy_copy = shutil.copytree(
+                        resolved_generation,
+                        wrangler_cwd / "site",
+                        symlinks=True,
+                    )
+                except OSError as exc:
                     await _mark_failed(
                         connection,
                         audit_id=audit_id,
@@ -299,14 +318,14 @@ async def publish_static_generation(
                         error_class=_safe_error_class(exc),
                     )
                     raise CloudflarePagesPublishError("static_audit_failed", audit_id) from None
-                if actual_manifest_sha256 != expected_manifest_sha256:
-                    await _mark_failed(
-                        connection,
-                        audit_id=audit_id,
-                        error_code="static_manifest_mismatch",
-                        error_class="StaticManifestMismatch",
-                    )
-                    raise CloudflarePagesPublishError("static_manifest_mismatch", audit_id)
+
+                await _audit_attempt_tree(
+                    connection,
+                    audit_id=audit_id,
+                    root=deploy_copy,
+                    expected_manifest_sha256=expected_manifest_sha256,
+                    forbidden_origins=resolved_forbidden_origins,
+                )
 
                 try:
                     process = await process_exec(
@@ -314,11 +333,11 @@ async def publish_static_generation(
                         str(_WRANGLER_SCRIPT),
                         "pages",
                         "deploy",
-                        ".",
+                        str(deploy_copy),
                         f"--project-name={resolved_config.project}",
                         f"--branch={resolved_config.branch}",
                         "--no-bundle",
-                        cwd=resolved_generation,
+                        cwd=wrangler_cwd,
                         env={
                             "CLOUDFLARE_API_TOKEN": resolved_config.api_token,
                             "CLOUDFLARE_ACCOUNT_ID": resolved_config.account_id,
@@ -362,6 +381,14 @@ async def publish_static_generation(
                         error_class="ProcessExitNonZero",
                     )
                     raise CloudflarePagesPublishError("process_exit_nonzero", audit_id)
+
+                await _audit_attempt_tree(
+                    connection,
+                    audit_id=audit_id,
+                    root=deploy_copy,
+                    expected_manifest_sha256=expected_manifest_sha256,
+                    forbidden_origins=resolved_forbidden_origins,
+                )
 
                 try:
                     smoke_passed = await asyncio.wait_for(
@@ -412,12 +439,46 @@ async def publish_static_generation(
                 )
                 await asyncio.shield(cleanup_task)
                 raise
+            finally:
+                if wrangler_workdir is not None:
+                    wrangler_workdir.cleanup()
 
 
 def _default_engine() -> AsyncEngine:
     from bot.db.engine import engine
 
     return engine
+
+
+async def _audit_attempt_tree(
+    connection: AsyncConnection,
+    *,
+    audit_id: int,
+    root: Path,
+    expected_manifest_sha256: str,
+    forbidden_origins: Iterable[str],
+) -> None:
+    try:
+        actual_manifest_sha256 = audit_static_tree(
+            root,
+            forbidden_origins=forbidden_origins,
+        )
+    except (StaticExportError, OSError) as exc:
+        await _mark_failed(
+            connection,
+            audit_id=audit_id,
+            error_code="static_audit_failed",
+            error_class=_safe_error_class(exc),
+        )
+        raise CloudflarePagesPublishError("static_audit_failed", audit_id) from None
+    if actual_manifest_sha256 != expected_manifest_sha256:
+        await _mark_failed(
+            connection,
+            audit_id=audit_id,
+            error_code="static_manifest_mismatch",
+            error_class="StaticManifestMismatch",
+        )
+        raise CloudflarePagesPublishError("static_manifest_mismatch", audit_id)
 
 
 def _require_nonempty_secret(value: str, *, name: str) -> None:

--- a/tests/services/test_cloudflare_pages.py
+++ b/tests/services/test_cloudflare_pages.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import shutil
 import subprocess
 import uuid
 from collections.abc import AsyncIterator
@@ -28,7 +29,7 @@ from bot.services.cloudflare_pages import (
     load_cloudflare_pages_config,
     publish_static_generation,
 )
-from bot.services.wiki_static_export import StaticWikiPage, export_static_site
+from bot.services.wiki_static_export import StaticWikiPage, audit_static_tree, export_static_site
 from tests.conftest import DEFAULT_LOCAL_POSTGRES_URL
 
 
@@ -192,6 +193,13 @@ def _static_generation(
         site_title=site_title,
         publication_authorized=True,
     )
+
+
+def _tree_snapshot(root: Path) -> dict[str, bytes | None]:
+    return {
+        path.relative_to(root).as_posix(): None if path.is_dir() else path.read_bytes()
+        for path in root.rglob("*")
+    }
 
 
 class _FakeProcess:
@@ -409,7 +417,7 @@ async def test_process_failure_is_durable_and_never_captures_output(
     assert kwargs["stdout"] is subprocess.DEVNULL
     assert kwargs["stderr"] is subprocess.DEVNULL
     assert kwargs["shell"] is False
-    assert kwargs["cwd"] == generation.generation_dir
+    assert kwargs["cwd"] != generation.generation_dir
     assert kwargs["env"] == {
         "CLOUDFLARE_API_TOKEN": config.api_token,
         "CLOUDFLARE_ACCOUNT_ID": config.account_id,
@@ -420,6 +428,131 @@ async def test_process_failure_is_durable_and_never_captures_output(
     assert rows[0]["status"] == "failed"
     assert rows[0]["error_code"] == "process_exit_nonzero"
     assert "secret" not in repr(rows[0]).lower()
+
+
+async def test_wrangler_workdir_cannot_mutate_immutable_generation(
+    tmp_path: Path,
+    publisher_engine: AsyncEngine,
+    clean_audit_rows: None,
+    pinned_runtime: tuple[Path, Path],
+    config: CloudflarePagesConfig,
+) -> None:
+    generation = _static_generation(tmp_path)
+    resolved_generation = generation.generation_dir.resolve()
+    canonical_before = _tree_snapshot(resolved_generation)
+    process_calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
+
+    async def wrangler_writes_cache(*args: object, **kwargs: object) -> _FakeProcess:
+        process_calls.append((args, kwargs))
+        cache_path = Path(kwargs["cwd"]) / ".wrangler" / "cache" / "pages.json"
+        cache_path.parent.mkdir(parents=True)
+        cache_path.write_text("{}\n", encoding="utf-8")
+        deploy_index = Path(args[4]) / "index.html"
+        deploy_index.write_bytes(deploy_index.read_bytes())
+        return _FakeProcess(returncode=0)
+
+    first = await publish_static_generation(
+        generation.generation_dir,
+        expected_manifest_sha256=generation.manifest_sha256,
+        config=config,
+        db_engine=publisher_engine,
+        process_exec=wrangler_writes_cache,
+        smoke_check=_smoke_ok,
+    )
+    second = await publish_static_generation(
+        generation.generation_dir,
+        expected_manifest_sha256=generation.manifest_sha256,
+        config=config,
+        db_engine=publisher_engine,
+        process_exec=wrangler_writes_cache,
+        smoke_check=_smoke_ok,
+    )
+
+    assert (first.status, second.status) == ("succeeded", "skipped")
+    assert len(process_calls) == 1
+    args, kwargs = process_calls[0]
+    deploy_copy = Path(args[4])
+    wrangler_workdir = Path(kwargs["cwd"])
+    assert deploy_copy.is_absolute()
+    assert deploy_copy != resolved_generation
+    assert str(resolved_generation) not in {str(arg) for arg in args}
+    assert wrangler_workdir.is_absolute()
+    assert deploy_copy.parent == wrangler_workdir
+    assert not wrangler_workdir.is_relative_to(resolved_generation)
+    assert not wrangler_workdir.exists()
+    assert not deploy_copy.exists()
+    assert not (resolved_generation / ".wrangler").exists()
+    assert _tree_snapshot(resolved_generation) == canonical_before
+    assert audit_static_tree(resolved_generation) == generation.manifest_sha256
+
+
+@pytest.mark.parametrize(
+    ("mutation", "expected_error", "expected_class"),
+    [
+        ("content", "static_audit_failed", "StaticExportSecurityError"),
+        ("extra-file", "static_audit_failed", "StaticExportSecurityError"),
+        ("valid-other-tree", "static_manifest_mismatch", "StaticManifestMismatch"),
+    ],
+)
+async def test_wrangler_target_mutation_fails_before_smoke_or_success(
+    tmp_path: Path,
+    publisher_engine: AsyncEngine,
+    clean_audit_rows: None,
+    pinned_runtime: tuple[Path, Path],
+    config: CloudflarePagesConfig,
+    mutation: str,
+    expected_error: str,
+    expected_class: str,
+) -> None:
+    generation = _static_generation(tmp_path)
+    other_generation = _static_generation(tmp_path / "other", site_title="Другая Wiki")
+    assert other_generation.manifest_sha256 != generation.manifest_sha256
+    resolved_generation = generation.generation_dir.resolve()
+    canonical_before = _tree_snapshot(resolved_generation)
+    temp_paths: list[Path] = []
+    smoke_calls = 0
+
+    async def mutate_deploy_target(*args: object, **kwargs: object) -> _FakeProcess:
+        deploy_copy = Path(args[4])
+        wrangler_workdir = Path(kwargs["cwd"])
+        temp_paths.extend((wrangler_workdir, deploy_copy))
+        cache_path = wrangler_workdir / ".wrangler" / "cache" / "pages.json"
+        cache_path.parent.mkdir(parents=True)
+        cache_path.write_text("{}\n", encoding="utf-8")
+        if mutation == "content":
+            target = deploy_copy / "index.html"
+            target.write_bytes(target.read_bytes() + b"\n")
+        elif mutation == "extra-file":
+            (deploy_copy / "unexpected.txt").write_text("mutated\n", encoding="utf-8")
+        else:
+            shutil.rmtree(deploy_copy)
+            shutil.copytree(other_generation.generation_dir, deploy_copy)
+        return _FakeProcess(returncode=0)
+
+    async def track_smoke(_url: str, _expected_payload: bytes) -> bool:
+        nonlocal smoke_calls
+        smoke_calls += 1
+        return True
+
+    with pytest.raises(CloudflarePagesPublishError) as raised:
+        await publish_static_generation(
+            generation.generation_dir,
+            expected_manifest_sha256=generation.manifest_sha256,
+            config=config,
+            db_engine=publisher_engine,
+            process_exec=mutate_deploy_target,
+            smoke_check=track_smoke,
+        )
+
+    assert raised.value.error_code == expected_error
+    assert smoke_calls == 0
+    assert all(not path.exists() for path in temp_paths)
+    assert _tree_snapshot(resolved_generation) == canonical_before
+    assert audit_static_tree(resolved_generation) == generation.manifest_sha256
+    rows = await _fetch_rows(publisher_engine)
+    assert [(row["status"], row["error_code"], row["error_class"]) for row in rows] == [
+        ("failed", expected_error, expected_class)
+    ]
 
 
 async def test_process_timeout_kills_once_without_retry(


### PR DESCRIPTION
## What changed

- Runs the pinned Wrangler process from a unique disposable workspace.
- Copies the audited canonical static generation into a disposable deploy tree; the canonical tree is never passed to Wrangler.
- Audits the deploy copy before process start and again after a zero exit code, before public smoke verification or durable success.
- Removes the complete temporary workspace on success, failure, timeout, and cancellation.

## Root cause

Wrangler previously ran with the canonical generation as its working directory. It created `.wrangler/cache/pages.json` there, so the next fail-closed static audit correctly rejected the formerly valid generation.

## Impact

Repeated publication is idempotent. Wrangler cache/state cannot mutate the canonical generation, and target mutations cannot be recorded as a successful deployment.

## Validation

- RED: canonical target exposure and a target mutation incorrectly reached success.
- GREEN: 64/64 independent reviewer static/publisher tests passed; local broader relevant suite 77/77 passed.
- Content mutation, extra file, and replacement with another valid tree all fail before smoke with durable typed audit rows.
- Cancellation/failure paths leave no `.wrangler-*` workspaces.
- Ruff, format, compileall, and `git show --check` passed.
- Independent review: no P0-P2 findings after amendment.
