### PR TITLE
fix: harden conversational QA guardrails

### DIFF
--- a/bot/db/repos/llm_synthesis_cache.py
+++ b/bot/db/repos/llm_synthesis_cache.py
@@ -85,6 +85,23 @@ class SynthesisCacheRepo:
         _log.debug("llm_synthesis_cache: bumped hit_count for id=%s", cache_id)
 
     @staticmethod
+    async def delete_by_id(
+        session: AsyncSession,
+        *,
+        cache_id: int,
+    ) -> int:
+        """Delete one exact cache row and return the affected-row count."""
+
+        result = await session.execute(
+            delete(LlmSynthesisCache).where(LlmSynthesisCache.id == cache_id)
+        )
+        rowcount = int(result.rowcount or 0)
+        if rowcount:
+            await session.flush()
+        _log.debug("llm_synthesis_cache: deleted unsafe row id=%s", cache_id)
+        return rowcount
+
+    @staticmethod
     async def invalidate_by_citation(
         session: AsyncSession,
         *,
@@ -129,9 +146,7 @@ class SynthesisCacheRepo:
                 if message_version_id in (citation_ids or [])
             ]
             if matching_ids:
-                del_stmt = delete(LlmSynthesisCache).where(
-                    LlmSynthesisCache.id.in_(matching_ids)
-                )
+                del_stmt = delete(LlmSynthesisCache).where(LlmSynthesisCache.id.in_(matching_ids))
                 del_result = await session.execute(del_stmt)
                 rowcount = del_result.rowcount
             else:

--- a/bot/handlers/qa.py
+++ b/bot/handlers/qa.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import html
 import logging
-from dataclasses import replace
 from datetime import datetime
 from typing import Any
 
@@ -34,8 +33,11 @@ from bot.services.message_persistence import persist_message_with_policy
 from bot.services.qa import run_qa
 from bot.services.qa_guardrails import (
     MAX_AI_ANSWER_CHARS,
+    SENSITIVE_QA_REFUSAL,
+    SENSITIVE_QA_TRACE_MARKER,
     acquire_daily_llm_question_slot,
     build_guarded_llm_query,
+    contains_secret_like_data,
     limit_answer_text,
 )
 from bot.services.qa_trigger import ShkoderQuestionFilter, TriggeredQuestion
@@ -255,7 +257,7 @@ def _escaped_text_with_budget(value: str, max_chars: int) -> str:
     return "…" if max_chars >= 1 else ""
 
 
-def _compact_author(user: object | None) -> str:
+def _compact_author_value(user: object | None) -> str:
     if user is None:
         return "—"
     first_name = getattr(user, "first_name", None)
@@ -265,19 +267,35 @@ def _compact_author(user: object | None) -> str:
         raw = str(first_name)
         if last_name:
             raw = f"{raw} {last_name}"
+        return raw
     elif username:
-        raw = f"@{username}"
-    else:
-        raw = "—"
-    return _escaped_text_with_budget(raw, 40)
+        return f"@{username}"
+    return "—"
+
+
+def _compact_author(user: object | None) -> str:
+    return _escaped_text_with_budget(_compact_author_value(user), 40)
 
 
 def _format_bounded_mention_response(
-    answer: AnswerWithCitations,
+    answer_text: str,
     bundle: EvidenceBundle,
     users_by_id: dict[int, object],
+    *,
+    sources_heading: str = "Источники:",
 ) -> str:
     """Render the entire mention answer, including sources, within 1200 chars."""
+
+    if contains_secret_like_data(answer_text) or any(
+        contains_secret_like_data(item.snippet)
+        or contains_secret_like_data(
+            _compact_author_value(
+                users_by_id.get(item.user_id) if item.user_id is not None else None
+            )
+        )
+        for item in bundle.items[:QA_EVIDENCE_LIMIT]
+    ):
+        return SENSITIVE_QA_REFUSAL
 
     source_lines: list[str] = []
     for idx, item in enumerate(bundle.items[:QA_EVIDENCE_LIMIT], start=1):
@@ -288,8 +306,11 @@ def _format_bounded_mention_response(
         snippet = _escaped_text_with_budget(item.snippet, 120)
         source_lines.append(f"[{idx}] {date_text} — {author}: {snippet}")
 
-    footer = "\n\n<b>Источники:</b>\n" + "\n".join(source_lines)
-    answer_budget = MAX_AI_ANSWER_CHARS - len(footer)
+    # ponytail: a fixed three-source footer avoids an HTML-aware truncator;
+    # add one only if Telegram formatting grows beyond this known-safe shape.
+    footer = f"<b>{html.escape(sources_heading)}</b>\n" + "\n".join(source_lines)
+    separator = "\n\n" if answer_text else ""
+    answer_budget = MAX_AI_ANSWER_CHARS - len(separator) - len(footer)
     if answer_budget < 1:
         # Defensive fallback for future footer changes.  Evidence identifiers
         # remain visible while untrusted snippets are omitted.
@@ -300,14 +321,27 @@ def _format_bounded_mention_response(
                 start=1,
             )
         ]
-        footer = "\n\n<b>Источники:</b>\n" + "\n".join(source_lines)
-        answer_budget = MAX_AI_ANSWER_CHARS - len(footer)
+        footer = f"<b>{html.escape(sources_heading)}</b>\n" + "\n".join(source_lines)
+        answer_budget = MAX_AI_ANSWER_CHARS - len(separator) - len(footer)
 
-    answer_text = _escaped_text_with_budget(answer.answer_text, answer_budget)
-    rendered = f"{answer_text}{footer}"
+    if answer_budget < 0:
+        raise ValueError("mention source footer exceeds configured limit")
+    bounded_answer = _escaped_text_with_budget(answer_text, answer_budget)
+    rendered = f"{bounded_answer}{separator}{footer}"
     if len(rendered) > MAX_AI_ANSWER_CHARS:
         raise ValueError("bounded mention response exceeds configured limit")
     return rendered
+
+
+async def _reply_to_mention(message: Message, text: str, **kwargs: Any) -> None:
+    """Apply the final secret/size fence shared by every mention reply."""
+
+    reply_text = text
+    if contains_secret_like_data(text) or contains_secret_like_data(html.unescape(text)):
+        reply_text = SENSITIVE_QA_REFUSAL
+    if len(reply_text) > MAX_AI_ANSWER_CHARS:
+        raise ValueError("mention reply exceeds configured limit")
+    await message.reply(reply_text, **kwargs)
 
 
 def _format_synth_card_footer(idx: int, item: EvidenceItem) -> str:
@@ -341,6 +375,25 @@ async def _write_trace(
         evidence_ids=evidence_ids,
         abstained=abstained,
         redact_query=redact_query,
+        source_chat_message_id=source_chat_message_id,
+    )
+
+
+async def _write_sensitive_trace(
+    session: AsyncSession,
+    *,
+    user_tg_id: int,
+    chat_id: int,
+    source_chat_message_id: int,
+) -> None:
+    await _write_trace(
+        session,
+        user_tg_id=user_tg_id,
+        chat_id=chat_id,
+        query=SENSITIVE_QA_TRACE_MARKER,
+        evidence_ids=[],
+        abstained=True,
+        redact_query=True,
         source_chat_message_id=source_chat_message_id,
     )
 
@@ -613,30 +666,52 @@ async def mention_question_handler(
 
     user = await UserRepo.get(session, sender.id)
     if user is None or not (user.is_member or user.is_admin):
-        await message.reply("Доступ только участникам сообщества.")
+        await _reply_to_mention(message, "Доступ только участникам сообщества.")
         return
 
     existing_trace = await QaTraceRepo.get_by_source_chat_message_id(
         session,
         persisted.chat_message.id,
     )
+    query = qa_question.query
+    query_redacted = False
+    raw_content = message.text if isinstance(message.text, str) else message.caption
+    if contains_secret_like_data(query) or (
+        isinstance(raw_content, str) and contains_secret_like_data(raw_content)
+    ):
+        await _reply_to_mention(message, SENSITIVE_QA_REFUSAL)
+        if existing_trace is None:
+            await _write_sensitive_trace(
+                session,
+                user_tg_id=sender.id,
+                chat_id=message.chat.id,
+                source_chat_message_id=persisted.chat_message.id,
+            )
+        return
     if existing_trace is not None:
         if existing_trace.llm_response_summary:
-            previous = _escaped_text_with_budget(
-                existing_trace.llm_response_summary,
-                MAX_AI_ANSWER_CHARS - 32,
-            )
-            await message.reply(
-                f"Уже отвечал на этот вопрос:\n\n{previous}",
-                parse_mode="HTML",
-            )
+            if contains_secret_like_data(existing_trace.llm_response_summary):
+                await _reply_to_mention(message, SENSITIVE_QA_REFUSAL)
+            else:
+                prefix = "Уже отвечал на этот вопрос:\n\n"
+                previous = _escaped_text_with_budget(
+                    existing_trace.llm_response_summary,
+                    MAX_AI_ANSWER_CHARS - len(prefix),
+                )
+                await _reply_to_mention(
+                    message,
+                    f"{prefix}{previous}",
+                    parse_mode="HTML",
+                )
         else:
-            await message.reply("Этот вопрос уже обработан.")
+            await _reply_to_mention(message, "Этот вопрос уже обработан.")
         return
 
-    query = qa_question.query
     if not query:
-        await message.reply("Напиши вопрос после упоминания Шкодера или в ответе ему.")
+        await _reply_to_mention(
+            message,
+            "Напиши вопрос после упоминания Шкодера или в ответе ему.",
+        )
         await _write_trace(
             session,
             user_tg_id=sender.id,
@@ -644,7 +719,7 @@ async def mention_question_handler(
             query="",
             evidence_ids=[],
             abstained=True,
-            redact_query=False,
+            redact_query=query_redacted,
             source_chat_message_id=persisted.chat_message.id,
         )
         return
@@ -652,7 +727,7 @@ async def mention_question_handler(
     # Conversational questions are AI-only.  The deterministic search service
     # remains an internal retrieval layer and is not exposed as a command.
     if not await FeatureFlagRepo.get(session, LLM_SYNTHESIS_FEATURE_FLAG):
-        await message.reply("AI-поиск по памяти сейчас недоступен.")
+        await _reply_to_mention(message, "AI-поиск по памяти сейчас недоступен.")
         await _write_trace(
             session,
             user_tg_id=sender.id,
@@ -660,7 +735,7 @@ async def mention_question_handler(
             query=query,
             evidence_ids=[],
             abstained=True,
-            redact_query=False,
+            redact_query=query_redacted,
             source_chat_message_id=persisted.chat_message.id,
         )
         return
@@ -669,11 +744,23 @@ async def mention_question_handler(
         session,
         query=query,
         chat_id=message.chat.id,
-        redact_query_in_audit=False,
+        redact_query_in_audit=query_redacted,
         limit=QA_EVIDENCE_LIMIT,
     )
+    if any(contains_secret_like_data(item.snippet) for item in result.bundle.items):
+        await _reply_to_mention(message, SENSITIVE_QA_REFUSAL)
+        await _write_sensitive_trace(
+            session,
+            user_tg_id=sender.id,
+            chat_id=message.chat.id,
+            source_chat_message_id=persisted.chat_message.id,
+        )
+        return
     if result.bundle.abstained or not result.bundle.evidence_ids:
-        await message.reply("Не нашёл достаточно подтверждений в памяти сообщества.")
+        await _reply_to_mention(
+            message,
+            "Не нашёл достаточно подтверждений в памяти сообщества.",
+        )
         await _write_trace(
             session,
             user_tg_id=sender.id,
@@ -681,28 +768,47 @@ async def mention_question_handler(
             query=query,
             evidence_ids=[],
             abstained=True,
-            redact_query=False,
+            redact_query=query_redacted,
             source_chat_message_id=persisted.chat_message.id,
         )
         return
 
     users_by_id: dict[int, object] = {}
+    sensitive_author = False
     for item in result.bundle.items:
         if item.user_id is None or item.user_id in users_by_id:
             continue
         author = await UserRepo.get(session, item.user_id)
         if author is not None:
+            if contains_secret_like_data(_compact_author_value(author)):
+                sensitive_author = True
+                break
             users_by_id[item.user_id] = author
+
+    if sensitive_author:
+        await _reply_to_mention(message, SENSITIVE_QA_REFUSAL)
+        await _write_sensitive_trace(
+            session,
+            user_tg_id=sender.id,
+            chat_id=message.chat.id,
+            source_chat_message_id=persisted.chat_message.id,
+        )
+        return
 
     quota = await acquire_daily_llm_question_slot(
         session,
         user_tg_id=sender.id,
     )
     if not quota.allowed:
-        deterministic_answer = _format_response(result.bundle, users_by_id)
-        await message.reply(
-            f"Лимит — {quota.limit} AI-вопроса в день. "
-            f"Показываю обычный поиск без AI.\n\n{deterministic_answer}",
+        deterministic_answer = _format_bounded_mention_response(
+            f"Лимит — {quota.limit} AI-вопроса в день. Показываю обычный поиск без AI.",
+            result.bundle,
+            users_by_id,
+            sources_heading="Найденные свидетельства:",
+        )
+        await _reply_to_mention(
+            message,
+            deterministic_answer,
             parse_mode="HTML",
             disable_web_page_preview=True,
         )
@@ -713,7 +819,7 @@ async def mention_question_handler(
             query=query,
             evidence_ids=result.bundle.evidence_ids,
             abstained=False,
-            redact_query=False,
+            redact_query=query_redacted,
             source_chat_message_id=persisted.chat_message.id,
         )
         return
@@ -726,7 +832,7 @@ async def mention_question_handler(
         query=query,
         evidence_ids=result.bundle.evidence_ids,
         abstained=False,
-        redact_query=False,
+        redact_query=query_redacted,
         source_chat_message_id=persisted.chat_message.id,
     )
     try:
@@ -752,43 +858,75 @@ async def mention_question_handler(
             extra={"qa_trace_id": trace.id, "chat_id": message.chat.id},
         )
         await session.commit()
-        await message.reply(
-            _format_response(result.bundle, users_by_id),
+        await _reply_to_mention(
+            message,
+            _format_bounded_mention_response(
+                "",
+                result.bundle,
+                users_by_id,
+                sources_heading="Найденные свидетельства:",
+            ),
             parse_mode="HTML",
             disable_web_page_preview=True,
         )
         return
 
-    if isinstance(synth_result, AnswerWithCitations):
-        bounded_answer = limit_answer_text(synth_result.answer_text)
-        if bounded_answer:
-            bounded_result = replace(synth_result, answer_text=bounded_answer)
-            reply_text = _format_bounded_mention_response(
-                bounded_result,
-                result.bundle,
-                users_by_id,
-            )
-            response_summary: str | None = bounded_answer
-        else:
-            reply_text = _format_response(result.bundle, users_by_id)
-            response_summary = None
-    else:
-        reply_text = _format_response(result.bundle, users_by_id)
+    sensitive_gateway_refusal = not isinstance(
+        synth_result, AnswerWithCitations
+    ) and synth_result.reason in {"sensitive_input", "sensitive_output"}
+    if sensitive_gateway_refusal:
+        reply_text = SENSITIVE_QA_REFUSAL
         response_summary = None
+        response_redacted = True
+    elif isinstance(synth_result, AnswerWithCitations):
+        try:
+            bounded_answer = limit_answer_text(synth_result.answer_text)
+        except ValueError:
+            reply_text = SENSITIVE_QA_REFUSAL
+            response_summary = None
+            response_redacted = True
+        else:
+            if bounded_answer:
+                reply_text = _format_bounded_mention_response(
+                    bounded_answer,
+                    result.bundle,
+                    users_by_id,
+                )
+                response_summary = bounded_answer
+                response_redacted = bounded_answer != synth_result.answer_text
+            else:
+                reply_text = _format_bounded_mention_response(
+                    "",
+                    result.bundle,
+                    users_by_id,
+                    sources_heading="Найденные свидетельства:",
+                )
+                response_summary = None
+                response_redacted = bool(synth_result.answer_text)
+    else:
+        reply_text = _format_bounded_mention_response(
+            "",
+            result.bundle,
+            users_by_id,
+            sources_heading="Найденные свидетельства:",
+        )
+        response_summary = None
+        response_redacted = False
 
     await QaTraceRepo.update_llm_fields(
         session,
         qa_trace_id=trace.id,
         llm_call_id=synth_result.llm_call_id,
         llm_response_summary=response_summary,
-        llm_response_redacted=False,
+        llm_response_redacted=response_redacted,
         cost_usd=synth_result.cost_usd,
     )
     # Provider usage, cache, trace, and the per-user quota ledger must survive
     # an outbound Telegram failure.  The middleware may roll back after a send
     # exception, so make the paid/audited transaction durable first.
     await session.commit()
-    await message.reply(
+    await _reply_to_mention(
+        message,
         reply_text,
         parse_mode="HTML",
         disable_web_page_preview=True,

--- a/bot/services/llm_gateway.py
+++ b/bot/services/llm_gateway.py
@@ -78,6 +78,7 @@ from bot.services.llm_providers import (
     ProviderStructuralError,
     ProviderTransientError,
 )
+from bot.services.qa_guardrails import contains_secret_like_data, limit_answer_text
 
 # Shared forget-event exclusion predicate — sourced from forget_predicate.py (#291).
 # Do NOT change this inline; update bot/services/forget_predicate.py instead.
@@ -95,6 +96,8 @@ AbstentionReason = Literal[
     "budget_exceeded",
     "provider_error",
     "forget_invalidated",
+    "sensitive_input",
+    "sensitive_output",
 ]
 
 
@@ -282,6 +285,8 @@ class SynthesisCacheRepoProtocol(Protocol):
 
     async def bump_hit(self, session: Any, *, cache_id: int) -> None: ...
 
+    async def delete_by_id(self, session: Any, *, cache_id: int) -> int: ...
+
     async def invalidate_by_citation(self, session: Any, *, message_version_id: int) -> int: ...
 
 
@@ -347,6 +352,30 @@ def _response_hash(answer_text: str) -> str:
     return hashlib.sha256(answer_text.encode("utf-8")).hexdigest()
 
 
+_SENSITIVE_INPUT_PROMPT_HASH = _prompt_hash("qa-sensitive-input-v1")
+_SAFE_QA_REQUEST_ID_RE = re.compile(r"[A-Za-z0-9._:-]{1,128}\Z")
+
+
+def _safe_qa_request_id(request_id: object) -> str | None:
+    if not isinstance(request_id, str):
+        return None
+    if _SAFE_QA_REQUEST_ID_RE.fullmatch(request_id) is None:
+        return None
+    if contains_secret_like_data(request_id):
+        return None
+    return request_id
+
+
+def _contains_sensitive_qa_output(answer_text: str) -> bool:
+    """Validate both raw and exact post-limit representations."""
+
+    try:
+        limit_answer_text(answer_text)
+    except ValueError:
+        return True
+    return False
+
+
 def _build_prompt(
     query_normalized: str,
     surviving_ids: tuple[int, ...] | list[int],
@@ -360,6 +389,9 @@ def _build_prompt(
     eligible, and at most three records leave the process.
     """
 
+    if contains_secret_like_data(query_normalized):
+        raise ValueError("sensitive Q&A input refused")
+
     surviving_set = set(surviving_ids)
     selected: list[EvidenceItem] = []
     seen: set[int] = set()
@@ -371,6 +403,9 @@ def _build_prompt(
         seen.add(evidence_id)
         if len(selected) == MAX_QA_EVIDENCE_ITEMS:
             break
+
+    if any(contains_secret_like_data(item.snippet) for item in selected):
+        raise ValueError("sensitive Q&A evidence refused")
 
     records = [
         json.dumps(
@@ -577,6 +612,34 @@ async def synthesize_answer(
             call_type="qa_synthesis",
         )
 
+    async def _reject_sensitive_cache(cached_row: Any, *, prompt_hash: str) -> Abstention:
+        await cache_repo.delete_by_id(session, cache_id=cached_row.id)
+        ledger_row = await _ledger(
+            error="sensitive_output",
+            cache_hit=True,
+            response_hash=None,
+            prompt_hash=prompt_hash,
+        )
+        return Abstention(
+            reason="sensitive_output",
+            cost_usd=Decimal("0"),
+            llm_call_id=ledger_row.id,
+        )
+
+    if contains_secret_like_data(query) or any(
+        contains_secret_like_data(item.snippet) for item in bundle.items
+    ):
+        row = await _ledger(
+            error="sensitive_input",
+            response_hash=None,
+            prompt_hash=_SENSITIVE_INPUT_PROMPT_HASH,
+        )
+        return Abstention(
+            reason="sensitive_input",
+            cost_usd=Decimal("0"),
+            llm_call_id=row.id,
+        )
+
     # Invariant 1 — empty bundle short-circuit.
     if not bundle.evidence_ids:
         # Empty bundle has no surviving set so we use an empty-prompt hash
@@ -658,15 +721,18 @@ async def synthesize_answer(
     )
     cached = await cache_repo.get_or_none(session, input_hash=cache_input_hash)
     if cached is not None:
+        if _contains_sensitive_qa_output(cached.answer_text):
+            return await _reject_sensitive_cache(cached, prompt_hash=prompt_hash)
+        cached_answer = cached.answer_text
         await cache_repo.bump_hit(session, cache_id=cached.id)
         row = await _ledger(
             error=None,
             cache_hit=True,
-            response_hash=_response_hash(cached.answer_text),
+            response_hash=_response_hash(cached_answer),
             prompt_hash=prompt_hash,
         )
         return AnswerWithCitations(
-            answer_text=cached.answer_text,
+            answer_text=cached_answer,
             citation_ids=tuple(cached.citation_ids),
             cost_usd=Decimal("0"),
             cache_hit=True,
@@ -712,15 +778,21 @@ async def synthesize_answer(
         # (a) re-check cache under the lock.
         cached_under_lock = await cache_repo.get_or_none(session, input_hash=cache_input_hash)
         if cached_under_lock is not None:
+            if _contains_sensitive_qa_output(cached_under_lock.answer_text):
+                return await _reject_sensitive_cache(
+                    cached_under_lock,
+                    prompt_hash=prompt_hash,
+                )
+            cached_answer = cached_under_lock.answer_text
             await cache_repo.bump_hit(session, cache_id=cached_under_lock.id)
             row = await _ledger(
                 error=None,
                 cache_hit=True,
-                response_hash=_response_hash(cached_under_lock.answer_text),
+                response_hash=_response_hash(cached_answer),
                 prompt_hash=prompt_hash,
             )
             return AnswerWithCitations(
-                answer_text=cached_under_lock.answer_text,
+                answer_text=cached_answer,
                 citation_ids=tuple(cached_under_lock.citation_ids),
                 cost_usd=Decimal("0"),
                 cache_hit=True,
@@ -764,6 +836,7 @@ async def synthesize_answer(
         provider_result = await provider.call(prompt=prompt, model=config.model)
     except ProviderTransientError as exc:
         latency = int((time.monotonic() - started) * 1000)
+        error_subtype = _safe_qa_provider_error_subtype(exc)
         await ledger_repo.update_placeholder(
             session,
             llm_call_id=placeholder_row.id,
@@ -773,13 +846,14 @@ async def synthesize_answer(
             tokens_out=0,
             request_id=None,
             latency_ms=latency,
-            error=f"provider_transient:{exc.subtype}",
+            error=f"provider_transient:{error_subtype}",
         )
         return Abstention(
             reason="provider_error",
             cost_usd=Decimal("0"),
             llm_call_id=placeholder_row.id,
         )
+
     except ProviderStructuralError as exc:
         error_subtype = _safe_qa_provider_error_subtype(exc)
         logger.error(
@@ -836,6 +910,32 @@ async def synthesize_answer(
             llm_call_id=placeholder_row.id,
         )
 
+    request_id = _safe_qa_request_id(provider_result.request_id)
+    answer_text = provider_result.answer_text
+    if _contains_sensitive_qa_output(answer_text):
+        latency = int((time.monotonic() - started) * 1000)
+        sensitive_output_cost = _estimate_cost(
+            config=config,
+            tokens_in=provider_result.tokens_in,
+            tokens_out=provider_result.tokens_out,
+        )
+        await ledger_repo.update_placeholder(
+            session,
+            llm_call_id=placeholder_row.id,
+            cost_usd=sensitive_output_cost,
+            response_hash=None,
+            tokens_in=provider_result.tokens_in,
+            tokens_out=provider_result.tokens_out,
+            request_id=request_id,
+            latency_ms=latency,
+            error="sensitive_output",
+        )
+        return Abstention(
+            reason="sensitive_output",
+            cost_usd=sensitive_output_cost,
+            llm_call_id=placeholder_row.id,
+        )
+
     # F5 — defensive abort when provider returns empty citation_ids while
     # bundle has surviving evidence. The real AnthropicProvider /
     # OpenAIProvider currently return ``tuple()`` unconditionally (T5-04
@@ -850,10 +950,10 @@ async def synthesize_answer(
             session,
             llm_call_id=placeholder_row.id,
             cost_usd=Decimal("0"),
-            response_hash=_response_hash(provider_result.answer_text),
+            response_hash=_response_hash(answer_text),
             tokens_in=provider_result.tokens_in,
             tokens_out=provider_result.tokens_out,
-            request_id=provider_result.request_id,
+            request_id=request_id,
             latency_ms=latency,
             error="provider_returned_no_citations",
         )
@@ -873,10 +973,10 @@ async def synthesize_answer(
             session,
             llm_call_id=placeholder_row.id,
             cost_usd=Decimal("0"),
-            response_hash=_response_hash(provider_result.answer_text),
+            response_hash=_response_hash(answer_text),
             tokens_in=provider_result.tokens_in,
             tokens_out=provider_result.tokens_out,
-            request_id=provider_result.request_id,
+            request_id=request_id,
             latency_ms=latency,
             error="citation_hallucination",
         )
@@ -902,13 +1002,17 @@ async def synthesize_answer(
     # validate the code shape via FakeCacheRepo's IntegrityError-on-duplicate
     # behaviour.
     try:
-        await cache_repo.store(
-            session,
-            input_hash=cache_input_hash,
-            answer_text=provider_result.answer_text,
-            citation_ids=list(provider_result.citation_ids),
-            model=config.model,
-        )
+        # Keep a UNIQUE-conflict rollback scoped to this SAVEPOINT. Without a
+        # nested transaction, PostgreSQL marks the caller's outer transaction
+        # failed and the race-recovery get/delete operations cannot run.
+        async with session.begin_nested():
+            await cache_repo.store(
+                session,
+                input_hash=cache_input_hash,
+                answer_text=answer_text,
+                citation_ids=list(provider_result.citation_ids),
+                model=config.model,
+            )
     except IntegrityError:
         # Another concurrent call beat us to STORE. Re-fetch and return that
         # row as the canonical answer; record this call's ledger row as a
@@ -917,19 +1021,38 @@ async def synthesize_answer(
         existing = await cache_repo.get_or_none(session, input_hash=cache_input_hash)
         if existing is not None:
             latency = int((time.monotonic() - started) * 1000)
+            if _contains_sensitive_qa_output(existing.answer_text):
+                await cache_repo.delete_by_id(session, cache_id=existing.id)
+                await ledger_repo.update_placeholder(
+                    session,
+                    llm_call_id=placeholder_row.id,
+                    cost_usd=cost_usd,
+                    response_hash=None,
+                    tokens_in=provider_result.tokens_in,
+                    tokens_out=provider_result.tokens_out,
+                    request_id=request_id,
+                    latency_ms=latency,
+                    error="sensitive_output",
+                )
+                return Abstention(
+                    reason="sensitive_output",
+                    cost_usd=cost_usd,
+                    llm_call_id=placeholder_row.id,
+                )
+            existing_answer = existing.answer_text
             await ledger_repo.update_placeholder(
                 session,
                 llm_call_id=placeholder_row.id,
                 cost_usd=cost_usd,
-                response_hash=_response_hash(existing.answer_text),
+                response_hash=_response_hash(existing_answer),
                 tokens_in=provider_result.tokens_in,
                 tokens_out=provider_result.tokens_out,
-                request_id=provider_result.request_id,
+                request_id=request_id,
                 latency_ms=latency,
                 error="cache_store_race_loser",
             )
             return AnswerWithCitations(
-                answer_text=existing.answer_text,
+                answer_text=existing_answer,
                 citation_ids=tuple(existing.citation_ids),
                 cost_usd=cost_usd,
                 cache_hit=False,  # provider was called; we just lost the store race
@@ -949,7 +1072,7 @@ async def synthesize_answer(
             response_hash=None,
             tokens_in=provider_result.tokens_in,
             tokens_out=provider_result.tokens_out,
-            request_id=provider_result.request_id,
+            request_id=request_id,
             latency_ms=latency,
             error="cache_store_race_winner_invalidated",
         )
@@ -968,15 +1091,15 @@ async def synthesize_answer(
         session,
         llm_call_id=placeholder_row.id,
         cost_usd=cost_usd,
-        response_hash=_response_hash(provider_result.answer_text),
+        response_hash=_response_hash(answer_text),
         tokens_in=provider_result.tokens_in,
         tokens_out=provider_result.tokens_out,
-        request_id=provider_result.request_id,
+        request_id=request_id,
         latency_ms=latency,
         error=None,
     )
     return AnswerWithCitations(
-        answer_text=provider_result.answer_text,
+        answer_text=answer_text,
         citation_ids=provider_result.citation_ids,
         cost_usd=cost_usd,
         cache_hit=False,

--- a/bot/services/qa_guardrails.py
+++ b/bot/services/qa_guardrails.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import hashlib
+import html
 import re
 import unicodedata
+from collections.abc import Iterator
 from dataclasses import dataclass
 from datetime import datetime, time, timedelta, timezone
 from zoneinfo import ZoneInfo
@@ -30,7 +32,27 @@ _LLM_GUARD_PREFIX = (
 )
 
 _CONTROL_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
+_DETECTOR_CONTROL_RE = re.compile(r"[\x00-\x1f\x7f]")
 _EXCESS_BLANK_LINES_RE = re.compile(r"\n{3,}")
+_TRUSTED_HEADLINE_TAG_RE = re.compile(r"</?b>", flags=re.IGNORECASE)
+SENSITIVE_QA_REFUSAL = "Не могу обработать этот запрос: в нём есть данные, похожие на секрет."
+SENSITIVE_QA_TRACE_MARKER = "[SENSITIVE_INPUT_BLOCKED]"
+
+_DIRECT_SECRET_RE = re.compile(
+    r"(?:"
+    r"sk-[A-Za-z0-9_-]{16,}"
+    r"|cfat_[A-Za-z0-9_-]{20,}"
+    r"|(?<!\d)[0-9]{8,10}:[A-Za-z0-9_-]{20,}"
+    r")(?![A-Za-z0-9_-])"
+)
+_NAMED_SECRET_ASSIGNMENT_PREFIX_RE = re.compile(
+    r"(?<![A-Za-z0-9])"
+    r"(?:api(?:[ _-]?key)|token|secret|password)"
+    r"(?![A-Za-z0-9])\s*[:=]\s*",
+    flags=re.IGNORECASE,
+)
+_ASSIGNMENT_DELIMITERS = frozenset(('"', "'", "`"))
+_NON_WHITESPACE_SEGMENT_RE = re.compile(r"\S+")
 
 
 @dataclass(frozen=True, slots=True)
@@ -41,10 +63,153 @@ class DailyQuotaDecision:
     resets_at: datetime
 
 
+def _looks_like_assigned_secret(value: str) -> bool:
+    """Return true only for long, varied assignment values."""
+
+    value = value.strip()
+    if any(char.isspace() for char in value):
+        return False
+    if len(value) < 16 or len(set(value)) < 4:
+        return False
+    character_classes = sum(
+        (
+            any(char.islower() for char in value),
+            any(char.isupper() for char in value),
+            any(char.isdigit() for char in value),
+            any(not char.isalnum() for char in value),
+        )
+    )
+    return character_classes >= 3 or (character_classes >= 2 and len(set(value)) >= 8)
+
+
+def _line_end_index(value: str, start: int) -> int:
+    """Return the first CR/LF boundary after ``start``, or ``len(value)``."""
+
+    cr_index = value.find("\r", start)
+    lf_index = value.find("\n", start)
+    candidates = [index for index in (cr_index, lf_index) if index >= 0]
+    return min(candidates, default=len(value))
+
+
+def _quoted_assignment_content(
+    value: str,
+    *,
+    start: int,
+    delimiter: str,
+    escaped_delimiter: bool,
+) -> tuple[str, int]:
+    """Extract one quoted value through its closing delimiter or EOL."""
+
+    line_end = _line_end_index(value, start)
+    if escaped_delimiter:
+        index = start
+        while index < line_end:
+            if value[index] != delimiter:
+                index += 1
+                continue
+
+            backslash_run = 0
+            run_index = index - 1
+            while run_index >= start and value[run_index] == "\\":
+                backslash_run += 1
+                run_index -= 1
+
+            # One outer-escape layer turns raw runs 1/5/... into an
+            # unescaped closing delimiter, while runs 3/7/... still encode an
+            # escaped delimiter inside the value. Even runs are ambiguous in
+            # this representation, so fail closed by continuing through EOL.
+            if backslash_run % 4 == 1:
+                return value[start:index], index + 1
+            index += 1
+        return value[start:line_end], line_end
+
+    escaped = False
+    index = start
+    while index < line_end:
+        character = value[index]
+        if character == delimiter and not escaped:
+            return value[start:index], index + 1
+        if character == "\\" and not escaped:
+            escaped = True
+        else:
+            escaped = False
+        index += 1
+    return value[start:line_end], line_end
+
+
+def _iter_assigned_value_candidates(value: str) -> Iterator[str]:
+    """Yield complete assigned tokens and quoted segments in linear time."""
+
+    consumed_until = 0
+    for match in _NAMED_SECRET_ASSIGNMENT_PREFIX_RE.finditer(value):
+        if match.start() < consumed_until:
+            continue
+
+        value_start = match.end()
+        if value_start >= len(value):
+            continue
+
+        escaped_delimiter = (
+            value[value_start] == "\\"
+            and value_start + 1 < len(value)
+            and value[value_start + 1] in _ASSIGNMENT_DELIMITERS
+        )
+        if escaped_delimiter:
+            delimiter = value[value_start + 1]
+            content, value_end = _quoted_assignment_content(
+                value,
+                start=value_start + 2,
+                delimiter=delimiter,
+                escaped_delimiter=True,
+            )
+        elif value[value_start] in _ASSIGNMENT_DELIMITERS:
+            delimiter = value[value_start]
+            content, value_end = _quoted_assignment_content(
+                value,
+                start=value_start + 1,
+                delimiter=delimiter,
+                escaped_delimiter=False,
+            )
+        else:
+            value_end = value_start
+            while value_end < len(value) and not value[value_end].isspace():
+                value_end += 1
+            content = value[value_start:value_end]
+
+        consumed_until = max(consumed_until, value_end)
+        stripped = content.strip()
+        if stripped:
+            yield stripped
+        if any(character.isspace() for character in content):
+            for segment_match in _NON_WHITESPACE_SEGMENT_RE.finditer(content):
+                segment = segment_match.group(0)
+                if segment != stripped:
+                    yield segment
+
+
+def contains_secret_like_data(value: str) -> bool:
+    """Detect high-confidence credential shapes without returning matched data."""
+
+    normalized = unicodedata.normalize("NFKC", value)
+    canonical = unicodedata.normalize("NFKC", html.unescape(normalized))
+    canonical = _DETECTOR_CONTROL_RE.sub("", canonical)
+    canonical = _TRUSTED_HEADLINE_TAG_RE.sub("", canonical)
+    for candidate_text in dict.fromkeys((normalized, canonical)):
+        if _DIRECT_SECRET_RE.search(candidate_text) is not None:
+            return True
+        for candidate in _iter_assigned_value_candidates(candidate_text):
+            if _looks_like_assigned_secret(candidate):
+                return True
+    return False
+
+
 def build_guarded_llm_query(query: str) -> str:
     """Wrap a bounded user query with non-negotiable evidence-only rules."""
 
-    guarded = f"{_LLM_GUARD_PREFIX}{query.strip()}"
+    normalized_query = unicodedata.normalize("NFKC", query).strip()
+    if contains_secret_like_data(normalized_query):
+        raise ValueError("sensitive Q&A input refused")
+    guarded = f"{_LLM_GUARD_PREFIX}{normalized_query}"
     if len(guarded) > MAX_GATEWAY_QUERY_CHARS:
         # Fail fast on contract drift instead of silently truncating away the
         # final instruction or part of the user's already-bounded question.
@@ -59,19 +224,27 @@ def limit_answer_text(answer_text: str) -> str:
     """Normalise provider output and cap the visible AI-authored answer."""
 
     value = unicodedata.normalize("NFKC", answer_text)
+    if contains_secret_like_data(value):
+        raise ValueError("sensitive Q&A output refused")
     value = _CONTROL_RE.sub("", value)
     value = _EXCESS_BLANK_LINES_RE.sub("\n\n", value).strip()
     if len(value) <= MAX_AI_ANSWER_CHARS:
-        return value
+        bounded = value
+    else:
+        # Reserve one character for the ellipsis. Prefer a word boundary when
+        # it is reasonably close; otherwise use a hard Unicode-codepoint cap.
+        clipped = value[: MAX_AI_ANSWER_CHARS - 1].rstrip()
+        last_space = clipped.rfind(" ")
+        if last_space >= int(MAX_AI_ANSWER_CHARS * 0.8):
+            clipped = clipped[:last_space].rstrip()
+        bounded = f"{clipped}…"
 
-    # Reserve one character for the ellipsis.  Prefer a word boundary when it
-    # is reasonably close; otherwise a hard Unicode-codepoint cap is safer
-    # than allowing an unbounded answer.
-    clipped = value[: MAX_AI_ANSWER_CHARS - 1].rstrip()
-    last_space = clipped.rfind(" ")
-    if last_space >= int(MAX_AI_ANSWER_CHARS * 0.8):
-        clipped = clipped[:last_space].rstrip()
-    return f"{clipped}…"
+    # Normalisation and truncation are transformations. Re-run the detector
+    # on their exact output so they can never reveal a signature that was not
+    # visible in the original representation.
+    if contains_secret_like_data(bounded):
+        raise ValueError("sensitive Q&A output refused")
+    return bounded
 
 
 def moscow_day_bounds_utc(now: datetime | None = None) -> tuple[datetime, datetime]:
@@ -143,8 +316,11 @@ __all__ = [
     "DAILY_LLM_QUESTION_LIMIT",
     "DailyQuotaDecision",
     "MAX_AI_ANSWER_CHARS",
+    "SENSITIVE_QA_REFUSAL",
+    "SENSITIVE_QA_TRACE_MARKER",
     "acquire_daily_llm_question_slot",
     "build_guarded_llm_query",
+    "contains_secret_like_data",
     "limit_answer_text",
     "moscow_day_bounds_utc",
 ]

--- a/tests/db/test_llm_synthesis_cache_repo.py
+++ b/tests/db/test_llm_synthesis_cache_repo.py
@@ -163,9 +163,7 @@ async def test_invalidate_by_citation_returns_zero_when_no_match(db_session) -> 
         model="claude-haiku",
     )
 
-    rowcount = await SynthesisCacheRepo.invalidate_by_citation(
-        db_session, message_version_id=999
-    )
+    rowcount = await SynthesisCacheRepo.invalidate_by_citation(db_session, message_version_id=999)
 
     assert rowcount == 0
 
@@ -245,3 +243,20 @@ async def test_get_or_none_idempotent_multiple_calls(db_session) -> None:
     assert r1 is not None
     assert r2 is not None
     assert r1.id == r2.id
+
+
+async def test_delete_by_id_removes_exact_row_and_is_idempotent(db_session) -> None:
+    from bot.db.repos.llm_synthesis_cache import SynthesisCacheRepo
+
+    h = _input_hash()
+    row = await SynthesisCacheRepo.store(
+        db_session,
+        input_hash=h,
+        answer_text="unsafe cached answer",
+        citation_ids=[101],
+        model="deepseek-v4-flash",
+    )
+
+    assert await SynthesisCacheRepo.delete_by_id(db_session, cache_id=row.id) == 1
+    assert await SynthesisCacheRepo.get_or_none(db_session, input_hash=h) is None
+    assert await SynthesisCacheRepo.delete_by_id(db_session, cache_id=row.id) == 0

--- a/tests/handlers/test_qa_mentions.py
+++ b/tests/handlers/test_qa_mentions.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 from decimal import Decimal
+from html.parser import HTMLParser
+import re
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock
 
@@ -13,6 +15,70 @@ from tests.conftest import import_module
 pytestmark = pytest.mark.usefixtures("app_env")
 
 COMMUNITY_CHAT_ID = -1001234567890
+
+FAKE_OPENAI_KEY = "sk-" + "proj-FAKEOPENAI0123456789"
+FAKE_DEEPSEEK_KEY = "sk-" + "FAKEDEEPSEEK0123456789"
+FAKE_CLOUDFLARE_TOKEN = "cfat_" + "FAKECLOUDFLARE0123456789"
+FAKE_TELEGRAM_TOKEN = "123456789" + ":FAKETELEGRAMBOT_TOKEN_0123456789"
+FAKE_GENERIC_KEY = "api_" + "key=FAKE_GENERIC_KEY_0123456789"
+FAKE_GENERIC_ASSIGNED_SECRET = "Az9!FAKE_TOKEN_0123456789"
+FAKE_LONG_PREFIX_ASSIGNMENT = 'token="' + ("a" * 256) + FAKE_GENERIC_ASSIGNED_SECRET + '"'
+FAKE_ESCAPED_INTERNAL_DELIMITER_ASSIGNMENT = (
+    r"token=\"prefix\\\" " + FAKE_GENERIC_ASSIGNED_SECRET + r"\""
+)
+FAKE_QUOTED_PREFIX_OUTPUT = (
+    ("x" * 960) + ' token="' + "Az9!FAKE_TOKEN_0123456789" + " extra" + ("z" * 400)
+)
+FAKE_SECRET_FAMILIES = (
+    pytest.param(FAKE_OPENAI_KEY, id="openai-token"),
+    pytest.param(FAKE_CLOUDFLARE_TOKEN, id="cloudflare-token"),
+    pytest.param(FAKE_TELEGRAM_TOKEN, id="telegram-token"),
+    pytest.param(
+        "OPENAI_API_" + "KEY = 'Az9!Fake_Named-Secret.012345'",
+        id="named-assignment",
+    ),
+)
+FAKE_HIGHLIGHT_SPLIT_SECRETS = (
+    pytest.param(
+        "<b>token</b>=Az9!FAKE_SECRET_0123456789",
+        id="highlight-named-assignment",
+    ),
+    pytest.param(
+        "s<b>k</b>-A1b2FAKEHIGHLIGHT0123456789",
+        id="highlight-direct-token",
+    ),
+    pytest.param(
+        "s\x00k-A1b2FAKECONTROL0123456789",
+        id="control-direct-token",
+    ),
+    pytest.param(
+        "to\x00ken=Az9!FAKE_CONTROL_0123456789",
+        id="control-named-assignment",
+    ),
+)
+
+
+class _TelegramHTMLValidator(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=False)
+        self.stack: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs) -> None:
+        self.stack.append(tag)
+
+    def handle_endtag(self, tag: str) -> None:
+        assert self.stack and self.stack.pop() == tag
+
+
+def _assert_bounded_valid_html(value: str) -> None:
+    from bot.services.qa_guardrails import MAX_AI_ANSWER_CHARS
+
+    assert len(value) <= MAX_AI_ANSWER_CHARS
+    parser = _TelegramHTMLValidator()
+    parser.feed(value)
+    parser.close()
+    assert parser.stack == []
+    assert re.search(r"&(?:#x?[0-9A-Fa-f]*|[A-Za-z]*)$", value) is None
 
 
 def _message(*, user_id: int = 1001, text: str = "@bot память") -> SimpleNamespace:
@@ -42,7 +108,12 @@ def _question(query: str = "что решили про память?"):
     )
 
 
-def _qa_result(*, abstained: bool = False):
+def _qa_result(
+    *,
+    abstained: bool = False,
+    snippet: str = "обсуждали память",
+    query_redacted: bool = False,
+):
     from bot.services.evidence import EvidenceBundle, EvidenceItem
     from bot.services.qa import QaResult
 
@@ -56,7 +127,7 @@ def _qa_result(*, abstained: bool = False):
                 chat_id=COMMUNITY_CHAT_ID,
                 message_id=77,
                 user_id=2002,
-                snippet="обсуждали память",
+                snippet=snippet,
                 ts_rank=0.9,
                 captured_at=now,
                 message_date=now,
@@ -70,7 +141,7 @@ def _qa_result(*, abstained: bool = False):
             abstained=abstained,
             created_at=now,
         ),
-        query_redacted=False,
+        query_redacted=query_redacted,
     )
 
 
@@ -209,6 +280,74 @@ async def test_third_daily_question_falls_back_to_deterministic_search(monkeypat
     assert trace_create.call_args.kwargs["evidence_ids"] == [101]
 
 
+@pytest.mark.parametrize("fallback", ["quota", "provider_error", "abstention"])
+async def test_every_dynamic_fallback_is_bounded_valid_html_and_secret_safe(
+    monkeypatch,
+    fallback: str,
+) -> None:
+    handler = import_module("bot.handlers.qa")
+    from bot.services.llm_gateway import Abstention
+
+    message = _message()
+    session = AsyncMock()
+    unsafe_snippet = "<b>" + ("x&" * 2_000)
+
+    _patch_common(handler, monkeypatch)
+    monkeypatch.setattr(handler.FeatureFlagRepo, "get", _flag_get(handler))
+    monkeypatch.setattr(
+        handler,
+        "run_qa",
+        AsyncMock(return_value=_qa_result(snippet=unsafe_snippet)),
+    )
+    monkeypatch.setattr(
+        handler,
+        "acquire_daily_llm_question_slot",
+        AsyncMock(
+            return_value=SimpleNamespace(
+                allowed=fallback != "quota",
+                used=2 if fallback == "quota" else 0,
+                limit=2,
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        handler.QaTraceRepo,
+        "create",
+        AsyncMock(return_value=SimpleNamespace(id=903)),
+    )
+    monkeypatch.setattr(handler.QaTraceRepo, "update_llm_fields", AsyncMock())
+    monkeypatch.setattr(
+        handler,
+        "_load_gateway_config",
+        Mock(return_value=SimpleNamespace(provider="deepseek")),
+    )
+    monkeypatch.setattr(handler, "_resolve_provider", Mock(return_value=object()))
+    if fallback == "provider_error":
+        synth_result: object = RuntimeError("provider unavailable")
+        monkeypatch.setattr(
+            handler,
+            "synthesize_answer",
+            AsyncMock(side_effect=synth_result),
+        )
+    else:
+        synth_result = Abstention(
+            reason="provider_error",
+            cost_usd=Decimal("0"),
+            llm_call_id=904,
+        )
+        monkeypatch.setattr(
+            handler,
+            "synthesize_answer",
+            AsyncMock(return_value=synth_result),
+        )
+
+    await handler.mention_question_handler(message, _question(), session)
+
+    response = message.reply.call_args.args[0]
+    _assert_bounded_valid_html(response)
+    assert "[1]" in response
+
+
 async def test_provider_exception_falls_back_without_logging_provider_payload(
     monkeypatch,
     caplog,
@@ -254,6 +393,368 @@ async def test_provider_exception_falls_back_without_logging_provider_payload(
     session.commit.assert_awaited_once()
 
 
+@pytest.mark.parametrize("secret", FAKE_SECRET_FAMILIES)
+async def test_sensitive_query_is_persisted_raw_then_refused_before_all_derived_sinks(
+    monkeypatch,
+    caplog,
+    secret: str,
+) -> None:
+    handler = import_module("bot.handlers.qa")
+
+    original_text = f"@bot вопрос {secret}"
+    message = _message(text=original_text)
+    question = _question(f"вопрос {secret}")
+    session = AsyncMock()
+    trace_create = AsyncMock(return_value=SimpleNamespace(id=910))
+    run_qa = AsyncMock()
+    quota = AsyncMock()
+    synthesize = AsyncMock()
+    load_config = Mock()
+    resolve_provider = Mock()
+
+    _patch_common(handler, monkeypatch)
+    monkeypatch.setattr(handler.FeatureFlagRepo, "get", _flag_get(handler))
+    monkeypatch.setattr(handler, "run_qa", run_qa)
+    monkeypatch.setattr(handler, "acquire_daily_llm_question_slot", quota)
+    monkeypatch.setattr(handler.QaTraceRepo, "create", trace_create)
+    monkeypatch.setattr(handler, "_load_gateway_config", load_config)
+    monkeypatch.setattr(handler, "_resolve_provider", resolve_provider)
+    monkeypatch.setattr(handler, "synthesize_answer", synthesize)
+    caplog.set_level("DEBUG")
+
+    await handler.mention_question_handler(message, question, session)
+
+    persisted_message = handler.persist_message_with_policy.await_args.args[1]
+    assert persisted_message is message
+    assert persisted_message.text == original_text
+
+    run_qa.assert_not_awaited()
+    quota.assert_not_awaited()
+    load_config.assert_not_called()
+    resolve_provider.assert_not_called()
+    synthesize.assert_not_awaited()
+    trace_kwargs = trace_create.await_args.kwargs
+    assert trace_kwargs["query"] == handler.SENSITIVE_QA_TRACE_MARKER
+    assert trace_kwargs["evidence_ids"] == []
+    assert trace_kwargs["abstained"] is True
+    assert trace_kwargs["redact_query"] is True
+    assert trace_kwargs["source_chat_message_id"] == 8501
+
+    message.reply.assert_awaited_once_with(handler.SENSITIVE_QA_REFUSAL)
+    assert secret not in str(trace_kwargs)
+    assert secret not in message.reply.await_args.args[0]
+    assert secret not in caplog.text
+    _assert_bounded_valid_html(message.reply.await_args.args[0])
+
+
+@pytest.mark.parametrize("content_field", ["text", "caption"])
+async def test_sensitive_tail_beyond_trigger_query_limit_is_refused_from_raw_message(
+    monkeypatch,
+    content_field: str,
+) -> None:
+    handler = import_module("bot.handlers.qa")
+    trigger = import_module("bot.services.qa_trigger")
+
+    secret = FAKE_OPENAI_KEY
+    raw_content = "@bot " + ("x" * trigger.MAX_USER_QUERY_CHARS) + f" {secret}"
+    message = _message(text=raw_content if content_field == "text" else "")
+    message.text = raw_content if content_field == "text" else None
+    message.caption = raw_content if content_field == "caption" else None
+    question = trigger.extract_triggered_question(
+        message,
+        expected_chat_id=COMMUNITY_CHAT_ID,
+        bot_id=9999,
+        bot_username="bot",
+    )
+    assert question is not None
+    assert question.was_truncated is True
+    assert secret not in question.query
+
+    session = AsyncMock()
+    trace_create = AsyncMock(return_value=SimpleNamespace(id=911))
+    run_qa = AsyncMock(side_effect=AssertionError("raw sensitive tail reached search"))
+    quota = AsyncMock()
+    synthesize = AsyncMock()
+
+    _patch_common(handler, monkeypatch)
+    monkeypatch.setattr(handler.FeatureFlagRepo, "get", _flag_get(handler))
+    monkeypatch.setattr(handler.QaTraceRepo, "create", trace_create)
+    monkeypatch.setattr(handler, "run_qa", run_qa)
+    monkeypatch.setattr(handler, "acquire_daily_llm_question_slot", quota)
+    monkeypatch.setattr(handler, "synthesize_answer", synthesize)
+
+    await handler.mention_question_handler(message, question, session)
+
+    persisted_message = handler.persist_message_with_policy.await_args.args[1]
+    assert getattr(persisted_message, content_field) == raw_content
+    run_qa.assert_not_awaited()
+    quota.assert_not_awaited()
+    synthesize.assert_not_awaited()
+    trace_kwargs = trace_create.await_args.kwargs
+    assert trace_kwargs["query"] == handler.SENSITIVE_QA_TRACE_MARKER
+    assert trace_kwargs["evidence_ids"] == []
+    assert trace_kwargs["redact_query"] is True
+    message.reply.assert_awaited_once_with(handler.SENSITIVE_QA_REFUSAL)
+
+
+@pytest.mark.parametrize("secret", (*FAKE_SECRET_FAMILIES, *FAKE_HIGHLIGHT_SPLIT_SECRETS))
+async def test_sensitive_evidence_is_refused_before_quota_provider_or_trace_payload(
+    monkeypatch,
+    caplog,
+    secret: str,
+) -> None:
+    handler = import_module("bot.handlers.qa")
+
+    message = _message()
+    session = AsyncMock()
+    trace_create = AsyncMock(return_value=SimpleNamespace(id=912))
+    quota = AsyncMock()
+    synthesize = AsyncMock()
+    load_config = Mock()
+    resolve_provider = Mock()
+
+    _patch_common(handler, monkeypatch)
+    monkeypatch.setattr(handler.FeatureFlagRepo, "get", _flag_get(handler))
+    monkeypatch.setattr(
+        handler,
+        "run_qa",
+        AsyncMock(return_value=_qa_result(snippet=f"evidence {secret}")),
+    )
+    monkeypatch.setattr(handler, "acquire_daily_llm_question_slot", quota)
+    monkeypatch.setattr(handler.QaTraceRepo, "create", trace_create)
+    monkeypatch.setattr(handler, "_load_gateway_config", load_config)
+    monkeypatch.setattr(handler, "_resolve_provider", resolve_provider)
+    monkeypatch.setattr(handler, "synthesize_answer", synthesize)
+    caplog.set_level("DEBUG")
+
+    await handler.mention_question_handler(message, _question(), session)
+
+    quota.assert_not_awaited()
+    load_config.assert_not_called()
+    resolve_provider.assert_not_called()
+    synthesize.assert_not_awaited()
+    trace_kwargs = trace_create.await_args.kwargs
+    assert trace_kwargs["query"] == handler.SENSITIVE_QA_TRACE_MARKER
+    assert trace_kwargs["evidence_ids"] == []
+    assert trace_kwargs["abstained"] is True
+    assert trace_kwargs["redact_query"] is True
+    assert trace_kwargs["source_chat_message_id"] == 8501
+    message.reply.assert_awaited_once_with(handler.SENSITIVE_QA_REFUSAL)
+    assert secret not in str(trace_kwargs)
+    assert secret not in message.reply.await_args.args[0]
+    assert secret not in caplog.text
+
+
+@pytest.mark.parametrize(
+    ("field_name", "secret"),
+    [
+        ("first_name", FAKE_OPENAI_KEY),
+        ("last_name", FAKE_CLOUDFLARE_TOKEN),
+        ("username", FAKE_TELEGRAM_TOKEN),
+    ],
+)
+async def test_sensitive_author_metadata_is_refused_before_quota_or_rendering(
+    monkeypatch,
+    caplog,
+    field_name: str,
+    secret: str,
+) -> None:
+    handler = import_module("bot.handlers.qa")
+
+    author_fields: dict[str, object | None] = {
+        "id": 2002,
+        "is_member": True,
+        "is_admin": False,
+        "first_name": "Author",
+        "last_name": None,
+        "username": "author",
+    }
+    author_fields[field_name] = secret
+    if field_name == "username":
+        author_fields["first_name"] = None
+
+    message = _message()
+    session = AsyncMock()
+    trace_create = AsyncMock(return_value=SimpleNamespace(id=915))
+    quota = AsyncMock(return_value=SimpleNamespace(allowed=False, used=2, limit=2))
+    synthesize = AsyncMock()
+
+    _patch_common(handler, monkeypatch)
+    monkeypatch.setattr(handler.FeatureFlagRepo, "get", _flag_get(handler))
+    monkeypatch.setattr(
+        handler.UserRepo,
+        "get",
+        AsyncMock(
+            side_effect=[
+                SimpleNamespace(id=1001, is_member=True, is_admin=False),
+                SimpleNamespace(**author_fields),
+            ]
+        ),
+    )
+    monkeypatch.setattr(handler, "run_qa", AsyncMock(return_value=_qa_result()))
+    monkeypatch.setattr(handler, "acquire_daily_llm_question_slot", quota)
+    monkeypatch.setattr(handler.QaTraceRepo, "create", trace_create)
+    monkeypatch.setattr(handler, "synthesize_answer", synthesize)
+    caplog.set_level("DEBUG")
+
+    await handler.mention_question_handler(message, _question(), session)
+
+    quota.assert_not_awaited()
+    synthesize.assert_not_awaited()
+    trace_kwargs = trace_create.await_args.kwargs
+    assert trace_kwargs["query"] == handler.SENSITIVE_QA_TRACE_MARKER
+    assert trace_kwargs["evidence_ids"] == []
+    assert trace_kwargs["redact_query"] is True
+    message.reply.assert_awaited_once_with(handler.SENSITIVE_QA_REFUSAL)
+    assert secret not in str(trace_kwargs)
+    assert secret not in message.reply.await_args.args[0]
+    assert secret not in caplog.text
+
+
+@pytest.mark.parametrize("reason", ["sensitive_input", "sensitive_output"])
+async def test_sensitive_gateway_abstention_maps_to_fixed_refusal_and_redacted_trace(
+    monkeypatch,
+    reason: str,
+) -> None:
+    handler = import_module("bot.handlers.qa")
+    from bot.services.llm_gateway import Abstention
+
+    message = _message()
+    session = AsyncMock()
+    trace_update = AsyncMock()
+
+    _patch_common(handler, monkeypatch)
+    monkeypatch.setattr(handler.FeatureFlagRepo, "get", _flag_get(handler))
+    monkeypatch.setattr(handler, "run_qa", AsyncMock(return_value=_qa_result()))
+    monkeypatch.setattr(
+        handler,
+        "acquire_daily_llm_question_slot",
+        AsyncMock(return_value=SimpleNamespace(allowed=True, used=0, limit=2)),
+    )
+    monkeypatch.setattr(
+        handler.QaTraceRepo,
+        "create",
+        AsyncMock(return_value=SimpleNamespace(id=913)),
+    )
+    monkeypatch.setattr(handler.QaTraceRepo, "update_llm_fields", trace_update)
+    monkeypatch.setattr(
+        handler,
+        "_load_gateway_config",
+        Mock(return_value=SimpleNamespace(provider="deepseek")),
+    )
+    monkeypatch.setattr(handler, "_resolve_provider", Mock(return_value=object()))
+    monkeypatch.setattr(
+        handler,
+        "synthesize_answer",
+        AsyncMock(
+            return_value=Abstention(
+                reason=reason,
+                cost_usd=Decimal("0.0042"),
+                llm_call_id=914,
+            )
+        ),
+    )
+
+    await handler.mention_question_handler(message, _question(), session)
+
+    update_kwargs = trace_update.await_args.kwargs
+    assert update_kwargs["llm_call_id"] == 914
+    assert update_kwargs["llm_response_summary"] is None
+    assert update_kwargs["llm_response_redacted"] is True
+    assert update_kwargs["cost_usd"] == Decimal("0.0042")
+    message.reply.assert_awaited_once_with(
+        handler.SENSITIVE_QA_REFUSAL,
+        parse_mode="HTML",
+        disable_web_page_preview=True,
+    )
+
+
+@pytest.mark.parametrize(
+    ("provider_answer", "forbidden_value"),
+    (
+        pytest.param(
+            "s\x00k-A1b2FAKECONTROL0123456789",
+            "sk-A1b2FAKECONTROL0123456789",
+            id="control-split",
+        ),
+        pytest.param(
+            FAKE_QUOTED_PREFIX_OUTPUT,
+            'token="' + "Az9!FAKE_TOKEN_0123456789",
+            id="quoted-prefix-before-truncation",
+        ),
+        pytest.param(
+            FAKE_LONG_PREFIX_ASSIGNMENT,
+            FAKE_GENERIC_ASSIGNED_SECRET,
+            id="long-low-class-prefix",
+        ),
+        pytest.param(
+            FAKE_ESCAPED_INTERNAL_DELIMITER_ASSIGNMENT,
+            FAKE_GENERIC_ASSIGNED_SECRET,
+            id="escaped-internal-delimiter",
+        ),
+    ),
+)
+async def test_transform_sensitive_provider_answer_never_reaches_trace_summary(
+    monkeypatch,
+    provider_answer: str,
+    forbidden_value: str,
+) -> None:
+    handler = import_module("bot.handlers.qa")
+    from bot.services.llm_gateway import AnswerWithCitations
+
+    message = _message()
+    session = AsyncMock()
+    trace_update = AsyncMock()
+
+    _patch_common(handler, monkeypatch)
+    monkeypatch.setattr(handler.FeatureFlagRepo, "get", _flag_get(handler))
+    monkeypatch.setattr(handler, "run_qa", AsyncMock(return_value=_qa_result()))
+    monkeypatch.setattr(
+        handler,
+        "acquire_daily_llm_question_slot",
+        AsyncMock(return_value=SimpleNamespace(allowed=True, used=0, limit=2)),
+    )
+    monkeypatch.setattr(
+        handler.QaTraceRepo,
+        "create",
+        AsyncMock(return_value=SimpleNamespace(id=916)),
+    )
+    monkeypatch.setattr(handler.QaTraceRepo, "update_llm_fields", trace_update)
+    monkeypatch.setattr(
+        handler,
+        "_load_gateway_config",
+        Mock(return_value=SimpleNamespace(provider="deepseek")),
+    )
+    monkeypatch.setattr(handler, "_resolve_provider", Mock(return_value=object()))
+    monkeypatch.setattr(
+        handler,
+        "synthesize_answer",
+        AsyncMock(
+            return_value=AnswerWithCitations(
+                answer_text=provider_answer,
+                citation_ids=(101,),
+                cost_usd=Decimal("0.0042"),
+                cache_hit=False,
+                llm_call_id=917,
+            )
+        ),
+    )
+
+    await handler.mention_question_handler(message, _question(), session)
+
+    update_kwargs = trace_update.await_args.kwargs
+    assert update_kwargs["llm_response_summary"] is None
+    assert update_kwargs["llm_response_redacted"] is True
+    assert provider_answer not in str(update_kwargs)
+    assert forbidden_value not in str(update_kwargs)
+    message.reply.assert_awaited_once_with(
+        handler.SENSITIVE_QA_REFUSAL,
+        parse_mode="HTML",
+        disable_web_page_preview=True,
+    )
+    assert forbidden_value not in message.reply.await_args.args[0]
+
+
 async def test_non_member_is_refused_before_search_or_provider(monkeypatch) -> None:
     handler = import_module("bot.handlers.qa")
     message = _message()
@@ -272,6 +773,7 @@ async def test_non_member_is_refused_before_search_or_provider(monkeypatch) -> N
     run_qa.assert_not_awaited()
     synthesize.assert_not_awaited()
     message.reply.assert_awaited_once_with("Доступ только участникам сообщества.")
+    _assert_bounded_valid_html(message.reply.await_args.args[0])
 
 
 async def test_no_evidence_abstains_without_consuming_quota(monkeypatch) -> None:
@@ -293,6 +795,7 @@ async def test_no_evidence_abstains_without_consuming_quota(monkeypatch) -> None
     quota.assert_not_awaited()
     synthesize.assert_not_awaited()
     assert "Не нашёл" in message.reply.call_args.args[0]
+    _assert_bounded_valid_html(message.reply.await_args.args[0])
 
 
 async def test_empty_trigger_query_prompts_without_search(monkeypatch) -> None:
@@ -310,6 +813,32 @@ async def test_empty_trigger_query_prompts_without_search(monkeypatch) -> None:
 
     run_qa.assert_not_awaited()
     assert "вопрос" in message.reply.call_args.args[0].lower()
+    _assert_bounded_valid_html(message.reply.await_args.args[0])
+
+
+async def test_disabled_llm_path_is_bounded_without_search_or_provider(monkeypatch) -> None:
+    handler = import_module("bot.handlers.qa")
+    message = _message()
+    session = AsyncMock()
+    run_qa = AsyncMock()
+    synthesize = AsyncMock()
+
+    _patch_common(handler, monkeypatch)
+    monkeypatch.setattr(
+        handler.FeatureFlagRepo,
+        "get",
+        _flag_get(handler, llm=False),
+    )
+    monkeypatch.setattr(handler, "run_qa", run_qa)
+    monkeypatch.setattr(handler, "synthesize_answer", synthesize)
+    monkeypatch.setattr(handler.QaTraceRepo, "create", AsyncMock())
+
+    await handler.mention_question_handler(message, _question(), session)
+
+    run_qa.assert_not_awaited()
+    synthesize.assert_not_awaited()
+    assert "недоступен" in message.reply.await_args.args[0]
+    _assert_bounded_valid_html(message.reply.await_args.args[0])
 
 
 def test_qa_handler_config_and_resolver_support_deepseek(monkeypatch) -> None:
@@ -399,7 +928,7 @@ async def test_redelivered_question_does_not_consume_second_llm_slot(monkeypatch
         AsyncMock(
             return_value=SimpleNamespace(
                 id=9901,
-                llm_response_summary="Уже сохранённый ответ",
+                llm_response_summary=f"Уже сохранённый ответ {FAKE_OPENAI_KEY} " + ("x&" * 2_000),
             )
         ),
     )
@@ -413,4 +942,48 @@ async def test_redelivered_question_does_not_consume_second_llm_slot(monkeypatch
     run_qa.assert_not_awaited()
     quota.assert_not_awaited()
     synthesize.assert_not_awaited()
-    assert "Уже сохранённый ответ" in message.reply.call_args.args[0]
+    assert message.reply.await_args.args[0] == handler.SENSITIVE_QA_REFUSAL
+    assert "Уже сохранённый ответ" not in message.reply.call_args.args[0]
+    assert FAKE_OPENAI_KEY not in message.reply.await_args.args[0]
+    _assert_bounded_valid_html(message.reply.await_args.args[0])
+
+
+async def test_redelivered_sensitive_query_is_refused_without_duplicate_trace(
+    monkeypatch,
+) -> None:
+    handler = import_module("bot.handlers.qa")
+    message = _message(text=f"@bot вопрос {FAKE_OPENAI_KEY}")
+    session = AsyncMock()
+    trace_create = AsyncMock()
+    run_qa = AsyncMock()
+    quota = AsyncMock()
+    synthesize = AsyncMock()
+
+    _patch_common(handler, monkeypatch)
+    monkeypatch.setattr(handler.FeatureFlagRepo, "get", _flag_get(handler))
+    monkeypatch.setattr(
+        handler.QaTraceRepo,
+        "get_by_source_chat_message_id",
+        AsyncMock(
+            return_value=SimpleNamespace(
+                id=9902,
+                llm_response_summary="previous safe answer",
+            )
+        ),
+    )
+    monkeypatch.setattr(handler.QaTraceRepo, "create", trace_create)
+    monkeypatch.setattr(handler, "run_qa", run_qa)
+    monkeypatch.setattr(handler, "acquire_daily_llm_question_slot", quota)
+    monkeypatch.setattr(handler, "synthesize_answer", synthesize)
+
+    await handler.mention_question_handler(
+        message,
+        _question(f"вопрос {FAKE_OPENAI_KEY}"),
+        session,
+    )
+
+    message.reply.assert_awaited_once_with(handler.SENSITIVE_QA_REFUSAL)
+    trace_create.assert_not_awaited()
+    run_qa.assert_not_awaited()
+    quota.assert_not_awaited()
+    synthesize.assert_not_awaited()

--- a/tests/services/test_llm_gateway.py
+++ b/tests/services/test_llm_gateway.py
@@ -28,6 +28,7 @@ from decimal import Decimal
 from typing import Any, Protocol
 
 import pytest
+from sqlalchemy.exc import IntegrityError
 
 from bot.services.evidence import EvidenceBundle
 from bot.services.llm_gateway import (
@@ -36,8 +37,11 @@ from bot.services.llm_gateway import (
     AnswerWithCitations,
     LLMGatewayConfig,
     SynthesisResult,
+    _build_prompt,
+    _cache_input_hash,
     _estimate_cost,
     _normalize_query,
+    _prompt_hash,
     synthesize_answer,
 )
 from bot.services.llm_providers import (
@@ -46,6 +50,24 @@ from bot.services.llm_providers import (
     ProviderTransientError,
 )
 from bot.services.search import SearchHit
+
+FAKE_GENERIC_ASSIGNED_SECRET = "Az9!FAKE_TOKEN_0123456789"
+FAKE_LONG_PREFIX_ASSIGNMENT = 'token="' + ("a" * 256) + FAKE_GENERIC_ASSIGNED_SECRET + '"'
+FAKE_ESCAPED_INTERNAL_DELIMITER_ASSIGNMENT = (
+    r"token=\"prefix\\\" " + FAKE_GENERIC_ASSIGNED_SECRET + r"\""
+)
+
+FAKE_SECRET_FAMILIES = (
+    "sk-" + "proj-FAKEOPENAI0123456789",
+    "cfat_" + "FAKECLOUDFLARE012345678901",
+    "123456789" + ":FAKETELEGRAMBOT_TOKEN_0123456789",
+    "DATABASE_" + "PASSWORD='Az9!FAKE.DB/0123456789'",
+    "s\x00k-A1b2FAKECONTROL0123456789",
+    "to\x00ken=Az9!FAKE_CONTROL_0123456789",
+    'token="' + "Az9!FAKE_TOKEN_0123456789" + " explanatory text",
+    FAKE_LONG_PREFIX_ASSIGNMENT,
+    FAKE_ESCAPED_INTERNAL_DELIMITER_ASSIGNMENT,
+)
 
 
 # ─── Fakes for T5-03 repos and forget-event surface ──────────────────────────
@@ -105,6 +127,8 @@ class SynthesisCacheRepoProtocol(Protocol):
     ) -> Any: ...
 
     async def bump_hit(self, session: Any, *, cache_id: int) -> None: ...
+
+    async def delete_by_id(self, session: Any, *, cache_id: int) -> int: ...
 
     async def invalidate_by_citation(self, session: Any, *, message_version_id: int) -> int: ...
 
@@ -230,6 +254,7 @@ class _CacheRow:
 class FakeCacheRepo:
     rows: dict[str, _CacheRow] = field(default_factory=dict)
     invalidated_ids: list[int] = field(default_factory=list)
+    deleted_ids: list[int] = field(default_factory=list)
     _next_id: int = 1
 
     async def get_or_none(self, session: Any, *, input_hash: str) -> _CacheRow | None:
@@ -260,6 +285,12 @@ class FakeCacheRepo:
             if row.id == cache_id:
                 row.hit_count += 1
                 return
+
+    async def delete_by_id(self, session: Any, *, cache_id: int) -> int:
+        self.deleted_ids.append(cache_id)
+        before = len(self.rows)
+        self.rows = {key: row for key, row in self.rows.items() if row.id != cache_id}
+        return before - len(self.rows)
 
     async def invalidate_by_citation(self, session: Any, *, message_version_id: int) -> int:
         self.invalidated_ids.append(message_version_id)
@@ -347,6 +378,18 @@ class _SessionExecutor:
         return _SessionResult(self._rows).scalar()
 
 
+class _FakeNestedTransaction:
+    def __init__(self, session: FakeSession) -> None:
+        self._session = session
+
+    async def __aenter__(self) -> _FakeNestedTransaction:
+        self._session.nested_depth += 1
+        return self
+
+    async def __aexit__(self, *exc_info: object) -> None:
+        self._session.nested_depth -= 1
+
+
 @dataclass
 class FakeSession:
     """Minimal ``AsyncSession`` stand-in.
@@ -362,6 +405,12 @@ class FakeSession:
     """
 
     query_results: list[list[dict[str, Any]]] = field(default_factory=list)
+    nested_depth: int = 0
+    nested_entries: int = 0
+
+    def begin_nested(self) -> _FakeNestedTransaction:
+        self.nested_entries += 1
+        return _FakeNestedTransaction(self)
 
     async def execute(self, *args: Any, **kwargs: Any) -> _SessionExecutor:
         stmt = args[0] if args else kwargs.get("statement")
@@ -377,7 +426,11 @@ class FakeSession:
 # ─── Helper: build a non-empty bundle ────────────────────────────────────────
 
 
-def _make_bundle(version_ids: tuple[int, ...] = (100, 101)) -> EvidenceBundle:
+def _make_bundle(
+    version_ids: tuple[int, ...] = (100, 101),
+    *,
+    snippet: str | None = None,
+) -> EvidenceBundle:
     timestamp = datetime(2026, 5, 2, 12, 0, tzinfo=timezone.utc)
     hits = [
         SearchHit(
@@ -386,7 +439,7 @@ def _make_bundle(version_ids: tuple[int, ...] = (100, 101)) -> EvidenceBundle:
             chat_id=-1001,
             message_id=300 + idx,
             user_id=42,
-            snippet=f"<b>match</b>{idx}",
+            snippet=snippet if snippet is not None else f"<b>match</b>{idx}",
             ts_rank=0.5 - idx * 0.01,
             captured_at=timestamp,
             message_date=timestamp,
@@ -600,6 +653,349 @@ async def test_source_filter_partial_keeps_subset() -> None:
     assert isinstance(res, AnswerWithCitations)
     assert res.citation_ids == (100,)
     assert len(provider.calls) == 1
+
+
+@pytest.mark.parametrize("secret", FAKE_SECRET_FAMILIES)
+@pytest.mark.parametrize("location", ["query", "evidence"])
+@pytest.mark.asyncio
+async def test_sensitive_input_abstains_before_cache_or_provider(
+    secret: str,
+    location: str,
+) -> None:
+    bundle = _make_bundle(
+        (100,),
+        snippet=secret if location == "evidence" else None,
+    )
+    ledger = FakeLedgerRepo()
+    cache = FakeCacheRepo()
+    provider = FakeProvider(citation_ids=(100,))
+
+    result = await synthesize_answer(
+        FakeSession(),  # type: ignore[arg-type]
+        bundle=bundle,
+        query=secret if location == "query" else "safe question",
+        config=_config(),
+        qa_trace_id=11,
+        ledger_repo=ledger,
+        cache_repo=cache,
+        provider=provider,
+    )
+
+    assert isinstance(result, Abstention)
+    assert result.reason == "sensitive_input"
+    assert provider.calls == []
+    assert cache.rows == {}
+    assert cache.deleted_ids == []
+    assert len(ledger.rows) == 1
+    assert ledger.rows[0].error == "sensitive_input"
+    assert ledger.rows[0].response_hash is None
+    assert secret not in repr(ledger.rows)
+
+
+@pytest.mark.parametrize("secret", FAKE_SECRET_FAMILIES)
+@pytest.mark.asyncio
+async def test_sensitive_provider_output_records_usage_but_is_never_cached_or_returned(
+    secret: str,
+) -> None:
+    bundle = _make_bundle((100,))
+    ledger = FakeLedgerRepo()
+    cache = FakeCacheRepo()
+    provider = FakeProvider(answer_text=f"provider echoed {secret}", citation_ids=(100,))
+
+    result = await synthesize_answer(
+        FakeSession(
+            query_results=[
+                [{"message_version_id": 100}],
+                [],
+            ]
+        ),  # type: ignore[arg-type]
+        bundle=bundle,
+        query="safe question",
+        config=_config(),
+        qa_trace_id=11,
+        ledger_repo=ledger,
+        cache_repo=cache,
+        provider=provider,
+    )
+
+    assert isinstance(result, Abstention)
+    assert result.reason == "sensitive_output"
+    assert len(provider.calls) == 1
+    assert cache.rows == {}
+    row = ledger.rows[-1]
+    assert row.error == "sensitive_output"
+    assert row.response_hash is None
+    assert row.tokens_in == provider.tokens_in
+    assert row.tokens_out == provider.tokens_out
+    assert row.cost_usd > 0
+    assert secret not in repr(ledger.rows)
+
+
+@pytest.mark.asyncio
+async def test_provider_output_is_refused_before_cache_when_post_limit_check_fails(
+    monkeypatch,
+) -> None:
+    def _reject_after_transform(_value: str) -> str:
+        raise ValueError("sensitive transformed output")
+
+    monkeypatch.setitem(
+        synthesize_answer.__globals__,
+        "contains_secret_like_data",
+        lambda _value: False,
+    )
+    monkeypatch.setitem(
+        synthesize_answer.__globals__,
+        "limit_answer_text",
+        _reject_after_transform,
+    )
+    bundle = _make_bundle((100,))
+    ledger = FakeLedgerRepo()
+    cache = FakeCacheRepo()
+    provider = FakeProvider(answer_text="apparently safe raw output", citation_ids=(100,))
+
+    result = await synthesize_answer(
+        FakeSession(
+            query_results=[
+                [{"message_version_id": 100}],
+                [],
+            ]
+        ),  # type: ignore[arg-type]
+        bundle=bundle,
+        query="safe question",
+        config=_config(),
+        qa_trace_id=11,
+        ledger_repo=ledger,
+        cache_repo=cache,
+        provider=provider,
+    )
+
+    assert isinstance(result, Abstention)
+    assert result.reason == "sensitive_output"
+    assert cache.rows == {}
+    assert ledger.rows[-1].error == "sensitive_output"
+    assert ledger.rows[-1].response_hash is None
+
+
+@pytest.mark.parametrize("secret", FAKE_SECRET_FAMILIES)
+@pytest.mark.asyncio
+async def test_sensitive_cached_answer_is_deleted_without_bump_or_provider(
+    secret: str,
+) -> None:
+    bundle = _make_bundle((100,))
+    ledger = FakeLedgerRepo()
+    cache = FakeCacheRepo()
+    provider = FakeProvider(citation_ids=(100,))
+    cfg = _config()
+    prompt = _build_prompt("q", (100,), evidence_items=bundle.items)
+    expected_hash = _cache_input_hash(
+        query_normalized="q",
+        citation_ids=(100,),
+        model=cfg.model,
+        prompt_template_version=f"{cfg.prompt_template_version}:{_prompt_hash(prompt)}",
+    )
+    cached = await cache.store(
+        FakeSession(),
+        input_hash=expected_hash,
+        answer_text=f"unsafe cached {secret}",
+        citation_ids=[100],
+        model=cfg.model,
+    )
+
+    result = await synthesize_answer(
+        FakeSession(
+            query_results=[
+                [{"message_version_id": 100}],
+                [],
+            ]
+        ),  # type: ignore[arg-type]
+        bundle=bundle,
+        query="q",
+        config=cfg,
+        qa_trace_id=11,
+        ledger_repo=ledger,
+        cache_repo=cache,
+        provider=provider,
+    )
+
+    assert isinstance(result, Abstention)
+    assert result.reason == "sensitive_output"
+    assert provider.calls == []
+    assert cache.rows == {}
+    assert cache.deleted_ids == [cached.id]
+    assert cached.hit_count == 0
+    assert ledger.rows[-1].error == "sensitive_output"
+    assert ledger.rows[-1].response_hash is None
+    assert secret not in repr(ledger.rows)
+
+
+@pytest.mark.asyncio
+async def test_cached_answer_is_quarantined_when_post_limit_check_fails(monkeypatch) -> None:
+    def _reject_after_transform(_value: str) -> str:
+        raise ValueError("sensitive transformed output")
+
+    monkeypatch.setitem(
+        synthesize_answer.__globals__,
+        "contains_secret_like_data",
+        lambda _value: False,
+    )
+    monkeypatch.setitem(
+        synthesize_answer.__globals__,
+        "limit_answer_text",
+        _reject_after_transform,
+    )
+    bundle = _make_bundle((100,))
+    ledger = FakeLedgerRepo()
+    cache = FakeCacheRepo()
+    provider = FakeProvider(citation_ids=(100,))
+    cfg = _config()
+    prompt = _build_prompt("q", (100,), evidence_items=bundle.items)
+    expected_hash = _cache_input_hash(
+        query_normalized="q",
+        citation_ids=(100,),
+        model=cfg.model,
+        prompt_template_version=f"{cfg.prompt_template_version}:{_prompt_hash(prompt)}",
+    )
+    cached = await cache.store(
+        FakeSession(),
+        input_hash=expected_hash,
+        answer_text="apparently safe cached output",
+        citation_ids=[100],
+        model=cfg.model,
+    )
+
+    result = await synthesize_answer(
+        FakeSession(
+            query_results=[
+                [{"message_version_id": 100}],
+                [],
+            ]
+        ),  # type: ignore[arg-type]
+        bundle=bundle,
+        query="q",
+        config=cfg,
+        qa_trace_id=11,
+        ledger_repo=ledger,
+        cache_repo=cache,
+        provider=provider,
+    )
+
+    assert isinstance(result, Abstention)
+    assert result.reason == "sensitive_output"
+    assert provider.calls == []
+    assert cache.rows == {}
+    assert cache.deleted_ids == [cached.id]
+    assert ledger.rows[-1].error == "sensitive_output"
+    assert ledger.rows[-1].response_hash is None
+
+
+@pytest.mark.asyncio
+async def test_long_prefix_sensitive_cache_found_under_lock_is_quarantined() -> None:
+    class _UnderLockCache(FakeCacheRepo):
+        get_calls: int = 0
+
+        async def get_or_none(self, session: Any, *, input_hash: str) -> _CacheRow | None:
+            self.get_calls += 1
+            if self.get_calls == 1:
+                return None
+            row = _CacheRow(
+                id=self._next_id,
+                input_hash=input_hash,
+                answer_text=FAKE_LONG_PREFIX_ASSIGNMENT,
+                citation_ids=[100],
+                model=_config().model,
+            )
+            self.rows[input_hash] = row
+            self._next_id += 1
+            return row
+
+    bundle = _make_bundle((100,))
+    ledger = FakeLedgerRepo()
+    cache = _UnderLockCache()
+    provider = FakeProvider(citation_ids=(100,))
+
+    result = await synthesize_answer(
+        FakeSession(
+            query_results=[
+                [{"message_version_id": 100}],
+                [],
+            ]
+        ),  # type: ignore[arg-type]
+        bundle=bundle,
+        query="q",
+        config=_config(),
+        qa_trace_id=11,
+        ledger_repo=ledger,
+        cache_repo=cache,
+        provider=provider,
+    )
+
+    assert isinstance(result, Abstention)
+    assert result.reason == "sensitive_output"
+    assert provider.calls == []
+    assert cache.rows == {}
+    assert cache.deleted_ids == [1]
+    assert ledger.rows[-1].error == "sensitive_output"
+    assert ledger.rows[-1].response_hash is None
+    assert FAKE_GENERIC_ASSIGNED_SECRET not in repr(ledger.rows)
+
+
+@pytest.mark.asyncio
+async def test_cache_store_race_unsafe_winner_is_deleted_and_abstained() -> None:
+    secret = FAKE_LONG_PREFIX_ASSIGNMENT
+
+    class _RaceCache(FakeCacheRepo):
+        async def store(
+            self,
+            session: Any,
+            *,
+            input_hash: str,
+            answer_text: str,
+            citation_ids: list[int],
+            model: str,
+        ) -> _CacheRow:
+            assert session.nested_depth == 1
+            winner = _CacheRow(
+                id=self._next_id,
+                input_hash=input_hash,
+                answer_text=f"unsafe winner {secret}",
+                citation_ids=list(citation_ids),
+                model=model,
+            )
+            self.rows[input_hash] = winner
+            self._next_id += 1
+            raise IntegrityError("cache insert", {}, RuntimeError("duplicate"))
+
+    bundle = _make_bundle((100,))
+    ledger = FakeLedgerRepo()
+    cache = _RaceCache()
+    provider = FakeProvider(answer_text="safe answer", citation_ids=(100,))
+    session = FakeSession(
+        query_results=[
+            [{"message_version_id": 100}],
+            [],
+        ]
+    )
+    result = await synthesize_answer(
+        session,  # type: ignore[arg-type]
+        bundle=bundle,
+        query="safe question",
+        config=_config(),
+        qa_trace_id=11,
+        ledger_repo=ledger,
+        cache_repo=cache,
+        provider=provider,
+    )
+
+    assert isinstance(result, Abstention)
+    assert result.reason == "sensitive_output"
+    assert cache.rows == {}
+    assert cache.deleted_ids == [1]
+    assert session.nested_entries == 1
+    assert session.nested_depth == 0
+    assert ledger.rows[-1].error == "sensitive_output"
+    assert ledger.rows[-1].response_hash is None
+    assert ledger.rows[-1].cost_usd > 0
+    assert secret not in repr(ledger.rows)
 
 
 # ─── Tests: invariant 3 — three-key tombstone gate ──────────────────────────
@@ -1007,6 +1403,83 @@ async def test_provider_transient_error_abstains(subtype: str) -> None:
     assert isinstance(res, Abstention)
     assert res.reason == "provider_error"
     assert ledger.rows[-1].error == f"provider_transient:{subtype}"
+
+
+@pytest.mark.asyncio
+async def test_provider_transient_subtype_is_sanitized_through_safe_taxonomy(caplog) -> None:
+    unsafe_subtype = "sk-" + "FAKEEXCEPTIONSUBTYPE0123456789"
+    ledger = FakeLedgerRepo()
+    provider = FakeProvider(
+        raise_exc=ProviderTransientError(unsafe_subtype, message=unsafe_subtype)
+    )
+    caplog.set_level(logging.ERROR, logger="bot.services.llm_gateway")
+
+    result = await synthesize_answer(
+        FakeSession(
+            query_results=[
+                [{"message_version_id": 100}],
+                [],
+            ]
+        ),  # type: ignore[arg-type]
+        bundle=_make_bundle((100,)),
+        query="safe question",
+        config=_config(),
+        qa_trace_id=11,
+        ledger_repo=ledger,
+        cache_repo=FakeCacheRepo(),
+        provider=provider,
+    )
+
+    assert isinstance(result, Abstention)
+    assert result.reason == "provider_error"
+    assert ledger.rows[-1].error == "provider_transient:unknown"
+    assert unsafe_subtype not in repr(ledger.rows)
+    assert unsafe_subtype not in caplog.text
+
+
+@pytest.mark.parametrize(
+    ("request_id", "expected"),
+    [
+        ("req_SAFE-123.abc:def", "req_SAFE-123.abc:def"),
+        ("req contains spaces", None),
+        ("r" * 129, None),
+        ("sk-" + "FAKEREQUESTID0123456789", None),
+        ("req_sk-" + "FAKEWRAPPEDREQUEST0123456789", None),
+        ("prefix_cfat_" + "FAKEWRAPPEDREQUEST0123456789", None),
+        ("req_12345678" + ":FAKEWRAPPEDREQUEST0123456789", None),
+        ("req/unsupported", None),
+    ],
+)
+@pytest.mark.asyncio
+async def test_provider_request_id_uses_strict_safe_allowlist(
+    request_id: str,
+    expected: str | None,
+) -> None:
+    ledger = FakeLedgerRepo()
+    result = await synthesize_answer(
+        FakeSession(
+            query_results=[
+                [{"message_version_id": 100}],
+                [],
+            ]
+        ),  # type: ignore[arg-type]
+        bundle=_make_bundle((100,)),
+        query="safe question",
+        config=_config(),
+        qa_trace_id=11,
+        ledger_repo=ledger,
+        cache_repo=FakeCacheRepo(),
+        provider=FakeProvider(
+            answer_text="safe answer",
+            citation_ids=(100,),
+            request_id=request_id,
+        ),
+    )
+
+    assert isinstance(result, AnswerWithCitations)
+    assert ledger.rows[-1].request_id == expected
+    if expected is None:
+        assert request_id not in repr(ledger.rows)
 
 
 @pytest.mark.parametrize(

--- a/tests/services/test_llm_gateway_evidence_prompt.py
+++ b/tests/services/test_llm_gateway_evidence_prompt.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
+import pytest
+
 from bot.services.evidence import EvidenceItem
 from bot.services.llm_gateway import (
     DEFAULT_PROMPT_TEMPLATE_VERSION,
@@ -62,6 +64,45 @@ def test_build_prompt_drops_items_outside_surviving_set():
     assert "private" not in prompt
     assert "allowed" in prompt
     assert "ALLOWED_CITATIONS: 22" in prompt
+
+
+@pytest.mark.parametrize(
+    ("query", "snippet"),
+    [
+        ("question " + "sk-" + "FAKEDEEPSEEK0123456789", "safe evidence"),
+        ("safe question", "cfat_" + "FAKECLOUDFLARE012345678901"),
+        (
+            "safe question",
+            "123456789" + ":FAKETELEGRAMBOT_TOKEN_0123456789",
+        ),
+        (
+            "safe question",
+            "DATABASE_" + "PASSWORD='Az9!FAKE.DB/0123456789'",
+        ),
+        (
+            "safe question",
+            "s\x00k-A1b2FAKECONTROL0123456789",
+        ),
+        (
+            "safe question",
+            "to\x00ken=Az9!FAKE_CONTROL_0123456789",
+        ),
+        (
+            "safe question",
+            "s\tk-A1b2FAKEGATEWAYCONTROL0123456789",
+        ),
+    ],
+)
+def test_build_prompt_refuses_secret_like_query_or_evidence(
+    query: str,
+    snippet: str,
+) -> None:
+    with pytest.raises(ValueError, match="sensitive"):
+        _build_prompt(
+            query,
+            (22,),
+            evidence_items=(_item(22, snippet),),
+        )
 
 
 def test_grounded_prompt_version_invalidates_pre_grounding_cache_keys():

--- a/tests/services/test_qa_guardrails.py
+++ b/tests/services/test_qa_guardrails.py
@@ -10,6 +10,185 @@ from tests.conftest import import_module
 
 pytestmark = pytest.mark.usefixtures("app_env")
 
+FAKE_GENERIC_ASSIGNED_SECRET = "Az9!FAKE_TOKEN_0123456789"
+FAKE_LONG_PREFIX_ASSIGNMENT = 'token="' + ("a" * 256) + FAKE_GENERIC_ASSIGNED_SECRET + '"'
+FAKE_ESCAPED_INTERNAL_DELIMITER_ASSIGNMENT = (
+    r"token=\"prefix\\\" " + FAKE_GENERIC_ASSIGNED_SECRET + r"\""
+)
+
+FAKE_SECRET_FAMILIES = (
+    "sk-" + "proj-FAKEOPENAI0123456789",
+    "cfat_" + "FAKECLOUDFLARE012345678901",
+    "123456789" + ":FAKETELEGRAMBOT_TOKEN_0123456789",
+    "OPENAI_API_" + "KEY = 'Az9!FAKE-generic/key+0123456789'",
+)
+
+FAKE_NAMED_ASSIGNMENTS = (
+    "api_" + "key=Az9!FAKE_GENERIC_0123456789",
+    "api-" + 'key : "Bz8$FAKE-GENERIC/0123456789"',
+    "api key = 'Cz7%FAKE+GENERIC/0123456789'",
+    "token=Dx6^FAKE_TOKEN_0123456789",
+    "secret = Ex5&FAKE_SECRET_0123456789",
+    "password: Fx4*FAKE_PASSWORD_0123456789",
+    "BOT_" + "TOKEN=Gx3!FAKE_BOT_0123456789",
+    "client_" + "secret='Hx2@FAKE_CLIENT_0123456789'",
+    "DATABASE_" + 'PASSWORD = "Ix1#FAKE.DB/0123456789"',
+    "DATABASE_" + 'PASSWORD="' + ("Ab9!" * 75) + '"',
+    'token="' + "Az9!FAKE_TOKEN_0123456789" + " explanatory text",
+    FAKE_LONG_PREFIX_ASSIGNMENT,
+    'token="explanation ' + FAKE_GENERIC_ASSIGNED_SECRET + '"',
+    "token=`" + FAKE_GENERIC_ASSIGNED_SECRET + "`",
+    'token=\\"' + FAKE_GENERIC_ASSIGNED_SECRET + '\\"',
+    FAKE_ESCAPED_INTERNAL_DELIMITER_ASSIGNMENT,
+)
+
+WRAPPED_DIRECT_SECRETS = (
+    "req_sk-" + "FAKEWRAPPEDOPENAI0123456789",
+    "prefix_cfat_" + "FAKEWRAPPEDCLOUDFLARE0123456789",
+    "req_12345678" + ":FAKEWRAPPEDTELEGRAM0123456789",
+)
+
+HIGHLIGHT_SPLIT_SECRETS = (
+    "<b>token</b>=Az9!FAKE_SECRET_0123456789",
+    "s<b>k</b>-A1b2FAKEHIGHLIGHT0123456789",
+)
+
+CONTROL_SPLIT_SECRETS = (
+    "s\x00k-A1b2FAKECONTROL0123456789",
+    "to\x00ken=Az9!FAKE_CONTROL_0123456789",
+    "s\tk-A1b2FAKETABCONTROL0123456789",
+    "s\nk-A1b2FAKELFCONTROL0123456789",
+    "s\rk-A1b2FAKECRCONTROL0123456789",
+    "to\tken=Az9!FAKE_TAB_CONTROL_0123456789",
+    "to\nken=Az9!FAKE_LF_CONTROL_0123456789",
+    "to\rken=Az9!FAKE_CR_CONTROL_0123456789",
+)
+
+SAFE_NEAR_MISSES = (
+    "sk-short",
+    "cfat_too_short",
+    "1234567:FAKETELEGRAMBOT_TOKEN_0123456789",
+    "12345678901:FAKETELEGRAMBOT_TOKEN_0123456789",
+    "token=public",
+    "secret=not-a-secret",
+    "password policy requires 16 characters",
+    "api_key_name is documentation",
+    "client_secret=placeholder",
+    "password = 'this is public documentation'",
+)
+
+
+@pytest.mark.parametrize("secret", (*FAKE_SECRET_FAMILIES, *FAKE_NAMED_ASSIGNMENTS))
+def test_contains_secret_like_data_detects_supported_high_confidence_shapes(
+    secret: str,
+) -> None:
+    guardrails = import_module("bot.services.qa_guardrails")
+
+    assert guardrails.contains_secret_like_data(f"before {secret} after") is True
+
+
+@pytest.mark.parametrize("delimiter", ('"', "'", "`"))
+@pytest.mark.parametrize(
+    "content",
+    (
+        ("a" * 256) + FAKE_GENERIC_ASSIGNED_SECRET,
+        "explanation " + FAKE_GENERIC_ASSIGNED_SECRET,
+    ),
+)
+def test_named_assignment_scans_every_delimited_segment_without_a_length_cap(
+    delimiter: str,
+    content: str,
+) -> None:
+    guardrails = import_module("bot.services.qa_guardrails")
+
+    assert guardrails.contains_secret_like_data(f"token={delimiter}{content}{delimiter}")
+
+
+def test_named_assignment_scans_the_entire_bare_token_without_a_length_cap() -> None:
+    guardrails = import_module("bot.services.qa_guardrails")
+
+    assert guardrails.contains_secret_like_data(
+        "token=" + ("a" * 256) + FAKE_GENERIC_ASSIGNED_SECRET
+    )
+
+
+@pytest.mark.parametrize("delimiter", ('"', "'", "`"))
+@pytest.mark.parametrize("internal_backslash_run", (3, 7))
+def test_escaped_assignment_keeps_escaped_internal_delimiters_inside_content(
+    delimiter: str,
+    internal_backslash_run: int,
+) -> None:
+    guardrails = import_module("bot.services.qa_guardrails")
+    payload = (
+        f"token=\\{delimiter}prefix"
+        + ("\\" * internal_backslash_run)
+        + delimiter
+        + " "
+        + FAKE_GENERIC_ASSIGNED_SECRET
+        + f"\\{delimiter}"
+    )
+
+    assert guardrails.contains_secret_like_data(payload)
+
+
+@pytest.mark.parametrize("delimiter", ('"', "'", "`"))
+@pytest.mark.parametrize(
+    ("backslash_run", "suffix_is_inside"),
+    ((1, False), (3, True), (5, False), (7, True)),
+)
+def test_escaped_assignment_delimiter_uses_outer_escape_parity(
+    delimiter: str,
+    backslash_run: int,
+    suffix_is_inside: bool,
+) -> None:
+    guardrails = import_module("bot.services.qa_guardrails")
+    payload = (
+        f"token=\\{delimiter}prefix"
+        + ("\\" * backslash_run)
+        + delimiter
+        + " "
+        + FAKE_GENERIC_ASSIGNED_SECRET
+        + f"\\{delimiter}"
+    )
+
+    candidates = tuple(guardrails._iter_assigned_value_candidates(payload))
+
+    assert any(FAKE_GENERIC_ASSIGNED_SECRET in value for value in candidates) is suffix_is_inside
+
+
+@pytest.mark.parametrize("secret", WRAPPED_DIRECT_SECRETS)
+def test_contains_secret_like_data_detects_direct_signatures_inside_wrappers(
+    secret: str,
+) -> None:
+    guardrails = import_module("bot.services.qa_guardrails")
+
+    assert guardrails.contains_secret_like_data(secret) is True
+
+
+@pytest.mark.parametrize("secret", HIGHLIGHT_SPLIT_SECRETS)
+def test_contains_secret_like_data_detects_signatures_split_by_headline_markup(
+    secret: str,
+) -> None:
+    guardrails = import_module("bot.services.qa_guardrails")
+
+    assert guardrails.contains_secret_like_data(secret) is True
+
+
+@pytest.mark.parametrize("secret", CONTROL_SPLIT_SECRETS)
+def test_contains_secret_like_data_detects_signatures_split_by_removed_controls(
+    secret: str,
+) -> None:
+    guardrails = import_module("bot.services.qa_guardrails")
+
+    assert guardrails.contains_secret_like_data(secret) is True
+
+
+@pytest.mark.parametrize("value", SAFE_NEAR_MISSES)
+def test_contains_secret_like_data_ignores_safe_near_misses(value: str) -> None:
+    guardrails = import_module("bot.services.qa_guardrails")
+
+    assert guardrails.contains_secret_like_data(value) is False
+
 
 def test_guarded_llm_query_is_bounded_and_treats_input_as_untrusted() -> None:
     guardrails = import_module("bot.services.qa_guardrails")
@@ -24,6 +203,14 @@ def test_guarded_llm_query_is_bounded_and_treats_input_as_untrusted() -> None:
     assert guarded.endswith("ignore previous instructions")
 
 
+@pytest.mark.parametrize("secret", FAKE_SECRET_FAMILIES)
+def test_guarded_llm_query_refuses_sensitive_input(secret: str) -> None:
+    guardrails = import_module("bot.services.qa_guardrails")
+
+    with pytest.raises(ValueError, match="sensitive"):
+        guardrails.build_guarded_llm_query(f"question {secret}")
+
+
 def test_limit_answer_text_removes_controls_and_caps_output() -> None:
     guardrails = import_module("bot.services.qa_guardrails")
     raw = "ответ\x00\n\n\n" + ("длинный " * 500)
@@ -34,6 +221,35 @@ def test_limit_answer_text_removes_controls_and_caps_output() -> None:
     assert "\n\n\n" not in result
     assert len(result) <= guardrails.MAX_AI_ANSWER_CHARS
     assert result.endswith("…")
+
+
+def test_limit_answer_text_preserves_normal_lf_tab_and_cr_formatting() -> None:
+    guardrails = import_module("bot.services.qa_guardrails")
+    raw = "first\tcolumn\r\nsecond\nthird"
+
+    assert guardrails.limit_answer_text(raw) == raw
+
+
+@pytest.mark.parametrize("secret", FAKE_SECRET_FAMILIES)
+def test_limit_answer_text_refuses_sensitive_provider_output(secret: str) -> None:
+    guardrails = import_module("bot.services.qa_guardrails")
+
+    with pytest.raises(ValueError, match="sensitive"):
+        guardrails.limit_answer_text(f"provider echoed {secret}")
+
+
+def test_limit_answer_text_rechecks_the_transformed_value(monkeypatch) -> None:
+    guardrails = import_module("bot.services.qa_guardrails")
+    raw = "safe words " * 500
+
+    monkeypatch.setattr(
+        guardrails,
+        "contains_secret_like_data",
+        lambda value: len(value) < len(raw),
+    )
+
+    with pytest.raises(ValueError, match="sensitive"):
+        guardrails.limit_answer_text(raw)
 
 
 def test_moscow_calendar_day_bounds_are_returned_in_utc() -> None:


### PR DESCRIPTION
## Summary

- fail closed on secret-like conversational QA input, evidence, provider output, request metadata, and cache rows
- bound every mention reply to 1200 characters while preserving safe HTML and normal whitespace
- keep the two-question Moscow-day LLM quota and deterministic over-quota fallback
- recover safely from PostgreSQL cache-store races through a SAVEPOINT

## Security contract

- fixed refusal; no redact-and-continue path for sensitive QA
- no unsafe response hash, trace summary, log payload, or cache persistence
- provider surface remains evidence-only and exposes no tools/functions
- detector canonicalization covers markup, Unicode, all C0 controls, quoted/escaped assignments, and stays linear on long input

## Verification

- 257 focused QA/provider/cache tests passed after rebase
- 204 privacy/eval tests passed
- real PostgreSQL SAVEPOINT acceptance passed in independent review
- Ruff, changed-file format check, compileall, privacy lint, and diff check passed
- independent review: PASS on byte-identical changed files
