### PR TITLE
feat: add semantic community Q&A

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,10 @@ LLM_MONTHLY_USD_CEILING=50.00
 # Images only. Historical Telegram exports without media files are retained as
 # missing_source metadata and are never invented or sent to the vision model.
 OPENAI_API_KEY=""
+EMBEDDING_MODEL=text-embedding-3-small
+EMBEDDING_DIMENSIONS=1536
+EMBEDDING_DAILY_USD_CEILING=1.00
+EMBEDDING_MONTHLY_USD_CEILING=10.00
 IMAGE_DESCRIPTION_MODEL=gpt-5-nano
 IMAGE_DESCRIPTION_DAILY_USD_CEILING=1.00
 IMAGE_DESCRIPTION_MONTHLY_USD_CEILING=10.00

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,11 +38,13 @@ jobs:
           trap 'docker rm --force shkoder-postgres-smoke >/dev/null 2>&1 || true' EXIT
           for _ in $(seq 1 30); do
             if docker exec shkoder-postgres-smoke \
-              pg_isready -U vibe -d vibe_gatekeeper >/dev/null; then
+              pg_isready -h 127.0.0.1 -U vibe -d vibe_gatekeeper >/dev/null; then
+              postgres_ready=true
               break
             fi
             sleep 1
           done
+          test "${postgres_ready:-false}" = "true"
           docker exec shkoder-postgres-smoke \
             psql -U vibe -d vibe_gatekeeper -v ON_ERROR_STOP=1 \
               -c 'CREATE EXTENSION vector;'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,13 +8,90 @@ on:
       - master
 
 jobs:
+  postgres-image-smoke:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install migration dependencies
+        run: pip install -e .
+
+      - name: Build production-compatible PostgreSQL image
+        run: docker build --file Dockerfile.postgres --tag shkoder-postgres:ci .
+
+      - name: Verify PostgreSQL and pgvector
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker run --detach --name shkoder-postgres-smoke \
+            --env POSTGRES_USER=vibe \
+            --env POSTGRES_PASSWORD=smoke-only \
+            --env POSTGRES_DB=vibe_gatekeeper \
+            --publish 55432:5432 \
+            shkoder-postgres:ci
+          trap 'docker rm --force shkoder-postgres-smoke >/dev/null 2>&1 || true' EXIT
+          for _ in $(seq 1 30); do
+            if docker exec shkoder-postgres-smoke \
+              pg_isready -U vibe -d vibe_gatekeeper >/dev/null; then
+              break
+            fi
+            sleep 1
+          done
+          docker exec shkoder-postgres-smoke \
+            psql -U vibe -d vibe_gatekeeper -v ON_ERROR_STOP=1 \
+              -c 'CREATE EXTENSION vector;'
+          vector_version=$(docker exec shkoder-postgres-smoke \
+            psql -U vibe -d vibe_gatekeeper -Atqc \
+              "SELECT extversion FROM pg_extension WHERE extname='vector'")
+          test "$vector_version" = "0.8.2"
+          postgres_major=$(docker exec shkoder-postgres-smoke \
+            psql -U vibe -d vibe_gatekeeper -Atqc \
+              "SELECT current_setting('server_version_num')::integer / 10000")
+          test "$postgres_major" = "15"
+          cosine_distance=$(docker exec shkoder-postgres-smoke \
+            psql -U vibe -d vibe_gatekeeper -Atqc \
+              "SELECT '[1,0,0]'::vector <=> '[1,0,0]'::vector")
+          test "$cosine_distance" = "0"
+
+          export DATABASE_URL=postgresql+asyncpg://vibe:smoke-only@127.0.0.1:55432/vibe_gatekeeper
+          alembic upgrade 089
+          alembic downgrade 088
+          alembic upgrade head
+          test "$(docker exec shkoder-postgres-smoke \
+            psql -U vibe -d vibe_gatekeeper -Atqc \
+              "SELECT version_num FROM alembic_version")" = "089"
+          test "$(docker exec shkoder-postgres-smoke \
+            psql -U vibe -d vibe_gatekeeper -Atqc \
+              "SELECT count(*) FROM information_schema.columns \
+               WHERE table_schema='public' AND table_name='semantic_qa_attempts' \
+                 AND column_name='delivery_started_at'")" = "1"
+          test "$(docker exec shkoder-postgres-smoke \
+            psql -U vibe -d vibe_gatekeeper -Atqc \
+              "SELECT count(*) FROM information_schema.columns \
+               WHERE table_schema='public' AND data_type='jsonb' \
+                 AND (table_name, column_name) IN ( \
+                   ('semantic_index_runs','reason_counts'), \
+                   ('semantic_retrieval_traces','candidate_ranks'), \
+                   ('semantic_retrieval_traces','result_source_ids'))")" = "3"
+          test "$(docker exec shkoder-postgres-smoke \
+            psql -U vibe -d vibe_gatekeeper -Atqc \
+              "SELECT count(*) FROM pg_constraint \
+               WHERE conname IN ('ck_llm_usage_ledger_nonnegative_usage', \
+                                 'ck_semantic_attempts_state') AND convalidated")" = "2"
+
   test:
     runs-on: ubuntu-latest
     permissions:
       contents: read
     services:
       postgres:
-        image: postgres:16
+        image: pgvector/pgvector:0.8.2-pg16-bookworm@sha256:00ba258a66dac104fd5171074a0084462a64a1369d8513f3d0a634e2f24d15bc
         env:
           POSTGRES_USER: vibe
           POSTGRES_PASSWORD: changeme

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -2,36 +2,15 @@ name: Evals
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "15 3 * * *"
 
 jobs:
-  evals-gate:
-    runs-on: ubuntu-latest
-    outputs:
-      enabled: ${{ steps.gate.outputs.enabled }}
-    steps:
-      - name: Check eval harness gate
-        id: gate
-        shell: bash
-        env:
-          EVAL_HARNESS_ENABLED_SECRET: ${{ secrets.EVAL_HARNESS_ENABLED }}
-        run: |
-          if [ "$EVAL_HARNESS_ENABLED_SECRET" = "true" ]; then
-            echo "enabled=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "enabled=false" >> "$GITHUB_OUTPUT"
-          fi
-
   evals:
-    needs: evals-gate
-    if: ${{ needs.evals-gate.outputs.enabled == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
     services:
       postgres:
-        image: postgres:16
+        image: pgvector/pgvector:0.8.2-pg16-bookworm@sha256:00ba258a66dac104fd5171074a0084462a64a1369d8513f3d0a634e2f24d15bc
         env:
           POSTGRES_USER: vibe
           POSTGRES_PASSWORD: changeme
@@ -85,19 +64,45 @@ jobs:
       - name: Run database migrations
         run: alembic upgrade head
 
-      - name: Run evals
+      - name: Run privacy and semantic eval contract tests
         shell: bash
         run: |
-          : > eval_results.jsonl
-          if [ ! -d tests/evals ] || [ -z "$(find tests/evals -name 'test_*.py' -print -quit)" ]; then
-            echo "tests/evals/ not yet populated — skipping eval run"
-            exit 0
-          fi
-          # NOTE: structured eval_results.jsonl emitter is a follow-up (see
-          # docs/memory-system/eval-results-schema.md). For now we run the
-          # privacy binding suite and fail the job on real pytest failure —
-          # NO `|| true` masking. CI green = privacy invariants hold.
-          EVAL_HARNESS_ENABLED=1 timeout 300 pytest -x --timeout=60 tests/evals/
+          set +e
+          EVAL_HARNESS_ENABLED=1 timeout 300 pytest -x --timeout=60 \
+            tests/evals/ \
+            tests/services/test_semantic_eval.py \
+            tests/scripts/test_evaluate_semantic_qa.py \
+            tests/scripts/test_run_semantic_qa_eval.py \
+            tests/scripts/test_postgres_image_contract.py
+          eval_status=$?
+          set -e
+          python - "$eval_status" <<'PY'
+          import json
+          import os
+          import sys
+
+          exit_code = int(sys.argv[1])
+          payload = {
+              "schema_version": 1,
+              "suite": "privacy-and-semantic-eval-contract-tests",
+              "status": "pass" if exit_code == 0 else "fail",
+              "exit_code": exit_code,
+              "commit_sha": os.environ.get("GITHUB_SHA", ""),
+              "contains_raw_text": False,
+          }
+          with open("eval_results.jsonl", "w", encoding="utf-8") as target:
+              target.write(json.dumps(payload, sort_keys=True) + "\n")
+          PY
+          exit "$eval_status"
+
+      - name: Validate sanitized private frozen eval report
+        shell: bash
+        env:
+          SEMANTIC_EVAL_REPORT_JSON: ${{ secrets.SEMANTIC_EVAL_REPORT_JSON }}
+        run: |
+          python -m scripts.evaluate_semantic_qa validate-report \
+            --expected-release-sha "$GITHUB_SHA" \
+            --artifact eval_results.jsonl
 
       - name: Upload eval results
         if: always()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ permissions:
 env:
   REGISTRY: ghcr.io
   IMAGE_BOT: ghcr.io/jekudy/vibe-gatekeeper-bot
+  IMAGE_DB: ghcr.io/jekudy/vibe-gatekeeper-postgres
   IMAGE_WEB: ghcr.io/jekudy/vibe-gatekeeper-web
 
 jobs:
@@ -66,3 +67,16 @@ jobs:
           tags: |
             ${{ env.IMAGE_WEB }}:${{ steps.meta.outputs.sha_tag }}
             ${{ env.IMAGE_WEB }}:main
+
+      - name: Build and push PostgreSQL image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile.postgres
+          push: true
+          labels: |
+            org.opencontainers.image.source=https://github.com/Jekudy/vibe-gatekeeper
+            org.opencontainers.image.revision=${{ github.event.workflow_run.head_sha }}
+          tags: |
+            ${{ env.IMAGE_DB }}:${{ steps.meta.outputs.sha_tag }}
+            ${{ env.IMAGE_DB }}:main

--- a/Dockerfile.bot
+++ b/Dockerfile.bot
@@ -27,6 +27,7 @@ COPY --chown=appuser:appuser pyproject.toml .
 COPY --chown=appuser:appuser bot/ bot/
 COPY --chown=appuser:appuser alembic/ alembic/
 COPY --chown=appuser:appuser alembic.ini .
+COPY --chown=appuser:appuser scripts/ scripts/
 RUN pip install --no-cache-dir --no-deps .
 
 USER appuser

--- a/Dockerfile.postgres
+++ b/Dockerfile.postgres
@@ -1,0 +1,30 @@
+# Production-compatible PostgreSQL 15 image with pgvector compiled on the
+# exact Alpine/musl base currently used by the Coolify database service.
+FROM postgres@sha256:1c52f5ad23db5d7648a63634444af76de48e63b860fccbe3e3a5458b2812eaed
+
+ARG PGVECTOR_VERSION=0.8.2
+ARG PGVECTOR_TARBALL_SHA256=69f4019389af05dc1c9548deb8628e62878e6e207c03907f2b8af2016472cdaa
+
+RUN set -eux; \
+    apk add --no-cache --virtual .pgvector-build \
+        build-base \
+        ca-certificates \
+        clang19 \
+        curl \
+        llvm19-dev; \
+    curl --fail --location --proto '=https' --tlsv1.2 \
+        --output /tmp/pgvector.tar.gz \
+        "https://github.com/pgvector/pgvector/archive/refs/tags/v${PGVECTOR_VERSION}.tar.gz"; \
+    echo "${PGVECTOR_TARBALL_SHA256}  /tmp/pgvector.tar.gz" | sha256sum -c -; \
+    mkdir /tmp/pgvector; \
+    tar --extract --gzip --file /tmp/pgvector.tar.gz \
+        --directory /tmp/pgvector --strip-components=1; \
+    make -C /tmp/pgvector clean; \
+    make -C /tmp/pgvector OPTFLAGS=""; \
+    make -C /tmp/pgvector install; \
+    mkdir -p /usr/share/doc/pgvector; \
+    cp /tmp/pgvector/LICENSE /tmp/pgvector/README.md /usr/share/doc/pgvector/; \
+    grep -F "default_version = '${PGVECTOR_VERSION}'" \
+        /usr/local/share/postgresql/extension/vector.control; \
+    rm -rf /tmp/pgvector /tmp/pgvector.tar.gz; \
+    apk del .pgvector-build

--- a/alembic/versions/089_semantic_qa.py
+++ b/alembic/versions/089_semantic_qa.py
@@ -154,14 +154,11 @@ def upgrade() -> None:
         sa.Column("embedding_model", sa.String(length=128), nullable=False),
         sa.Column("embedding_model_version", sa.String(length=64), nullable=False),
         sa.Column("embedding_dimensions", sa.Integer(), nullable=False),
-        sa.Column("embedding", Vector(1536), nullable=False),
+        sa.Column("embedding_status", sa.String(length=16), nullable=False),
+        sa.Column("chunk_text", sa.Text(), nullable=True),
+        sa.Column("embedding", Vector(1536), nullable=True),
         sa.Column("llm_usage_ledger_id", sa.BigInteger(), nullable=False),
-        sa.Column(
-            "indexed_at",
-            sa.DateTime(timezone=True),
-            nullable=False,
-            server_default=sa.text("now()"),
-        ),
+        sa.Column("indexed_at", sa.DateTime(timezone=True), nullable=True),
         sa.Column("invalidated_at", sa.DateTime(timezone=True), nullable=True),
         sa.Column("invalidation_reason", sa.String(length=64), nullable=True),
         sa.CheckConstraint(
@@ -171,6 +168,20 @@ def upgrade() -> None:
         sa.CheckConstraint(
             "chunk_index >= 0 AND chunk_count > 0 AND chunk_index < chunk_count",
             name="ck_semantic_units_chunk_bounds",
+        ),
+        sa.CheckConstraint(
+            "embedding_status IN ('reserved','completed','failed')",
+            name="ck_semantic_units_embedding_status",
+        ),
+        sa.CheckConstraint(
+            "(embedding_status = 'reserved' AND embedding IS NULL "
+            "AND chunk_text IS NULL AND indexed_at IS NULL) OR "
+            "(embedding_status = 'completed' AND embedding IS NOT NULL "
+            "AND chunk_text IS NOT NULL AND length(trim(chunk_text)) BETWEEN 1 AND 800 "
+            "AND indexed_at IS NOT NULL) OR "
+            "(embedding_status = 'failed' AND embedding IS NULL "
+            "AND chunk_text IS NULL AND indexed_at IS NULL)",
+            name="ck_semantic_units_embedding_state",
         ),
         sa.CheckConstraint(
             "(invalidated_at IS NULL) = (invalidation_reason IS NULL)",

--- a/alembic/versions/089_semantic_qa.py
+++ b/alembic/versions/089_semantic_qa.py
@@ -146,6 +146,8 @@ def upgrade() -> None:
         sa.Column("source_type", sa.String(length=32), nullable=False),
         sa.Column("source_id", sa.String(length=64), nullable=False),
         sa.Column("source_revision", sa.String(length=128), nullable=False),
+        sa.Column("chunk_index", sa.SmallInteger(), nullable=False, server_default="0"),
+        sa.Column("chunk_count", sa.SmallInteger(), nullable=False, server_default="1"),
         sa.Column("chat_id", sa.BigInteger(), nullable=False),
         sa.Column("content_hash", sa.String(length=128), nullable=False),
         sa.Column("embedding_provider", sa.String(length=64), nullable=False),
@@ -167,6 +169,10 @@ def upgrade() -> None:
         ),
         sa.CheckConstraint("embedding_dimensions = 1536", name="ck_semantic_units_dimensions"),
         sa.CheckConstraint(
+            "chunk_index >= 0 AND chunk_count > 0 AND chunk_index < chunk_count",
+            name="ck_semantic_units_chunk_bounds",
+        ),
+        sa.CheckConstraint(
             "(invalidated_at IS NULL) = (invalidation_reason IS NULL)",
             name="ck_semantic_units_invalidation_pair",
         ),
@@ -181,6 +187,7 @@ def upgrade() -> None:
             "source_type",
             "source_id",
             "source_revision",
+            "chunk_index",
             "content_hash",
             "embedding_model",
             name="uq_semantic_units_identity",

--- a/alembic/versions/089_semantic_qa.py
+++ b/alembic/versions/089_semantic_qa.py
@@ -1,0 +1,402 @@
+"""Add pgvector-backed semantic Q&A storage and durable daily quota.
+
+Revision ID: 089
+Revises: 088
+Create Date: 2026-07-16
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from pgvector.sqlalchemy import Vector
+from sqlalchemy.dialects.postgresql import JSONB
+
+
+revision: str = "089"
+down_revision: Union[str, Sequence[str], None] = "088"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_OLD_CALL_TYPES = (
+    "'unknown','qa_synthesis','digest_daily','digest_weekly',"
+    "'graph_projection','extract_candidates','butler_decision','butler_summary',"
+    "'wiki_compilation','image_description'"
+)
+_NEW_CALL_TYPES = _OLD_CALL_TYPES + ",'semantic_embedding'"
+
+
+def _add_call_type_constraint(values: str) -> None:
+    op.execute(
+        "ALTER TABLE llm_usage_ledger "
+        "ADD CONSTRAINT ck_llm_usage_ledger_call_type "
+        f"CHECK (call_type IN ({values})) NOT VALID"
+    )
+    op.execute("ALTER TABLE llm_usage_ledger VALIDATE CONSTRAINT ck_llm_usage_ledger_call_type")
+
+
+def upgrade() -> None:
+    # Extension files must already exist in the same-major PostgreSQL image. Repo/CI
+    # stay on PG16; the production preflight switches its existing PG15 service to
+    # the pinned PG15+pgvector image before this migration runs.
+    op.execute("CREATE EXTENSION IF NOT EXISTS vector")
+
+    op.add_column("users", sa.Column("is_bot", sa.Boolean(), nullable=True))
+    op.execute(
+        """
+        WITH author_evidence (user_id, is_bot) AS (
+            SELECT cm.user_id,
+                   CASE cm.raw_json #>> '{from_user,is_bot}'
+                       WHEN 'true' THEN TRUE
+                       WHEN 'false' THEN FALSE
+                   END
+            FROM chat_messages AS cm
+            WHERE cm.raw_json #>> '{from_user,is_bot}' IN ('true', 'false')
+
+            UNION ALL
+
+            SELECT u.id,
+                   CASE tu.raw_json #>> '{message,from_user,is_bot}'
+                       WHEN 'true' THEN TRUE
+                       WHEN 'false' THEN FALSE
+                   END
+            FROM telegram_updates AS tu
+            JOIN users AS u
+              ON u.id::text = tu.raw_json #>> '{message,from_user,id}'
+            WHERE tu.raw_json #>> '{message,from_user,is_bot}' IN ('true', 'false')
+
+            UNION ALL
+
+            SELECT u.id,
+                   CASE tu.raw_json #>> '{edited_message,from_user,is_bot}'
+                       WHEN 'true' THEN TRUE
+                       WHEN 'false' THEN FALSE
+                   END
+            FROM telegram_updates AS tu
+            JOIN users AS u
+              ON u.id::text = tu.raw_json #>> '{edited_message,from_user,id}'
+            WHERE tu.raw_json #>> '{edited_message,from_user,is_bot}' IN ('true', 'false')
+        ),
+        resolved_authors AS (
+            SELECT user_id, bool_or(is_bot) AS is_bot
+            FROM author_evidence
+            GROUP BY user_id
+        )
+        UPDATE users AS u
+        SET is_bot = source.is_bot
+        FROM resolved_authors AS source
+        WHERE u.id = source.user_id
+        """
+    )
+
+    op.execute("ALTER TABLE llm_usage_ledger DROP CONSTRAINT ck_llm_usage_ledger_call_type")
+    _add_call_type_constraint(_NEW_CALL_TYPES)
+    op.execute(
+        "ALTER TABLE llm_usage_ledger "
+        "ADD CONSTRAINT ck_llm_usage_ledger_nonnegative_usage "
+        "CHECK (tokens_in >= 0 AND tokens_out >= 0 AND cost_usd >= 0 AND latency_ms >= 0) "
+        "NOT VALID"
+    )
+    op.execute(
+        "ALTER TABLE llm_usage_ledger VALIDATE CONSTRAINT ck_llm_usage_ledger_nonnegative_usage"
+    )
+
+    op.create_table(
+        "semantic_index_runs",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("run_type", sa.String(length=32), nullable=False),
+        sa.Column("embedding_provider", sa.String(length=64), nullable=False),
+        sa.Column("embedding_model", sa.String(length=128), nullable=False),
+        sa.Column("embedding_dimensions", sa.Integer(), nullable=False),
+        sa.Column("status", sa.String(length=32), nullable=False),
+        sa.Column("eligible_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("indexed_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("skipped_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("failed_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column(
+            "reason_counts",
+            JSONB(),
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+        sa.Column("cursor", sa.String(length=255), nullable=True),
+        sa.Column(
+            "started_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.CheckConstraint(
+            "run_type IN ('backfill','reindex')", name="ck_semantic_index_runs_type"
+        ),
+        sa.CheckConstraint(
+            "status IN ('running','completed','failed')",
+            name="ck_semantic_index_runs_status",
+        ),
+        sa.CheckConstraint("embedding_dimensions > 0", name="ck_semantic_index_runs_dimensions"),
+        sa.PrimaryKeyConstraint("id", name="pk_semantic_index_runs"),
+    )
+
+    op.create_table(
+        "semantic_retrieval_units",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("source_type", sa.String(length=32), nullable=False),
+        sa.Column("source_id", sa.String(length=64), nullable=False),
+        sa.Column("source_revision", sa.String(length=128), nullable=False),
+        sa.Column("chat_id", sa.BigInteger(), nullable=False),
+        sa.Column("content_hash", sa.String(length=128), nullable=False),
+        sa.Column("embedding_provider", sa.String(length=64), nullable=False),
+        sa.Column("embedding_model", sa.String(length=128), nullable=False),
+        sa.Column("embedding_model_version", sa.String(length=64), nullable=False),
+        sa.Column("embedding_dimensions", sa.Integer(), nullable=False),
+        sa.Column("embedding", Vector(1536), nullable=False),
+        sa.Column("llm_usage_ledger_id", sa.BigInteger(), nullable=False),
+        sa.Column(
+            "indexed_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column("invalidated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("invalidation_reason", sa.String(length=64), nullable=True),
+        sa.CheckConstraint(
+            "source_type IN ('message','card')", name="ck_semantic_units_source_type"
+        ),
+        sa.CheckConstraint("embedding_dimensions = 1536", name="ck_semantic_units_dimensions"),
+        sa.CheckConstraint(
+            "(invalidated_at IS NULL) = (invalidation_reason IS NULL)",
+            name="ck_semantic_units_invalidation_pair",
+        ),
+        sa.PrimaryKeyConstraint("id", name="pk_semantic_retrieval_units"),
+        sa.ForeignKeyConstraint(
+            ["llm_usage_ledger_id"],
+            ["llm_usage_ledger.id"],
+            name="fk_semantic_units_llm_usage_ledger_id",
+            ondelete="RESTRICT",
+        ),
+        sa.UniqueConstraint(
+            "source_type",
+            "source_id",
+            "source_revision",
+            "content_hash",
+            "embedding_model",
+            name="uq_semantic_units_identity",
+        ),
+    )
+    op.create_index(
+        "ix_semantic_units_chat_active",
+        "semantic_retrieval_units",
+        ["chat_id", "invalidated_at"],
+    )
+    op.create_index(
+        "ix_semantic_units_source",
+        "semantic_retrieval_units",
+        ["source_type", "source_id"],
+    )
+
+    op.create_table(
+        "semantic_retrieval_unit_sources",
+        sa.Column("unit_id", sa.BigInteger(), nullable=False),
+        sa.Column("message_version_id", sa.Integer(), nullable=False),
+        sa.Column("position", sa.SmallInteger(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["unit_id"],
+            ["semantic_retrieval_units.id"],
+            name="fk_semantic_unit_sources_unit_id",
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["message_version_id"],
+            ["message_versions.id"],
+            name="fk_semantic_unit_sources_message_version_id",
+            ondelete="CASCADE",
+        ),
+        sa.CheckConstraint("position >= 0", name="ck_semantic_unit_sources_position"),
+        sa.PrimaryKeyConstraint("unit_id", "message_version_id", name="pk_semantic_unit_sources"),
+        sa.UniqueConstraint("unit_id", "position", name="uq_semantic_unit_sources_position"),
+    )
+    op.create_index(
+        "ix_semantic_unit_sources_message_version_id",
+        "semantic_retrieval_unit_sources",
+        ["message_version_id"],
+    )
+
+    op.create_table(
+        "semantic_qa_attempts",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("idempotency_key", sa.String(length=128), nullable=False),
+        sa.Column("user_tg_id", sa.BigInteger(), nullable=False),
+        sa.Column("chat_id", sa.BigInteger(), nullable=False),
+        sa.Column("source_chat_message_id", sa.Integer(), nullable=True),
+        sa.Column("local_day", sa.Date(), nullable=False),
+        sa.Column("slot_number", sa.SmallInteger(), nullable=True),
+        sa.Column("status", sa.String(length=16), nullable=False),
+        sa.Column("outcome", sa.String(length=32), nullable=True),
+        sa.Column("qa_trace_id", sa.BigInteger(), nullable=True),
+        sa.Column("embedding_llm_call_id", sa.BigInteger(), nullable=True),
+        sa.Column("synthesis_llm_call_id", sa.BigInteger(), nullable=True),
+        sa.Column(
+            "reserved_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column("delivery_started_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("finalized_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["source_chat_message_id"],
+            ["chat_messages.id"],
+            name="fk_semantic_qa_attempts_source_chat_message_id",
+            ondelete="SET NULL",
+        ),
+        sa.ForeignKeyConstraint(
+            ["qa_trace_id"],
+            ["qa_traces.id"],
+            name="fk_semantic_qa_attempts_qa_trace_id",
+            ondelete="SET NULL",
+        ),
+        sa.ForeignKeyConstraint(
+            ["embedding_llm_call_id"],
+            ["llm_usage_ledger.id"],
+            name="fk_semantic_qa_attempts_embedding_call_id",
+            ondelete="SET NULL",
+        ),
+        sa.ForeignKeyConstraint(
+            ["synthesis_llm_call_id"],
+            ["llm_usage_ledger.id"],
+            name="fk_semantic_qa_attempts_synthesis_call_id",
+            ondelete="SET NULL",
+        ),
+        sa.CheckConstraint(
+            "slot_number IS NULL OR slot_number IN (1,2)", name="ck_semantic_attempts_slot"
+        ),
+        sa.CheckConstraint(
+            "status IN ('denied','reserved','consumed','released')",
+            name="ck_semantic_attempts_status",
+        ),
+        sa.CheckConstraint(
+            "outcome IS NULL OR outcome IN ('answered','abstained','technical_failure','quota_denied')",
+            name="ck_semantic_attempts_outcome",
+        ),
+        sa.CheckConstraint(
+            "(status = 'denied' AND slot_number IS NULL AND outcome = 'quota_denied' "
+            "AND delivery_started_at IS NULL) OR "
+            "(status = 'reserved' AND slot_number IS NOT NULL AND finalized_at IS NULL AND "
+            "((outcome IS NULL AND delivery_started_at IS NULL) OR "
+            "(outcome IN ('answered','abstained') AND delivery_started_at IS NOT NULL))) OR "
+            "(status = 'consumed' AND slot_number IS NOT NULL "
+            "AND outcome IN ('answered','abstained') AND delivery_started_at IS NOT NULL "
+            "AND finalized_at IS NOT NULL) OR "
+            "(status = 'released' AND slot_number IS NOT NULL "
+            "AND outcome = 'technical_failure' AND finalized_at IS NOT NULL)",
+            name="ck_semantic_attempts_state",
+        ),
+        sa.PrimaryKeyConstraint("id", name="pk_semantic_qa_attempts"),
+        sa.UniqueConstraint("idempotency_key", name="uq_semantic_qa_attempts_idempotency_key"),
+    )
+    op.create_index(
+        "uq_semantic_qa_attempts_active_slot",
+        "semantic_qa_attempts",
+        ["user_tg_id", "local_day", "slot_number"],
+        unique=True,
+        postgresql_where=sa.text("status IN ('reserved','consumed')"),
+    )
+    op.create_index(
+        "ix_semantic_qa_attempts_user_day",
+        "semantic_qa_attempts",
+        ["user_tg_id", "local_day", "status"],
+    )
+
+    op.create_table(
+        "semantic_retrieval_traces",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("attempt_id", sa.BigInteger(), nullable=False),
+        sa.Column("qa_trace_id", sa.BigInteger(), nullable=True),
+        sa.Column("query_hash", sa.CHAR(length=64), nullable=False),
+        sa.Column("embedding_model", sa.String(length=128), nullable=False),
+        sa.Column("retrieval_mode", sa.String(length=32), nullable=False),
+        sa.Column("candidate_ranks", JSONB(), nullable=False),
+        sa.Column("result_source_ids", JSONB(), nullable=False),
+        sa.Column("fts_latency_ms", sa.Integer(), nullable=False),
+        sa.Column("vector_latency_ms", sa.Integer(), nullable=False),
+        sa.Column("fusion_latency_ms", sa.Integer(), nullable=False),
+        sa.Column("total_latency_ms", sa.Integer(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["attempt_id"],
+            ["semantic_qa_attempts.id"],
+            name="fk_semantic_retrieval_traces_attempt_id",
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["qa_trace_id"],
+            ["qa_traces.id"],
+            name="fk_semantic_retrieval_traces_qa_trace_id",
+            ondelete="SET NULL",
+        ),
+        sa.CheckConstraint(
+            "retrieval_mode IN ('hybrid','fts_fallback','shadow')",
+            name="ck_semantic_retrieval_traces_mode",
+        ),
+        sa.CheckConstraint(
+            "fts_latency_ms >= 0 AND vector_latency_ms >= 0 AND fusion_latency_ms >= 0 "
+            "AND total_latency_ms >= 0",
+            name="ck_semantic_retrieval_traces_latency",
+        ),
+        sa.PrimaryKeyConstraint("id", name="pk_semantic_retrieval_traces"),
+        sa.UniqueConstraint("attempt_id", name="uq_semantic_retrieval_traces_attempt_id"),
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF EXISTS (SELECT 1 FROM semantic_index_runs)
+               OR EXISTS (SELECT 1 FROM semantic_retrieval_units)
+               OR EXISTS (SELECT 1 FROM semantic_retrieval_unit_sources)
+               OR EXISTS (SELECT 1 FROM semantic_qa_attempts)
+               OR EXISTS (SELECT 1 FROM semantic_retrieval_traces)
+               OR EXISTS (
+                    SELECT 1 FROM llm_usage_ledger
+                    WHERE call_type = 'semantic_embedding'
+               ) THEN
+                RAISE EXCEPTION
+                    'Cannot downgrade 089 with semantic Q&A audit data; disable the flag and restore the pre-migration backup';
+            END IF;
+        END
+        $$
+        """
+    )
+    op.drop_table("semantic_retrieval_traces")
+    op.drop_index("ix_semantic_qa_attempts_user_day", table_name="semantic_qa_attempts")
+    op.drop_index("uq_semantic_qa_attempts_active_slot", table_name="semantic_qa_attempts")
+    op.drop_table("semantic_qa_attempts")
+    op.drop_index(
+        "ix_semantic_unit_sources_message_version_id",
+        table_name="semantic_retrieval_unit_sources",
+    )
+    op.drop_table("semantic_retrieval_unit_sources")
+    op.drop_index("ix_semantic_units_source", table_name="semantic_retrieval_units")
+    op.drop_index("ix_semantic_units_chat_active", table_name="semantic_retrieval_units")
+    op.drop_table("semantic_retrieval_units")
+    op.drop_table("semantic_index_runs")
+    op.drop_constraint(
+        "ck_llm_usage_ledger_nonnegative_usage",
+        "llm_usage_ledger",
+        type_="check",
+    )
+    op.execute("ALTER TABLE llm_usage_ledger DROP CONSTRAINT ck_llm_usage_ledger_call_type")
+    _add_call_type_constraint(_OLD_CALL_TYPES)
+    op.drop_column("users", "is_bot")
+    # The extension is shared database infrastructure. Do not drop it during an
+    # application downgrade; other schemas may legitimately depend on it.

--- a/alembic/versions/089_semantic_qa.py
+++ b/alembic/versions/089_semantic_qa.py
@@ -262,6 +262,12 @@ def upgrade() -> None:
             nullable=False,
             server_default=sa.text("now()"),
         ),
+        sa.Column(
+            "progress_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
         sa.Column("delivery_started_at", sa.DateTime(timezone=True), nullable=True),
         sa.Column("finalized_at", sa.DateTime(timezone=True), nullable=True),
         sa.ForeignKeyConstraint(

--- a/bot/db/locks.py
+++ b/bot/db/locks.py
@@ -7,10 +7,10 @@ paths that all read+write the same (chat_id, message_id) row.
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from bot.services.advisory_locks import chat_message_advisory_key
 
-async def advisory_lock_chat_message(
-    session: AsyncSession, chat_id: int, message_id: int
-) -> None:
+
+async def advisory_lock_chat_message(session: AsyncSession, chat_id: int, message_id: int) -> None:
     """Acquire pg_advisory_xact_lock keyed by (chat_id, message_id).
 
     Releases automatically at end of transaction. Cooperative with ``with_for_update()``
@@ -18,5 +18,5 @@ async def advisory_lock_chat_message(
 
     Key format: ``chat_msg:{chat_id}:{message_id}``. All handlers MUST use this format.
     """
-    key = f"chat_msg:{chat_id}:{message_id}"
+    key = chat_message_advisory_key(chat_id, message_id)
     await session.execute(text("SELECT pg_advisory_xact_lock(hashtext(:k))"), {"k": key})

--- a/bot/db/models.py
+++ b/bot/db/models.py
@@ -797,6 +797,10 @@ class SemanticRetrievalUnit(Base):
         CheckConstraint("source_type IN ('message','card')", name="ck_semantic_units_source_type"),
         CheckConstraint("embedding_dimensions = 1536", name="ck_semantic_units_dimensions"),
         CheckConstraint(
+            "chunk_index >= 0 AND chunk_count > 0 AND chunk_index < chunk_count",
+            name="ck_semantic_units_chunk_bounds",
+        ),
+        CheckConstraint(
             "(invalidated_at IS NULL) = (invalidation_reason IS NULL)",
             name="ck_semantic_units_invalidation_pair",
         ),
@@ -804,6 +808,7 @@ class SemanticRetrievalUnit(Base):
             "source_type",
             "source_id",
             "source_revision",
+            "chunk_index",
             "content_hash",
             "embedding_model",
             name="uq_semantic_units_identity",
@@ -816,6 +821,8 @@ class SemanticRetrievalUnit(Base):
     source_type: Mapped[str] = mapped_column(String(32), nullable=False)
     source_id: Mapped[str] = mapped_column(String(64), nullable=False)
     source_revision: Mapped[str] = mapped_column(String(128), nullable=False)
+    chunk_index: Mapped[int] = mapped_column(SmallInteger, nullable=False, server_default="0")
+    chunk_count: Mapped[int] = mapped_column(SmallInteger, nullable=False, server_default="1")
     chat_id: Mapped[int] = mapped_column(BigInteger, nullable=False)
     content_hash: Mapped[str] = mapped_column(String(128), nullable=False)
     embedding_provider: Mapped[str] = mapped_column(String(64), nullable=False)

--- a/bot/db/models.py
+++ b/bot/db/models.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import date, datetime
 from decimal import Decimal
 
 from sqlalchemy import (
@@ -9,6 +9,7 @@ from sqlalchemy import (
     Boolean,
     CheckConstraint,
     Computed,
+    Date,
     DateTime,
     ForeignKey,
     Index,
@@ -25,6 +26,7 @@ from sqlalchemy import (
 )
 import uuid as _uuid_module
 
+from pgvector.sqlalchemy import Vector
 from sqlalchemy.dialects.postgresql import JSONB, TSVECTOR
 from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
@@ -114,6 +116,9 @@ class User(Base):
     is_imported_only: Mapped[bool] = mapped_column(
         Boolean, nullable=False, server_default=text("false"), default=False
     )
+    # NULL is intentionally fail-closed for semantic indexing: only authors
+    # positively identified by Telegram as human have is_bot=False.
+    is_bot: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
 
     intro: Mapped[Intro | None] = relationship(
         "Intro", back_populates="user", foreign_keys="[Intro.user_id]"
@@ -752,6 +757,211 @@ class QaTrace(Base):
     cost_usd: Mapped[Decimal | None] = mapped_column(Numeric(10, 6), nullable=True)
 
 
+class SemanticIndexRun(Base):
+    __tablename__ = "semantic_index_runs"
+    __table_args__ = (
+        CheckConstraint("run_type IN ('backfill','reindex')", name="ck_semantic_index_runs_type"),
+        CheckConstraint(
+            "status IN ('running','completed','failed')",
+            name="ck_semantic_index_runs_status",
+        ),
+        CheckConstraint("embedding_dimensions > 0", name="ck_semantic_index_runs_dimensions"),
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    run_type: Mapped[str] = mapped_column(String(32), nullable=False)
+    embedding_provider: Mapped[str] = mapped_column(String(64), nullable=False)
+    embedding_model: Mapped[str] = mapped_column(String(128), nullable=False)
+    embedding_dimensions: Mapped[int] = mapped_column(Integer, nullable=False)
+    status: Mapped[str] = mapped_column(String(32), nullable=False)
+    eligible_count: Mapped[int] = mapped_column(Integer, nullable=False, server_default="0")
+    indexed_count: Mapped[int] = mapped_column(Integer, nullable=False, server_default="0")
+    skipped_count: Mapped[int] = mapped_column(Integer, nullable=False, server_default="0")
+    failed_count: Mapped[int] = mapped_column(Integer, nullable=False, server_default="0")
+    reason_counts: Mapped[dict] = mapped_column(
+        JSON().with_variant(JSONB(), "postgresql"),
+        nullable=False,
+        default=dict,
+        server_default="{}",
+    )
+    cursor: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    started_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    completed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+
+class SemanticRetrievalUnit(Base):
+    __tablename__ = "semantic_retrieval_units"
+    __table_args__ = (
+        CheckConstraint("source_type IN ('message','card')", name="ck_semantic_units_source_type"),
+        CheckConstraint("embedding_dimensions = 1536", name="ck_semantic_units_dimensions"),
+        CheckConstraint(
+            "(invalidated_at IS NULL) = (invalidation_reason IS NULL)",
+            name="ck_semantic_units_invalidation_pair",
+        ),
+        UniqueConstraint(
+            "source_type",
+            "source_id",
+            "source_revision",
+            "content_hash",
+            "embedding_model",
+            name="uq_semantic_units_identity",
+        ),
+        Index("ix_semantic_units_chat_active", "chat_id", "invalidated_at"),
+        Index("ix_semantic_units_source", "source_type", "source_id"),
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    source_type: Mapped[str] = mapped_column(String(32), nullable=False)
+    source_id: Mapped[str] = mapped_column(String(64), nullable=False)
+    source_revision: Mapped[str] = mapped_column(String(128), nullable=False)
+    chat_id: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    content_hash: Mapped[str] = mapped_column(String(128), nullable=False)
+    embedding_provider: Mapped[str] = mapped_column(String(64), nullable=False)
+    embedding_model: Mapped[str] = mapped_column(String(128), nullable=False)
+    embedding_model_version: Mapped[str] = mapped_column(String(64), nullable=False)
+    embedding_dimensions: Mapped[int] = mapped_column(Integer, nullable=False)
+    embedding: Mapped[list[float]] = mapped_column(Vector(1536), nullable=False)
+    llm_usage_ledger_id: Mapped[int] = mapped_column(
+        BigInteger, ForeignKey("llm_usage_ledger.id", ondelete="RESTRICT"), nullable=False
+    )
+    indexed_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    invalidated_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    invalidation_reason: Mapped[str | None] = mapped_column(String(64), nullable=True)
+
+
+class SemanticRetrievalUnitSource(Base):
+    __tablename__ = "semantic_retrieval_unit_sources"
+    __table_args__ = (
+        CheckConstraint("position >= 0", name="ck_semantic_unit_sources_position"),
+        UniqueConstraint("unit_id", "position", name="uq_semantic_unit_sources_position"),
+        Index("ix_semantic_unit_sources_message_version_id", "message_version_id"),
+    )
+
+    unit_id: Mapped[int] = mapped_column(
+        BigInteger,
+        ForeignKey("semantic_retrieval_units.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    message_version_id: Mapped[int] = mapped_column(
+        Integer,
+        ForeignKey("message_versions.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    position: Mapped[int] = mapped_column(SmallInteger, nullable=False)
+
+
+class SemanticQaAttempt(Base):
+    __tablename__ = "semantic_qa_attempts"
+    __table_args__ = (
+        CheckConstraint(
+            "slot_number IS NULL OR slot_number IN (1,2)", name="ck_semantic_attempts_slot"
+        ),
+        CheckConstraint(
+            "status IN ('denied','reserved','consumed','released')",
+            name="ck_semantic_attempts_status",
+        ),
+        CheckConstraint(
+            "outcome IS NULL OR outcome IN ('answered','abstained','technical_failure','quota_denied')",
+            name="ck_semantic_attempts_outcome",
+        ),
+        CheckConstraint(
+            "(status = 'denied' AND slot_number IS NULL AND outcome = 'quota_denied' "
+            "AND delivery_started_at IS NULL) OR "
+            "(status = 'reserved' AND slot_number IS NOT NULL AND finalized_at IS NULL AND "
+            "((outcome IS NULL AND delivery_started_at IS NULL) OR "
+            "(outcome IN ('answered','abstained') AND delivery_started_at IS NOT NULL))) OR "
+            "(status = 'consumed' AND slot_number IS NOT NULL "
+            "AND outcome IN ('answered','abstained') AND delivery_started_at IS NOT NULL "
+            "AND finalized_at IS NOT NULL) OR "
+            "(status = 'released' AND slot_number IS NOT NULL "
+            "AND outcome = 'technical_failure' AND finalized_at IS NOT NULL)",
+            name="ck_semantic_attempts_state",
+        ),
+        UniqueConstraint("idempotency_key", name="uq_semantic_qa_attempts_idempotency_key"),
+        Index(
+            "uq_semantic_qa_attempts_active_slot",
+            "user_tg_id",
+            "local_day",
+            "slot_number",
+            unique=True,
+            postgresql_where=text("status IN ('reserved','consumed')"),
+        ),
+        Index("ix_semantic_qa_attempts_user_day", "user_tg_id", "local_day", "status"),
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    idempotency_key: Mapped[str] = mapped_column(String(128), nullable=False)
+    user_tg_id: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    chat_id: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    source_chat_message_id: Mapped[int | None] = mapped_column(
+        Integer, ForeignKey("chat_messages.id", ondelete="SET NULL"), nullable=True
+    )
+    local_day: Mapped[date] = mapped_column(Date, nullable=False)
+    slot_number: Mapped[int | None] = mapped_column(SmallInteger, nullable=True)
+    status: Mapped[str] = mapped_column(String(16), nullable=False)
+    outcome: Mapped[str | None] = mapped_column(String(32), nullable=True)
+    qa_trace_id: Mapped[int | None] = mapped_column(
+        BigInteger, ForeignKey("qa_traces.id", ondelete="SET NULL"), nullable=True
+    )
+    embedding_llm_call_id: Mapped[int | None] = mapped_column(
+        BigInteger, ForeignKey("llm_usage_ledger.id", ondelete="SET NULL"), nullable=True
+    )
+    synthesis_llm_call_id: Mapped[int | None] = mapped_column(
+        BigInteger, ForeignKey("llm_usage_ledger.id", ondelete="SET NULL"), nullable=True
+    )
+    reserved_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    delivery_started_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    finalized_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+
+class SemanticRetrievalTrace(Base):
+    __tablename__ = "semantic_retrieval_traces"
+    __table_args__ = (
+        CheckConstraint(
+            "retrieval_mode IN ('hybrid','fts_fallback','shadow')",
+            name="ck_semantic_retrieval_traces_mode",
+        ),
+        CheckConstraint(
+            "fts_latency_ms >= 0 AND vector_latency_ms >= 0 "
+            "AND fusion_latency_ms >= 0 AND total_latency_ms >= 0",
+            name="ck_semantic_retrieval_traces_latency",
+        ),
+        UniqueConstraint("attempt_id", name="uq_semantic_retrieval_traces_attempt_id"),
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    attempt_id: Mapped[int] = mapped_column(
+        BigInteger, ForeignKey("semantic_qa_attempts.id", ondelete="CASCADE"), nullable=False
+    )
+    qa_trace_id: Mapped[int | None] = mapped_column(
+        BigInteger, ForeignKey("qa_traces.id", ondelete="SET NULL"), nullable=True
+    )
+    query_hash: Mapped[str] = mapped_column(CHAR(64), nullable=False)
+    embedding_model: Mapped[str] = mapped_column(String(128), nullable=False)
+    retrieval_mode: Mapped[str] = mapped_column(String(32), nullable=False)
+    candidate_ranks: Mapped[dict] = mapped_column(
+        JSON().with_variant(JSONB(), "postgresql"), nullable=False
+    )
+    result_source_ids: Mapped[list[str]] = mapped_column(
+        JSON().with_variant(JSONB(), "postgresql"), nullable=False
+    )
+    fts_latency_ms: Mapped[int] = mapped_column(Integer, nullable=False)
+    vector_latency_ms: Mapped[int] = mapped_column(Integer, nullable=False)
+    fusion_latency_ms: Mapped[int] = mapped_column(Integer, nullable=False)
+    total_latency_ms: Mapped[int] = mapped_column(Integer, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+
+
 class IntroRefreshTracking(Base):
     __tablename__ = "intro_refresh_tracking"
 
@@ -994,8 +1204,10 @@ class LlmUsageLedger(Base):
     """Per-call audit log for every LLM gateway invocation (T5-02 / alembic 024).
 
     Written by ``bot/services/llm_gateway.py`` for every call outcome, including
-    cache hits, abstentions, budget refusals, and errors. Never committed by the
-    gateway itself — the caller (handler) owns the transaction.
+    cache hits, abstentions, budget refusals, and errors. Most calls remain in
+    the caller transaction; paid semantic embedding/synthesis calls durably
+    commit an explicit ``reserved_in_flight`` row before provider dispatch and
+    replace that marker with the terminal audit outcome afterward.
 
     All numeric fields (tokens, cost, latency) use server defaults of 0 so that
     partial rows created for budget-guard placeholders are self-consistent.
@@ -1007,6 +1219,10 @@ class LlmUsageLedger(Base):
 
     __tablename__ = "llm_usage_ledger"
     __table_args__ = (
+        CheckConstraint(
+            "tokens_in >= 0 AND tokens_out >= 0 AND cost_usd >= 0 AND latency_ms >= 0",
+            name="ck_llm_usage_ledger_nonnegative_usage",
+        ),
         Index("ix_llm_usage_ledger_qa_trace_id", "qa_trace_id"),
         Index("ix_llm_usage_ledger_model_created_at", "model", "created_at"),
         Index("ix_llm_usage_ledger_created_at", "created_at"),
@@ -1041,7 +1257,7 @@ class LlmUsageLedger(Base):
     # call_type added in migration 064; migration 080 adds wiki/image rollout calls.
     # 'unknown' (legacy / default), 'qa_synthesis', 'digest_daily', 'digest_weekly',
     # 'graph_projection', 'extract_candidates', 'butler_decision', 'butler_summary',
-    # 'wiki_compilation', 'image_description'.
+    # 'wiki_compilation', 'image_description', 'semantic_embedding'.
     # Caller SHOULD always pass explicitly; 'unknown' is the fallback only for legacy rows.
     call_type: Mapped[str] = mapped_column(
         String(32), nullable=False, server_default=text("'unknown'")

--- a/bot/db/models.py
+++ b/bot/db/models.py
@@ -937,6 +937,9 @@ class SemanticQaAttempt(Base):
     reserved_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=func.now()
     )
+    progress_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
     delivery_started_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True
     )

--- a/bot/db/models.py
+++ b/bot/db/models.py
@@ -801,6 +801,20 @@ class SemanticRetrievalUnit(Base):
             name="ck_semantic_units_chunk_bounds",
         ),
         CheckConstraint(
+            "embedding_status IN ('reserved','completed','failed')",
+            name="ck_semantic_units_embedding_status",
+        ),
+        CheckConstraint(
+            "(embedding_status = 'reserved' AND embedding IS NULL "
+            "AND chunk_text IS NULL AND indexed_at IS NULL) OR "
+            "(embedding_status = 'completed' AND embedding IS NOT NULL "
+            "AND chunk_text IS NOT NULL AND length(trim(chunk_text)) BETWEEN 1 AND 800 "
+            "AND indexed_at IS NOT NULL) OR "
+            "(embedding_status = 'failed' AND embedding IS NULL "
+            "AND chunk_text IS NULL AND indexed_at IS NULL)",
+            name="ck_semantic_units_embedding_state",
+        ),
+        CheckConstraint(
             "(invalidated_at IS NULL) = (invalidation_reason IS NULL)",
             name="ck_semantic_units_invalidation_pair",
         ),
@@ -829,13 +843,13 @@ class SemanticRetrievalUnit(Base):
     embedding_model: Mapped[str] = mapped_column(String(128), nullable=False)
     embedding_model_version: Mapped[str] = mapped_column(String(64), nullable=False)
     embedding_dimensions: Mapped[int] = mapped_column(Integer, nullable=False)
-    embedding: Mapped[list[float]] = mapped_column(Vector(1536), nullable=False)
+    embedding_status: Mapped[str] = mapped_column(String(16), nullable=False)
+    chunk_text: Mapped[str | None] = mapped_column(Text, nullable=True)
+    embedding: Mapped[list[float] | None] = mapped_column(Vector(1536), nullable=True)
     llm_usage_ledger_id: Mapped[int] = mapped_column(
         BigInteger, ForeignKey("llm_usage_ledger.id", ondelete="RESTRICT"), nullable=False
     )
-    indexed_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), nullable=False, server_default=func.now()
-    )
+    indexed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     invalidated_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     invalidation_reason: Mapped[str | None] = mapped_column(String(64), nullable=True)
 

--- a/bot/db/repos/feature_flag.py
+++ b/bot/db/repos/feature_flag.py
@@ -19,6 +19,21 @@ from bot.db.models import FeatureFlag
 
 class FeatureFlagRepo:
     @staticmethod
+    async def any_enabled(session: AsyncSession, flag_key: str) -> bool:
+        """Return whether the flag is enabled globally or for any explicit scope."""
+
+        stmt = (
+            select(FeatureFlag.id)
+            .where(
+                FeatureFlag.flag_key == flag_key,
+                FeatureFlag.enabled.is_(True),
+            )
+            .limit(1)
+        )
+        result = await session.execute(stmt)
+        return result.scalar_one_or_none() is not None
+
+    @staticmethod
     async def get(
         session: AsyncSession,
         flag_key: str,

--- a/bot/db/repos/forget_event.py
+++ b/bot/db/repos/forget_event.py
@@ -15,11 +15,15 @@ Any other transition raises ``ValueError`` immediately (before any DB call).
 
 from __future__ import annotations
 
-from sqlalchemy import func, select, update
+from sqlalchemy import func, select, text, update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from bot.db.models import ForgetEvent
+from bot.services.advisory_locks import (
+    forget_target_advisory_key,
+    session_uses_postgresql,
+)
 
 # Valid transitions: key = current status, value = set of allowed next statuses.
 _ALLOWED_TRANSITIONS: dict[str, frozenset[str]] = {
@@ -56,6 +60,18 @@ class ForgetEventRepo:
         This is race-safe: two concurrent callers both pass no application-level check;
         one wins the insert, the other hits the conflict path and fetches the winner's row.
         """
+        if (
+            target_type in {"message", "user", "message_hash"}
+            and target_id is not None
+            and session_uses_postgresql(session)
+        ):
+            # Serialize the first visible pending tombstone with governed
+            # evidence delivery. The delivery side holds the same key through
+            # its final revalidation and Telegram call.
+            await session.execute(
+                text("SELECT pg_advisory_xact_lock(hashtext(:lock_key))"),
+                {"lock_key": forget_target_advisory_key(target_type, target_id)},
+            )
         stmt = (
             pg_insert(ForgetEvent)
             .values(
@@ -139,9 +155,7 @@ class ForgetEventRepo:
             )
 
         # Compute which current statuses may transition to the requested status.
-        allowed_old = [
-            old for old, nexts in _ALLOWED_TRANSITIONS.items() if status in nexts
-        ]
+        allowed_old = [old for old, nexts in _ALLOWED_TRANSITIONS.items() if status in nexts]
 
         values: dict = {"status": status, "updated_at": func.now()}
         if cascade_status is not None:
@@ -164,9 +178,7 @@ class ForgetEventRepo:
         # Re-fetch with populate_existing=True so identity-map cache (expire_on_commit=False
         # in bot/db/engine.py) does not shadow the actual current DB status in the error
         # message. Without this flag a stale cached row would mislead the caller.
-        actual = await session.get(
-            ForgetEvent, forget_event_id, populate_existing=True
-        )
+        actual = await session.get(ForgetEvent, forget_event_id, populate_existing=True)
         if actual is None:
             raise ValueError(f"ForgetEvent(id={forget_event_id}) not found")
         allowed_next = _ALLOWED_TRANSITIONS.get(actual.status, frozenset())
@@ -212,9 +224,7 @@ class ForgetEventRepo:
             return row
 
         # Either the id doesn't exist or the row is not in 'processing'.
-        actual = await session.get(
-            ForgetEvent, forget_event_id, populate_existing=True
-        )
+        actual = await session.get(ForgetEvent, forget_event_id, populate_existing=True)
         if actual is None:
             raise ValueError(f"ForgetEvent(id={forget_event_id}) not found")
         raise ValueError(

--- a/bot/db/repos/llm_usage_ledger.py
+++ b/bot/db/repos/llm_usage_ledger.py
@@ -11,7 +11,7 @@ from calendar import monthrange
 from datetime import date, datetime, time, timezone
 from decimal import Decimal
 
-from sqlalchemy import func, select, update
+from sqlalchemy import case, func, select, update
 
 from bot.db.models import LlmUsageLedger
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -101,9 +101,7 @@ class LedgerRepo:
         if call_type is not None:
             filters.append(LlmUsageLedger.call_type == call_type)
 
-        result = await session.execute(
-            select(func.sum(LlmUsageLedger.cost_usd)).where(*filters)
-        )
+        result = await session.execute(select(func.sum(LlmUsageLedger.cost_usd)).where(*filters))
         total = result.scalar_one_or_none()
         return Decimal(str(total)) if total is not None else Decimal("0")
 
@@ -136,9 +134,7 @@ class LedgerRepo:
         if call_type is not None:
             filters.append(LlmUsageLedger.call_type == call_type)
 
-        result = await session.execute(
-            select(func.sum(LlmUsageLedger.cost_usd)).where(*filters)
-        )
+        result = await session.execute(select(func.sum(LlmUsageLedger.cost_usd)).where(*filters))
         total = result.scalar_one_or_none()
         return Decimal(str(total)) if total is not None else Decimal("0")
 
@@ -175,7 +171,12 @@ class LedgerRepo:
                 cost_usd=cost_usd,
                 latency_ms=latency_ms,
                 request_id=request_id,
-                response_hash=response_hash,
+                # A forget cascade may redact this row while the provider call
+                # is still in flight. Do not resurrect its response hash.
+                response_hash=case(
+                    (LlmUsageLedger.prompt_hash.is_(None), None),
+                    else_=response_hash,
+                ),
                 error=error,
             )
         )

--- a/bot/db/repos/qa_trace.py
+++ b/bot/db/repos/qa_trace.py
@@ -53,6 +53,25 @@ class QaTraceRepo:
         )
 
     @staticmethod
+    async def update_retrieval_fields(
+        session: AsyncSession,
+        *,
+        qa_trace_id: int,
+        evidence_ids: list[int],
+        abstained: bool,
+    ) -> None:
+        """Attach the governed retrieval result to a durable pre-call trace."""
+
+        result = await session.execute(
+            update(QaTrace)
+            .where(QaTrace.id == qa_trace_id)
+            .values(evidence_ids=list(evidence_ids), abstained=abstained)
+        )
+        if getattr(result, "rowcount", None) != 1:
+            raise LookupError(f"QaTrace(id={qa_trace_id}) not found")
+        await session.flush()
+
+    @staticmethod
     async def update_llm_fields(
         session: AsyncSession,
         *,
@@ -94,4 +113,24 @@ class QaTraceRepo:
                 f"QaTrace(id={qa_trace_id}) not found — handler step 1 (create) "
                 "must precede step 3 (update_llm_fields)"
             )
+        await session.flush()
+
+    @staticmethod
+    async def clear_undelivered_llm_summary(
+        session: AsyncSession,
+        *,
+        qa_trace_id: int,
+    ) -> None:
+        """Remove content that was prepared but never delivered to Telegram."""
+
+        result = await session.execute(
+            update(QaTrace)
+            .where(QaTrace.id == qa_trace_id)
+            .values(
+                llm_response_summary=None,
+                llm_response_redacted=True,
+            )
+        )
+        if getattr(result, "rowcount", None) != 1:
+            raise LookupError(f"QaTrace(id={qa_trace_id}) not found")
         await session.flush()

--- a/bot/db/repos/semantic_quota.py
+++ b/bot/db/repos/semantic_quota.py
@@ -31,8 +31,8 @@ class SemanticQuotaDecision:
     qa_trace_id: int | None = None
 
 
-def _lock_id(user_tg_id: int, local_day: str) -> int:
-    payload = f"semantic_qa:{user_tg_id}:{local_day}".encode("ascii")
+def _user_lock_id(user_tg_id: int) -> int:
+    payload = f"semantic_qa_user:{user_tg_id}".encode("ascii")
     return int.from_bytes(hashlib.sha256(payload).digest()[:8], "big", signed=True)
 
 
@@ -61,12 +61,12 @@ class SemanticQuotaRepo:
         local_day = start_utc.astimezone(MOSCOW_TZ).date()
         await session.execute(
             text("SELECT pg_advisory_xact_lock(:lock_id)"),
-            {"lock_id": _lock_id(user_tg_id, local_day.isoformat())},
+            {"lock_id": _user_lock_id(user_tg_id)},
         )
         await SemanticQuotaRepo.release_stale_reserved(
             session,
             user_tg_id=user_tg_id,
-            local_day=local_day,
+            through_local_day=local_day,
             stale_before=effective_now - SemanticQuotaRepo.STALE_RESERVATION_AFTER,
             finalized_at=effective_now,
         )
@@ -163,15 +163,17 @@ class SemanticQuotaRepo:
         session: AsyncSession,
         *,
         user_tg_id: int,
-        local_day: date,
+        through_local_day: date,
         stale_before: datetime,
         finalized_at: datetime | None = None,
     ) -> int:
-        """Reconcile crashed reservations during the next admission lock.
+        """Reconcile crashed reservations through the current Moscow day.
 
         A durable delivery intent is conservatively consumed: Telegram may
         have accepted the message even if the process died before the final DB
-        commit. Reservations that never reached delivery are released.
+        commit. Reservations that never reached delivery are released. The
+        user-scoped admission lock makes reconciliation atomic across the day
+        boundary and prevents an old idempotent replay from remaining reserved.
         """
 
         effective_finalized_at = finalized_at or datetime.now(timezone.utc)
@@ -179,9 +181,9 @@ class SemanticQuotaRepo:
             update(SemanticQaAttempt)
             .where(
                 SemanticQaAttempt.user_tg_id == user_tg_id,
-                SemanticQaAttempt.local_day == local_day,
+                SemanticQaAttempt.local_day <= through_local_day,
                 SemanticQaAttempt.status == "reserved",
-                SemanticQaAttempt.reserved_at < stale_before,
+                SemanticQaAttempt.progress_at < stale_before,
                 SemanticQaAttempt.delivery_started_at.is_not(None),
             )
             .values(
@@ -193,9 +195,9 @@ class SemanticQuotaRepo:
             update(SemanticQaAttempt)
             .where(
                 SemanticQaAttempt.user_tg_id == user_tg_id,
-                SemanticQaAttempt.local_day == local_day,
+                SemanticQaAttempt.local_day <= through_local_day,
                 SemanticQaAttempt.status == "reserved",
-                SemanticQaAttempt.reserved_at < stale_before,
+                SemanticQaAttempt.progress_at < stale_before,
                 SemanticQaAttempt.delivery_started_at.is_(None),
             )
             .values(
@@ -235,6 +237,7 @@ class SemanticQuotaRepo:
                 qa_trace_id=qa_trace_id,
                 embedding_llm_call_id=embedding_llm_call_id,
                 synthesis_llm_call_id=synthesis_llm_call_id,
+                progress_at=datetime.now(timezone.utc),
                 delivery_started_at=datetime.now(timezone.utc),
             )
         )
@@ -255,7 +258,7 @@ class SemanticQuotaRepo:
                 SemanticQaAttempt.id == attempt_id,
                 SemanticQaAttempt.status == "reserved",
             )
-            .values(qa_trace_id=qa_trace_id)
+            .values(qa_trace_id=qa_trace_id, progress_at=datetime.now(timezone.utc))
         )
         if getattr(result, "rowcount", None) != 1:
             raise LookupError("semantic Q&A reservation is not active")
@@ -274,7 +277,10 @@ class SemanticQuotaRepo:
                 SemanticQaAttempt.id == attempt_id,
                 SemanticQaAttempt.status == "reserved",
             )
-            .values(embedding_llm_call_id=embedding_llm_call_id)
+            .values(
+                embedding_llm_call_id=embedding_llm_call_id,
+                progress_at=datetime.now(timezone.utc),
+            )
         )
         if getattr(result, "rowcount", None) != 1:
             raise LookupError("semantic Q&A reservation is not active")
@@ -305,17 +311,48 @@ class SemanticQuotaRepo:
                 qa_trace_id=qa_trace_id,
                 embedding_llm_call_id=embedding_llm_call_id,
                 synthesis_llm_call_id=synthesis_llm_call_id,
+                progress_at=datetime.now(timezone.utc),
                 finalized_at=datetime.now(MOSCOW_TZ),
             )
         )
         if getattr(result, "rowcount", None) != 1:
-            raise LookupError("semantic Q&A attempt is missing or already finalized")
+            existing = (
+                await session.execute(
+                    select(SemanticQaAttempt.status, SemanticQaAttempt.outcome).where(
+                        SemanticQaAttempt.id == attempt_id
+                    )
+                )
+            ).one_or_none()
+            if existing is not None and existing.status == status and existing.outcome == outcome:
+                return
+            raise LookupError("semantic Q&A attempt is missing or finalized differently")
         if qa_trace_id is not None:
             await session.execute(
                 update(SemanticRetrievalTrace)
                 .where(SemanticRetrievalTrace.attempt_id == attempt_id)
                 .values(qa_trace_id=qa_trace_id)
             )
+        await session.flush()
+
+    @staticmethod
+    async def touch(
+        session: AsyncSession,
+        *,
+        attempt_id: int,
+    ) -> None:
+        """Renew a live reservation before a potentially blocking phase."""
+
+        result = await session.execute(
+            update(SemanticQaAttempt)
+            .where(
+                SemanticQaAttempt.id == attempt_id,
+                SemanticQaAttempt.status == "reserved",
+                SemanticQaAttempt.delivery_started_at.is_(None),
+            )
+            .values(progress_at=datetime.now(timezone.utc))
+        )
+        if getattr(result, "rowcount", None) != 1:
+            raise LookupError("semantic Q&A reservation lease is no longer active")
         await session.flush()
 
     @staticmethod

--- a/bot/db/repos/semantic_quota.py
+++ b/bot/db/repos/semantic_quota.py
@@ -1,0 +1,338 @@
+"""Durable two-per-Moscow-day semantic Q&A admission state machine."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta, timezone
+from typing import Literal
+
+from sqlalchemy import select, text, update
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from bot.db.models import SemanticQaAttempt, SemanticRetrievalTrace
+from bot.services.qa_guardrails import DAILY_LLM_QUESTION_LIMIT, MOSCOW_TZ, moscow_day_bounds_utc
+
+
+AttemptOutcome = Literal["answered", "abstained", "technical_failure"]
+
+
+@dataclass(frozen=True, slots=True)
+class SemanticQuotaDecision:
+    allowed: bool
+    attempt_id: int
+    used: int
+    limit: int
+    resets_at: datetime
+    replayed: bool = False
+    status: str | None = None
+    outcome: str | None = None
+    qa_trace_id: int | None = None
+
+
+def _lock_id(user_tg_id: int, local_day: str) -> int:
+    payload = f"semantic_qa:{user_tg_id}:{local_day}".encode("ascii")
+    return int.from_bytes(hashlib.sha256(payload).digest()[:8], "big", signed=True)
+
+
+class SemanticQuotaRepo:
+    STALE_RESERVATION_AFTER = timedelta(minutes=15)
+
+    @staticmethod
+    async def reserve(
+        session: AsyncSession,
+        *,
+        idempotency_key: str,
+        user_tg_id: int,
+        chat_id: int,
+        source_chat_message_id: int | None,
+        now: datetime | None = None,
+        limit: int = DAILY_LLM_QUESTION_LIMIT,
+    ) -> SemanticQuotaDecision:
+        """Reserve one slot atomically; caller must commit before providers."""
+
+        if not idempotency_key or len(idempotency_key) > 128:
+            raise ValueError("semantic quota idempotency_key must contain 1..128 characters")
+        if limit != DAILY_LLM_QUESTION_LIMIT:
+            raise ValueError("semantic Q&A daily limit is fixed at two")
+        effective_now = now or datetime.now(timezone.utc)
+        start_utc, end_utc = moscow_day_bounds_utc(effective_now)
+        local_day = start_utc.astimezone(MOSCOW_TZ).date()
+        await session.execute(
+            text("SELECT pg_advisory_xact_lock(:lock_id)"),
+            {"lock_id": _lock_id(user_tg_id, local_day.isoformat())},
+        )
+        await SemanticQuotaRepo.release_stale_reserved(
+            session,
+            user_tg_id=user_tg_id,
+            local_day=local_day,
+            stale_before=effective_now - SemanticQuotaRepo.STALE_RESERVATION_AFTER,
+            finalized_at=effective_now,
+        )
+
+        existing_result = await session.execute(
+            select(SemanticQaAttempt).where(SemanticQaAttempt.idempotency_key == idempotency_key)
+        )
+        existing = existing_result.scalar_one_or_none()
+        if existing is not None:
+            return SemanticQuotaDecision(
+                # Telegram retries reuse the same source message. They must
+                # never dispatch a second paid provider call, including while
+                # the original attempt is still reserved.
+                allowed=False,
+                attempt_id=existing.id,
+                used=await SemanticQuotaRepo._active_count(
+                    session,
+                    user_tg_id=user_tg_id,
+                    local_day=local_day,
+                ),
+                limit=limit,
+                resets_at=end_utc,
+                replayed=True,
+                status=existing.status,
+                outcome=existing.outcome,
+                qa_trace_id=existing.qa_trace_id,
+            )
+
+        active_result = await session.execute(
+            select(SemanticQaAttempt.slot_number)
+            .where(
+                SemanticQaAttempt.user_tg_id == user_tg_id,
+                SemanticQaAttempt.local_day == local_day,
+                SemanticQaAttempt.status.in_(("reserved", "consumed")),
+            )
+            .order_by(SemanticQaAttempt.slot_number.asc())
+        )
+        used_slots = {int(slot) for slot in active_result.scalars() if slot is not None}
+        available_slot = next((slot for slot in (1, 2) if slot not in used_slots), None)
+        if available_slot is None:
+            statement = (
+                pg_insert(SemanticQaAttempt)
+                .values(
+                    idempotency_key=idempotency_key,
+                    user_tg_id=user_tg_id,
+                    chat_id=chat_id,
+                    source_chat_message_id=source_chat_message_id,
+                    local_day=local_day,
+                    slot_number=None,
+                    status="denied",
+                    outcome="quota_denied",
+                )
+                .returning(SemanticQaAttempt.id)
+            )
+            denied_result = await session.execute(statement)
+            attempt_id = int(denied_result.scalar_one())
+            return SemanticQuotaDecision(
+                allowed=False,
+                attempt_id=attempt_id,
+                used=len(used_slots),
+                limit=limit,
+                resets_at=end_utc,
+                status="denied",
+                outcome="quota_denied",
+            )
+
+        statement = (
+            pg_insert(SemanticQaAttempt)
+            .values(
+                idempotency_key=idempotency_key,
+                user_tg_id=user_tg_id,
+                chat_id=chat_id,
+                source_chat_message_id=source_chat_message_id,
+                local_day=local_day,
+                slot_number=available_slot,
+                status="reserved",
+                outcome=None,
+            )
+            .returning(SemanticQaAttempt.id)
+        )
+        reserved_result = await session.execute(statement)
+        attempt_id = int(reserved_result.scalar_one())
+        return SemanticQuotaDecision(
+            allowed=True,
+            attempt_id=attempt_id,
+            used=len(used_slots),
+            limit=limit,
+            resets_at=end_utc,
+            status="reserved",
+        )
+
+    @staticmethod
+    async def release_stale_reserved(
+        session: AsyncSession,
+        *,
+        user_tg_id: int,
+        local_day: date,
+        stale_before: datetime,
+        finalized_at: datetime | None = None,
+    ) -> int:
+        """Reconcile crashed reservations during the next admission lock.
+
+        A durable delivery intent is conservatively consumed: Telegram may
+        have accepted the message even if the process died before the final DB
+        commit. Reservations that never reached delivery are released.
+        """
+
+        effective_finalized_at = finalized_at or datetime.now(timezone.utc)
+        delivered_result = await session.execute(
+            update(SemanticQaAttempt)
+            .where(
+                SemanticQaAttempt.user_tg_id == user_tg_id,
+                SemanticQaAttempt.local_day == local_day,
+                SemanticQaAttempt.status == "reserved",
+                SemanticQaAttempt.reserved_at < stale_before,
+                SemanticQaAttempt.delivery_started_at.is_not(None),
+            )
+            .values(
+                status="consumed",
+                finalized_at=effective_finalized_at,
+            )
+        )
+        released_result = await session.execute(
+            update(SemanticQaAttempt)
+            .where(
+                SemanticQaAttempt.user_tg_id == user_tg_id,
+                SemanticQaAttempt.local_day == local_day,
+                SemanticQaAttempt.status == "reserved",
+                SemanticQaAttempt.reserved_at < stale_before,
+                SemanticQaAttempt.delivery_started_at.is_(None),
+            )
+            .values(
+                status="released",
+                outcome="technical_failure",
+                finalized_at=effective_finalized_at,
+            )
+        )
+        await session.flush()
+        return int(getattr(delivered_result, "rowcount", 0) or 0) + int(
+            getattr(released_result, "rowcount", 0) or 0
+        )
+
+    @staticmethod
+    async def mark_delivery_started(
+        session: AsyncSession,
+        *,
+        attempt_id: int,
+        outcome: Literal["answered", "abstained"],
+        qa_trace_id: int,
+        embedding_llm_call_id: int,
+        synthesis_llm_call_id: int | None,
+    ) -> None:
+        """Persist an irreversible delivery intent before the Telegram call."""
+
+        if outcome not in ("answered", "abstained"):
+            raise ValueError("delivery intent must consume semantic quota")
+        result = await session.execute(
+            update(SemanticQaAttempt)
+            .where(
+                SemanticQaAttempt.id == attempt_id,
+                SemanticQaAttempt.status == "reserved",
+                SemanticQaAttempt.delivery_started_at.is_(None),
+            )
+            .values(
+                outcome=outcome,
+                qa_trace_id=qa_trace_id,
+                embedding_llm_call_id=embedding_llm_call_id,
+                synthesis_llm_call_id=synthesis_llm_call_id,
+                delivery_started_at=datetime.now(timezone.utc),
+            )
+        )
+        if getattr(result, "rowcount", None) != 1:
+            raise LookupError("semantic Q&A delivery intent is missing or already started")
+        await session.flush()
+
+    @staticmethod
+    async def attach_trace(
+        session: AsyncSession,
+        *,
+        attempt_id: int,
+        qa_trace_id: int,
+    ) -> None:
+        result = await session.execute(
+            update(SemanticQaAttempt)
+            .where(
+                SemanticQaAttempt.id == attempt_id,
+                SemanticQaAttempt.status == "reserved",
+            )
+            .values(qa_trace_id=qa_trace_id)
+        )
+        if getattr(result, "rowcount", None) != 1:
+            raise LookupError("semantic Q&A reservation is not active")
+        await session.flush()
+
+    @staticmethod
+    async def attach_embedding_call(
+        session: AsyncSession,
+        *,
+        attempt_id: int,
+        embedding_llm_call_id: int,
+    ) -> None:
+        result = await session.execute(
+            update(SemanticQaAttempt)
+            .where(
+                SemanticQaAttempt.id == attempt_id,
+                SemanticQaAttempt.status == "reserved",
+            )
+            .values(embedding_llm_call_id=embedding_llm_call_id)
+        )
+        if getattr(result, "rowcount", None) != 1:
+            raise LookupError("semantic Q&A reservation is not active")
+        await session.flush()
+
+    @staticmethod
+    async def finalize(
+        session: AsyncSession,
+        *,
+        attempt_id: int,
+        outcome: AttemptOutcome,
+        qa_trace_id: int | None = None,
+        embedding_llm_call_id: int | None = None,
+        synthesis_llm_call_id: int | None = None,
+    ) -> None:
+        if outcome not in ("answered", "abstained", "technical_failure"):
+            raise ValueError("unsupported semantic Q&A outcome")
+        status = "released" if outcome == "technical_failure" else "consumed"
+        result = await session.execute(
+            update(SemanticQaAttempt)
+            .where(
+                SemanticQaAttempt.id == attempt_id,
+                SemanticQaAttempt.status == "reserved",
+            )
+            .values(
+                status=status,
+                outcome=outcome,
+                qa_trace_id=qa_trace_id,
+                embedding_llm_call_id=embedding_llm_call_id,
+                synthesis_llm_call_id=synthesis_llm_call_id,
+                finalized_at=datetime.now(MOSCOW_TZ),
+            )
+        )
+        if getattr(result, "rowcount", None) != 1:
+            raise LookupError("semantic Q&A attempt is missing or already finalized")
+        if qa_trace_id is not None:
+            await session.execute(
+                update(SemanticRetrievalTrace)
+                .where(SemanticRetrievalTrace.attempt_id == attempt_id)
+                .values(qa_trace_id=qa_trace_id)
+            )
+        await session.flush()
+
+    @staticmethod
+    async def _active_count(
+        session: AsyncSession,
+        *,
+        user_tg_id: int,
+        local_day: date,
+    ) -> int:
+        result = await session.execute(
+            select(SemanticQaAttempt.id).where(
+                SemanticQaAttempt.user_tg_id == user_tg_id,
+                SemanticQaAttempt.local_day == local_day,
+                SemanticQaAttempt.status.in_(("reserved", "consumed")),
+            )
+        )
+        return len(result.scalars().all())
+
+
+__all__ = ["SemanticQuotaDecision", "SemanticQuotaRepo"]

--- a/bot/db/repos/user.py
+++ b/bot/db/repos/user.py
@@ -15,25 +15,31 @@ class UserRepo:
         username: str | None,
         first_name: str,
         last_name: str | None,
+        is_bot: bool | None = None,
     ) -> User:
+        values = {
+            "id": telegram_id,
+            "username": username,
+            "first_name": first_name,
+            "last_name": last_name,
+            "is_imported_only": False,
+            "is_bot": is_bot,
+        }
+        update_values: dict[str, object] = {
+            "username": username,
+            "first_name": first_name,
+            "last_name": last_name,
+            "is_imported_only": False,
+        }
+        if is_bot is not None:
+            update_values["is_bot"] = is_bot
         # Use PostgreSQL ON CONFLICT for race-condition safety
         stmt = (
             pg_insert(User)
-            .values(
-                id=telegram_id,
-                username=username,
-                first_name=first_name,
-                last_name=last_name,
-                is_imported_only=False,
-            )
+            .values(**values)
             .on_conflict_do_update(
                 index_elements=[User.id],
-                set_={
-                    "username": username,
-                    "first_name": first_name,
-                    "last_name": last_name,
-                    "is_imported_only": False,
-                },
+                set_=update_values,
             )
         )
         await session.execute(stmt)

--- a/bot/handlers/chat_events.py
+++ b/bot/handlers/chat_events.py
@@ -146,6 +146,7 @@ async def _handle_join(
         username=tg_user.username,
         first_name=tg_user.first_name,
         last_name=tg_user.last_name,
+        is_bot=getattr(tg_user, "is_bot", None),
     )
 
     is_admin = tg_user.id in settings.ADMIN_IDS

--- a/bot/handlers/chat_messages.py
+++ b/bot/handlers/chat_messages.py
@@ -50,6 +50,7 @@ async def save_chat_message(
         username=message.from_user.username,
         first_name=message.from_user.first_name,
         last_name=message.from_user.last_name,
+        is_bot=getattr(message.from_user, "is_bot", None),
     )
 
     # Persist with policy detection (advisory lock + governance + mark creation).

--- a/bot/handlers/qa.py
+++ b/bot/handlers/qa.py
@@ -2,13 +2,25 @@ from __future__ import annotations
 
 import html
 import logging
+import re
 from datetime import datetime
 from typing import Any
 
 from aiogram import Router
-from aiogram.exceptions import TelegramForbiddenError
+from aiogram.exceptions import (
+    TelegramAPIError,
+    TelegramBadRequest,
+    TelegramConflictError,
+    TelegramEntityTooLarge,
+    TelegramForbiddenError,
+    TelegramMigrateToChat,
+    TelegramNotFound,
+    TelegramRetryAfter,
+    TelegramUnauthorizedError,
+)
 from aiogram.filters import CommandObject
 from aiogram.types import Message
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from bot.config import settings
@@ -17,20 +29,28 @@ from bot.db.repos.feature_flag import FeatureFlagRepo
 from bot.db.repos.llm_synthesis_cache import SynthesisCacheRepo
 from bot.db.repos.llm_usage_ledger import LedgerRepo
 from bot.db.repos.qa_trace import QaTraceRepo
+from bot.db.repos.semantic_quota import SemanticQuotaRepo
 from bot.db.repos.user import UserRepo
 from bot.services.evidence import EvidenceBundle, EvidenceItem
 from bot.services.governance import detect_policy
 from bot.services.llm_gateway import (
     AnswerWithCitations,
+    EmbeddingBudgetExceeded,
     LLMGatewayConfig,
     _safe_qa_provider_error_subtype,
+    filter_surviving_evidence,
+    hold_evidence_delivery_locks,
     load_gateway_config,
     resolve_provider,
     synthesize_answer,
 )
-from bot.services.llm_providers import LLMProvider
+from bot.services.llm_providers import (
+    LLMProvider,
+    ProviderStructuralError,
+    ProviderTransientError,
+)
 from bot.services.message_persistence import persist_message_with_policy
-from bot.services.qa import run_qa
+from bot.services.qa import SemanticRetrievalError, run_qa, run_semantic_qa
 from bot.services.qa_guardrails import (
     MAX_AI_ANSWER_CHARS,
     SENSITIVE_QA_REFUSAL,
@@ -48,11 +68,41 @@ router = Router(name="qa")
 
 QA_FEATURE_FLAG = "memory.qa.enabled"
 LLM_SYNTHESIS_FEATURE_FLAG = "memory.qa.llm_synthesis.enabled"
+SEMANTIC_QA_FEATURE_FLAG = "memory.qa.semantic.enabled"
 QA_EVIDENCE_LIMIT = 3
+SEMANTIC_QA_EVIDENCE_LIMIT = 5
+SEMANTIC_SYNTHESIS_PROVIDER = "deepseek"
+SEMANTIC_SYNTHESIS_MODEL = "deepseek-v4-flash"
 
 # The evidence-bearing prompt shipped after the original v1.0.0 cache format.
 # Keep this pin explicit so old ungrounded cache rows can never be reused.
 DEFAULT_PROMPT_TEMPLATE_VERSION = "v1.1.0"
+_MV_CITATION_RE = re.compile(r"\[\[mv:(\d+)\]\]")
+_SEMANTIC_REPLAY_HTML_PREFIX = "semantic-html-v1:"
+_CONTENT_ABSTENTION_REASONS = frozenset(
+    {
+        "empty_bundle",
+        "all_filtered",
+        "forget_invalidated",
+        "sensitive_input",
+        "sensitive_output",
+        "insufficient_evidence",
+    }
+)
+_DEFINITIVE_TELEGRAM_REJECTIONS = (
+    TelegramBadRequest,
+    TelegramConflictError,
+    TelegramEntityTooLarge,
+    TelegramForbiddenError,
+    TelegramMigrateToChat,
+    TelegramNotFound,
+    TelegramRetryAfter,
+    TelegramUnauthorizedError,
+)
+
+
+class EvidenceInvalidatedBeforeDelivery(RuntimeError):
+    """Final governed evidence changed before Telegram dispatch."""
 
 
 def _short_chat_id(chat_id: int) -> str:
@@ -293,18 +343,23 @@ def _format_bounded_mention_response(
                 users_by_id.get(item.user_id) if item.user_id is not None else None
             )
         )
-        for item in bundle.items[:QA_EVIDENCE_LIMIT]
+        for item in bundle.items[:SEMANTIC_QA_EVIDENCE_LIMIT]
     ):
         return SENSITIVE_QA_REFUSAL
 
     source_lines: list[str] = []
-    for idx, item in enumerate(bundle.items[:QA_EVIDENCE_LIMIT], start=1):
+    short_chat_id = _short_chat_id(bundle.chat_id)
+    for idx, item in enumerate(bundle.items[:SEMANTIC_QA_EVIDENCE_LIMIT], start=1):
         date_text = item.message_date.astimezone().strftime("%Y-%m-%d")
         author = _compact_author(
             users_by_id.get(item.user_id) if item.user_id is not None else None
         )
         snippet = _escaped_text_with_budget(item.snippet, 120)
-        source_lines.append(f"[{idx}] {date_text} — {author}: {snippet}")
+        link = f"https://t.me/c/{short_chat_id}/{item.message_id}"
+        source_lines.append(
+            f'[{idx}] <a href="{html.escape(link, quote=True)}">источник</a> · '
+            f"{date_text} — {author}: {snippet}"
+        )
 
     # ponytail: a fixed three-source footer avoids an HTML-aware truncator;
     # add one only if Telegram formatting grows beyond this known-safe shape.
@@ -312,12 +367,12 @@ def _format_bounded_mention_response(
     separator = "\n\n" if answer_text else ""
     answer_budget = MAX_AI_ANSWER_CHARS - len(separator) - len(footer)
     if answer_budget < 1:
-        # Defensive fallback for future footer changes.  Evidence identifiers
-        # remain visible while untrusted snippets are omitted.
+        # Keep citations useful even with five worst-case sources.  Snippets
+        # and authors are optional, clickable provenance is not.
         source_lines = [
-            f"[{idx}] message_version_id:{item.message_version_id}"
+            f'[{idx}] <a href="https://t.me/c/{short_chat_id}/{item.message_id}">источник</a>'
             for idx, item in enumerate(
-                bundle.items[:QA_EVIDENCE_LIMIT],
+                bundle.items[:SEMANTIC_QA_EVIDENCE_LIMIT],
                 start=1,
             )
         ]
@@ -331,6 +386,21 @@ def _format_bounded_mention_response(
     if len(rendered) > MAX_AI_ANSWER_CHARS:
         raise ValueError("bounded mention response exceeds configured limit")
     return rendered
+
+
+def _normalize_provider_citations(answer_text: str, bundle: EvidenceBundle) -> str:
+    """Map validated provider mvid markers to deterministic visible source numbers."""
+
+    positions = {item.message_version_id: index for index, item in enumerate(bundle.items, start=1)}
+
+    def replace(match: re.Match[str]) -> str:
+        message_version_id = int(match.group(1))
+        position = positions.get(message_version_id)
+        if position is None:
+            raise ValueError("provider citation is absent from the rendered evidence bundle")
+        return f"[{position}]"
+
+    return _MV_CITATION_RE.sub(replace, answer_text)
 
 
 async def _reply_to_mention(message: Message, text: str, **kwargs: Any) -> None:
@@ -398,6 +468,819 @@ async def _write_sensitive_trace(
     )
 
 
+async def _bundle_users(
+    session: AsyncSession,
+    bundle: EvidenceBundle,
+) -> tuple[dict[int, object], bool]:
+    users_by_id: dict[int, object] = {}
+    for item in bundle.items:
+        if item.user_id is None or item.user_id in users_by_id:
+            continue
+        author = await UserRepo.get(session, item.user_id)
+        if author is None:
+            continue
+        if contains_secret_like_data(_compact_author_value(author)):
+            return {}, True
+        users_by_id[item.user_id] = author
+    return users_by_id, False
+
+
+async def _ordinary_search_result(
+    session: AsyncSession,
+    *,
+    query: str,
+    chat_id: int,
+    query_redacted: bool,
+    exclude_chat_message_id: int,
+):
+    return await run_qa(
+        session,
+        query=query,
+        chat_id=chat_id,
+        redact_query_in_audit=query_redacted,
+        limit=SEMANTIC_QA_EVIDENCE_LIMIT,
+        exclude_chat_message_id=exclude_chat_message_id,
+        human_only=True,
+    )
+
+
+async def _reply_with_ordinary_search(
+    message: Message,
+    *,
+    bundle: EvidenceBundle,
+    users_by_id: dict[int, object],
+    notice: str,
+) -> None:
+    if bundle.abstained:
+        reply_text = f"{notice}\n\nОбычный поиск тоже не нашёл подходящих свидетельств."
+    else:
+        reply_text = _format_bounded_mention_response(
+            notice,
+            bundle,
+            users_by_id,
+            sources_heading="Обычный поиск — найденные свидетельства:",
+        )
+    await _reply_to_mention(
+        message,
+        reply_text,
+        parse_mode="HTML",
+        disable_web_page_preview=True,
+    )
+
+
+async def _reply_with_governed_ordinary_search(
+    message: Message,
+    session: AsyncSession,
+    *,
+    bundle: EvidenceBundle,
+    notice: str,
+) -> None:
+    """Revalidate ordinary evidence under the same locks as privacy writers."""
+
+    if bundle.abstained or not bundle.evidence_ids:
+        await _reply_with_ordinary_search(
+            message,
+            bundle=bundle,
+            users_by_id={},
+            notice=notice,
+        )
+        return
+    await session.commit()
+    async with hold_evidence_delivery_locks(session, bundle):
+        locked_bundle = await filter_surviving_evidence(
+            session,
+            bundle,
+            max_evidence_items=SEMANTIC_QA_EVIDENCE_LIMIT,
+        )
+        if tuple(locked_bundle.evidence_ids) != tuple(bundle.evidence_ids):
+            await _reply_to_mention(
+                message,
+                f"{notice}\n\nИсточники изменились; обычный поиск больше не показывает эти свидетельства.",
+            )
+            return
+        users_by_id, sensitive_author = await _bundle_users(session, locked_bundle)
+        if sensitive_author:
+            await _reply_to_mention(message, SENSITIVE_QA_REFUSAL)
+            return
+        await _reply_with_ordinary_search(
+            message,
+            bundle=locked_bundle,
+            users_by_id=users_by_id,
+            notice=notice,
+        )
+
+
+async def _reply_semantic_replay(
+    message: Message,
+    session: AsyncSession,
+    *,
+    source_chat_message_id: int,
+    status: str | None,
+    outcome: str | None,
+) -> None:
+    # Never replay stored generated content: it may have become stale between
+    # the idempotent attempt and a completed forget cascade.
+    del session, source_chat_message_id, outcome
+    if status == "reserved":
+        await _reply_to_mention(message, "Этот semantic AI-запрос уже обрабатывается.")
+        return
+    await _reply_to_mention(
+        message,
+        "Этот semantic AI-запрос уже был обработан; провайдеры повторно не вызывались.",
+    )
+
+
+async def _deliver_and_consume_semantic_attempt(
+    message: Message,
+    session: AsyncSession,
+    *,
+    attempt_id: int,
+    outcome: str,
+    qa_trace_id: int,
+    embedding_llm_call_id: int,
+    synthesis_llm_call_id: int | None,
+    reply_text: str,
+    clear_summary_on_failure: bool = False,
+    parse_mode: str | None = None,
+    disable_web_page_preview: bool | None = None,
+    delivery_bundle: EvidenceBundle | None = None,
+    expected_evidence_ids: tuple[int, ...] = (),
+) -> None:
+    """Persist delivery intent, then consume or definitively release the quota."""
+
+    delivery_intent_durable = False
+
+    async def release_pre_delivery_database_failure(exc: SQLAlchemyError) -> None:
+        """Release only while Telegram delivery is provably impossible."""
+
+        await session.rollback()
+        logger.error(
+            "semantic_qa_pre_delivery_database_failed",
+            extra={"attempt_id": attempt_id, "error_class": type(exc).__name__},
+        )
+        if clear_summary_on_failure:
+            await QaTraceRepo.clear_undelivered_llm_summary(
+                session,
+                qa_trace_id=qa_trace_id,
+            )
+        await SemanticQuotaRepo.finalize(
+            session,
+            attempt_id=attempt_id,
+            outcome="technical_failure",
+            qa_trace_id=qa_trace_id,
+            embedding_llm_call_id=embedding_llm_call_id,
+            synthesis_llm_call_id=synthesis_llm_call_id,
+        )
+        await session.commit()
+        await _reply_to_mention(
+            message,
+            "Semantic AI-ответ технически недоступен; лимит не списан.",
+        )
+
+    async def deliver() -> None:
+        nonlocal delivery_intent_durable
+        await SemanticQuotaRepo.mark_delivery_started(
+            session,
+            attempt_id=attempt_id,
+            outcome=outcome,  # type: ignore[arg-type]  # handler passes answered/abstained only
+            qa_trace_id=qa_trace_id,
+            embedding_llm_call_id=embedding_llm_call_id,
+            synthesis_llm_call_id=synthesis_llm_call_id,
+        )
+        # Durable intent prevents a post-send DB failure from later releasing
+        # a response that Telegram may already have delivered.
+        await session.commit()
+        delivery_intent_durable = True
+        try:
+            await _reply_to_mention(
+                message,
+                reply_text,
+                parse_mode=parse_mode,
+                disable_web_page_preview=disable_web_page_preview,
+            )
+        except _DEFINITIVE_TELEGRAM_REJECTIONS:
+            await session.rollback()
+            if clear_summary_on_failure:
+                await QaTraceRepo.clear_undelivered_llm_summary(
+                    session,
+                    qa_trace_id=qa_trace_id,
+                )
+            await SemanticQuotaRepo.finalize(
+                session,
+                attempt_id=attempt_id,
+                outcome="technical_failure",
+                qa_trace_id=qa_trace_id,
+                embedding_llm_call_id=embedding_llm_call_id,
+                synthesis_llm_call_id=synthesis_llm_call_id,
+            )
+            await session.commit()
+            raise
+        except TelegramAPIError as exc:
+            # Network/5xx failures are ambiguous: Telegram may have accepted
+            # the message before the client lost the response. Conservatively
+            # consume the already-durable delivery intent so retries cannot
+            # produce more than two semantic answers in a Moscow day.
+            await session.rollback()
+            logger.error(
+                "semantic_qa_telegram_delivery_ambiguous",
+                extra={"attempt_id": attempt_id, "error_class": type(exc).__name__},
+            )
+            await SemanticQuotaRepo.finalize(
+                session,
+                attempt_id=attempt_id,
+                outcome=outcome,  # type: ignore[arg-type]
+                qa_trace_id=qa_trace_id,
+                embedding_llm_call_id=embedding_llm_call_id,
+                synthesis_llm_call_id=synthesis_llm_call_id,
+            )
+            await session.commit()
+            raise
+        await SemanticQuotaRepo.finalize(
+            session,
+            attempt_id=attempt_id,
+            outcome=outcome,
+            qa_trace_id=qa_trace_id,
+            embedding_llm_call_id=embedding_llm_call_id,
+            synthesis_llm_call_id=synthesis_llm_call_id,
+        )
+        await session.commit()
+
+    try:
+        # Provider/cache/trace audit must survive a Telegram failure. Committing
+        # before the dedicated delivery lock also avoids a lock-order deadlock
+        # with a forget cascade that deletes an uncommitted cache row.
+        await session.commit()
+        if delivery_bundle is None:
+            await deliver()
+            return
+
+        async with hold_evidence_delivery_locks(session, delivery_bundle):
+            locked_bundle = await filter_surviving_evidence(
+                session,
+                delivery_bundle,
+                max_evidence_items=SEMANTIC_QA_EVIDENCE_LIMIT,
+            )
+            if tuple(locked_bundle.evidence_ids) != expected_evidence_ids:
+                for item in delivery_bundle.items:
+                    for message_version_id in (
+                        item.message_version_id,
+                        *item.card_source_message_version_ids,
+                    ):
+                        await SynthesisCacheRepo.invalidate_by_citation(
+                            session,
+                            message_version_id=message_version_id,
+                        )
+                if clear_summary_on_failure:
+                    await QaTraceRepo.clear_undelivered_llm_summary(
+                        session,
+                        qa_trace_id=qa_trace_id,
+                    )
+                await session.commit()
+                raise EvidenceInvalidatedBeforeDelivery
+            await deliver()
+    except SQLAlchemyError as exc:
+        if delivery_intent_durable:
+            raise
+        await release_pre_delivery_database_failure(exc)
+
+
+async def _reply_after_technical_release(
+    message: Message,
+    session: AsyncSession,
+    *,
+    query: str,
+    chat_id: int,
+    query_redacted: bool,
+    exclude_chat_message_id: int,
+    notice: str,
+) -> None:
+    """Best-effort ordinary search after quota was already released durably."""
+
+    try:
+        ordinary = await _ordinary_search_result(
+            session,
+            query=query,
+            chat_id=chat_id,
+            query_redacted=query_redacted,
+            exclude_chat_message_id=exclude_chat_message_id,
+        )
+        users_by_id, sensitive_author = await _bundle_users(session, ordinary.bundle)
+        await session.commit()
+    except SQLAlchemyError as exc:
+        await session.rollback()
+        logger.error(
+            "semantic_qa_ordinary_fallback_failed",
+            extra={"chat_id": chat_id, "error_class": type(exc).__name__},
+        )
+        await _reply_to_mention(message, f"{notice} Лимит не списан.")
+        return
+    if sensitive_author:
+        await _reply_to_mention(message, SENSITIVE_QA_REFUSAL)
+        return
+    await _reply_with_governed_ordinary_search(
+        message,
+        session,
+        bundle=ordinary.bundle,
+        notice=notice,
+    )
+
+
+async def _semantic_mention_question(
+    *,
+    message: Message,
+    session: AsyncSession,
+    sender_id: int,
+    persisted_chat_message_id: int,
+    query: str,
+    query_redacted: bool,
+) -> None:
+    """Execute the complete admitted semantic Q&A state machine."""
+
+    quota = await SemanticQuotaRepo.reserve(
+        session,
+        idempotency_key=f"chat-message:{persisted_chat_message_id}",
+        user_tg_id=sender_id,
+        chat_id=message.chat.id,
+        source_chat_message_id=persisted_chat_message_id,
+    )
+    # Reservation must be visible before any paid provider call and releases
+    # the transaction advisory lock for concurrent requests from this member.
+    await session.commit()
+
+    if getattr(quota, "replayed", False):
+        await _reply_semantic_replay(
+            message,
+            session,
+            source_chat_message_id=persisted_chat_message_id,
+            status=getattr(quota, "status", None),
+            outcome=getattr(quota, "outcome", None),
+        )
+        return
+
+    if not quota.allowed:
+        ordinary = await _ordinary_search_result(
+            session,
+            query=query,
+            chat_id=message.chat.id,
+            query_redacted=query_redacted,
+            exclude_chat_message_id=persisted_chat_message_id,
+        )
+        users_by_id, sensitive_author = await _bundle_users(session, ordinary.bundle)
+        if sensitive_author:
+            await _reply_to_mention(message, SENSITIVE_QA_REFUSAL)
+            return
+        await _write_trace(
+            session,
+            user_tg_id=sender_id,
+            chat_id=message.chat.id,
+            query=query,
+            evidence_ids=ordinary.bundle.evidence_ids,
+            abstained=ordinary.bundle.abstained,
+            redact_query=query_redacted,
+            source_chat_message_id=persisted_chat_message_id,
+        )
+        await session.commit()
+        await _reply_with_governed_ordinary_search(
+            message,
+            session,
+            bundle=ordinary.bundle,
+            notice=(
+                f"Лимит — {quota.limit} semantic AI-вопроса в день. "
+                "Embedding и AI-синтез не вызывались."
+            ),
+        )
+        return
+
+    try:
+        trace = await QaTraceRepo.create(
+            session,
+            user_tg_id=sender_id,
+            chat_id=message.chat.id,
+            query=query,
+            evidence_ids=[],
+            abstained=False,
+            redact_query=query_redacted,
+            source_chat_message_id=persisted_chat_message_id,
+        )
+        await SemanticQuotaRepo.attach_trace(
+            session,
+            attempt_id=quota.attempt_id,
+            qa_trace_id=trace.id,
+        )
+        # The user/query ownership chain is durable before embedding HTTP.
+        await session.commit()
+    except SQLAlchemyError as exc:
+        await session.rollback()
+        logger.error(
+            "semantic_qa_trace_setup_failed",
+            extra={
+                "attempt_id": quota.attempt_id,
+                "chat_id": message.chat.id,
+                "error_class": type(exc).__name__,
+            },
+        )
+        await SemanticQuotaRepo.finalize(
+            session,
+            attempt_id=quota.attempt_id,
+            outcome="technical_failure",
+        )
+        await session.commit()
+        await _reply_to_mention(
+            message,
+            "Semantic AI-поиск технически недоступен; лимит не списан.",
+        )
+        return
+
+    try:
+        semantic = await run_semantic_qa(
+            session,
+            query=query,
+            chat_id=message.chat.id,
+            redact_query_in_audit=query_redacted,
+            attempt_id=quota.attempt_id,
+            qa_trace_id=trace.id,
+            exclude_chat_message_id=persisted_chat_message_id,
+        )
+    except (
+        EmbeddingBudgetExceeded,
+        ProviderStructuralError,
+        ProviderTransientError,
+        SemanticRetrievalError,
+        ValueError,
+    ) as exc:
+        logger.error(
+            "semantic_qa_embedding_failed",
+            extra={
+                "attempt_id": quota.attempt_id,
+                "chat_id": message.chat.id,
+                "error_class": type(exc).__name__,
+                "error_subtype": _safe_qa_provider_error_subtype(exc),
+            },
+        )
+        embedding_call_id = getattr(
+            exc,
+            "llm_usage_ledger_id",
+            getattr(exc, "embedding_llm_call_id", None),
+        )
+        await SemanticQuotaRepo.finalize(
+            session,
+            attempt_id=quota.attempt_id,
+            outcome="technical_failure",
+            qa_trace_id=trace.id,
+            embedding_llm_call_id=embedding_call_id,
+        )
+        # Release first: ordinary fallback failure must not consume quota.
+        await session.commit()
+        await _reply_after_technical_release(
+            message,
+            session,
+            query=query,
+            chat_id=message.chat.id,
+            query_redacted=query_redacted,
+            exclude_chat_message_id=persisted_chat_message_id,
+            notice="Semantic AI-поиск технически недоступен. Показываю обычный поиск без AI.",
+        )
+        return
+    except SQLAlchemyError as exc:
+        await session.rollback()
+        logger.error(
+            "semantic_qa_database_failed",
+            extra={
+                "attempt_id": quota.attempt_id,
+                "chat_id": message.chat.id,
+                "error_class": type(exc).__name__,
+            },
+        )
+        await SemanticQuotaRepo.finalize(
+            session,
+            attempt_id=quota.attempt_id,
+            outcome="technical_failure",
+            qa_trace_id=trace.id,
+        )
+        await session.commit()
+        await _reply_after_technical_release(
+            message,
+            session,
+            query=query,
+            chat_id=message.chat.id,
+            query_redacted=query_redacted,
+            exclude_chat_message_id=persisted_chat_message_id,
+            notice="Semantic AI-поиск технически недоступен.",
+        )
+        return
+
+    if semantic.bundle.abstained or not semantic.bundle.evidence_ids:
+        await _deliver_and_consume_semantic_attempt(
+            message,
+            session,
+            attempt_id=quota.attempt_id,
+            outcome="abstained",
+            qa_trace_id=trace.id,
+            embedding_llm_call_id=semantic.embedding_llm_call_id,
+            synthesis_llm_call_id=None,
+            reply_text="Не нашёл достаточно подтверждений в памяти сообщества.",
+        )
+        return
+
+    if any(contains_secret_like_data(item.snippet) for item in semantic.bundle.items):
+        await QaTraceRepo.update_retrieval_fields(
+            session,
+            qa_trace_id=trace.id,
+            evidence_ids=[],
+            abstained=True,
+        )
+        await _deliver_and_consume_semantic_attempt(
+            message,
+            session,
+            attempt_id=quota.attempt_id,
+            outcome="abstained",
+            qa_trace_id=trace.id,
+            embedding_llm_call_id=semantic.embedding_llm_call_id,
+            synthesis_llm_call_id=None,
+            reply_text=SENSITIVE_QA_REFUSAL,
+        )
+        return
+
+    try:
+        cfg = _load_gateway_config()
+        if cfg.provider != SEMANTIC_SYNTHESIS_PROVIDER or cfg.model != SEMANTIC_SYNTHESIS_MODEL:
+            raise ValueError("semantic Q&A synthesis requires DeepSeek V4 Flash configuration")
+        provider = _resolve_provider(cfg.provider)
+        synth_result = await synthesize_answer(
+            session,
+            bundle=semantic.bundle,
+            query=build_guarded_llm_query(query),
+            config=cfg,
+            qa_trace_id=trace.id,
+            ledger_repo=LedgerRepo(),
+            cache_repo=SynthesisCacheRepo(),
+            provider=provider,
+            max_evidence_items=SEMANTIC_QA_EVIDENCE_LIMIT,
+            durable_placeholder=True,
+            revalidate_after_provider=True,
+        )
+    except (ValueError, SQLAlchemyError) as exc:
+        if isinstance(exc, SQLAlchemyError):
+            await session.rollback()
+        logger.error(
+            "semantic_qa_synthesis_config_failed",
+            extra={
+                "attempt_id": quota.attempt_id,
+                "qa_trace_id": trace.id,
+                "error_class": type(exc).__name__,
+            },
+        )
+        await SemanticQuotaRepo.finalize(
+            session,
+            attempt_id=quota.attempt_id,
+            outcome="technical_failure",
+            qa_trace_id=trace.id,
+            embedding_llm_call_id=semantic.embedding_llm_call_id,
+        )
+        await session.commit()
+        await _reply_after_technical_release(
+            message,
+            session,
+            query=query,
+            chat_id=message.chat.id,
+            query_redacted=query_redacted,
+            exclude_chat_message_id=persisted_chat_message_id,
+            notice="AI-синтез технически недоступен. Показываю обычный поиск без AI.",
+        )
+        return
+
+    if isinstance(synth_result, AnswerWithCitations):
+        try:
+            render_bundle = await filter_surviving_evidence(
+                session,
+                semantic.bundle,
+                max_evidence_items=SEMANTIC_QA_EVIDENCE_LIMIT,
+            )
+        except SQLAlchemyError as exc:
+            await session.rollback()
+            logger.error(
+                "semantic_qa_render_revalidation_failed",
+                extra={
+                    "attempt_id": quota.attempt_id,
+                    "error_class": type(exc).__name__,
+                },
+            )
+            await SemanticQuotaRepo.finalize(
+                session,
+                attempt_id=quota.attempt_id,
+                outcome="technical_failure",
+                qa_trace_id=trace.id,
+                embedding_llm_call_id=semantic.embedding_llm_call_id,
+                synthesis_llm_call_id=synth_result.llm_call_id,
+            )
+            await session.commit()
+            await _reply_after_technical_release(
+                message,
+                session,
+                query=query,
+                chat_id=message.chat.id,
+                query_redacted=query_redacted,
+                exclude_chat_message_id=persisted_chat_message_id,
+                notice="AI-синтез технически недоступен.",
+            )
+            return
+
+        expected_ids = synth_result.surviving_evidence_ids
+        if tuple(render_bundle.evidence_ids) != expected_ids or not set(
+            synth_result.citation_ids
+        ).issubset(expected_ids):
+            await QaTraceRepo.update_retrieval_fields(
+                session,
+                qa_trace_id=trace.id,
+                evidence_ids=render_bundle.evidence_ids,
+                abstained=True,
+            )
+            await QaTraceRepo.update_llm_fields(
+                session,
+                qa_trace_id=trace.id,
+                llm_call_id=synth_result.llm_call_id,
+                llm_response_summary=None,
+                llm_response_redacted=True,
+                cost_usd=synth_result.cost_usd,
+            )
+            await _deliver_and_consume_semantic_attempt(
+                message,
+                session,
+                attempt_id=quota.attempt_id,
+                outcome="abstained",
+                qa_trace_id=trace.id,
+                embedding_llm_call_id=semantic.embedding_llm_call_id,
+                synthesis_llm_call_id=synth_result.llm_call_id,
+                reply_text="Не нашёл достаточно подтверждений в памяти сообщества.",
+            )
+            return
+
+        users_by_id, sensitive_author = await _bundle_users(session, render_bundle)
+        if sensitive_author or any(
+            contains_secret_like_data(item.snippet) for item in render_bundle.items
+        ):
+            await QaTraceRepo.update_retrieval_fields(
+                session,
+                qa_trace_id=trace.id,
+                evidence_ids=[],
+                abstained=True,
+            )
+            await QaTraceRepo.update_llm_fields(
+                session,
+                qa_trace_id=trace.id,
+                llm_call_id=synth_result.llm_call_id,
+                llm_response_summary=None,
+                llm_response_redacted=True,
+                cost_usd=synth_result.cost_usd,
+            )
+            await _deliver_and_consume_semantic_attempt(
+                message,
+                session,
+                attempt_id=quota.attempt_id,
+                outcome="abstained",
+                qa_trace_id=trace.id,
+                embedding_llm_call_id=semantic.embedding_llm_call_id,
+                synthesis_llm_call_id=synth_result.llm_call_id,
+                reply_text=SENSITIVE_QA_REFUSAL,
+            )
+            return
+
+        try:
+            normalized_answer = _normalize_provider_citations(
+                synth_result.answer_text,
+                render_bundle,
+            )
+            reply_text = _format_bounded_mention_response(
+                normalized_answer,
+                render_bundle,
+                users_by_id,
+            )
+        except ValueError as exc:
+            logger.error(
+                "semantic_qa_citation_render_failed",
+                extra={
+                    "attempt_id": quota.attempt_id,
+                    "error_class": type(exc).__name__,
+                },
+            )
+            await SemanticQuotaRepo.finalize(
+                session,
+                attempt_id=quota.attempt_id,
+                outcome="technical_failure",
+                qa_trace_id=trace.id,
+                embedding_llm_call_id=semantic.embedding_llm_call_id,
+                synthesis_llm_call_id=synth_result.llm_call_id,
+            )
+            await session.commit()
+            await _reply_after_technical_release(
+                message,
+                session,
+                query=query,
+                chat_id=message.chat.id,
+                query_redacted=query_redacted,
+                exclude_chat_message_id=persisted_chat_message_id,
+                notice="AI-синтез технически недоступен.",
+            )
+            return
+
+        await QaTraceRepo.update_llm_fields(
+            session,
+            qa_trace_id=trace.id,
+            llm_call_id=synth_result.llm_call_id,
+            llm_response_summary=f"{_SEMANTIC_REPLAY_HTML_PREFIX}{reply_text}",
+            llm_response_redacted=False,
+            cost_usd=synth_result.cost_usd,
+        )
+        try:
+            await _deliver_and_consume_semantic_attempt(
+                message,
+                session,
+                attempt_id=quota.attempt_id,
+                outcome="answered",
+                qa_trace_id=trace.id,
+                embedding_llm_call_id=semantic.embedding_llm_call_id,
+                synthesis_llm_call_id=synth_result.llm_call_id,
+                reply_text=reply_text,
+                clear_summary_on_failure=True,
+                parse_mode="HTML",
+                disable_web_page_preview=True,
+                delivery_bundle=render_bundle,
+                expected_evidence_ids=tuple(render_bundle.evidence_ids),
+            )
+        except EvidenceInvalidatedBeforeDelivery:
+            await QaTraceRepo.update_retrieval_fields(
+                session,
+                qa_trace_id=trace.id,
+                evidence_ids=[],
+                abstained=True,
+            )
+            await QaTraceRepo.update_llm_fields(
+                session,
+                qa_trace_id=trace.id,
+                llm_call_id=synth_result.llm_call_id,
+                llm_response_summary=None,
+                llm_response_redacted=True,
+                cost_usd=synth_result.cost_usd,
+            )
+            await _deliver_and_consume_semantic_attempt(
+                message,
+                session,
+                attempt_id=quota.attempt_id,
+                outcome="abstained",
+                qa_trace_id=trace.id,
+                embedding_llm_call_id=semantic.embedding_llm_call_id,
+                synthesis_llm_call_id=synth_result.llm_call_id,
+                reply_text="Не нашёл достаточно подтверждений в памяти сообщества.",
+            )
+        return
+
+    quota_outcome = (
+        "abstained" if synth_result.reason in _CONTENT_ABSTENTION_REASONS else "technical_failure"
+    )
+    await QaTraceRepo.update_llm_fields(
+        session,
+        qa_trace_id=trace.id,
+        llm_call_id=synth_result.llm_call_id,
+        llm_response_summary=None,
+        llm_response_redacted=synth_result.reason.startswith("sensitive_"),
+        cost_usd=synth_result.cost_usd,
+    )
+    if quota_outcome == "technical_failure":
+        await SemanticQuotaRepo.finalize(
+            session,
+            attempt_id=quota.attempt_id,
+            outcome=quota_outcome,
+            qa_trace_id=trace.id,
+            embedding_llm_call_id=semantic.embedding_llm_call_id,
+            synthesis_llm_call_id=synth_result.llm_call_id,
+        )
+        await session.commit()
+        await _reply_after_technical_release(
+            message,
+            session,
+            query=query,
+            chat_id=message.chat.id,
+            query_redacted=query_redacted,
+            exclude_chat_message_id=persisted_chat_message_id,
+            notice="AI-синтез технически недоступен. Показываю обычный поиск без AI.",
+        )
+    else:
+        await _deliver_and_consume_semantic_attempt(
+            message,
+            session,
+            attempt_id=quota.attempt_id,
+            outcome="abstained",
+            qa_trace_id=trace.id,
+            embedding_llm_call_id=semantic.embedding_llm_call_id,
+            synthesis_llm_call_id=synth_result.llm_call_id,
+            reply_text=(
+                SENSITIVE_QA_REFUSAL
+                if synth_result.reason.startswith("sensitive_")
+                else "Не нашёл достаточно подтверждений в памяти сообщества."
+            ),
+        )
+
+
 async def recall_handler(
     message: Message,
     command: CommandObject,
@@ -415,6 +1298,7 @@ async def recall_handler(
             username=getattr(message.from_user, "username", None),
             first_name=getattr(message.from_user, "first_name", None),
             last_name=getattr(message.from_user, "last_name", None),
+            is_bot=getattr(message.from_user, "is_bot", None),
         )
         await persist_message_with_policy(
             session,
@@ -653,6 +1537,7 @@ async def mention_question_handler(
         username=getattr(sender, "username", None),
         first_name=sender.first_name,
         last_name=getattr(sender, "last_name", None),
+        is_bot=getattr(sender, "is_bot", None),
     )
     persisted = await persist_message_with_policy(
         session,
@@ -689,22 +1574,10 @@ async def mention_question_handler(
             )
         return
     if existing_trace is not None:
-        if existing_trace.llm_response_summary:
-            if contains_secret_like_data(existing_trace.llm_response_summary):
-                await _reply_to_mention(message, SENSITIVE_QA_REFUSAL)
-            else:
-                prefix = "Уже отвечал на этот вопрос:\n\n"
-                previous = _escaped_text_with_budget(
-                    existing_trace.llm_response_summary,
-                    MAX_AI_ANSWER_CHARS - len(prefix),
-                )
-                await _reply_to_mention(
-                    message,
-                    f"{prefix}{previous}",
-                    parse_mode="HTML",
-                )
-        else:
-            await _reply_to_mention(message, "Этот вопрос уже обработан.")
+        await _reply_to_mention(
+            message,
+            "Этот вопрос уже обработан; сохранённый ответ повторно не показывается.",
+        )
         return
 
     if not query:
@@ -737,6 +1610,25 @@ async def mention_question_handler(
             abstained=True,
             redact_query=query_redacted,
             source_chat_message_id=persisted.chat_message.id,
+        )
+        return
+
+    semantic_enabled = await FeatureFlagRepo.get(session, SEMANTIC_QA_FEATURE_FLAG)
+    if not semantic_enabled:
+        semantic_enabled = await FeatureFlagRepo.get(
+            session,
+            SEMANTIC_QA_FEATURE_FLAG,
+            scope_type="user",
+            scope_id=str(sender.id),
+        )
+    if semantic_enabled:
+        await _semantic_mention_question(
+            message=message,
+            session=session,
+            sender_id=sender.id,
+            persisted_chat_message_id=persisted.chat_message.id,
+            query=query,
+            query_redacted=query_redacted,
         )
         return
 

--- a/bot/handlers/qa.py
+++ b/bot/handlers/qa.py
@@ -1057,6 +1057,7 @@ async def _semantic_mention_question(
         )
         return
 
+    durable_trace_id: int | None = None
     try:
         # The quota commit above releases persistence's caller-transaction
         # chat-message lock. This dedicated fence now covers every query-bearing
@@ -1082,6 +1083,7 @@ async def _semantic_mention_question(
                     qa_trace_id=trace.id,
                 )
                 await session.commit()
+                durable_trace_id = trace.id
             except LookupError as exc:
                 await _reply_semantic_lease_lost(
                     message,
@@ -1198,7 +1200,7 @@ async def _semantic_mention_question(
             session,
             attempt_id=quota.attempt_id,
             outcome="technical_failure",
-            qa_trace_id=trace.id,
+            qa_trace_id=durable_trace_id,
         )
         await session.commit()
         await _reply_after_technical_release(

--- a/bot/handlers/qa.py
+++ b/bot/handlers/qa.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import html
 import logging
 import re
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any
 
 from aiogram import Router
@@ -50,7 +50,12 @@ from bot.services.llm_providers import (
     ProviderTransientError,
 )
 from bot.services.message_persistence import persist_message_with_policy
-from bot.services.qa import SemanticRetrievalError, run_qa, run_semantic_qa
+from bot.services.qa import (
+    SemanticRetrievalError,
+    persist_semantic_retrieval_trace,
+    run_qa,
+    run_semantic_qa,
+)
 from bot.services.qa_guardrails import (
     MAX_AI_ANSWER_CHARS,
     SENSITIVE_QA_REFUSAL,
@@ -103,6 +108,10 @@ _DEFINITIVE_TELEGRAM_REJECTIONS = (
 
 class EvidenceInvalidatedBeforeDelivery(RuntimeError):
     """Final governed evidence changed before Telegram dispatch."""
+
+
+class SemanticQuestionInvalidated(RuntimeError):
+    """The persisted source question was removed before provider dispatch."""
 
 
 def _short_chat_id(chat_id: int) -> str:
@@ -534,19 +543,30 @@ async def _reply_with_governed_ordinary_search(
     *,
     bundle: EvidenceBundle,
     notice: str,
+    required_governed_bundle: EvidenceBundle | None = None,
 ) -> None:
     """Revalidate ordinary evidence under the same locks as privacy writers."""
 
-    if bundle.abstained or not bundle.evidence_ids:
-        await _reply_with_ordinary_search(
-            message,
-            bundle=bundle,
-            users_by_id={},
-            notice=notice,
-        )
-        return
     await session.commit()
-    async with hold_evidence_delivery_locks(session, bundle):
+    lock_bundle = _merge_governance_bundles(bundle, required_governed_bundle)
+    async with hold_evidence_delivery_locks(session, lock_bundle):
+        if required_governed_bundle is not None and not await _question_is_governed(
+            session,
+            required_governed_bundle,
+        ):
+            await _reply_to_mention(
+                message,
+                "Этот вопрос уже удалён из памяти; ответ не показывается.",
+            )
+            return
+        if bundle.abstained or not bundle.evidence_ids:
+            await _reply_with_ordinary_search(
+                message,
+                bundle=bundle,
+                users_by_id={},
+                notice=notice,
+            )
+            return
         locked_bundle = await filter_surviving_evidence(
             session,
             bundle,
@@ -605,6 +625,7 @@ async def _deliver_and_consume_semantic_attempt(
     disable_web_page_preview: bool | None = None,
     delivery_bundle: EvidenceBundle | None = None,
     expected_evidence_ids: tuple[int, ...] = (),
+    required_governed_bundle: EvidenceBundle | None = None,
 ) -> None:
     """Persist delivery intent, then consume or definitively release the quota."""
 
@@ -710,17 +731,53 @@ async def _deliver_and_consume_semantic_attempt(
         # before the dedicated delivery lock also avoids a lock-order deadlock
         # with a forget cascade that deletes an uncommitted cache row.
         await session.commit()
-        if delivery_bundle is None:
+        if delivery_bundle is None and required_governed_bundle is None:
             await deliver()
             return
+        if delivery_bundle is None:
+            assert required_governed_bundle is not None
+            async with hold_evidence_delivery_locks(session, required_governed_bundle):
+                if not await _question_is_governed(session, required_governed_bundle):
+                    if clear_summary_on_failure:
+                        await QaTraceRepo.clear_undelivered_llm_summary(
+                            session,
+                            qa_trace_id=qa_trace_id,
+                        )
+                    await SemanticQuotaRepo.finalize(
+                        session,
+                        attempt_id=attempt_id,
+                        outcome="technical_failure",
+                        qa_trace_id=qa_trace_id,
+                        embedding_llm_call_id=embedding_llm_call_id,
+                        synthesis_llm_call_id=synthesis_llm_call_id,
+                    )
+                    await session.commit()
+                    await _reply_to_mention(
+                        message,
+                        "Этот вопрос уже удалён из памяти; semantic-лимит не списан.",
+                    )
+                    return
+                await deliver()
+                return
 
-        async with hold_evidence_delivery_locks(session, delivery_bundle):
+        lock_bundle = _merge_governance_bundles(
+            delivery_bundle,
+            required_governed_bundle,
+        )
+        async with hold_evidence_delivery_locks(session, lock_bundle):
+            required_is_governed = required_governed_bundle is None or await _question_is_governed(
+                session,
+                required_governed_bundle,
+            )
             locked_bundle = await filter_surviving_evidence(
                 session,
                 delivery_bundle,
                 max_evidence_items=SEMANTIC_QA_EVIDENCE_LIMIT,
             )
-            if tuple(locked_bundle.evidence_ids) != expected_evidence_ids:
+            if (
+                not required_is_governed
+                or tuple(locked_bundle.evidence_ids) != expected_evidence_ids
+            ):
                 for item in delivery_bundle.items:
                     for message_version_id in (
                         item.message_version_id,
@@ -738,6 +795,28 @@ async def _deliver_and_consume_semantic_attempt(
                 await session.commit()
                 raise EvidenceInvalidatedBeforeDelivery
             await deliver()
+    except LookupError as exc:
+        if delivery_intent_durable:
+            await session.rollback()
+            logger.error(
+                "semantic_qa_post_delivery_lease_already_reconciled",
+                extra={"attempt_id": attempt_id, "error_class": type(exc).__name__},
+            )
+            return
+        if clear_summary_on_failure:
+            await session.rollback()
+            await QaTraceRepo.clear_undelivered_llm_summary(
+                session,
+                qa_trace_id=qa_trace_id,
+            )
+            await session.commit()
+        await _reply_semantic_lease_lost(
+            message,
+            session,
+            attempt_id=attempt_id,
+            phase="delivery",
+            error=exc,
+        )
     except SQLAlchemyError as exc:
         if delivery_intent_durable:
             raise
@@ -753,6 +832,7 @@ async def _reply_after_technical_release(
     query_redacted: bool,
     exclude_chat_message_id: int,
     notice: str,
+    required_governed_bundle: EvidenceBundle,
 ) -> None:
     """Best-effort ordinary search after quota was already released durably."""
 
@@ -764,8 +844,6 @@ async def _reply_after_technical_release(
             query_redacted=query_redacted,
             exclude_chat_message_id=exclude_chat_message_id,
         )
-        users_by_id, sensitive_author = await _bundle_users(session, ordinary.bundle)
-        await session.commit()
     except SQLAlchemyError as exc:
         await session.rollback()
         logger.error(
@@ -774,14 +852,133 @@ async def _reply_after_technical_release(
         )
         await _reply_to_mention(message, f"{notice} Лимит не списан.")
         return
-    if sensitive_author:
-        await _reply_to_mention(message, SENSITIVE_QA_REFUSAL)
-        return
     await _reply_with_governed_ordinary_search(
         message,
         session,
         bundle=ordinary.bundle,
         notice=notice,
+        required_governed_bundle=required_governed_bundle,
+    )
+
+
+def _semantic_question_bundle(
+    message: Message,
+    *,
+    current_message_version_id: int | None,
+    persisted_chat_message_id: int,
+    query: str,
+) -> EvidenceBundle:
+    """Build the governed provenance bundle for the persisted source question."""
+
+    if current_message_version_id is None:
+        raise LookupError("semantic question is missing its current message version")
+    return EvidenceBundle(
+        query=query,
+        chat_id=message.chat.id,
+        items=(
+            EvidenceItem(
+                message_version_id=current_message_version_id,
+                chat_message_id=persisted_chat_message_id,
+                chat_id=message.chat.id,
+                message_id=message.message_id,
+                user_id=None,
+                snippet="",
+                ts_rank=1.0,
+                captured_at=message.date,
+                message_date=message.date,
+            ),
+        ),
+        abstained=False,
+        created_at=datetime.now(timezone.utc),
+    )
+
+
+def _merge_governance_bundles(
+    first: EvidenceBundle,
+    second: EvidenceBundle | None,
+) -> EvidenceBundle:
+    """Combine complete lock provenance without changing either delivery bundle."""
+
+    if second is None:
+        return first
+    if first.chat_id != second.chat_id:
+        raise ValueError("governance lock bundles must belong to the same chat")
+    return EvidenceBundle(
+        query=first.query,
+        chat_id=first.chat_id,
+        items=(*first.items, *second.items),
+        abstained=False,
+        created_at=min(first.created_at, second.created_at),
+    )
+
+
+async def _question_is_governed(
+    session: AsyncSession,
+    question_bundle: EvidenceBundle,
+) -> bool:
+    surviving = await filter_surviving_evidence(
+        session,
+        question_bundle,
+        max_evidence_items=1,
+    )
+    return tuple(surviving.evidence_ids) == tuple(question_bundle.evidence_ids)
+
+
+async def _release_invalidated_semantic_question(
+    message: Message,
+    session: AsyncSession,
+    *,
+    attempt_id: int,
+    qa_trace_id: int | None,
+    embedding_llm_call_id: int | None,
+) -> None:
+    logger.info(
+        "semantic_qa_question_invalidated",
+        extra={"attempt_id": attempt_id, "qa_trace_id": qa_trace_id},
+    )
+    try:
+        await SemanticQuotaRepo.finalize(
+            session,
+            attempt_id=attempt_id,
+            outcome="technical_failure",
+            qa_trace_id=qa_trace_id,
+            embedding_llm_call_id=embedding_llm_call_id,
+        )
+        await session.commit()
+    except LookupError:
+        # A concurrent admission may already have reconciled an expired lease.
+        # The question is still suppressed; never resurrect or deliver it.
+        await session.rollback()
+        logger.info(
+            "semantic_qa_invalidated_lease_already_reconciled",
+            extra={"attempt_id": attempt_id, "qa_trace_id": qa_trace_id},
+        )
+    await _reply_to_mention(
+        message,
+        "Этот вопрос уже удалён из памяти; semantic-лимит не списан.",
+    )
+
+
+async def _reply_semantic_lease_lost(
+    message: Message,
+    session: AsyncSession,
+    *,
+    attempt_id: int,
+    phase: str,
+    error: LookupError,
+) -> None:
+    await session.rollback()
+    logger.error(
+        "semantic_qa_reservation_lease_lost",
+        extra={
+            "attempt_id": attempt_id,
+            "phase": phase,
+            "error_class": type(error).__name__,
+        },
+    )
+    await _reply_to_mention(
+        message,
+        "Semantic AI-запрос истёк до выдачи ответа; лимит не списан.",
     )
 
 
@@ -791,6 +988,7 @@ async def _semantic_mention_question(
     session: AsyncSession,
     sender_id: int,
     persisted_chat_message_id: int,
+    question_bundle: EvidenceBundle,
     query: str,
     query_redacted: bool,
 ) -> None:
@@ -818,28 +1016,35 @@ async def _semantic_mention_question(
         return
 
     if not quota.allowed:
-        ordinary = await _ordinary_search_result(
-            session,
-            query=query,
-            chat_id=message.chat.id,
-            query_redacted=query_redacted,
-            exclude_chat_message_id=persisted_chat_message_id,
-        )
-        users_by_id, sensitive_author = await _bundle_users(session, ordinary.bundle)
-        if sensitive_author:
-            await _reply_to_mention(message, SENSITIVE_QA_REFUSAL)
-            return
-        await _write_trace(
-            session,
-            user_tg_id=sender_id,
-            chat_id=message.chat.id,
-            query=query,
-            evidence_ids=ordinary.bundle.evidence_ids,
-            abstained=ordinary.bundle.abstained,
-            redact_query=query_redacted,
-            source_chat_message_id=persisted_chat_message_id,
-        )
-        await session.commit()
+        async with hold_evidence_delivery_locks(session, question_bundle):
+            if not await _question_is_governed(session, question_bundle):
+                await _reply_to_mention(
+                    message,
+                    "Этот вопрос уже удалён из памяти; обычный поиск не выполнялся.",
+                )
+                return
+            ordinary = await _ordinary_search_result(
+                session,
+                query=query,
+                chat_id=message.chat.id,
+                query_redacted=query_redacted,
+                exclude_chat_message_id=persisted_chat_message_id,
+            )
+            users_by_id, sensitive_author = await _bundle_users(session, ordinary.bundle)
+            if sensitive_author:
+                await _reply_to_mention(message, SENSITIVE_QA_REFUSAL)
+                return
+            await _write_trace(
+                session,
+                user_tg_id=sender_id,
+                chat_id=message.chat.id,
+                query=query,
+                evidence_ids=ordinary.bundle.evidence_ids,
+                abstained=ordinary.bundle.abstained,
+                redact_query=query_redacted,
+                source_chat_message_id=persisted_chat_message_id,
+            )
+            await session.commit()
         await _reply_with_governed_ordinary_search(
             message,
             session,
@@ -848,59 +1053,96 @@ async def _semantic_mention_question(
                 f"Лимит — {quota.limit} semantic AI-вопроса в день. "
                 "Embedding и AI-синтез не вызывались."
             ),
+            required_governed_bundle=question_bundle,
         )
         return
 
     try:
-        trace = await QaTraceRepo.create(
-            session,
-            user_tg_id=sender_id,
-            chat_id=message.chat.id,
-            query=query,
-            evidence_ids=[],
-            abstained=False,
-            redact_query=query_redacted,
-            source_chat_message_id=persisted_chat_message_id,
-        )
-        await SemanticQuotaRepo.attach_trace(
-            session,
-            attempt_id=quota.attempt_id,
-            qa_trace_id=trace.id,
-        )
-        # The user/query ownership chain is durable before embedding HTTP.
-        await session.commit()
-    except SQLAlchemyError as exc:
-        await session.rollback()
-        logger.error(
-            "semantic_qa_trace_setup_failed",
-            extra={
-                "attempt_id": quota.attempt_id,
-                "chat_id": message.chat.id,
-                "error_class": type(exc).__name__,
-            },
-        )
-        await SemanticQuotaRepo.finalize(
-            session,
-            attempt_id=quota.attempt_id,
-            outcome="technical_failure",
-        )
-        await session.commit()
-        await _reply_to_mention(
+        # The quota commit above releases persistence's caller-transaction
+        # chat-message lock. This dedicated fence now covers every query-bearing
+        # row created before and during embedding; all writes are committed
+        # before the fence is released so a waiting cascade can erase them.
+        async with hold_evidence_delivery_locks(session, question_bundle):
+            if not await _question_is_governed(session, question_bundle):
+                raise SemanticQuestionInvalidated
+            try:
+                trace = await QaTraceRepo.create(
+                    session,
+                    user_tg_id=sender_id,
+                    chat_id=message.chat.id,
+                    query=query,
+                    evidence_ids=[],
+                    abstained=False,
+                    redact_query=query_redacted,
+                    source_chat_message_id=persisted_chat_message_id,
+                )
+                await SemanticQuotaRepo.attach_trace(
+                    session,
+                    attempt_id=quota.attempt_id,
+                    qa_trace_id=trace.id,
+                )
+                await session.commit()
+            except LookupError as exc:
+                await _reply_semantic_lease_lost(
+                    message,
+                    session,
+                    attempt_id=quota.attempt_id,
+                    phase="trace_setup",
+                    error=exc,
+                )
+                return
+            except SQLAlchemyError as exc:
+                await session.rollback()
+                logger.error(
+                    "semantic_qa_trace_setup_failed",
+                    extra={
+                        "attempt_id": quota.attempt_id,
+                        "chat_id": message.chat.id,
+                        "error_class": type(exc).__name__,
+                    },
+                )
+                await SemanticQuotaRepo.finalize(
+                    session,
+                    attempt_id=quota.attempt_id,
+                    outcome="technical_failure",
+                )
+                await session.commit()
+                await _reply_to_mention(
+                    message,
+                    "Semantic AI-поиск технически недоступен; лимит не списан.",
+                )
+                return
+            semantic = await run_semantic_qa(
+                session,
+                query=query,
+                chat_id=message.chat.id,
+                redact_query_in_audit=query_redacted,
+                attempt_id=quota.attempt_id,
+                qa_trace_id=trace.id,
+                exclude_chat_message_id=persisted_chat_message_id,
+            )
+            # Close the read transaction before acquiring the complete
+            # question+evidence fence. Retrieval-derived rows are deliberately
+            # persisted only in that next, non-nested phase.
+            await session.commit()
+    except SemanticQuestionInvalidated:
+        await _release_invalidated_semantic_question(
             message,
-            "Semantic AI-поиск технически недоступен; лимит не списан.",
+            session,
+            attempt_id=quota.attempt_id,
+            qa_trace_id=None,
+            embedding_llm_call_id=None,
         )
         return
-
-    try:
-        semantic = await run_semantic_qa(
+    except LookupError as exc:
+        await _reply_semantic_lease_lost(
+            message,
             session,
-            query=query,
-            chat_id=message.chat.id,
-            redact_query_in_audit=query_redacted,
             attempt_id=quota.attempt_id,
-            qa_trace_id=trace.id,
-            exclude_chat_message_id=persisted_chat_message_id,
+            phase="embedding",
+            error=exc,
         )
+        return
     except (
         EmbeddingBudgetExceeded,
         ProviderStructuralError,
@@ -939,6 +1181,7 @@ async def _semantic_mention_question(
             query_redacted=query_redacted,
             exclude_chat_message_id=persisted_chat_message_id,
             notice="Semantic AI-поиск технически недоступен. Показываю обычный поиск без AI.",
+            required_governed_bundle=question_bundle,
         )
         return
     except SQLAlchemyError as exc:
@@ -966,10 +1209,95 @@ async def _semantic_mention_question(
             query_redacted=query_redacted,
             exclude_chat_message_id=persisted_chat_message_id,
             notice="Semantic AI-поиск технически недоступен.",
+            required_governed_bundle=question_bundle,
         )
         return
 
-    if semantic.bundle.abstained or not semantic.bundle.evidence_ids:
+    retrieval_lock_bundle = _merge_governance_bundles(
+        question_bundle,
+        semantic.bundle,
+    )
+    retrieval_invalidated = False
+    try:
+        async with hold_evidence_delivery_locks(session, retrieval_lock_bundle):
+            await SemanticQuotaRepo.touch(session, attempt_id=quota.attempt_id)
+            if not await _question_is_governed(session, question_bundle):
+                raise SemanticQuestionInvalidated
+            governed_retrieval = await filter_surviving_evidence(
+                session,
+                semantic.bundle,
+                max_evidence_items=SEMANTIC_QA_EVIDENCE_LIMIT,
+            )
+            retrieval_invalidated = tuple(governed_retrieval.evidence_ids) != tuple(
+                semantic.bundle.evidence_ids
+            )
+            if retrieval_invalidated:
+                await QaTraceRepo.update_retrieval_fields(
+                    session,
+                    qa_trace_id=trace.id,
+                    evidence_ids=[],
+                    abstained=True,
+                )
+            else:
+                await persist_semantic_retrieval_trace(
+                    session,
+                    result=semantic,
+                    query=query,
+                    attempt_id=quota.attempt_id,
+                    qa_trace_id=trace.id,
+                )
+            # No retrieval-derived row may appear after a waiting source
+            # cascade has completed; commit every such row before union unlock.
+            await session.commit()
+    except SemanticQuestionInvalidated:
+        await _release_invalidated_semantic_question(
+            message,
+            session,
+            attempt_id=quota.attempt_id,
+            qa_trace_id=trace.id,
+            embedding_llm_call_id=semantic.embedding_llm_call_id,
+        )
+        return
+    except LookupError as exc:
+        await _reply_semantic_lease_lost(
+            message,
+            session,
+            attempt_id=quota.attempt_id,
+            phase="retrieval_trace",
+            error=exc,
+        )
+        return
+    except SQLAlchemyError as exc:
+        await session.rollback()
+        logger.error(
+            "semantic_qa_retrieval_trace_failed",
+            extra={
+                "attempt_id": quota.attempt_id,
+                "chat_id": message.chat.id,
+                "error_class": type(exc).__name__,
+            },
+        )
+        await SemanticQuotaRepo.finalize(
+            session,
+            attempt_id=quota.attempt_id,
+            outcome="technical_failure",
+            qa_trace_id=trace.id,
+            embedding_llm_call_id=semantic.embedding_llm_call_id,
+        )
+        await session.commit()
+        await _reply_after_technical_release(
+            message,
+            session,
+            query=query,
+            chat_id=message.chat.id,
+            query_redacted=query_redacted,
+            exclude_chat_message_id=persisted_chat_message_id,
+            notice="Semantic trace технически недоступен.",
+            required_governed_bundle=question_bundle,
+        )
+        return
+
+    if retrieval_invalidated or semantic.bundle.abstained or not semantic.bundle.evidence_ids:
         await _deliver_and_consume_semantic_attempt(
             message,
             session,
@@ -979,6 +1307,7 @@ async def _semantic_mention_question(
             embedding_llm_call_id=semantic.embedding_llm_call_id,
             synthesis_llm_call_id=None,
             reply_text="Не нашёл достаточно подтверждений в памяти сообщества.",
+            required_governed_bundle=question_bundle,
         )
         return
 
@@ -998,6 +1327,7 @@ async def _semantic_mention_question(
             embedding_llm_call_id=semantic.embedding_llm_call_id,
             synthesis_llm_call_id=None,
             reply_text=SENSITIVE_QA_REFUSAL,
+            required_governed_bundle=question_bundle,
         )
         return
 
@@ -1006,19 +1336,57 @@ async def _semantic_mention_question(
         if cfg.provider != SEMANTIC_SYNTHESIS_PROVIDER or cfg.model != SEMANTIC_SYNTHESIS_MODEL:
             raise ValueError("semantic Q&A synthesis requires DeepSeek V4 Flash configuration")
         provider = _resolve_provider(cfg.provider)
-        synth_result = await synthesize_answer(
-            session,
-            bundle=semantic.bundle,
-            query=build_guarded_llm_query(query),
-            config=cfg,
-            qa_trace_id=trace.id,
-            ledger_repo=LedgerRepo(),
-            cache_repo=SynthesisCacheRepo(),
-            provider=provider,
-            max_evidence_items=SEMANTIC_QA_EVIDENCE_LIMIT,
-            durable_placeholder=True,
-            revalidate_after_provider=True,
+        # Keep every evidence writer blocked from the final governance check
+        # through provider dispatch and cache/ledger materialization.  The
+        # dedicated lock connection survives the placeholder commit inside the
+        # gateway, so a concurrent deletion cannot expose removed text
+        # to the provider.
+        provider_lock_bundle = _merge_governance_bundles(
+            question_bundle,
+            semantic.bundle,
         )
+        async with hold_evidence_delivery_locks(session, provider_lock_bundle):
+            await SemanticQuotaRepo.touch(session, attempt_id=quota.attempt_id)
+            await session.commit()
+            if not await _question_is_governed(session, question_bundle):
+                raise SemanticQuestionInvalidated
+            synth_result = await synthesize_answer(
+                session,
+                bundle=semantic.bundle,
+                query=build_guarded_llm_query(query),
+                config=cfg,
+                qa_trace_id=trace.id,
+                ledger_repo=LedgerRepo(),
+                cache_repo=SynthesisCacheRepo(),
+                provider=provider,
+                max_evidence_items=SEMANTIC_QA_EVIDENCE_LIMIT,
+                durable_placeholder=True,
+                revalidate_after_provider=True,
+                cache_enabled=False,
+            )
+            # The provider result and final ledger mutation must be visible
+            # before the union fence is released. A waiting cascade can then
+            # remove/redact the complete committed state without lock inversion.
+            await SemanticQuotaRepo.touch(session, attempt_id=quota.attempt_id)
+            await session.commit()
+    except SemanticQuestionInvalidated:
+        await _release_invalidated_semantic_question(
+            message,
+            session,
+            attempt_id=quota.attempt_id,
+            qa_trace_id=trace.id,
+            embedding_llm_call_id=semantic.embedding_llm_call_id,
+        )
+        return
+    except LookupError as exc:
+        await _reply_semantic_lease_lost(
+            message,
+            session,
+            attempt_id=quota.attempt_id,
+            phase="synthesis",
+            error=exc,
+        )
+        return
     except (ValueError, SQLAlchemyError) as exc:
         if isinstance(exc, SQLAlchemyError):
             await session.rollback()
@@ -1046,16 +1414,122 @@ async def _semantic_mention_question(
             query_redacted=query_redacted,
             exclude_chat_message_id=persisted_chat_message_id,
             notice="AI-синтез технически недоступен. Показываю обычный поиск без AI.",
+            required_governed_bundle=question_bundle,
         )
         return
 
     if isinstance(synth_result, AnswerWithCitations):
         try:
-            render_bundle = await filter_surviving_evidence(
+            # Reacquire the complete sorted union for the render/trace phase.
+            # The provider ledger is already committed. Any summary written
+            # here is committed before unlock, so a waiting cascade observes
+            # and removes the complete state instead of racing a later update.
+            async with hold_evidence_delivery_locks(session, provider_lock_bundle):
+                await SemanticQuotaRepo.touch(session, attempt_id=quota.attempt_id)
+                if not await _question_is_governed(session, question_bundle):
+                    raise SemanticQuestionInvalidated
+                render_bundle = await filter_surviving_evidence(
+                    session,
+                    semantic.bundle,
+                    max_evidence_items=SEMANTIC_QA_EVIDENCE_LIMIT,
+                )
+
+                expected_ids = synth_result.surviving_evidence_ids
+                if tuple(render_bundle.evidence_ids) != expected_ids or not set(
+                    synth_result.citation_ids
+                ).issubset(expected_ids):
+                    await QaTraceRepo.update_retrieval_fields(
+                        session,
+                        qa_trace_id=trace.id,
+                        evidence_ids=render_bundle.evidence_ids,
+                        abstained=True,
+                    )
+                    await QaTraceRepo.update_llm_fields(
+                        session,
+                        qa_trace_id=trace.id,
+                        llm_call_id=synth_result.llm_call_id,
+                        llm_response_summary=None,
+                        llm_response_redacted=True,
+                        cost_usd=synth_result.cost_usd,
+                    )
+                    await _deliver_and_consume_semantic_attempt(
+                        message,
+                        session,
+                        attempt_id=quota.attempt_id,
+                        outcome="abstained",
+                        qa_trace_id=trace.id,
+                        embedding_llm_call_id=semantic.embedding_llm_call_id,
+                        synthesis_llm_call_id=synth_result.llm_call_id,
+                        reply_text="Не нашёл достаточно подтверждений в памяти сообщества.",
+                    )
+                    return
+
+                users_by_id, sensitive_author = await _bundle_users(session, render_bundle)
+                if sensitive_author or any(
+                    contains_secret_like_data(item.snippet) for item in render_bundle.items
+                ):
+                    await QaTraceRepo.update_retrieval_fields(
+                        session,
+                        qa_trace_id=trace.id,
+                        evidence_ids=[],
+                        abstained=True,
+                    )
+                    await QaTraceRepo.update_llm_fields(
+                        session,
+                        qa_trace_id=trace.id,
+                        llm_call_id=synth_result.llm_call_id,
+                        llm_response_summary=None,
+                        llm_response_redacted=True,
+                        cost_usd=synth_result.cost_usd,
+                    )
+                    await _deliver_and_consume_semantic_attempt(
+                        message,
+                        session,
+                        attempt_id=quota.attempt_id,
+                        outcome="abstained",
+                        qa_trace_id=trace.id,
+                        embedding_llm_call_id=semantic.embedding_llm_call_id,
+                        synthesis_llm_call_id=synth_result.llm_call_id,
+                        reply_text=SENSITIVE_QA_REFUSAL,
+                    )
+                    return
+
+                normalized_answer = _normalize_provider_citations(
+                    synth_result.answer_text,
+                    render_bundle,
+                )
+                reply_text = _format_bounded_mention_response(
+                    normalized_answer,
+                    render_bundle,
+                    users_by_id,
+                )
+                await QaTraceRepo.update_llm_fields(
+                    session,
+                    qa_trace_id=trace.id,
+                    llm_call_id=synth_result.llm_call_id,
+                    llm_response_summary=f"{_SEMANTIC_REPLAY_HTML_PREFIX}{reply_text}",
+                    llm_response_redacted=False,
+                    cost_usd=synth_result.cost_usd,
+                )
+                await session.commit()
+        except SemanticQuestionInvalidated:
+            await _release_invalidated_semantic_question(
+                message,
                 session,
-                semantic.bundle,
-                max_evidence_items=SEMANTIC_QA_EVIDENCE_LIMIT,
+                attempt_id=quota.attempt_id,
+                qa_trace_id=trace.id,
+                embedding_llm_call_id=semantic.embedding_llm_call_id,
             )
+            return
+        except LookupError as exc:
+            await _reply_semantic_lease_lost(
+                message,
+                session,
+                attempt_id=quota.attempt_id,
+                phase="render",
+                error=exc,
+            )
+            return
         except SQLAlchemyError as exc:
             await session.rollback()
             logger.error(
@@ -1082,79 +1556,9 @@ async def _semantic_mention_question(
                 query_redacted=query_redacted,
                 exclude_chat_message_id=persisted_chat_message_id,
                 notice="AI-синтез технически недоступен.",
+                required_governed_bundle=question_bundle,
             )
             return
-
-        expected_ids = synth_result.surviving_evidence_ids
-        if tuple(render_bundle.evidence_ids) != expected_ids or not set(
-            synth_result.citation_ids
-        ).issubset(expected_ids):
-            await QaTraceRepo.update_retrieval_fields(
-                session,
-                qa_trace_id=trace.id,
-                evidence_ids=render_bundle.evidence_ids,
-                abstained=True,
-            )
-            await QaTraceRepo.update_llm_fields(
-                session,
-                qa_trace_id=trace.id,
-                llm_call_id=synth_result.llm_call_id,
-                llm_response_summary=None,
-                llm_response_redacted=True,
-                cost_usd=synth_result.cost_usd,
-            )
-            await _deliver_and_consume_semantic_attempt(
-                message,
-                session,
-                attempt_id=quota.attempt_id,
-                outcome="abstained",
-                qa_trace_id=trace.id,
-                embedding_llm_call_id=semantic.embedding_llm_call_id,
-                synthesis_llm_call_id=synth_result.llm_call_id,
-                reply_text="Не нашёл достаточно подтверждений в памяти сообщества.",
-            )
-            return
-
-        users_by_id, sensitive_author = await _bundle_users(session, render_bundle)
-        if sensitive_author or any(
-            contains_secret_like_data(item.snippet) for item in render_bundle.items
-        ):
-            await QaTraceRepo.update_retrieval_fields(
-                session,
-                qa_trace_id=trace.id,
-                evidence_ids=[],
-                abstained=True,
-            )
-            await QaTraceRepo.update_llm_fields(
-                session,
-                qa_trace_id=trace.id,
-                llm_call_id=synth_result.llm_call_id,
-                llm_response_summary=None,
-                llm_response_redacted=True,
-                cost_usd=synth_result.cost_usd,
-            )
-            await _deliver_and_consume_semantic_attempt(
-                message,
-                session,
-                attempt_id=quota.attempt_id,
-                outcome="abstained",
-                qa_trace_id=trace.id,
-                embedding_llm_call_id=semantic.embedding_llm_call_id,
-                synthesis_llm_call_id=synth_result.llm_call_id,
-                reply_text=SENSITIVE_QA_REFUSAL,
-            )
-            return
-
-        try:
-            normalized_answer = _normalize_provider_citations(
-                synth_result.answer_text,
-                render_bundle,
-            )
-            reply_text = _format_bounded_mention_response(
-                normalized_answer,
-                render_bundle,
-                users_by_id,
-            )
         except ValueError as exc:
             logger.error(
                 "semantic_qa_citation_render_failed",
@@ -1180,17 +1584,9 @@ async def _semantic_mention_question(
                 query_redacted=query_redacted,
                 exclude_chat_message_id=persisted_chat_message_id,
                 notice="AI-синтез технически недоступен.",
+                required_governed_bundle=question_bundle,
             )
             return
-
-        await QaTraceRepo.update_llm_fields(
-            session,
-            qa_trace_id=trace.id,
-            llm_call_id=synth_result.llm_call_id,
-            llm_response_summary=f"{_SEMANTIC_REPLAY_HTML_PREFIX}{reply_text}",
-            llm_response_redacted=False,
-            cost_usd=synth_result.cost_usd,
-        )
         try:
             await _deliver_and_consume_semantic_attempt(
                 message,
@@ -1206,6 +1602,7 @@ async def _semantic_mention_question(
                 disable_web_page_preview=True,
                 delivery_bundle=render_bundle,
                 expected_evidence_ids=tuple(render_bundle.evidence_ids),
+                required_governed_bundle=question_bundle,
             )
         except EvidenceInvalidatedBeforeDelivery:
             await QaTraceRepo.update_retrieval_fields(
@@ -1231,6 +1628,7 @@ async def _semantic_mention_question(
                 embedding_llm_call_id=semantic.embedding_llm_call_id,
                 synthesis_llm_call_id=synth_result.llm_call_id,
                 reply_text="Не нашёл достаточно подтверждений в памяти сообщества.",
+                required_governed_bundle=question_bundle,
             )
         return
 
@@ -1263,6 +1661,7 @@ async def _semantic_mention_question(
             query_redacted=query_redacted,
             exclude_chat_message_id=persisted_chat_message_id,
             notice="AI-синтез технически недоступен. Показываю обычный поиск без AI.",
+            required_governed_bundle=question_bundle,
         )
     else:
         await _deliver_and_consume_semantic_attempt(
@@ -1278,6 +1677,7 @@ async def _semantic_mention_question(
                 if synth_result.reason.startswith("sensitive_")
                 else "Не нашёл достаточно подтверждений в памяти сообщества."
             ),
+            required_governed_bundle=question_bundle,
         )
 
 
@@ -1622,11 +2022,18 @@ async def mention_question_handler(
             scope_id=str(sender.id),
         )
     if semantic_enabled:
+        question_bundle = _semantic_question_bundle(
+            message,
+            current_message_version_id=persisted.chat_message.current_version_id,
+            persisted_chat_message_id=persisted.chat_message.id,
+            query=query,
+        )
         await _semantic_mention_question(
             message=message,
             session=session,
             sender_id=sender.id,
             persisted_chat_message_id=persisted.chat_message.id,
+            question_bundle=question_bundle,
             query=query,
             query_redacted=query_redacted,
         )

--- a/bot/handlers/start.py
+++ b/bot/handlers/start.py
@@ -51,6 +51,7 @@ async def cmd_start(
         username=tg_user.username,
         first_name=tg_user.first_name,
         last_name=tg_user.last_name,
+        is_bot=getattr(tg_user, "is_bot", None),
     )
 
     # Check for active application (filling / pending / privacy_block)
@@ -132,6 +133,7 @@ async def cmd_refresh(
         username=tg_user.username,
         first_name=tg_user.first_name,
         last_name=tg_user.last_name,
+        is_bot=getattr(tg_user, "is_bot", None),
     )
 
     if not user.is_member:

--- a/bot/middlewares/normalized_memory_persistence.py
+++ b/bot/middlewares/normalized_memory_persistence.py
@@ -55,6 +55,7 @@ class NormalizedMemoryPersistenceMiddleware(BaseMiddleware):
             username=sender.username,
             first_name=sender.first_name,
             last_name=sender.last_name,
+            is_bot=getattr(sender, "is_bot", None),
         )
         raw_update = data.get("raw_update")
         result = await persist_message_with_policy(

--- a/bot/services/advisory_locks.py
+++ b/bot/services/advisory_locks.py
@@ -1,0 +1,83 @@
+"""Safe dedicated-transaction PostgreSQL advisory-lock scopes."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Iterable
+from contextlib import asynccontextmanager
+from typing import Any
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncConnection, AsyncEngine, AsyncSession
+
+
+def _engine_for_session(session: AsyncSession) -> AsyncEngine | None:
+    bind: Any = session.bind
+    if isinstance(bind, AsyncEngine):
+        return bind
+    if isinstance(bind, AsyncConnection):
+        return bind.engine
+    return None
+
+
+def session_uses_postgresql(session: AsyncSession) -> bool:
+    return getattr(getattr(session.bind, "dialect", None), "name", None) == "postgresql"
+
+
+def chat_message_advisory_key(chat_id: int, message_id: int) -> str:
+    return f"chat_msg:{chat_id}:{message_id}"
+
+
+def forget_target_advisory_key(target_type: str, target_id: str) -> str:
+    if target_type not in {"message", "user", "message_hash"}:
+        raise ValueError(f"unsupported forget target lock type: {target_type}")
+    return f"forget_target:{target_type}:{target_id}"
+
+
+@asynccontextmanager
+async def hold_session_advisory_locks(
+    session: AsyncSession,
+    lock_ids: Iterable[int],
+    *,
+    lock_keys: Iterable[str] = (),
+) -> AsyncIterator[None]:
+    """Hold sorted xact locks in a dedicated transaction across caller commits.
+
+    The transaction belongs to a separate checked-out connection, so application
+    commits inside the protected scope cannot release its locks. Transaction-level
+    locks require no manual unlock and cannot leak when the connection returns to
+    the pool after an exception or task cancellation.
+    """
+
+    ordered = sorted(set(lock_ids))
+    ordered_keys = sorted(set(lock_keys))
+    if not ordered and not ordered_keys:
+        yield
+        return
+    engine = _engine_for_session(session)
+    if engine is None or not session_uses_postgresql(session):
+        # Unit fakes and non-PostgreSQL tests cannot execute advisory locks.
+        # Production is PostgreSQL and always takes the dedicated lock path.
+        yield
+        return
+
+    async with engine.connect() as connection:
+        async with connection.begin():
+            for lock_id in ordered:
+                await connection.execute(
+                    text("SELECT pg_advisory_xact_lock(:lock_id)"),
+                    {"lock_id": lock_id},
+                )
+            for lock_key in ordered_keys:
+                await connection.execute(
+                    text("SELECT pg_advisory_xact_lock(hashtext(:lock_key))"),
+                    {"lock_key": lock_key},
+                )
+            yield
+
+
+__all__ = [
+    "chat_message_advisory_key",
+    "forget_target_advisory_key",
+    "hold_session_advisory_locks",
+    "session_uses_postgresql",
+]

--- a/bot/services/advisory_locks.py
+++ b/bot/services/advisory_locks.py
@@ -6,7 +6,7 @@ from collections.abc import AsyncIterator, Iterable
 from contextlib import asynccontextmanager
 from typing import Any
 
-from sqlalchemy import text
+from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncConnection, AsyncEngine, AsyncSession
 
 
@@ -31,6 +31,42 @@ def forget_target_advisory_key(target_type: str, target_id: str) -> str:
     if target_type not in {"message", "user", "message_hash"}:
         raise ValueError(f"unsupported forget target lock type: {target_type}")
     return f"forget_target:{target_type}:{target_id}"
+
+
+async def governed_message_lock_keys(
+    session: AsyncSession,
+    message_version_ids: Iterable[int],
+) -> tuple[str, ...]:
+    """Return every writer lock key protecting governed message provenance."""
+
+    ids = tuple(sorted(set(message_version_ids)))
+    if not ids:
+        return ()
+    from bot.db.models import ChatMessage, MessageVersion
+
+    result = await session.execute(
+        select(
+            MessageVersion.content_hash,
+            ChatMessage.id.label("chat_message_id"),
+            ChatMessage.user_id,
+            ChatMessage.chat_id,
+            ChatMessage.message_id,
+        )
+        .join(ChatMessage, ChatMessage.id == MessageVersion.chat_message_id)
+        .where(MessageVersion.id.in_(ids))
+    )
+    lock_keys: set[str] = set()
+    for row in result:
+        lock_keys.update(
+            {
+                chat_message_advisory_key(int(row.chat_id), int(row.message_id)),
+                forget_target_advisory_key("message", str(row.chat_message_id)),
+                forget_target_advisory_key("message_hash", str(row.content_hash)),
+            }
+        )
+        if row.user_id is not None:
+            lock_keys.add(forget_target_advisory_key("user", str(row.user_id)))
+    return tuple(sorted(lock_keys))
 
 
 @asynccontextmanager
@@ -78,6 +114,7 @@ async def hold_session_advisory_locks(
 __all__ = [
     "chat_message_advisory_key",
     "forget_target_advisory_key",
+    "governed_message_lock_keys",
     "hold_session_advisory_locks",
     "session_uses_postgresql",
 ]

--- a/bot/services/advisory_locks.py
+++ b/bot/services/advisory_locks.py
@@ -7,7 +7,8 @@ from contextlib import asynccontextmanager
 from typing import Any
 
 from sqlalchemy import select, text
-from sqlalchemy.ext.asyncio import AsyncConnection, AsyncEngine, AsyncSession
+from sqlalchemy.ext.asyncio import AsyncConnection, AsyncEngine, AsyncSession, create_async_engine
+from sqlalchemy.pool import NullPool
 
 
 def _engine_for_session(session: AsyncSession) -> AsyncEngine | None:
@@ -96,19 +97,27 @@ async def hold_session_advisory_locks(
         yield
         return
 
-    async with engine.connect() as connection:
-        async with connection.begin():
-            for lock_id in ordered:
-                await connection.execute(
-                    text("SELECT pg_advisory_xact_lock(:lock_id)"),
-                    {"lock_id": lock_id},
-                )
-            for lock_key in ordered_keys:
-                await connection.execute(
-                    text("SELECT pg_advisory_xact_lock(hashtext(:lock_key))"),
-                    {"lock_key": lock_key},
-                )
-            yield
+    # This lock connection must coexist with caller queries while the caller's
+    # session may already hold the sole application-pool slot. A short-lived
+    # NullPool engine prevents deterministic pool_size=1 deadlocks and makes
+    # lock capacity independent from request concurrency.
+    lock_engine = create_async_engine(engine.url, poolclass=NullPool)
+    try:
+        async with lock_engine.connect() as connection:
+            async with connection.begin():
+                for lock_id in ordered:
+                    await connection.execute(
+                        text("SELECT pg_advisory_xact_lock(:lock_id)"),
+                        {"lock_id": lock_id},
+                    )
+                for lock_key in ordered_keys:
+                    await connection.execute(
+                        text("SELECT pg_advisory_xact_lock(hashtext(:lock_key))"),
+                        {"lock_key": lock_key},
+                    )
+                yield
+    finally:
+        await lock_engine.dispose()
 
 
 __all__ = [

--- a/bot/services/forget_cascade.py
+++ b/bot/services/forget_cascade.py
@@ -417,26 +417,43 @@ async def _cascade_semantic_retrieval(session: AsyncSession, event) -> int:
     ledger_ids = {int(row.llm_usage_ledger_id) for row in unit_rows}
     attempt_ids: set[int] = set()
     qa_trace_ids: set[int] = set()
+    parent_chat_message_ids: set[int] = set()
 
     attempt_filters = []
-    if affected_mvids:
+    if event.target_type == "message":
+        # A persisted question can have a QaTrace even when no semantic attempt
+        # was admitted (quota denial) or no MessageVersion survived. Resolve it
+        # directly from the forget target instead of relying on attempt FKs.
+        parent_chat_message_ids.add(int(event.target_id))
+    if event.target_type == "message_hash" and affected_mvids:
         parent_result = await session.execute(
             select(MessageVersion.chat_message_id)
             .where(MessageVersion.id.in_(affected_mvids))
             .distinct()
         )
-        parent_chat_message_ids = {
+        parent_chat_message_ids.update(
             int(chat_message_id) for chat_message_id in parent_result.scalars()
-        }
-        if parent_chat_message_ids:
-            # The forgotten message can itself be a semantic question. It is
-            # deliberately excluded from retrieval results, so source-key
-            # matching alone cannot find its query_hash/embedding ledger row.
-            attempt_filters.append(
-                SemanticQaAttempt.source_chat_message_id.in_(parent_chat_message_ids)
-            )
+        )
+    if parent_chat_message_ids:
+        # The forgotten message can itself be a semantic question. It is
+        # deliberately excluded from retrieval results, so source-key matching
+        # cannot find its raw query or provider ledgers.
+        attempt_filters.append(
+            SemanticQaAttempt.source_chat_message_id.in_(parent_chat_message_ids)
+        )
     if event.target_type == "user":
         attempt_filters.append(SemanticQaAttempt.user_tg_id == int(event.target_id))
+
+    qa_trace_filters = []
+    if parent_chat_message_ids:
+        qa_trace_filters.append(QaTrace.source_chat_message_id.in_(parent_chat_message_ids))
+    if event.target_type == "user":
+        qa_trace_filters.append(QaTrace.user_tg_id == int(event.target_id))
+    if qa_trace_filters:
+        direct_trace_result = await session.execute(
+            select(QaTrace.id).where(or_(*qa_trace_filters))
+        )
+        qa_trace_ids.update(int(trace_id) for trace_id in direct_trace_result.scalars())
 
     if attempt_filters:
         attempts_result = await session.execute(

--- a/bot/services/forget_cascade.py
+++ b/bot/services/forget_cascade.py
@@ -39,15 +39,20 @@ import struct
 from typing import Any
 
 from aiogram import Bot
-from sqlalchemy import delete, func, select, text, update
+from sqlalchemy import delete, func, or_, select, text, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from bot.db.engine import async_session
 from bot.db.models import (
+    CardSource,
     ChatMessage,
     LlmUsageLedger,
     MessageVersion,
     QaTrace,
+    SemanticQaAttempt,
+    SemanticRetrievalTrace,
+    SemanticRetrievalUnit,
+    SemanticRetrievalUnitSource,
 )
 from bot.db.repos.feature_flag import FeatureFlagRepo
 from bot.db.repos.forget_event import ForgetEventRepo
@@ -122,6 +127,7 @@ def _p6_event_advisory_lock_id(event_id) -> int:
     (lock_id,) = struct.unpack(">q", digest[:8])
     return lock_id
 
+
 # Feature flag key — read by the scheduler tick to decide whether to run the worker.
 CASCADE_WORKER_FLAG = "memory.forget.cascade_worker.enabled"
 
@@ -132,6 +138,11 @@ CASCADE_WORKER_FLAG = "memory.forget.cascade_worker.enabled"
 # replaces the per-layer function and existing rows are reprocessed naturally.
 CASCADE_LAYER_ORDER: tuple[str, ...] = (
     "chat_messages",
+    # Issue #404 semantic memory is a derived privacy surface. Purge vectors,
+    # provenance, and content-derived audit hashes while message_versions and
+    # card_sources still exist, because both are required to resolve every
+    # affected message/card revision. The durable quota attempt row survives.
+    "semantic_retrieval",
     "message_versions",
     "qa_traces",
     # Phase 5 / T5-04 layers — ORDER binding per contracts.md §8:
@@ -200,6 +211,7 @@ _LAYER_APPLICABLE_TARGET_TYPES: dict[str, frozenset[str]] = {
     # content_hash). Restricting them here makes the dispatcher route
     # message_hash through Phase 5 layers without raising in Phase 1.
     "chat_messages": frozenset({"message", "user"}),
+    "semantic_retrieval": frozenset({"message", "message_hash", "user"}),
     "message_versions": frozenset({"message", "user"}),
     "qa_traces": frozenset({"user"}),  # user-targeted forgets only
     # Phase 5 / T5-04 layers — applicability per contracts.md §8:
@@ -304,8 +316,284 @@ async def _cascade_chat_messages(session: AsyncSession, event) -> int:
 
     # Should not reach here: _process_one_event guards unsupported target_types
     # before calling _LAYER_FUNCS.  Raise so a regression surfaces immediately.
-    raise ValueError(
-        f"_cascade_chat_messages: unsupported target_type={event.target_type!r}"
+    raise ValueError(f"_cascade_chat_messages: unsupported target_type={event.target_type!r}")
+
+
+async def _semantic_affected_mvids(session: AsyncSession, event) -> list[int]:
+    """Resolve every message revision covered by a semantic-memory purge.
+
+    Unlike the Phase 6 card resolver, a ``message`` target intentionally returns
+    *all* versions of the chat message. Old semantic units are retained after an
+    edit for audit/idempotency, so purging only ``current_version_id`` would leave
+    stale vectors derived from the forgotten body behind.
+    """
+    if event.target_id is None:
+        raise ValueError(
+            f"forget_event target_type={event.target_type!r} requires a non-None target_id"
+        )
+
+    if event.target_type == "message":
+        try:
+            chat_message_id = int(event.target_id)
+        except (TypeError, ValueError):
+            raise ValueError(
+                "forget_event target_type='message' requires integer target_id; "
+                f"got {event.target_id!r}"
+            )
+        statement = select(MessageVersion.id).where(
+            MessageVersion.chat_message_id == chat_message_id
+        )
+    elif event.target_type == "message_hash":
+        statement = select(MessageVersion.id).where(
+            MessageVersion.content_hash == str(event.target_id)
+        )
+    elif event.target_type == "user":
+        try:
+            telegram_id = int(event.target_id)
+        except (TypeError, ValueError):
+            raise ValueError(
+                "forget_event target_type='user' requires integer target_id "
+                f"(telegram_id); got {event.target_id!r}"
+            )
+        statement = (
+            select(MessageVersion.id)
+            .join(ChatMessage, ChatMessage.id == MessageVersion.chat_message_id)
+            .where(ChatMessage.user_id == telegram_id)
+        )
+    else:
+        raise ValueError(f"_semantic_affected_mvids: unsupported target_type={event.target_type!r}")
+
+    result = await session.execute(statement)
+    return sorted({int(message_version_id) for message_version_id in result.scalars()})
+
+
+async def _cascade_semantic_retrieval(session: AsyncSession, event) -> int:
+    """Purge issue #404 semantic derived data while preserving budget audit.
+
+    The layer runs before ``message_versions`` and ``card_sources`` are mutated.
+    It therefore can resolve message and card source keys, remove every vector
+    unit plus its normalized provenance, and redact the hashes of the embedding
+    ledger calls that produced those units. For a user forget, query retrieval
+    traces are deleted as derived content while the quota-attempt row survives;
+    the attempt's provider-ledger hashes are also NULLed. Cost, token, latency,
+    outcome, and slot aggregates remain intact, matching the existing Phase 5
+    ``NULL hashes, preserve audit aggregates`` policy.
+    """
+    from sqlalchemy import String, bindparam
+    from sqlalchemy.dialects.postgresql import ARRAY as PG_ARRAY
+
+    affected_mvids = await _semantic_affected_mvids(session, event)
+    unit_rows: list[Any] = []
+    affected_source_keys = {
+        f"message:{message_version_id}" for message_version_id in affected_mvids
+    }
+
+    if affected_mvids:
+        units_result = await session.execute(
+            select(
+                SemanticRetrievalUnit.id,
+                SemanticRetrievalUnit.llm_usage_ledger_id,
+            )
+            .join(
+                SemanticRetrievalUnitSource,
+                SemanticRetrievalUnitSource.unit_id == SemanticRetrievalUnit.id,
+            )
+            .where(SemanticRetrievalUnitSource.message_version_id.in_(affected_mvids))
+            .distinct()
+        )
+        unit_rows = list(units_result.all())
+
+        # A card may have surfaced through FTS even when its semantic unit was
+        # never built. Resolve card keys from canonical provenance as well so
+        # no retrieval trace retains a forgotten-source reference.
+        card_result = await session.execute(
+            select(CardSource.card_id)
+            .where(CardSource.message_version_id.in_(affected_mvids))
+            .distinct()
+        )
+        affected_source_keys.update(f"card:{card_id}" for card_id in card_result.scalars())
+
+    unit_ids = {int(row.id) for row in unit_rows}
+    ledger_ids = {int(row.llm_usage_ledger_id) for row in unit_rows}
+    attempt_ids: set[int] = set()
+    qa_trace_ids: set[int] = set()
+
+    attempt_filters = []
+    if affected_mvids:
+        parent_result = await session.execute(
+            select(MessageVersion.chat_message_id)
+            .where(MessageVersion.id.in_(affected_mvids))
+            .distinct()
+        )
+        parent_chat_message_ids = {
+            int(chat_message_id) for chat_message_id in parent_result.scalars()
+        }
+        if parent_chat_message_ids:
+            # The forgotten message can itself be a semantic question. It is
+            # deliberately excluded from retrieval results, so source-key
+            # matching alone cannot find its query_hash/embedding ledger row.
+            attempt_filters.append(
+                SemanticQaAttempt.source_chat_message_id.in_(parent_chat_message_ids)
+            )
+    if event.target_type == "user":
+        attempt_filters.append(SemanticQaAttempt.user_tg_id == int(event.target_id))
+
+    if attempt_filters:
+        attempts_result = await session.execute(
+            select(
+                SemanticQaAttempt.id,
+                SemanticQaAttempt.qa_trace_id,
+                SemanticQaAttempt.embedding_llm_call_id,
+                SemanticQaAttempt.synthesis_llm_call_id,
+            ).where(or_(*attempt_filters))
+        )
+        for row in attempts_result.all():
+            attempt_ids.add(int(row.id))
+            if row.qa_trace_id is not None:
+                qa_trace_ids.add(int(row.qa_trace_id))
+            if row.embedding_llm_call_id is not None:
+                ledger_ids.add(int(row.embedding_llm_call_id))
+            if row.synthesis_llm_call_id is not None:
+                ledger_ids.add(int(row.synthesis_llm_call_id))
+
+    qa_traces_redacted = 0
+    if qa_trace_ids:
+        qa_result = await session.execute(
+            update(QaTrace)
+            .where(QaTrace.id.in_(qa_trace_ids))
+            .values(
+                query_text=None,
+                query_redacted=True,
+                llm_response_summary=None,
+                llm_response_redacted=True,
+            )
+            .returning(QaTrace.id)
+        )
+        qa_traces_redacted = len(qa_result.scalars().all())
+
+    traces_deleted = 0
+    if attempt_ids:
+        trace_result = await session.execute(
+            delete(SemanticRetrievalTrace)
+            .where(SemanticRetrievalTrace.attempt_id.in_(attempt_ids))
+            .returning(SemanticRetrievalTrace.id)
+        )
+        traces_deleted += len(trace_result.scalars().all())
+
+    if affected_source_keys:
+        # candidate_ranks is a JSON object keyed by ``message:<mvid>`` or
+        # ``card:<uuid>``; result_source_ids is a JSON array of the same keys.
+        # Delete the derived trace instead of replacing non-null JSON/hash
+        # columns with an invented sentinel.
+        trace_statement = text(
+            "DELETE FROM semantic_retrieval_traces AS trace "
+            "WHERE EXISTS ("
+            "  SELECT 1 "
+            "  FROM jsonb_array_elements_text(trace.result_source_ids::jsonb) "
+            "       AS result_key(value) "
+            "  WHERE result_key.value = ANY(:source_keys)"
+            ") OR EXISTS ("
+            "  SELECT 1 "
+            "  FROM jsonb_object_keys(trace.candidate_ranks::jsonb) "
+            "       AS candidate_key(value) "
+            "  WHERE candidate_key.value = ANY(:source_keys)"
+            ") "
+            "RETURNING trace.attempt_id"
+        ).bindparams(bindparam("source_keys", type_=PG_ARRAY(String())))
+        trace_result = await session.execute(
+            trace_statement,
+            {"source_keys": sorted(affected_source_keys)},
+        )
+        source_trace_attempt_ids = {int(attempt_id) for attempt_id in trace_result.scalars().all()}
+        traces_deleted += len(source_trace_attempt_ids)
+        if source_trace_attempt_ids:
+            synthesis_result = await session.execute(
+                select(
+                    SemanticQaAttempt.qa_trace_id,
+                    SemanticQaAttempt.synthesis_llm_call_id,
+                ).where(
+                    SemanticQaAttempt.id.in_(source_trace_attempt_ids),
+                )
+            )
+            source_qa_trace_ids: set[int] = set()
+            for row in synthesis_result.all():
+                if row.qa_trace_id is not None:
+                    source_qa_trace_ids.add(int(row.qa_trace_id))
+                if row.synthesis_llm_call_id is not None:
+                    ledger_ids.add(int(row.synthesis_llm_call_id))
+            if source_qa_trace_ids:
+                qa_trace_ids.update(source_qa_trace_ids)
+                source_qa_result = await session.execute(
+                    update(QaTrace)
+                    .where(QaTrace.id.in_(source_qa_trace_ids))
+                    .values(
+                        llm_response_summary=None,
+                        llm_response_redacted=True,
+                    )
+                    .returning(QaTrace.id)
+                )
+                qa_traces_redacted += len(source_qa_result.scalars().all())
+
+    # Durable provider placeholders are linked to qa_trace_id before HTTP
+    # dispatch, while attempt-level embedding/synthesis FKs are attached only
+    # after a result exists. Discover both in-flight calls through the trace so
+    # a concurrent forget can irreversibly redact their hashes as well.
+    if qa_trace_ids:
+        trace_ledger_result = await session.execute(
+            select(LlmUsageLedger.id).where(LlmUsageLedger.qa_trace_id.in_(qa_trace_ids))
+        )
+        ledger_ids.update(int(value) for value in trace_ledger_result.scalars())
+
+    ledger_hashes_redacted = 0
+    if ledger_ids:
+        ledger_result = await session.execute(
+            update(LlmUsageLedger)
+            .where(
+                LlmUsageLedger.id.in_(ledger_ids),
+                (LlmUsageLedger.prompt_hash.is_not(None))
+                | (LlmUsageLedger.response_hash.is_not(None)),
+            )
+            .values(prompt_hash=None, response_hash=None)
+            .returning(LlmUsageLedger.id)
+        )
+        ledger_hashes_redacted = len(ledger_result.scalars().all())
+
+    provenance_deleted = 0
+    units_deleted = 0
+    if unit_ids:
+        provenance_result = await session.execute(
+            delete(SemanticRetrievalUnitSource)
+            .where(SemanticRetrievalUnitSource.unit_id.in_(unit_ids))
+            .returning(SemanticRetrievalUnitSource.unit_id)
+        )
+        provenance_deleted = len(provenance_result.scalars().all())
+        units_result = await session.execute(
+            delete(SemanticRetrievalUnit)
+            .where(SemanticRetrievalUnit.id.in_(unit_ids))
+            .returning(SemanticRetrievalUnit.id)
+        )
+        units_deleted = len(units_result.scalars().all())
+
+    await session.flush()
+    logger.info(
+        "semantic_forget_cascade_completed",
+        extra={
+            "forget_event_id": event.id,
+            "target_type": event.target_type,
+            "affected_message_version_count": len(affected_mvids),
+            "semantic_unit_count": units_deleted,
+            "semantic_provenance_count": provenance_deleted,
+            "semantic_trace_count": traces_deleted,
+            "qa_trace_count": qa_traces_redacted,
+            "semantic_ledger_hash_count": ledger_hashes_redacted,
+        },
+    )
+    return (
+        units_deleted
+        + provenance_deleted
+        + traces_deleted
+        + qa_traces_redacted
+        + ledger_hashes_redacted
     )
 
 
@@ -392,9 +680,7 @@ async def _cascade_message_versions(session: AsyncSession, event) -> int:
         return result.rowcount or 0
 
     # Should not reach here: _process_one_event guards unsupported target_types.
-    raise ValueError(
-        f"_cascade_message_versions: unsupported target_type={event.target_type!r}"
-    )
+    raise ValueError(f"_cascade_message_versions: unsupported target_type={event.target_type!r}")
 
 
 async def _cascade_qa_traces(session: AsyncSession, event) -> int:
@@ -412,9 +698,7 @@ async def _cascade_qa_traces(session: AsyncSession, event) -> int:
     try:
         telegram_id = int(event.target_id)
     except (TypeError, ValueError):
-        raise ValueError(
-            f"target_id must be integer telegram_id; got {event.target_id!r}"
-        )
+        raise ValueError(f"target_id must be integer telegram_id; got {event.target_id!r}")
 
     stmt = (
         update(QaTrace)
@@ -443,8 +727,7 @@ async def _cascade_llm_synthesis_cache(session: AsyncSession, event) -> int:
 
     target_types:
 
-    * ``message`` — resolve the chat_message's current_version_id → call
-      ``SynthesisCacheRepo.invalidate_by_citation`` once.
+    * ``message`` — invalidate every revision of the chat_message.
     * ``message_hash`` — resolve all message_version_ids sharing the
       ``content_hash`` → invalidate each.
     * ``user`` — bulk DELETE every cache row citing ANY of the user's
@@ -457,39 +740,8 @@ async def _cascade_llm_synthesis_cache(session: AsyncSession, event) -> int:
             f"forget_event target_type={event.target_type!r} requires non-None target_id"
         )
 
-    if event.target_type == "message":
-        try:
-            cm_id = int(event.target_id)
-        except (TypeError, ValueError):
-            raise ValueError(
-                f"forget_event target_type='message' requires integer target_id; "
-                f"got {event.target_id!r}"
-            )
-        # Resolve current_version_id of the chat_message. The chat_messages
-        # cascade layer (which runs earlier) NULLed text/caption/raw_json but
-        # left current_version_id intact, so this read still resolves.
-        row = (
-            await session.execute(
-                select(ChatMessage.current_version_id).where(ChatMessage.id == cm_id)
-            )
-        ).first()
-        if row is None or row[0] is None:
-            return 0
-        return await SynthesisCacheRepo.invalidate_by_citation(
-            session, message_version_id=int(row[0])
-        )
-
-    if event.target_type == "message_hash":
-        # Resolve every message_version_id whose chat_message has the given
-        # content_hash. (The hash is stored on message_versions.content_hash;
-        # chat_messages does NOT carry content_hash. So we query
-        # message_versions directly.)
-        target_hash = str(event.target_id)
-        version_ids = (
-            await session.execute(
-                select(MessageVersion.id).where(MessageVersion.content_hash == target_hash)
-            )
-        ).scalars().all()
+    if event.target_type in {"message", "message_hash", "user"}:
+        version_ids = await _semantic_affected_mvids(session, event)
         total = 0
         for vid in version_ids:
             total += await SynthesisCacheRepo.invalidate_by_citation(
@@ -497,37 +749,7 @@ async def _cascade_llm_synthesis_cache(session: AsyncSession, event) -> int:
             )
         return total
 
-    if event.target_type == "user":
-        try:
-            telegram_id = int(event.target_id)
-        except (TypeError, ValueError):
-            raise ValueError(
-                f"forget_event target_type='user' requires integer target_id (telegram_id); "
-                f"got {event.target_id!r}"
-            )
-        # Resolve user's complete set of message_version_ids and invalidate
-        # every cache row whose ``citation_ids`` JSONB array intersects.
-        # The chat_messages layer NULLed body fields but the user_id column
-        # is preserved, so this query resolves correctly regardless of layer
-        # ordering. Iterates per-id (instead of a single DELETE) so the
-        # repo's portable PG / SQLite fallback path is reused.
-        version_ids = (
-            await session.execute(
-                select(MessageVersion.id)
-                .join(ChatMessage, ChatMessage.id == MessageVersion.chat_message_id)
-                .where(ChatMessage.user_id == telegram_id)
-            )
-        ).scalars().all()
-        total = 0
-        for vid in version_ids:
-            total += await SynthesisCacheRepo.invalidate_by_citation(
-                session, message_version_id=int(vid)
-            )
-        return total
-
-    raise ValueError(
-        f"_cascade_llm_synthesis_cache: unsupported target_type={event.target_type!r}"
-    )
+    raise ValueError(f"_cascade_llm_synthesis_cache: unsupported target_type={event.target_type!r}")
 
 
 async def _cascade_qa_traces_llm(session: AsyncSession, event) -> int:
@@ -540,12 +762,11 @@ async def _cascade_qa_traces_llm(session: AsyncSession, event) -> int:
 
     target_types:
 
-    * ``message`` — NULL ``llm_response_summary`` on every trace whose
-      ``evidence_ids JSONB`` contains the chat_message's current_version_id.
+    * ``message`` — redact summaries citing any revision of the chat_message.
     * ``message_hash`` — NULL on every trace citing ANY version_id matching
       the content_hash.
-    * ``user`` — NULL ``llm_response_summary`` for every trace owned by the
-      user (query_text already handled by Phase 4 ``_cascade_qa_traces``).
+    * ``user`` — redact traces owned by the user and traces citing any of the
+      user's message revisions.
 
     Returns rowcount.
     """
@@ -554,71 +775,31 @@ async def _cascade_qa_traces_llm(session: AsyncSession, event) -> int:
             f"forget_event target_type={event.target_type!r} requires non-None target_id"
         )
 
-    if event.target_type == "message":
-        try:
-            cm_id = int(event.target_id)
-        except (TypeError, ValueError):
-            raise ValueError(
-                f"target_type='message' requires integer target_id; got {event.target_id!r}"
-            )
-        # Resolve the chat_message's current_version_id (preserved across the
-        # Phase 1 cascade layers).
-        row = (
-            await session.execute(
-                select(ChatMessage.current_version_id).where(ChatMessage.id == cm_id)
-            )
-        ).first()
-        if row is None or row[0] is None:
-            return 0
-        vid = int(row[0])
-        # JSONB containment: NULL summary on traces citing this version.
-        stmt = text(
-            "UPDATE qa_traces SET llm_response_summary = NULL "
-            "WHERE evidence_ids @> CAST(:vid AS jsonb)"
-        )
-        result = await session.execute(stmt, {"vid": f"[{vid}]"})
-        await session.flush()
-        return result.rowcount or 0
-
-    if event.target_type == "message_hash":
-        target_hash = str(event.target_id)
-        version_ids = (
-            await session.execute(
-                select(MessageVersion.id).where(MessageVersion.content_hash == target_hash)
-            )
-        ).scalars().all()
+    if event.target_type in {"message", "message_hash", "user"}:
+        version_ids = await _semantic_affected_mvids(session, event)
         total = 0
         for vid in version_ids:
             stmt = text(
-                "UPDATE qa_traces SET llm_response_summary = NULL "
+                "UPDATE qa_traces SET llm_response_summary = NULL, "
+                "llm_response_redacted = TRUE "
                 "WHERE evidence_ids @> CAST(:vid AS jsonb)"
             )
             result = await session.execute(stmt, {"vid": f"[{int(vid)}]"})
             total += result.rowcount or 0
-        if total:
-            await session.flush()
+        if event.target_type == "user":
+            owner_result = await session.execute(
+                update(QaTrace)
+                .where(QaTrace.user_tg_id == int(event.target_id))
+                .values(
+                    llm_response_summary=None,
+                    llm_response_redacted=True,
+                )
+            )
+            total += owner_result.rowcount or 0
+        await session.flush()
         return total
 
-    if event.target_type == "user":
-        try:
-            telegram_id = int(event.target_id)
-        except (TypeError, ValueError):
-            raise ValueError(
-                f"target_type='user' requires integer target_id (telegram_id); "
-                f"got {event.target_id!r}"
-            )
-        stmt = (
-            update(QaTrace)
-            .where(QaTrace.user_tg_id == telegram_id)
-            .values(llm_response_summary=None)
-        )
-        result = await session.execute(stmt)
-        await session.flush()
-        return result.rowcount or 0
-
-    raise ValueError(
-        f"_cascade_qa_traces_llm: unsupported target_type={event.target_type!r}"
-    )
+    raise ValueError(f"_cascade_qa_traces_llm: unsupported target_type={event.target_type!r}")
 
 
 async def _cascade_llm_usage_ledger(session: AsyncSession, event) -> int:
@@ -648,9 +829,7 @@ async def _cascade_llm_usage_ledger(session: AsyncSession, event) -> int:
     try:
         telegram_id = int(event.target_id)
     except (TypeError, ValueError):
-        raise ValueError(
-            f"target_id must be integer telegram_id; got {event.target_id!r}"
-        )
+        raise ValueError(f"target_id must be integer telegram_id; got {event.target_id!r}")
 
     subq = select(QaTrace.id).where(QaTrace.user_tg_id == telegram_id)
     stmt = (
@@ -737,14 +916,11 @@ async def _cascade_card_sources_on_forget(session: AsyncSession, event) -> int:
             cm_id = int(event.target_id)
         except (TypeError, ValueError):
             raise ValueError(
-                f"target_type='message' requires integer target_id; "
-                f"got {event.target_id!r}"
+                f"target_type='message' requires integer target_id; got {event.target_id!r}"
             )
         row = (
             await session.execute(
-                select(ChatMessage.current_version_id).where(
-                    ChatMessage.id == cm_id
-                )
+                select(ChatMessage.current_version_id).where(ChatMessage.id == cm_id)
             )
         ).first()
         if row is None or row[0] is None:
@@ -757,11 +933,11 @@ async def _cascade_card_sources_on_forget(session: AsyncSession, event) -> int:
             int(v)
             for v in (
                 await session.execute(
-                    select(MessageVersion.id).where(
-                        MessageVersion.content_hash == target_hash
-                    )
+                    select(MessageVersion.id).where(MessageVersion.content_hash == target_hash)
                 )
-            ).scalars().all()
+            )
+            .scalars()
+            .all()
         ]
         if not mvids:
             return 0
@@ -782,15 +958,16 @@ async def _cascade_card_sources_on_forget(session: AsyncSession, event) -> int:
                     .join(ChatMessage, ChatMessage.id == MessageVersion.chat_message_id)
                     .where(ChatMessage.user_id == telegram_id)
                 )
-            ).scalars().all()
+            )
+            .scalars()
+            .all()
         ]
         if not mvids:
             return 0
 
     else:
         raise ValueError(
-            f"_cascade_card_sources_on_forget: unsupported target_type="
-            f"{event.target_type!r}"
+            f"_cascade_card_sources_on_forget: unsupported target_type={event.target_type!r}"
         )
 
     # ── Step B: gather affected card_ids and lock them FOR UPDATE ────────────
@@ -802,7 +979,9 @@ async def _cascade_card_sources_on_forget(session: AsyncSession, event) -> int:
                 .where(CardSource.message_version_id.in_(mvids))
                 .distinct()
             )
-        ).scalars().all()
+        )
+        .scalars()
+        .all()
     ]
     if not affected_card_ids:
         return 0
@@ -812,9 +991,7 @@ async def _cascade_card_sources_on_forget(session: AsyncSession, event) -> int:
     # apply_forget_event orchestrator level, but this guards stragglers
     # inserted under a PREVIOUS advisory lock that has since released.
     await session.execute(
-        select(KnowledgeCard)
-        .where(KnowledgeCard.id.in_(affected_card_ids))
-        .with_for_update()
+        select(KnowledgeCard).where(KnowledgeCard.id.in_(affected_card_ids)).with_for_update()
     )
 
     # ── Step C: DELETE matching card_sources rows ────────────────────────────
@@ -827,14 +1004,10 @@ async def _cascade_card_sources_on_forget(session: AsyncSession, event) -> int:
     # ── Step D: per-card recount + demote when remaining == 0 ────────────────
     # PHASE6_PLAN.md §5.A.5 privacy invariant: archived_reason carries only
     # the forget_event_id reference, never quoted body content.
-    archived_reason = (
-        f"all sources forgotten via cascade {event.id}"
-    )
+    archived_reason = f"all sources forgotten via cascade {event.id}"
     for card_id in affected_card_ids:
         remaining = (
-            await session.execute(
-                select(CardSource).where(CardSource.card_id == card_id).limit(1)
-            )
+            await session.execute(select(CardSource).where(CardSource.card_id == card_id).limit(1))
         ).scalar()
         if remaining is None:
             # All sources gone → demote.
@@ -875,9 +1048,9 @@ async def _cascade_digests(session: AsyncSession, event) -> int:
     # Resolve card_source ids whose message_version is in the affected set.
     # This MUST happen BEFORE the card_sources cascade layer DELETEs the rows.
     cs_rows = await session.execute(
-        text(
-            "SELECT id::text FROM card_sources WHERE message_version_id = ANY(:mvids)"
-        ).bindparams(bindparam("mvids", type_=PG_ARRAY(BigInteger))),
+        text("SELECT id::text FROM card_sources WHERE message_version_id = ANY(:mvids)").bindparams(
+            bindparam("mvids", type_=PG_ARRAY(BigInteger))
+        ),
         {"mvids": list(mvids)},
     )
     affected_cs_ids = {r[0] for r in cs_rows}
@@ -931,9 +1104,7 @@ async def _cascade_digests(session: AsyncSession, event) -> int:
             )
             count += 1
         except Exception:
-            logger.exception(
-                "_cascade_digests: redact failed for digest_id=%s", digest_id
-            )
+            logger.exception("_cascade_digests: redact failed for digest_id=%s", digest_id)
     return count
 
 
@@ -985,9 +1156,7 @@ async def _cascade_wiki_pages(session: AsyncSession, event) -> int:
         text(
             "SELECT DISTINCT wiki_page_id::text FROM wiki_page_message_sources "
             "WHERE message_version_id = ANY(:mvids)"
-        ).bindparams(
-            bindparam("mvids", type_=_ARRAY_BIGINT)
-        ),
+        ).bindparams(bindparam("mvids", type_=_ARRAY_BIGINT)),
         {"mvids": list(mvids)},
     )
     direct_page_ids: set[str] = {r[0] for r in direct_rows}
@@ -999,9 +1168,7 @@ async def _cascade_wiki_pages(session: AsyncSession, event) -> int:
             "FROM wiki_page_card_sources wpcs "
             "JOIN card_sources cs ON cs.card_id = wpcs.card_id "
             "WHERE cs.message_version_id = ANY(:mvids)"
-        ).bindparams(
-            bindparam("mvids", type_=_ARRAY_BIGINT)
-        ),
+        ).bindparams(bindparam("mvids", type_=_ARRAY_BIGINT)),
         {"mvids": list(mvids)},
     )
     transitive_page_ids: set[str] = {r[0] for r in transitive_rows}
@@ -1067,9 +1234,7 @@ async def _cascade_wiki_pages(session: AsyncSession, event) -> int:
         surviving_direct = direct_total - len(set(gov.invalid_mvids))
         surviving_cards = card_total - len(set(gov.invalid_card_ids))
         # archived when every cited source is invalid (or there are none).
-        new_status = (
-            "archived" if (surviving_direct <= 0 and surviving_cards <= 0) else "stale"
-        )
+        new_status = "archived" if (surviving_direct <= 0 and surviving_cards <= 0) else "stale"
 
         # UPDATE wiki_pages: set page_status, public_enabled=false, AND robots
         # policy back to 'noindex' (Codex MED #6 fix part b — cascade flip
@@ -1190,9 +1355,7 @@ async def _cascade_wiki_revisions(session: AsyncSession, event) -> int:
             "    SELECT jsonb_build_array(v::bigint) "
             "    FROM unnest(CAST(:mvids AS bigint[])) AS v"
             ")"
-        ).bindparams(
-            bindparam("mvids", type_=_ARRAY_BIGINT)
-        ),
+        ).bindparams(bindparam("mvids", type_=_ARRAY_BIGINT)),
         {
             "redact_text": redact_text,
             "event_id": event.id,
@@ -1710,6 +1873,8 @@ async def _cascade_butler_undo_invocations(session: AsyncSession, event) -> int:
 # skipped. When a future phase adds a layer's table, add its function here.
 _LAYER_FUNCS: dict[str, Any] = {
     "chat_messages": _cascade_chat_messages,
+    # Issue #404: derived vector/provenance purge must precede message redaction.
+    "semantic_retrieval": _cascade_semantic_retrieval,
     "message_versions": _cascade_message_versions,
     "qa_traces": _cascade_qa_traces,
     # T5-04 Phase 5 layers — ORDER binding per contracts.md §8.
@@ -1763,9 +1928,7 @@ async def _resolve_affected_mvids(session: AsyncSession, event) -> list[int]:
             return []
         row = (
             await session.execute(
-                select(ChatMessage.current_version_id).where(
-                    ChatMessage.id == cm_id
-                )
+                select(ChatMessage.current_version_id).where(ChatMessage.id == cm_id)
             )
         ).first()
         if row is None or row[0] is None:
@@ -1775,12 +1938,14 @@ async def _resolve_affected_mvids(session: AsyncSession, event) -> list[int]:
     if event.target_type == "message_hash":
         target_hash = str(event.target_id)
         rows = (
-            await session.execute(
-                select(MessageVersion.id).where(
-                    MessageVersion.content_hash == target_hash
+            (
+                await session.execute(
+                    select(MessageVersion.id).where(MessageVersion.content_hash == target_hash)
                 )
             )
-        ).scalars().all()
+            .scalars()
+            .all()
+        )
         return [int(v) for v in rows]
 
     if event.target_type == "user":
@@ -1789,12 +1954,16 @@ async def _resolve_affected_mvids(session: AsyncSession, event) -> list[int]:
         except (TypeError, ValueError):
             return []
         rows = (
-            await session.execute(
-                select(MessageVersion.id)
-                .join(ChatMessage, ChatMessage.id == MessageVersion.chat_message_id)
-                .where(ChatMessage.user_id == telegram_id)
+            (
+                await session.execute(
+                    select(MessageVersion.id)
+                    .join(ChatMessage, ChatMessage.id == MessageVersion.chat_message_id)
+                    .where(ChatMessage.user_id == telegram_id)
+                )
             )
-        ).scalars().all()
+            .scalars()
+            .all()
+        )
         return [int(v) for v in rows]
 
     return []
@@ -1897,9 +2066,7 @@ async def _process_one_event(session: AsyncSession, event, bot: Bot | None = Non
 
             # Step 3: per-mvid advisory locks (sorted) — matches the order
             # /approve acquires them in, preserving deadlock-avoidance.
-            for lock_id in sorted(
-                _p6_mvid_advisory_lock_id(m) for m in affected_mvids
-            ):
+            for lock_id in sorted(_p6_mvid_advisory_lock_id(m) for m in affected_mvids):
                 await session.execute(
                     text("SELECT pg_advisory_xact_lock(:lock_id)"),
                     {"lock_id": lock_id},
@@ -2003,9 +2170,7 @@ async def run_cascade_worker_once(
         # WHERE-status filter; if another worker already claimed this row, the
         # repo raises ValueError and we skip silently.
         try:
-            claimed = await ForgetEventRepo.mark_status(
-                session, event.id, status="processing"
-            )
+            claimed = await ForgetEventRepo.mark_status(session, event.id, status="processing")
         except ValueError:
             logger.debug(
                 "cascade_worker: skipping already-claimed forget_event id=%s",
@@ -2064,9 +2229,7 @@ async def cascade_worker_tick(
         if not await FeatureFlagRepo.get(own_session, CASCADE_WORKER_FLAG):
             return {"claimed": 0, "processed": 0, "failed": 0}
         try:
-            stats = await run_cascade_worker_once(
-                own_session, bot=bot, batch_size=batch_size
-            )
+            stats = await run_cascade_worker_once(own_session, bot=bot, batch_size=batch_size)
             await own_session.commit()
             return stats
         except Exception:

--- a/bot/services/llm_gateway.py
+++ b/bot/services/llm_gateway.py
@@ -1688,12 +1688,15 @@ async def embed_texts(
     ledger_repo: LedgerRepoProtocol,
     provider: Any | None = None,
     qa_trace_id: int | None = None,
+    outcome_recorder: Any | None = None,
 ) -> EmbeddingGatewayResult:
     """Create audited embeddings through the shared provider boundary.
 
     The gateway commits the conservative ledger reservation while holding the
     budget lock, so concurrent calls can observe it before either provider is
-    entered. The caller owns the final cost/result commit boundary.
+    entered. When an outcome recorder is supplied, its durable claim is
+    committed with the reservation and its terminal state is committed with
+    the final ledger update.
     """
 
     from bot.services.llm_pricing import estimate_cost
@@ -1774,6 +1777,13 @@ async def embed_texts(
                 error="reserved_in_flight",
                 call_type="semantic_embedding",
             )
+        claim_ledger_id = budget_row.id if budget_row is not None else placeholder_row.id
+        if outcome_recorder is not None:
+            await outcome_recorder.reserve(
+                session,
+                llm_usage_ledger_id=claim_ledger_id,
+                budget_denied=budget_row is not None,
+            )
         # Publish the reservation and release the transaction-scoped lock.
         await session.commit()
     except Exception:
@@ -1800,33 +1810,51 @@ async def embed_texts(
             if subtype in {"auth", "bad_request", "model_not_found", "rate_limit"}
             else reservation_cost
         )
-        await ledger_repo.update_placeholder(
-            session,
-            llm_call_id=placeholder_row.id,
-            cost_usd=terminal_cost,
-            response_hash=None,
-            tokens_in=0,
-            tokens_out=0,
-            request_id=None,
-            latency_ms=int((_monotonic() - started) * 1000),
-            error=f"provider_{type(exc).__name__}:{subtype}",
-        )
-        await session.commit()
+        try:
+            await ledger_repo.update_placeholder(
+                session,
+                llm_call_id=placeholder_row.id,
+                cost_usd=terminal_cost,
+                response_hash=None,
+                tokens_in=0,
+                tokens_out=0,
+                request_id=None,
+                latency_ms=int((_monotonic() - started) * 1000),
+                error=f"provider_{type(exc).__name__}:{subtype}",
+            )
+            if outcome_recorder is not None:
+                await outcome_recorder.fail(
+                    session,
+                    llm_usage_ledger_id=placeholder_row.id,
+                )
+            await session.commit()
+        except Exception:
+            await session.rollback()
+            raise
         setattr(exc, "llm_usage_ledger_id", placeholder_row.id)
         raise
     except Exception as exc:
-        await ledger_repo.update_placeholder(
-            session,
-            llm_call_id=placeholder_row.id,
-            cost_usd=reservation_cost,
-            response_hash=None,
-            tokens_in=0,
-            tokens_out=0,
-            request_id=None,
-            latency_ms=int((_monotonic() - started) * 1000),
-            error=f"provider_unknown:{type(exc).__name__}",
-        )
-        await session.commit()
+        try:
+            await ledger_repo.update_placeholder(
+                session,
+                llm_call_id=placeholder_row.id,
+                cost_usd=reservation_cost,
+                response_hash=None,
+                tokens_in=0,
+                tokens_out=0,
+                request_id=None,
+                latency_ms=int((_monotonic() - started) * 1000),
+                error=f"provider_unknown:{type(exc).__name__}",
+            )
+            if outcome_recorder is not None:
+                await outcome_recorder.fail(
+                    session,
+                    llm_usage_ledger_id=placeholder_row.id,
+                )
+            await session.commit()
+        except Exception:
+            await session.rollback()
+            raise
         setattr(exc, "llm_usage_ledger_id", placeholder_row.id)
         raise
     cost = estimate_cost(
@@ -1835,18 +1863,28 @@ async def embed_texts(
         tokens_out=0,
     )
     request_id = _safe_qa_request_id(provider_result.request_id)
-    await ledger_repo.update_placeholder(
-        session,
-        llm_call_id=placeholder_row.id,
-        cost_usd=cost,
-        response_hash=_embedding_response_hash(provider_result.vectors),
-        tokens_in=provider_result.tokens_in,
-        tokens_out=0,
-        request_id=request_id,
-        latency_ms=provider_result.raw_latency_ms,
-        error=None,
-    )
-    await session.commit()
+    try:
+        await ledger_repo.update_placeholder(
+            session,
+            llm_call_id=placeholder_row.id,
+            cost_usd=cost,
+            response_hash=_embedding_response_hash(provider_result.vectors),
+            tokens_in=provider_result.tokens_in,
+            tokens_out=0,
+            request_id=request_id,
+            latency_ms=provider_result.raw_latency_ms,
+            error=None,
+        )
+        if outcome_recorder is not None:
+            await outcome_recorder.complete(
+                session,
+                llm_usage_ledger_id=placeholder_row.id,
+                vectors=provider_result.vectors,
+            )
+        await session.commit()
+    except Exception:
+        await session.rollback()
+        raise
     return EmbeddingGatewayResult(
         vectors=provider_result.vectors,
         tokens_in=provider_result.tokens_in,

--- a/bot/services/llm_gateway.py
+++ b/bot/services/llm_gateway.py
@@ -1713,6 +1713,11 @@ def _embedding_response_hash(vectors: tuple[tuple[float, ...], ...]) -> str:
     return hashlib.sha256(payload.encode("ascii")).hexdigest()
 
 
+_EMBEDDING_BUDGET_DENIED_PROMPT_HASH = hashlib.sha256(
+    b"embedding_budget_exceeded_without_provider_dispatch"
+).hexdigest()
+
+
 async def embed_texts(
     session: AsyncSession,
     *,
@@ -1727,9 +1732,10 @@ async def embed_texts(
 
     The gateway commits the conservative ledger reservation while holding the
     budget lock, so concurrent calls can observe it before either provider is
-    entered. When an outcome recorder is supplied, its durable claim is
-    committed with the reservation and its terminal state is committed with
-    the final ledger update.
+    entered. When an outcome recorder is supplied, its durable paid-attempt
+    claim is committed with the reservation and its terminal state is committed
+    with the final ledger update. A budget denial creates only a content-free
+    audit row because no provider dispatch occurred and a future run must retry.
     """
 
     from bot.services.llm_pricing import estimate_cost
@@ -1782,7 +1788,7 @@ async def embed_texts(
                 qa_trace_id=qa_trace_id,
                 provider="openai",
                 model=config.model,
-                prompt_hash=prompt_hash,
+                prompt_hash=_EMBEDDING_BUDGET_DENIED_PROMPT_HASH,
                 response_hash=None,
                 tokens_in=0,
                 tokens_out=0,

--- a/bot/services/llm_gateway.py
+++ b/bot/services/llm_gateway.py
@@ -628,6 +628,7 @@ async def synthesize_answer(
     max_evidence_items: int = MAX_QA_EVIDENCE_ITEMS,
     durable_placeholder: bool = False,
     revalidate_after_provider: bool = False,
+    cache_enabled: bool = True,
 ) -> SynthesisResult:
     """Single Phase 5 LLM entry point.
 
@@ -664,6 +665,9 @@ async def synthesize_answer(
     provider:
         ``LLMProvider`` Protocol implementation (Anthropic by default,
         OpenAI fallback via ``config.provider``). Tests inject fakes.
+    cache_enabled:
+        Disable answer-cache reads and writes for erase-sensitive flows whose
+        source question is not part of the citation provenance.
 
     Returns
     -------
@@ -802,7 +806,11 @@ async def synthesize_answer(
         # message_version_id therefore cannot reuse a stale answer.
         prompt_template_version=f"{config.prompt_template_version}:{prompt_hash}",
     )
-    cached = await cache_repo.get_or_none(session, input_hash=cache_input_hash)
+    cached = (
+        await cache_repo.get_or_none(session, input_hash=cache_input_hash)
+        if cache_enabled
+        else None
+    )
     if cached is not None:
         if _contains_sensitive_qa_output(cached.answer_text):
             return await _reject_sensitive_cache(cached, prompt_hash=prompt_hash)
@@ -868,7 +876,11 @@ async def synthesize_answer(
     try:
         await session.execute(lock_sql, {"lock_id": LLM_BUDGET_LOCK_ID})
         # (a) re-check cache under the lock.
-        cached_under_lock = await cache_repo.get_or_none(session, input_hash=cache_input_hash)
+        cached_under_lock = (
+            await cache_repo.get_or_none(session, input_hash=cache_input_hash)
+            if cache_enabled
+            else None
+        )
         if cached_under_lock is not None:
             if _contains_sensitive_qa_output(cached_under_lock.answer_text):
                 early_result = await _reject_sensitive_cache(
@@ -1177,6 +1189,27 @@ async def synthesize_answer(
     # Success — persist cache row (with surviving_ids in citation_ids JSONB,
     # NOT the pre-filter bundle.evidence_ids) + UPDATE placeholder + return.
     cost_usd = provider_result_cost
+    if not cache_enabled:
+        latency = int((time.monotonic() - started) * 1000)
+        await ledger_repo.update_placeholder(
+            session,
+            llm_call_id=placeholder_row.id,
+            cost_usd=cost_usd,
+            response_hash=_response_hash(answer_text),
+            tokens_in=provider_result.tokens_in,
+            tokens_out=provider_result.tokens_out,
+            request_id=request_id,
+            latency_ms=latency,
+            error=None,
+        )
+        return AnswerWithCitations(
+            answer_text=answer_text,
+            citation_ids=provider_result.citation_ids,
+            cost_usd=cost_usd,
+            cache_hit=False,
+            llm_call_id=placeholder_row.id,
+            surviving_evidence_ids=ordered_surviving_ids,
+        )
     # F4-RACE-FIX (Codex round-2 HIGH-2): cache store may race with a
     # concurrent winner that also dispatched between unlock and store. The
     # ``input_hash`` UNIQUE constraint catches the duplicate; we treat it as

--- a/bot/services/llm_gateway.py
+++ b/bot/services/llm_gateway.py
@@ -51,9 +51,12 @@ import os
 import re
 import time
 import uuid
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from decimal import Decimal
+from time import monotonic as _monotonic
 from typing import TYPE_CHECKING, Any, Callable, Literal, Mapping, Protocol, Sequence
 
 if TYPE_CHECKING:
@@ -98,6 +101,7 @@ AbstentionReason = Literal[
     "forget_invalidated",
     "sensitive_input",
     "sensitive_output",
+    "insufficient_evidence",
 ]
 
 
@@ -110,6 +114,9 @@ class AnswerWithCitations:
     cost_usd: Decimal
     cache_hit: bool
     llm_call_id: int
+    # Exact ordered evidence anchors that survived governance and were
+    # eligible for this answer. Default keeps legacy constructors compatible.
+    surviving_evidence_ids: tuple[int, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -145,6 +152,26 @@ class VisionGatewayConfig:
 
 
 @dataclass(frozen=True)
+class EmbeddingGatewayConfig:
+    """Independent OpenAI embedding model and spend ceilings."""
+
+    model: str
+    dimensions: int
+    daily_ceiling_usd: Decimal
+    monthly_ceiling_usd: Decimal
+
+
+@dataclass(frozen=True)
+class EmbeddingGatewayResult:
+    vectors: tuple[tuple[float, ...], ...]
+    tokens_in: int
+    cost_usd: Decimal
+    llm_usage_ledger_id: int
+    request_id: str
+    latency_ms: int
+
+
+@dataclass(frozen=True)
 class ImageDescriptionResult:
     description: str
     model: str
@@ -162,6 +189,14 @@ class ImageDescriptionOutcomeRef:
 
 class ImageDescriptionBudgetExceeded(RuntimeError):
     """Image description was refused by the configured cost ceiling."""
+
+
+class EmbeddingBudgetExceeded(RuntimeError):
+    """Embedding call was refused by its independent spend ceiling."""
+
+    def __init__(self, *, llm_usage_ledger_id: int) -> None:
+        super().__init__("embedding spend ceiling exceeded")
+        self.llm_usage_ledger_id = llm_usage_ledger_id
 
 
 class ImageDescriptionAmbiguousError(RuntimeError):
@@ -305,6 +340,7 @@ VISION_BUDGET_LOCK_ID: int = int.from_bytes(
 MAX_QUERY_LENGTH = 256
 MAX_QA_EVIDENCE_ITEMS = 3
 MAX_QA_EVIDENCE_SNIPPET_CHARS = 800
+SEMANTIC_QA_RESERVED_OUTPUT_TOKENS = 512
 MAX_WIKI_CARD_SOURCES = 64
 MAX_WIKI_DIRECT_SOURCES = 128
 MAX_WIKI_PRIOR_BODY_CHARS = 100_000
@@ -381,12 +417,13 @@ def _build_prompt(
     surviving_ids: tuple[int, ...] | list[int],
     *,
     evidence_items: tuple[EvidenceItem, ...] | list[EvidenceItem] = (),
+    max_evidence_items: int = MAX_QA_EVIDENCE_ITEMS,
 ) -> str:
     """Render a bounded evidence-only prompt for provider dispatch.
 
     Evidence is serialized as JSONL so snippets remain data even when they
     contain prompt-like text or delimiter strings. Only post-filter IDs are
-    eligible, and at most three records leave the process.
+    eligible; legacy callers default to three records and semantic QA requests five.
     """
 
     if contains_secret_like_data(query_normalized):
@@ -401,7 +438,7 @@ def _build_prompt(
             continue
         selected.append(item)
         seen.add(evidence_id)
-        if len(selected) == MAX_QA_EVIDENCE_ITEMS:
+        if len(selected) == max_evidence_items:
             break
 
     if any(contains_secret_like_data(item.snippet) for item in selected):
@@ -437,22 +474,22 @@ def _build_prompt(
 # ─── SQL fragments ──────────────────────────────────────────────────────────
 
 
-# Built from primitives so the literal policy strings live as constants. The
-# policy values still match what bot/services/search.py:91+ enforces.
-_POLICY_OFFRECORD = "off" + "record"
-_POLICY_FORGOTTEN = "for" + "gotten"
-
 _SOURCE_FILTER_SQL = text(
-    """
+    f"""
     SELECT mv.id AS message_version_id
     FROM message_versions AS mv
-    JOIN chat_messages AS c
-        ON c.id = mv.chat_message_id
-        AND c.current_version_id = mv.id
+    JOIN chat_messages AS cm
+        ON cm.id = mv.chat_message_id
+        AND cm.current_version_id = mv.id
+    JOIN users AS author ON author.id = cm.user_id
     WHERE mv.id = ANY(:ids)
-        AND c.memory_policy NOT IN (:p_off, :p_forgot)
-        AND c.is_redacted = FALSE
+        AND cm.chat_id = :chat_id
+        AND author.is_bot = FALSE
+        AND cm.memory_policy = 'normal'
+        AND COALESCE(cm.message_kind, 'text') NOT IN ('voice', 'audio')
+        AND cm.is_redacted = FALSE
         AND mv.is_redacted = FALSE
+        AND {_FORGET_EXCLUDES}
     """
 )
 
@@ -494,15 +531,25 @@ _TOMBSTONE_GATE_SQL = text(
     """
 )
 
-# Session-scoped advisory lock used by the placeholder-pattern path: held
-# only across the cost-read + placeholder INSERT (sub-millisecond), then
-# released BEFORE dispatching the provider HTTP call. Closes F1 (lock
-# held across HTTP + global serialisation on bursts). The transaction-
-# scoped variant (``pg_advisory_xact_lock``) is intentionally NOT used —
-# it would only release at outer-tx commit, which happens AFTER the
-# provider round-trip.
+# Legacy callers keep the session-scoped lock.  Semantic callers use the
+# transaction-scoped lock and commit their durable reservation before provider
+# dispatch, which both publishes the reservation and releases the lock.
 _BUDGET_LOCK_SESSION_SQL = text("SELECT pg_advisory_lock(:lock_id)")
 _BUDGET_UNLOCK_SESSION_SQL = text("SELECT pg_advisory_unlock(:lock_id)")
+_BUDGET_LOCK_XACT_SQL = text("SELECT pg_advisory_xact_lock(:lock_id)")
+
+_APPROVED_CARD_PROVENANCE_SQL = text(
+    """
+    SELECT
+        kc.id::text AS card_id,
+        ARRAY_AGG(cs.message_version_id ORDER BY cs.position, cs.id) AS source_ids
+    FROM knowledge_cards AS kc
+    JOIN card_sources AS cs ON cs.card_id = kc.id
+    WHERE kc.id::text = ANY(:card_ids)
+      AND kc.card_status = 'approved'
+    GROUP BY kc.id
+    """
+)
 
 
 # ─── Gateway entry point ────────────────────────────────────────────────────
@@ -528,6 +575,44 @@ def _safe_qa_provider_error_subtype(exc: BaseException) -> str:
     return "unknown"
 
 
+def _ambiguous_provider_error_cost(
+    *, durable_placeholder: bool, reservation_cost: Decimal, subtype: str
+) -> Decimal:
+    """Keep the reservation when the provider may have processed the call."""
+
+    if durable_placeholder and subtype in {
+        "timeout",
+        "5xx",
+        "connection_reset",
+        "contract_violation",
+        "unknown",
+    }:
+        return reservation_cost
+    return Decimal("0")
+
+
+def _validate_provider_result(result: Any) -> None:
+    """Fail closed before malformed usage can reduce budget aggregates."""
+
+    if not isinstance(result.answer_text, str):
+        raise ProviderStructuralError(
+            "contract_violation",
+            message="provider answer_text must be a string",
+        )
+    if (
+        type(result.tokens_in) is not int
+        or type(result.tokens_out) is not int
+        or result.tokens_in < 0
+        or result.tokens_out < 0
+        or type(result.raw_latency_ms) is not int
+        or result.raw_latency_ms < 0
+    ):
+        raise ProviderStructuralError(
+            "contract_violation",
+            message="provider usage must contain non-negative integer counters",
+        )
+
+
 async def synthesize_answer(
     session: AsyncSession,
     *,
@@ -538,17 +623,20 @@ async def synthesize_answer(
     ledger_repo: LedgerRepoProtocol,
     cache_repo: SynthesisCacheRepoProtocol,
     provider: LLMProvider,
+    max_evidence_items: int = MAX_QA_EVIDENCE_ITEMS,
+    durable_placeholder: bool = False,
+    revalidate_after_provider: bool = False,
 ) -> SynthesisResult:
     """Single Phase 5 LLM entry point.
 
     Parameters
     ----------
     session:
-        Async session. The caller owns the transaction lifecycle; this
-        function flushes via the repos but never commits.
+        Async session. The caller owns the transaction lifecycle; semantic
+        callers may opt into one pre-provider placeholder commit.
     bundle:
-        Phase 4 ``EvidenceBundle``. ``bundle.evidence_ids`` is the
-        authoritative whitelist for citation enforcement (invariant 7).
+        Phase 4 ``EvidenceBundle``. Full card provenance is revalidated and
+        the resulting anchor IDs become the citation whitelist.
     query:
         Raw user query. Normalised internally via :func:`_normalize_query`.
     config:
@@ -581,6 +669,8 @@ async def synthesize_answer(
         Either ``AnswerWithCitations`` on success or ``Abstention`` on any
         documented refusal path. Never raises on documented failure paths.
     """
+    if not 1 <= max_evidence_items <= 8:
+        raise ValueError("max_evidence_items must be between 1 and 8")
     query_normalized = _normalize_query(query)
 
     async def _ledger(
@@ -652,13 +742,21 @@ async def synthesize_answer(
             llm_call_id=row.id,
         )
 
-    # Invariant 2 — source filter (defense-in-depth).
-    surviving_ids_list = await _source_filter(session, bundle.evidence_ids)
-    if not surviving_ids_list:
+    # Invariants 2/3 — one authoritative governance filter over every message
+    # in card provenance, not only the display anchor.
+    governed_bundle, tombstoned_ids = await _filter_governed_evidence(
+        session,
+        bundle,
+        max_evidence_items=max_evidence_items,
+    )
+    if not governed_bundle.items:
         empty_prompt_hash = _prompt_hash(_build_prompt(query_normalized, ()))
-        row = await _ledger(error="all_filtered", prompt_hash=empty_prompt_hash)
+        reason: AbstentionReason = "forget_invalidated" if tombstoned_ids else "all_filtered"
+        for vid in tombstoned_ids:
+            await cache_repo.invalidate_by_citation(session, message_version_id=vid)
+        row = await _ledger(error=reason, prompt_hash=empty_prompt_hash)
         return Abstention(
-            reason="all_filtered",
+            reason=reason,
             cost_usd=Decimal("0"),
             llm_call_id=row.id,
         )
@@ -667,25 +765,9 @@ async def synthesize_answer(
     # cache key, citation enforcement, and the cache STORE payload. Closes
     # F2/F3 (citation enforcement + cache poisoning by pre-filter ids).
     # Sorted for determinism so prompt body is order-independent.
-    surviving_id_set = set(surviving_ids_list)
-    selected_items: list[EvidenceItem] = []
-    selected_ids: set[int] = set()
-    for item in bundle.items:
-        evidence_id = item.message_version_id
-        if evidence_id not in surviving_id_set or evidence_id in selected_ids:
-            continue
-        selected_items.append(item)
-        selected_ids.add(evidence_id)
-        if len(selected_items) == MAX_QA_EVIDENCE_ITEMS:
-            break
-    if not selected_items:
-        empty_prompt_hash = _prompt_hash(_build_prompt(query_normalized, ()))
-        row = await _ledger(error="all_filtered", prompt_hash=empty_prompt_hash)
-        return Abstention(
-            reason="all_filtered",
-            cost_usd=Decimal("0"),
-            llm_call_id=row.id,
-        )
+    selected_items = list(governed_bundle.items)
+    ordered_surviving_ids = tuple(item.message_version_id for item in selected_items)
+    full_provenance_ids = _bundle_provenance_ids(selected_items)
 
     surviving_ids: tuple[int, ...] = tuple(
         sorted(item.message_version_id for item in selected_items)
@@ -694,11 +776,10 @@ async def synthesize_answer(
         query_normalized,
         surviving_ids,
         evidence_items=selected_items,
+        max_evidence_items=max_evidence_items,
     )
     prompt_hash = _prompt_hash(prompt)
 
-    # Invariant 3 — forget-invalidation gate (three tombstone keys).
-    tombstoned_ids = await _forget_tombstone_check(session, list(surviving_ids))
     if tombstoned_ids:
         for vid in tombstoned_ids:
             await cache_repo.invalidate_by_citation(session, message_version_id=vid)
@@ -712,7 +793,7 @@ async def synthesize_answer(
     # Invariant 4 — cache lookup (AFTER step 3 so tombstoned content stays out).
     cache_input_hash = _cache_input_hash(
         query_normalized=query_normalized,
-        citation_ids=surviving_ids,
+        citation_ids=tuple(sorted(full_provenance_ids)),
         model=config.model,
         # The prompt hash binds mutable evidence text (not just source IDs)
         # into the cache key.  A revised card snippet under the same anchor
@@ -733,10 +814,15 @@ async def synthesize_answer(
         )
         return AnswerWithCitations(
             answer_text=cached_answer,
-            citation_ids=tuple(cached.citation_ids),
+            citation_ids=tuple(
+                citation_id
+                for citation_id in cached.citation_ids
+                if citation_id in set(surviving_ids)
+            ),
             cost_usd=Decimal("0"),
             cache_hit=True,
             llm_call_id=row.id,
+            surviving_evidence_ids=ordered_surviving_ids,
         )
 
     # Invariant 5 — placeholder ledger row pattern (closes F1 + F4).
@@ -748,11 +834,11 @@ async def synthesize_answer(
     #      cache_hit row WITHOUT dispatching provider.
     #   b) read daily / monthly totals via repo.
     #   c) if over ceiling — insert ledger row with error='budget_exceeded'.
-    #   d) else — insert PLACEHOLDER ledger row (cost_usd=0, error=NULL,
-    #      response_hash=NULL, tokens=0). Concurrent callers observe the
-    #      placeholder via daily/monthly cost aggregates AFTER it's UPDATEd
-    #      with the real cost post-dispatch.
-    #   e) release the lock + commit the inner tx BEFORE provider dispatch.
+    #   d) else — insert a PLACEHOLDER ledger row. Semantic callers reserve a
+    #      conservative non-zero cost and commit it before dispatch; legacy
+    #      callers retain the prior zero-cost outer-transaction behaviour.
+    #   e) release the lock; semantic callers have already committed the
+    #      reservation before provider dispatch.
     #
     # Provider dispatch then runs WITHOUT holding the lock, so bursts no
     # longer serialise globally on the 5-15s HTTP call.
@@ -760,73 +846,96 @@ async def synthesize_answer(
     # The lock is session-scoped (``pg_advisory_lock`` + ``pg_advisory_unlock``)
     # rather than transaction-scoped so we control release timing.
     #
-    # KNOWN LIMITATION until T5-04: placeholder INSERT is NOT committed before
-    # lock release. Under Postgres read-committed isolation, concurrent gateway
-    # calls can miss each other's in-flight reservations between unlock and
-    # the outer handler tx commit (which happens AFTER provider HTTP returns).
-    # Daily budget ceiling may overshoot by up to N*call_cost where N = burst
-    # size. Acceptable for Wave 1 ship (flag default OFF; no production burst).
-    # T5-04 integration test MUST exercise burst load under real Postgres and
-    # either (a) wire savepoint-commit inside the lock window, or (b) move
-    # placeholder INSERT to a dedicated short-lived connection.
-    #
     # Unit tests use a fake session that no-ops both lock SQL statements; the
     # ordering test asserts lock_idx < unlock_idx < provider_idx.
     placeholder_row: Any
+    reservation_cost = Decimal("0")
+    if durable_placeholder:
+        # Character-count-as-token deliberately overestimates prompt usage;
+        # 512 is the semantic DeepSeek adapter's configured output ceiling.
+        reservation_cost = max(
+            _estimate_cost(
+                config=config,
+                tokens_in=len(prompt),
+                tokens_out=SEMANTIC_QA_RESERVED_OUTPUT_TOKENS,
+            ),
+            Decimal("0.000001"),
+        )
+    early_result: SynthesisResult | None = None
+    lock_sql = _BUDGET_LOCK_XACT_SQL if durable_placeholder else _BUDGET_LOCK_SESSION_SQL
     try:
-        await session.execute(_BUDGET_LOCK_SESSION_SQL, {"lock_id": LLM_BUDGET_LOCK_ID})
+        await session.execute(lock_sql, {"lock_id": LLM_BUDGET_LOCK_ID})
         # (a) re-check cache under the lock.
         cached_under_lock = await cache_repo.get_or_none(session, input_hash=cache_input_hash)
         if cached_under_lock is not None:
             if _contains_sensitive_qa_output(cached_under_lock.answer_text):
-                return await _reject_sensitive_cache(
+                early_result = await _reject_sensitive_cache(
                     cached_under_lock,
                     prompt_hash=prompt_hash,
                 )
-            cached_answer = cached_under_lock.answer_text
-            await cache_repo.bump_hit(session, cache_id=cached_under_lock.id)
-            row = await _ledger(
-                error=None,
-                cache_hit=True,
-                response_hash=_response_hash(cached_answer),
-                prompt_hash=prompt_hash,
-            )
-            return AnswerWithCitations(
-                answer_text=cached_answer,
-                citation_ids=tuple(cached_under_lock.citation_ids),
-                cost_usd=Decimal("0"),
-                cache_hit=True,
-                llm_call_id=row.id,
-            )
+            else:
+                cached_answer = cached_under_lock.answer_text
+                await cache_repo.bump_hit(session, cache_id=cached_under_lock.id)
+                row = await _ledger(
+                    error=None,
+                    cache_hit=True,
+                    response_hash=_response_hash(cached_answer),
+                    prompt_hash=prompt_hash,
+                )
+                early_result = AnswerWithCitations(
+                    answer_text=cached_answer,
+                    citation_ids=tuple(
+                        citation_id
+                        for citation_id in cached_under_lock.citation_ids
+                        if citation_id in set(surviving_ids)
+                    ),
+                    cost_usd=Decimal("0"),
+                    cache_hit=True,
+                    llm_call_id=row.id,
+                    surviving_evidence_ids=ordered_surviving_ids,
+                )
 
-        # (b) read totals.
-        over_budget = await _budget_check(session, config, ledger_repo)
-        if over_budget:
-            # (c) budget_exceeded ledger row.
-            row = await _ledger(error="budget_exceeded", prompt_hash=prompt_hash)
-            return Abstention(
-                reason="budget_exceeded",
-                cost_usd=Decimal("0"),
-                llm_call_id=row.id,
+        if early_result is None:
+            # (b) read totals.
+            over_budget = await _budget_check(
+                session,
+                config,
+                ledger_repo,
+                pending_cost=reservation_cost,
             )
-
-        # (d) placeholder ledger row.
-        placeholder_row = await _ledger(
-            error=None,
-            cost_usd=Decimal("0"),
-            response_hash=None,
-            tokens_in=0,
-            tokens_out=0,
-            prompt_hash=prompt_hash,
-        )
+            if over_budget:
+                # (c) budget_exceeded ledger row.
+                row = await _ledger(error="budget_exceeded", prompt_hash=prompt_hash)
+                early_result = Abstention(
+                    reason="budget_exceeded",
+                    cost_usd=Decimal("0"),
+                    llm_call_id=row.id,
+                )
+            else:
+                # (d) placeholder ledger row.
+                placeholder_row = await _ledger(
+                    error="reserved_in_flight" if durable_placeholder else None,
+                    cost_usd=reservation_cost,
+                    response_hash=None,
+                    tokens_in=0,
+                    tokens_out=0,
+                    prompt_hash=prompt_hash,
+                )
+        if durable_placeholder:
+            await session.commit()
+    except Exception:
+        if durable_placeholder:
+            await session.rollback()
+        raise
     finally:
-        # (e) release lock regardless of outcome. Even if we returned early
-        # above via early `return` statements inside the try block, this
-        # finally clause still runs and unlocks. NOTE: this requires the
-        # SQL execute itself not to raise — production code under T5-04 uses
-        # ``session.begin_nested()`` or a fresh connection so lock release
-        # is guaranteed even on session-level errors.
-        await session.execute(_BUDGET_UNLOCK_SESSION_SQL, {"lock_id": LLM_BUDGET_LOCK_ID})
+        if not durable_placeholder:
+            await session.execute(
+                _BUDGET_UNLOCK_SESSION_SQL,
+                {"lock_id": LLM_BUDGET_LOCK_ID},
+            )
+
+    if early_result is not None:
+        return early_result
 
     # Invariant 6 — provider dispatch with categorised error handling.
     # Provider HTTP runs OUTSIDE the lock so concurrent gateway calls no
@@ -834,13 +943,19 @@ async def synthesize_answer(
     started = time.monotonic()
     try:
         provider_result = await provider.call(prompt=prompt, model=config.model)
+        _validate_provider_result(provider_result)
     except ProviderTransientError as exc:
         latency = int((time.monotonic() - started) * 1000)
         error_subtype = _safe_qa_provider_error_subtype(exc)
+        failure_cost = _ambiguous_provider_error_cost(
+            durable_placeholder=durable_placeholder,
+            reservation_cost=reservation_cost,
+            subtype=error_subtype,
+        )
         await ledger_repo.update_placeholder(
             session,
             llm_call_id=placeholder_row.id,
-            cost_usd=Decimal("0"),
+            cost_usd=failure_cost,
             response_hash=None,
             tokens_in=0,
             tokens_out=0,
@@ -850,7 +965,7 @@ async def synthesize_answer(
         )
         return Abstention(
             reason="provider_error",
-            cost_usd=Decimal("0"),
+            cost_usd=failure_cost,
             llm_call_id=placeholder_row.id,
         )
 
@@ -868,10 +983,15 @@ async def synthesize_answer(
 
         observability.emit_stop_signal("llm_provider_structural")
         latency = int((time.monotonic() - started) * 1000)
+        failure_cost = _ambiguous_provider_error_cost(
+            durable_placeholder=durable_placeholder,
+            reservation_cost=reservation_cost,
+            subtype=error_subtype,
+        )
         await ledger_repo.update_placeholder(
             session,
             llm_call_id=placeholder_row.id,
-            cost_usd=Decimal("0"),
+            cost_usd=failure_cost,
             response_hash=None,
             tokens_in=0,
             tokens_out=0,
@@ -881,22 +1001,28 @@ async def synthesize_answer(
         )
         return Abstention(
             reason="provider_error",
-            cost_usd=Decimal("0"),
+            cost_usd=failure_cost,
             llm_call_id=placeholder_row.id,
         )
     except Exception as exc:
+        error_subtype = _safe_qa_provider_error_subtype(exc)
         logger.error(
             "qa_llm_provider_failed",
             extra={
                 "error_class": type(exc).__name__,
-                "error_subtype": _safe_qa_provider_error_subtype(exc),
+                "error_subtype": error_subtype,
             },
         )
         latency = int((time.monotonic() - started) * 1000)
+        failure_cost = _ambiguous_provider_error_cost(
+            durable_placeholder=durable_placeholder,
+            reservation_cost=reservation_cost,
+            subtype=error_subtype,
+        )
         await ledger_repo.update_placeholder(
             session,
             llm_call_id=placeholder_row.id,
-            cost_usd=Decimal("0"),
+            cost_usd=failure_cost,
             response_hash=None,
             tokens_in=0,
             tokens_out=0,
@@ -906,19 +1032,59 @@ async def synthesize_answer(
         )
         return Abstention(
             reason="provider_error",
-            cost_usd=Decimal("0"),
+            cost_usd=failure_cost,
             llm_call_id=placeholder_row.id,
         )
 
+    if revalidate_after_provider:
+        post_provider_bundle, post_provider_tombstones = await _filter_governed_evidence(
+            session,
+            governed_bundle,
+            max_evidence_items=max_evidence_items,
+        )
+        post_provider_ids = tuple(item.message_version_id for item in post_provider_bundle.items)
+        if post_provider_ids != ordered_surviving_ids:
+            latency = int((time.monotonic() - started) * 1000)
+            revalidation_cost = _estimate_cost(
+                config=config,
+                tokens_in=provider_result.tokens_in,
+                tokens_out=provider_result.tokens_out,
+            )
+            for vid in post_provider_tombstones:
+                await cache_repo.invalidate_by_citation(
+                    session,
+                    message_version_id=vid,
+                )
+            reason: AbstentionReason = (
+                "forget_invalidated" if post_provider_tombstones else "all_filtered"
+            )
+            await ledger_repo.update_placeholder(
+                session,
+                llm_call_id=placeholder_row.id,
+                cost_usd=revalidation_cost,
+                response_hash=None,
+                tokens_in=provider_result.tokens_in,
+                tokens_out=provider_result.tokens_out,
+                request_id=_safe_qa_request_id(provider_result.request_id),
+                latency_ms=latency,
+                error=f"{reason}_after_provider",
+            )
+            return Abstention(
+                reason=reason,
+                cost_usd=revalidation_cost,
+                llm_call_id=placeholder_row.id,
+            )
+
+    provider_result_cost = _estimate_cost(
+        config=config,
+        tokens_in=provider_result.tokens_in,
+        tokens_out=provider_result.tokens_out,
+    )
     request_id = _safe_qa_request_id(provider_result.request_id)
     answer_text = provider_result.answer_text
     if _contains_sensitive_qa_output(answer_text):
         latency = int((time.monotonic() - started) * 1000)
-        sensitive_output_cost = _estimate_cost(
-            config=config,
-            tokens_in=provider_result.tokens_in,
-            tokens_out=provider_result.tokens_out,
-        )
+        sensitive_output_cost = provider_result_cost
         await ledger_repo.update_placeholder(
             session,
             llm_call_id=placeholder_row.id,
@@ -936,6 +1102,26 @@ async def synthesize_answer(
             llm_call_id=placeholder_row.id,
         )
 
+    if answer_text.strip() == "INSUFFICIENT_EVIDENCE":
+        latency = int((time.monotonic() - started) * 1000)
+        abstention_cost = provider_result_cost
+        await ledger_repo.update_placeholder(
+            session,
+            llm_call_id=placeholder_row.id,
+            cost_usd=abstention_cost,
+            response_hash=_response_hash(answer_text),
+            tokens_in=provider_result.tokens_in,
+            tokens_out=provider_result.tokens_out,
+            request_id=request_id,
+            latency_ms=latency,
+            error="insufficient_evidence",
+        )
+        return Abstention(
+            reason="insufficient_evidence",
+            cost_usd=abstention_cost,
+            llm_call_id=placeholder_row.id,
+        )
+
     # F5 — defensive abort when provider returns empty citation_ids while
     # bundle has surviving evidence. The real AnthropicProvider /
     # OpenAIProvider currently return ``tuple()`` unconditionally (T5-04
@@ -949,7 +1135,7 @@ async def synthesize_answer(
         await ledger_repo.update_placeholder(
             session,
             llm_call_id=placeholder_row.id,
-            cost_usd=Decimal("0"),
+            cost_usd=provider_result_cost,
             response_hash=_response_hash(answer_text),
             tokens_in=provider_result.tokens_in,
             tokens_out=provider_result.tokens_out,
@@ -959,7 +1145,7 @@ async def synthesize_answer(
         )
         return Abstention(
             reason="provider_error",
-            cost_usd=Decimal("0"),
+            cost_usd=provider_result_cost,
             llm_call_id=placeholder_row.id,
         )
 
@@ -972,7 +1158,7 @@ async def synthesize_answer(
         await ledger_repo.update_placeholder(
             session,
             llm_call_id=placeholder_row.id,
-            cost_usd=Decimal("0"),
+            cost_usd=provider_result_cost,
             response_hash=_response_hash(answer_text),
             tokens_in=provider_result.tokens_in,
             tokens_out=provider_result.tokens_out,
@@ -982,17 +1168,13 @@ async def synthesize_answer(
         )
         return Abstention(
             reason="provider_error",
-            cost_usd=Decimal("0"),
+            cost_usd=provider_result_cost,
             llm_call_id=placeholder_row.id,
         )
 
     # Success — persist cache row (with surviving_ids in citation_ids JSONB,
     # NOT the pre-filter bundle.evidence_ids) + UPDATE placeholder + return.
-    cost_usd = _estimate_cost(
-        config=config,
-        tokens_in=provider_result.tokens_in,
-        tokens_out=provider_result.tokens_out,
-    )
+    cost_usd = provider_result_cost
     # F4-RACE-FIX (Codex round-2 HIGH-2): cache store may race with a
     # concurrent winner that also dispatched between unlock and store. The
     # ``input_hash`` UNIQUE constraint catches the duplicate; we treat it as
@@ -1010,7 +1192,7 @@ async def synthesize_answer(
                 session,
                 input_hash=cache_input_hash,
                 answer_text=answer_text,
-                citation_ids=list(provider_result.citation_ids),
+                citation_ids=list(full_provenance_ids),
                 model=config.model,
             )
     except IntegrityError:
@@ -1053,10 +1235,15 @@ async def synthesize_answer(
             )
             return AnswerWithCitations(
                 answer_text=existing_answer,
-                citation_ids=tuple(existing.citation_ids),
+                citation_ids=tuple(
+                    citation_id
+                    for citation_id in existing.citation_ids
+                    if citation_id in surviving_id_set
+                ),
                 cost_usd=cost_usd,
                 cache_hit=False,  # provider was called; we just lost the store race
                 llm_call_id=placeholder_row.id,
+                surviving_evidence_ids=ordered_surviving_ids,
             )
         # Race-recovery edge case (Codex round-3): IntegrityError fired but
         # the existing row is GONE by the time we re-fetch. Plausible
@@ -1104,24 +1291,182 @@ async def synthesize_answer(
         cost_usd=cost_usd,
         cache_hit=False,
         llm_call_id=placeholder_row.id,
+        surviving_evidence_ids=ordered_surviving_ids,
     )
 
 
 # ─── Internal SQL adapters ───────────────────────────────────────────────────
 
 
-async def _source_filter(session: AsyncSession, evidence_ids: list[int]) -> list[int]:
+async def _source_filter(
+    session: AsyncSession,
+    evidence_ids: list[int],
+    *,
+    chat_id: int,
+) -> list[int]:
     """Return surviving message_version_ids per invariant 2."""
     result = await session.execute(
         _SOURCE_FILTER_SQL,
         {
             "ids": evidence_ids,
-            "p_off": _POLICY_OFFRECORD,
-            "p_forgot": _POLICY_FORGOTTEN,
+            "chat_id": chat_id,
         },
     )
     rows = result.mappings().all()
     return [int(r["message_version_id"]) for r in rows]
+
+
+def _item_provenance_ids(item: EvidenceItem) -> tuple[int, ...]:
+    if item.source_type != "card":
+        return (item.message_version_id,)
+    return tuple(dict.fromkeys((item.message_version_id, *item.card_source_message_version_ids)))
+
+
+def _bundle_provenance_ids(items: Sequence[EvidenceItem]) -> tuple[int, ...]:
+    """Flatten full governed provenance while preserving deterministic order."""
+
+    return tuple(
+        dict.fromkeys(source_id for item in items for source_id in _item_provenance_ids(item))
+    )
+
+
+@asynccontextmanager
+async def hold_evidence_delivery_locks(
+    session: AsyncSession,
+    bundle: EvidenceBundle,
+) -> AsyncIterator[None]:
+    """Serialize final presentation with forget/edit/card-governance writers."""
+
+    from bot.db.models import ChatMessage, MessageVersion
+    from bot.services.advisory_locks import (
+        chat_message_advisory_key,
+        forget_target_advisory_key,
+        hold_session_advisory_locks,
+    )
+    from bot.services.forget_cascade import _p6_mvid_advisory_lock_id
+
+    provenance_ids = _bundle_provenance_ids(bundle.items)
+    metadata_result = await session.execute(
+        select(
+            MessageVersion.id,
+            MessageVersion.content_hash,
+            ChatMessage.id.label("chat_message_id"),
+            ChatMessage.user_id,
+            ChatMessage.chat_id,
+            ChatMessage.message_id,
+        )
+        .join(ChatMessage, ChatMessage.id == MessageVersion.chat_message_id)
+        .where(MessageVersion.id.in_(provenance_ids))
+    )
+    lock_keys: set[str] = set()
+    for row in metadata_result:
+        lock_keys.update(
+            {
+                chat_message_advisory_key(int(row.chat_id), int(row.message_id)),
+                forget_target_advisory_key("message", str(row.chat_message_id)),
+                forget_target_advisory_key("message_hash", str(row.content_hash)),
+            }
+        )
+        if row.user_id is not None:
+            lock_keys.add(forget_target_advisory_key("user", str(row.user_id)))
+    lock_ids = (_p6_mvid_advisory_lock_id(value) for value in provenance_ids)
+    async with hold_session_advisory_locks(
+        session,
+        lock_ids,
+        lock_keys=lock_keys,
+    ):
+        yield
+
+
+async def _filter_governed_evidence(
+    session: AsyncSession,
+    bundle: EvidenceBundle,
+    *,
+    max_evidence_items: int,
+) -> tuple[EvidenceBundle, tuple[int, ...]]:
+    """Return ordered, anchor-deduplicated evidence with full provenance valid."""
+
+    if not 1 <= max_evidence_items <= 8:
+        raise ValueError("max_evidence_items must be between 1 and 8")
+    # A card is eligible only when the current canonical row is approved and
+    # the bundle carries its exact complete, ordered source set.  This closes
+    # stale-search races where a card is archived or its provenance changes
+    # between retrieval and provider dispatch.
+    card_ids = list(
+        dict.fromkeys(
+            str(item.card_id)
+            for item in bundle.items
+            if item.source_type == "card" and item.card_id is not None
+        )
+    )
+    canonical_cards: dict[str, tuple[int, ...]] = {}
+    if card_ids:
+        card_result = await session.execute(
+            _APPROVED_CARD_PROVENANCE_SQL,
+            {"card_ids": card_ids},
+        )
+        canonical_cards = {
+            str(row["card_id"]): tuple(int(value) for value in row["source_ids"])
+            for row in card_result.mappings().all()
+        }
+
+    candidates: list[EvidenceItem] = []
+    for item in bundle.items:
+        if item.source_type == "card":
+            canonical = canonical_cards.get(str(item.card_id))
+            supplied = tuple(item.card_source_message_version_ids)
+            if not canonical or supplied != canonical or item.message_version_id != canonical[0]:
+                continue
+        candidates.append(item)
+
+    provenance_ids = list(_bundle_provenance_ids(candidates))
+    if not provenance_ids:
+        return EvidenceBundle(
+            query=bundle.query,
+            chat_id=bundle.chat_id,
+            items=(),
+            abstained=True,
+            created_at=bundle.created_at,
+        ), ()
+
+    source_survivors = set(await _source_filter(session, provenance_ids, chat_id=bundle.chat_id))
+    tombstoned = tuple(await _forget_tombstone_check(session, provenance_ids))
+    allowed_ids = source_survivors.difference(tombstoned)
+    selected: list[EvidenceItem] = []
+    selected_anchors: set[int] = set()
+    for item in candidates:
+        anchor = item.message_version_id
+        if anchor in selected_anchors:
+            continue
+        if not set(_item_provenance_ids(item)).issubset(allowed_ids):
+            continue
+        selected.append(item)
+        selected_anchors.add(anchor)
+        if len(selected) == max_evidence_items:
+            break
+    return EvidenceBundle(
+        query=bundle.query,
+        chat_id=bundle.chat_id,
+        items=tuple(selected),
+        abstained=not selected,
+        created_at=bundle.created_at,
+    ), tombstoned
+
+
+async def filter_surviving_evidence(
+    session: AsyncSession,
+    bundle: EvidenceBundle,
+    *,
+    max_evidence_items: int = MAX_QA_EVIDENCE_ITEMS,
+) -> EvidenceBundle:
+    """Public presentation fence using the same policy as provider dispatch."""
+
+    filtered, _tombstoned = await _filter_governed_evidence(
+        session,
+        bundle,
+        max_evidence_items=max_evidence_items,
+    )
+    return filtered
 
 
 async def _forget_tombstone_check(session: AsyncSession, evidence_ids: list[int]) -> list[int]:
@@ -1154,6 +1499,8 @@ async def _budget_check(
     session: AsyncSession,
     config: LLMGatewayConfig,
     ledger_repo: LedgerRepoProtocol,
+    *,
+    pending_cost: Decimal = Decimal("0"),
 ) -> bool:
     """Read daily / monthly cost totals via repo; return True iff over ceiling.
 
@@ -1169,9 +1516,17 @@ async def _budget_check(
     today = datetime.now(timezone.utc).date()
     daily_total = await ledger_repo.daily_cost_usd(session, day=today)
     monthly_total = await ledger_repo.monthly_cost_usd(session, year=today.year, month=today.month)
-    if daily_total >= config.daily_ceiling_usd:
+    if (
+        daily_total >= config.daily_ceiling_usd
+        if pending_cost == 0
+        else daily_total + pending_cost > config.daily_ceiling_usd
+    ):
         return True
-    if monthly_total >= config.monthly_ceiling_usd:
+    if (
+        monthly_total >= config.monthly_ceiling_usd
+        if pending_cost == 0
+        else monthly_total + pending_cost > config.monthly_ceiling_usd
+    ):
         return True
     return False
 
@@ -1192,6 +1547,9 @@ def _estimate_cost(*, config: LLMGatewayConfig, tokens_in: int, tokens_out: int)
     Adding a stop signal here (rather than raising) preserves the
     gatekeeper-immune invariant (#1 HANDOFF §1).
     """
+    if type(tokens_in) is not int or type(tokens_out) is not int or tokens_in < 0 or tokens_out < 0:
+        raise ValueError("token counts must be non-negative integers")
+
     from bot.services.llm_pricing import estimate_cost
 
     try:
@@ -1298,6 +1656,227 @@ def resolve_provider(
             json_output=deepseek_json_output,
         )
     raise ValueError(f"unknown provider: {provider_name}")
+
+
+def load_embedding_gateway_config() -> EmbeddingGatewayConfig:
+    """Load the fixed OpenAI semantic-embedding contract from environment."""
+
+    from bot.services.llm_providers.openai_embeddings import (
+        DEFAULT_OPENAI_EMBEDDING_MODEL,
+        OPENAI_EMBEDDING_DIMENSIONS,
+    )
+
+    model = os.environ.get("EMBEDDING_MODEL", DEFAULT_OPENAI_EMBEDDING_MODEL)
+    try:
+        dimensions = int(os.environ.get("EMBEDDING_DIMENSIONS", str(OPENAI_EMBEDDING_DIMENSIONS)))
+        daily = Decimal(os.environ.get("EMBEDDING_DAILY_USD_CEILING", "1.00"))
+        monthly = Decimal(os.environ.get("EMBEDDING_MONTHLY_USD_CEILING", "10.00"))
+    except (ValueError, ArithmeticError) as exc:
+        raise ValueError("invalid embedding gateway numeric configuration") from exc
+    if model != DEFAULT_OPENAI_EMBEDDING_MODEL:
+        raise ValueError("EMBEDDING_MODEL must be text-embedding-3-small")
+    if dimensions != OPENAI_EMBEDDING_DIMENSIONS:
+        raise ValueError("EMBEDDING_DIMENSIONS must be 1536")
+    if daily <= 0 or monthly <= 0:
+        raise ValueError("embedding spend ceilings must be positive")
+    return EmbeddingGatewayConfig(
+        model=model,
+        dimensions=dimensions,
+        daily_ceiling_usd=daily,
+        monthly_ceiling_usd=monthly,
+    )
+
+
+def _embedding_prompt_hash(*, inputs: Sequence[str], model: str, dimensions: int) -> str:
+    digest = hashlib.sha256()
+    digest.update(f"{model}:{dimensions}:".encode("ascii"))
+    for value in inputs:
+        encoded = value.encode("utf-8")
+        digest.update(len(encoded).to_bytes(8, "big"))
+        digest.update(encoded)
+    return digest.hexdigest()
+
+
+def _embedding_response_hash(vectors: tuple[tuple[float, ...], ...]) -> str:
+    payload = json.dumps(vectors, ensure_ascii=True, separators=(",", ":"))
+    return hashlib.sha256(payload.encode("ascii")).hexdigest()
+
+
+async def embed_texts(
+    session: AsyncSession,
+    *,
+    inputs: Sequence[str],
+    config: EmbeddingGatewayConfig,
+    ledger_repo: LedgerRepoProtocol,
+    provider: Any | None = None,
+    qa_trace_id: int | None = None,
+) -> EmbeddingGatewayResult:
+    """Create audited embeddings through the shared provider boundary.
+
+    The gateway commits the conservative ledger reservation while holding the
+    budget lock, so concurrent calls can observe it before either provider is
+    entered. The caller owns the final cost/result commit boundary.
+    """
+
+    from bot.services.llm_pricing import estimate_cost
+    from bot.services.llm_providers import ProviderStructuralError, ProviderTransientError
+    from bot.services.llm_providers.openai_embeddings import OpenAIEmbeddingsProvider
+
+    values = tuple(inputs)
+    if not values:
+        raise ValueError("embedding inputs must not be empty")
+    if config.dimensions != 1536 or config.model != "text-embedding-3-small":
+        raise ValueError("unsupported embedding gateway configuration")
+    if config.daily_ceiling_usd <= 0 or config.monthly_ceiling_usd <= 0:
+        raise ValueError("embedding spend ceilings must be positive")
+
+    prompt_hash = _embedding_prompt_hash(
+        inputs=values,
+        model=config.model,
+        dimensions=config.dimensions,
+    )
+    # A conservative pre-call reservation prevents a burst from bypassing the
+    # ceiling. Actual provider tokens replace this value after a response.
+    reservation_tokens = sum(len(value) for value in values)
+    reservation_cost = estimate_cost(
+        model=config.model,
+        tokens_in=reservation_tokens,
+        tokens_out=0,
+    )
+    today = datetime.now(timezone.utc).date()
+    placeholder_row: Any | None = None
+    budget_row: Any | None = None
+    await session.execute(_BUDGET_LOCK_XACT_SQL, {"lock_id": LLM_BUDGET_LOCK_ID})
+    try:
+        daily_total = await ledger_repo.daily_cost_usd(
+            session,
+            day=today,
+            call_type="semantic_embedding",
+        )
+        monthly_total = await ledger_repo.monthly_cost_usd(
+            session,
+            year=today.year,
+            month=today.month,
+            call_type="semantic_embedding",
+        )
+        if (
+            daily_total + reservation_cost > config.daily_ceiling_usd
+            or monthly_total + reservation_cost > config.monthly_ceiling_usd
+        ):
+            budget_row = await ledger_repo.record(
+                session,
+                qa_trace_id=qa_trace_id,
+                provider="openai",
+                model=config.model,
+                prompt_hash=prompt_hash,
+                response_hash=None,
+                tokens_in=0,
+                tokens_out=0,
+                cost_usd=Decimal("0"),
+                latency_ms=0,
+                request_id=None,
+                cache_hit=False,
+                error="budget_exceeded",
+                call_type="semantic_embedding",
+            )
+        else:
+            placeholder_row = await ledger_repo.record(
+                session,
+                qa_trace_id=qa_trace_id,
+                provider="openai",
+                model=config.model,
+                prompt_hash=prompt_hash,
+                response_hash=None,
+                tokens_in=0,
+                tokens_out=0,
+                cost_usd=reservation_cost,
+                latency_ms=0,
+                request_id=None,
+                cache_hit=False,
+                error="reserved_in_flight",
+                call_type="semantic_embedding",
+            )
+        # Publish the reservation and release the transaction-scoped lock.
+        await session.commit()
+    except Exception:
+        await session.rollback()
+        raise
+
+    if budget_row is not None:
+        raise EmbeddingBudgetExceeded(llm_usage_ledger_id=budget_row.id)
+    if placeholder_row is None:
+        raise RuntimeError("embedding ledger reservation was not created")
+
+    active_provider = provider or OpenAIEmbeddingsProvider()
+    started = _monotonic()
+    try:
+        provider_result = await active_provider.embed(
+            inputs=values,
+            model=config.model,
+            dimensions=config.dimensions,
+        )
+    except (ProviderTransientError, ProviderStructuralError) as exc:
+        subtype = _safe_qa_provider_error_subtype(exc)
+        terminal_cost = (
+            Decimal("0")
+            if subtype in {"auth", "bad_request", "model_not_found", "rate_limit"}
+            else reservation_cost
+        )
+        await ledger_repo.update_placeholder(
+            session,
+            llm_call_id=placeholder_row.id,
+            cost_usd=terminal_cost,
+            response_hash=None,
+            tokens_in=0,
+            tokens_out=0,
+            request_id=None,
+            latency_ms=int((_monotonic() - started) * 1000),
+            error=f"provider_{type(exc).__name__}:{subtype}",
+        )
+        await session.commit()
+        setattr(exc, "llm_usage_ledger_id", placeholder_row.id)
+        raise
+    except Exception as exc:
+        await ledger_repo.update_placeholder(
+            session,
+            llm_call_id=placeholder_row.id,
+            cost_usd=reservation_cost,
+            response_hash=None,
+            tokens_in=0,
+            tokens_out=0,
+            request_id=None,
+            latency_ms=int((_monotonic() - started) * 1000),
+            error=f"provider_unknown:{type(exc).__name__}",
+        )
+        await session.commit()
+        setattr(exc, "llm_usage_ledger_id", placeholder_row.id)
+        raise
+    cost = estimate_cost(
+        model=config.model,
+        tokens_in=provider_result.tokens_in,
+        tokens_out=0,
+    )
+    request_id = _safe_qa_request_id(provider_result.request_id)
+    await ledger_repo.update_placeholder(
+        session,
+        llm_call_id=placeholder_row.id,
+        cost_usd=cost,
+        response_hash=_embedding_response_hash(provider_result.vectors),
+        tokens_in=provider_result.tokens_in,
+        tokens_out=0,
+        request_id=request_id,
+        latency_ms=provider_result.raw_latency_ms,
+        error=None,
+    )
+    await session.commit()
+    return EmbeddingGatewayResult(
+        vectors=provider_result.vectors,
+        tokens_in=provider_result.tokens_in,
+        cost_usd=cost,
+        llm_usage_ledger_id=placeholder_row.id,
+        request_id=request_id or "",
+        latency_ms=provider_result.raw_latency_ms,
+    )
 
 
 def load_vision_gateway_config() -> VisionGatewayConfig:
@@ -4373,6 +4952,9 @@ __all__ = [
     "DigestEmptyWindowError",
     "DigestGatewayError",
     "DigestProviderError",
+    "EmbeddingBudgetExceeded",
+    "EmbeddingGatewayConfig",
+    "EmbeddingGatewayResult",
     "ExtractGraphTriplesResult",
     "GraphTriple",
     "LLM_BUDGET_LOCK_ID",
@@ -4398,6 +4980,10 @@ __all__ = [
     "_resolve_entity",
     "extract_candidates",
     "extract_graph_triples",
+    "embed_texts",
+    "filter_surviving_evidence",
+    "hold_evidence_delivery_locks",
+    "load_embedding_gateway_config",
     "load_gateway_config",
     "plan_butler_action",
     "resolve_provider",

--- a/bot/services/llm_gateway.py
+++ b/bot/services/llm_gateway.py
@@ -474,6 +474,8 @@ def _build_prompt(
 # ─── SQL fragments ──────────────────────────────────────────────────────────
 
 
+# Only the static _FORGET_EXCLUDES fragment is interpolated; runtime values are bound.
+# nosemgrep: python.sqlalchemy.security.audit.avoid-sqlalchemy-text.avoid-sqlalchemy-text
 _SOURCE_FILTER_SQL = text(
     f"""
     SELECT mv.id AS message_version_id

--- a/bot/services/llm_gateway.py
+++ b/bot/services/llm_gateway.py
@@ -1339,38 +1339,14 @@ async def hold_evidence_delivery_locks(
 ) -> AsyncIterator[None]:
     """Serialize final presentation with forget/edit/card-governance writers."""
 
-    from bot.db.models import ChatMessage, MessageVersion
     from bot.services.advisory_locks import (
-        chat_message_advisory_key,
-        forget_target_advisory_key,
+        governed_message_lock_keys,
         hold_session_advisory_locks,
     )
     from bot.services.forget_cascade import _p6_mvid_advisory_lock_id
 
     provenance_ids = _bundle_provenance_ids(bundle.items)
-    metadata_result = await session.execute(
-        select(
-            MessageVersion.id,
-            MessageVersion.content_hash,
-            ChatMessage.id.label("chat_message_id"),
-            ChatMessage.user_id,
-            ChatMessage.chat_id,
-            ChatMessage.message_id,
-        )
-        .join(ChatMessage, ChatMessage.id == MessageVersion.chat_message_id)
-        .where(MessageVersion.id.in_(provenance_ids))
-    )
-    lock_keys: set[str] = set()
-    for row in metadata_result:
-        lock_keys.update(
-            {
-                chat_message_advisory_key(int(row.chat_id), int(row.message_id)),
-                forget_target_advisory_key("message", str(row.chat_message_id)),
-                forget_target_advisory_key("message_hash", str(row.content_hash)),
-            }
-        )
-        if row.user_id is not None:
-            lock_keys.add(forget_target_advisory_key("user", str(row.user_id)))
+    lock_keys = await governed_message_lock_keys(session, provenance_ids)
     lock_ids = (_p6_mvid_advisory_lock_id(value) for value in provenance_ids)
     async with hold_session_advisory_locks(
         session,

--- a/bot/services/llm_pricing.py
+++ b/bot/services/llm_pricing.py
@@ -61,6 +61,11 @@ MODEL_PRICING: dict[str, ModelPricing] = {
         input_per_million_tokens_usd=Decimal("0.05"),
         output_per_million_tokens_usd=Decimal("0.40"),
     ),
+    # OpenAI model catalog, verified 2026-07-16: $0.02 / 1M input tokens.
+    "text-embedding-3-small": ModelPricing(
+        input_per_million_tokens_usd=Decimal("0.02"),
+        output_per_million_tokens_usd=Decimal("0"),
+    ),
 }
 
 

--- a/bot/services/llm_providers/deepseek.py
+++ b/bot/services/llm_providers/deepseek.py
@@ -88,11 +88,20 @@ class DeepSeekProvider:
         try:
             payload: dict[str, Any] = response.json()
             answer_text = payload["choices"][0]["message"]["content"]
-            usage = payload.get("usage") or {}
+            usage = payload["usage"]
             if not isinstance(answer_text, str):
                 raise TypeError("content must be a string")
-            tokens_in = int(usage.get("prompt_tokens", 0))
-            tokens_out = int(usage.get("completion_tokens", 0))
+            if not isinstance(usage, dict):
+                raise TypeError("usage must be an object")
+            tokens_in = usage["prompt_tokens"]
+            tokens_out = usage["completion_tokens"]
+            if (
+                type(tokens_in) is not int
+                or type(tokens_out) is not int
+                or tokens_in < 0
+                or tokens_out < 0
+            ):
+                raise TypeError("usage token counts must be non-negative integers")
         except (KeyError, IndexError, TypeError, ValueError) as exc:
             raise ProviderStructuralError(
                 "contract_violation",

--- a/bot/services/llm_providers/openai_embeddings.py
+++ b/bot/services/llm_providers/openai_embeddings.py
@@ -1,0 +1,264 @@
+"""Strict OpenAI embeddings adapter for semantic community-memory retrieval."""
+
+from __future__ import annotations
+
+import math
+import os
+import time
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+from . import ProviderStructuralError, ProviderTransientError
+
+
+DEFAULT_OPENAI_EMBEDDING_MODEL = "text-embedding-3-small"
+OPENAI_EMBEDDINGS_BASE_URL = "https://api.openai.com/v1/"
+OPENAI_EMBEDDING_DIMENSIONS = 1536
+
+# Product-side request bounds.  They deliberately stay below the provider's
+# account-dependent limits so one malformed retrieval unit cannot create an
+# unbounded payload or monopolise a worker.
+MAX_EMBEDDING_BATCH_SIZE = 100
+MAX_EMBEDDING_INPUT_CHARS = 8_000
+MAX_EMBEDDING_BATCH_CHARS = 64_000
+
+
+@dataclass(frozen=True, slots=True)
+class EmbeddingResult:
+    vectors: tuple[tuple[float, ...], ...]
+    tokens_in: int
+    request_id: str
+    raw_latency_ms: int
+
+
+class OpenAIEmbeddingsProvider:
+    """Create ordered 1536-dimensional embeddings without retries or fallback."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        client: httpx.AsyncClient | None = None,
+    ) -> None:
+        self._api_key = api_key
+        self._client = client
+
+    async def embed(
+        self,
+        *,
+        inputs: Sequence[str],
+        model: str = DEFAULT_OPENAI_EMBEDDING_MODEL,
+        dimensions: int = OPENAI_EMBEDDING_DIMENSIONS,
+    ) -> EmbeddingResult:
+        normalized_inputs = self._validate_request(
+            inputs=inputs,
+            model=model,
+            dimensions=dimensions,
+        )
+
+        api_key = self._api_key
+        if api_key is None:
+            api_key = os.environ.get("OPENAI_API_KEY")
+        if not api_key:
+            raise ProviderStructuralError("auth", message="OPENAI_API_KEY is missing")
+
+        owns_client = self._client is None
+        client = self._client or httpx.AsyncClient(
+            base_url=OPENAI_EMBEDDINGS_BASE_URL,
+            timeout=httpx.Timeout(30.0, connect=10.0),
+        )
+        started = time.monotonic()
+        try:
+            response = await client.post(
+                "embeddings",
+                headers={"Authorization": f"Bearer {api_key}"},
+                json={
+                    "model": model,
+                    "input": list(normalized_inputs),
+                    "dimensions": dimensions,
+                    "encoding_format": "float",
+                },
+            )
+        except httpx.TimeoutException as exc:
+            raise ProviderTransientError(
+                "timeout",
+                message="OpenAI embeddings request timed out",
+            ) from exc
+        except httpx.TransportError as exc:
+            raise ProviderTransientError(
+                "connection_reset",
+                message="OpenAI embeddings network request failed",
+            ) from exc
+        finally:
+            if owns_client:
+                await client.aclose()
+
+        self._raise_for_status(response)
+        vectors, tokens_in = self._parse_response(
+            response=response,
+            expected_count=len(normalized_inputs),
+            expected_model=model,
+            dimensions=dimensions,
+        )
+        return EmbeddingResult(
+            vectors=vectors,
+            tokens_in=tokens_in,
+            request_id=response.headers.get("x-request-id", ""),
+            raw_latency_ms=int((time.monotonic() - started) * 1000),
+        )
+
+    @staticmethod
+    def _validate_request(
+        *,
+        inputs: Sequence[str],
+        model: str,
+        dimensions: int,
+    ) -> tuple[str, ...]:
+        if isinstance(inputs, (str, bytes)) or not isinstance(inputs, Sequence):
+            raise ProviderStructuralError(
+                "bad_request",
+                message="embedding inputs must be a sequence of strings",
+            )
+        values = tuple(inputs)
+        if not values:
+            raise ProviderStructuralError(
+                "bad_request",
+                message="embedding inputs must not be empty",
+            )
+        if len(values) > MAX_EMBEDDING_BATCH_SIZE:
+            raise ProviderStructuralError(
+                "bad_request",
+                message=f"embedding batch exceeds {MAX_EMBEDDING_BATCH_SIZE} inputs",
+            )
+        if model != DEFAULT_OPENAI_EMBEDDING_MODEL:
+            raise ProviderStructuralError(
+                "model_not_found",
+                message="unsupported OpenAI embedding model",
+            )
+        if type(dimensions) is not int or dimensions != OPENAI_EMBEDDING_DIMENSIONS:
+            raise ProviderStructuralError(
+                "bad_request",
+                message=f"embedding dimensions must equal {OPENAI_EMBEDDING_DIMENSIONS}",
+            )
+
+        total_chars = 0
+        for index, value in enumerate(values):
+            if not isinstance(value, str):
+                raise ProviderStructuralError(
+                    "bad_request",
+                    message=f"embedding input at index {index} must be a string",
+                )
+            if not value.strip():
+                raise ProviderStructuralError(
+                    "bad_request",
+                    message=f"embedding input at index {index} must not be blank",
+                )
+            if len(value) > MAX_EMBEDDING_INPUT_CHARS:
+                raise ProviderStructuralError(
+                    "bad_request",
+                    message=(
+                        f"embedding input at index {index} exceeds "
+                        f"{MAX_EMBEDDING_INPUT_CHARS} characters"
+                    ),
+                )
+            total_chars += len(value)
+
+        if total_chars > MAX_EMBEDDING_BATCH_CHARS:
+            raise ProviderStructuralError(
+                "bad_request",
+                message=f"embedding batch exceeds {MAX_EMBEDDING_BATCH_CHARS} characters",
+            )
+        return values
+
+    @staticmethod
+    def _raise_for_status(response: httpx.Response) -> None:
+        status = response.status_code
+        if 200 <= status < 300:
+            return
+        if status in (401, 403):
+            raise ProviderStructuralError("auth", message="OpenAI authentication failed")
+        if status == 404:
+            raise ProviderStructuralError(
+                "model_not_found",
+                message="OpenAI embeddings endpoint or model was not found",
+            )
+        if status == 429:
+            raise ProviderTransientError("rate_limit", message="OpenAI rate limit exceeded")
+        if status >= 500:
+            raise ProviderTransientError("5xx", message="OpenAI service unavailable")
+        raise ProviderStructuralError(
+            "bad_request",
+            message="OpenAI rejected embeddings request",
+        )
+
+    @staticmethod
+    def _parse_response(
+        *,
+        response: httpx.Response,
+        expected_count: int,
+        expected_model: str,
+        dimensions: int,
+    ) -> tuple[tuple[tuple[float, ...], ...], int]:
+        try:
+            body: Any = response.json()
+            if not isinstance(body, dict) or body.get("object") != "list":
+                raise TypeError("response must be an embedding list")
+            if body.get("model") != expected_model:
+                raise ValueError("response model does not match request")
+
+            data = body.get("data")
+            if not isinstance(data, list) or len(data) != expected_count:
+                raise ValueError("response embedding count does not match request")
+
+            parsed_vectors: list[tuple[float, ...]] = []
+            for expected_index, item in enumerate(data):
+                if not isinstance(item, dict) or item.get("object") != "embedding":
+                    raise TypeError("response item must be an embedding object")
+                index = item.get("index")
+                if type(index) is not int or index != expected_index:
+                    raise ValueError("response embedding order does not match request")
+                raw_vector = item.get("embedding")
+                if not isinstance(raw_vector, list) or len(raw_vector) != dimensions:
+                    raise ValueError("response embedding dimensions do not match request")
+
+                vector: list[float] = []
+                for value in raw_vector:
+                    if isinstance(value, bool) or not isinstance(value, (int, float)):
+                        raise TypeError("embedding value must be numeric")
+                    numeric = float(value)
+                    if not math.isfinite(numeric):
+                        raise ValueError("embedding value must be finite")
+                    vector.append(numeric)
+                parsed_vectors.append(tuple(vector))
+
+            usage = body.get("usage")
+            if not isinstance(usage, dict):
+                raise TypeError("response usage must be an object")
+            tokens_in = usage.get("prompt_tokens")
+            total_tokens = usage.get("total_tokens")
+            if type(tokens_in) is not int or tokens_in < 0:
+                raise ValueError("prompt_tokens must be a non-negative integer")
+            if type(total_tokens) is not int or total_tokens < tokens_in:
+                raise ValueError("total_tokens must be an integer not below prompt_tokens")
+        except (OverflowError, TypeError, ValueError) as exc:
+            raise ProviderStructuralError(
+                "contract_violation",
+                message="OpenAI embeddings response did not match the expected contract",
+            ) from exc
+
+        return tuple(parsed_vectors), tokens_in
+
+
+__all__ = [
+    "DEFAULT_OPENAI_EMBEDDING_MODEL",
+    "EmbeddingResult",
+    "MAX_EMBEDDING_BATCH_CHARS",
+    "MAX_EMBEDDING_BATCH_SIZE",
+    "MAX_EMBEDDING_INPUT_CHARS",
+    "OPENAI_EMBEDDING_DIMENSIONS",
+    "OPENAI_EMBEDDINGS_BASE_URL",
+    "OpenAIEmbeddingsProvider",
+]

--- a/bot/services/qa.py
+++ b/bot/services/qa.py
@@ -1,17 +1,63 @@
 from __future__ import annotations
 
+import hashlib
+import logging
 from dataclasses import dataclass
+from decimal import Decimal
 
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from bot.db.models import SemanticRetrievalTrace
+from bot.db.repos.llm_usage_ledger import LedgerRepo
+from bot.db.repos.qa_trace import QaTraceRepo
+from bot.db.repos.semantic_quota import SemanticQuotaRepo
 from bot.services.evidence import EvidenceBundle
+from bot.services.llm_gateway import embed_texts, load_embedding_gateway_config
+from bot.services.semantic_index import HybridSearchResult, hybrid_search
 from bot.services.search import search_messages
+
+
+logger = logging.getLogger(__name__)
+
+
+def _semantic_evidence_provenance_ids(bundle: EvidenceBundle) -> list[int]:
+    """Persist every card source in the privacy-cascade audit binding."""
+
+    return list(
+        dict.fromkeys(
+            source_id
+            for item in bundle.items
+            for source_id in (
+                (item.message_version_id, *item.card_source_message_version_ids)
+                if item.source_type == "card"
+                else (item.message_version_id,)
+            )
+        )
+    )
 
 
 @dataclass(frozen=True)
 class QaResult:
     bundle: EvidenceBundle
     query_redacted: bool
+
+
+@dataclass(frozen=True)
+class SemanticQaResult:
+    bundle: EvidenceBundle
+    query_redacted: bool
+    embedding_llm_call_id: int
+    embedding_cost_usd: Decimal
+    retrieval: HybridSearchResult
+
+
+class SemanticRetrievalError(RuntimeError):
+    """Expected database failure after a paid embedding was durably audited."""
+
+    def __init__(self, *, embedding_llm_call_id: int) -> None:
+        super().__init__("semantic hybrid retrieval failed")
+        self.embedding_llm_call_id = embedding_llm_call_id
 
 
 async def run_qa(
@@ -21,7 +67,108 @@ async def run_qa(
     chat_id: int,
     redact_query_in_audit: bool,
     limit: int = 3,
+    exclude_chat_message_id: int | None = None,
+    human_only: bool = False,
 ) -> QaResult:
-    hits = await search_messages(session, query, chat_id=chat_id, limit=limit)
+    hits = await search_messages(
+        session,
+        query,
+        chat_id=chat_id,
+        limit=limit,
+        exclude_chat_message_id=exclude_chat_message_id,
+        human_only=human_only,
+    )
     bundle = EvidenceBundle.from_hits(query, chat_id, hits)
     return QaResult(bundle=bundle, query_redacted=redact_query_in_audit)
+
+
+async def run_semantic_qa(
+    session: AsyncSession,
+    *,
+    query: str,
+    chat_id: int,
+    redact_query_in_audit: bool,
+    attempt_id: int,
+    qa_trace_id: int,
+    exclude_chat_message_id: int | None,
+    provider=None,
+) -> SemanticQaResult:
+    """Run one admitted query through embedding and governed hybrid retrieval."""
+
+    config = load_embedding_gateway_config()
+    embedding = await embed_texts(
+        session,
+        inputs=[query],
+        config=config,
+        ledger_repo=LedgerRepo(),
+        provider=provider,
+        qa_trace_id=qa_trace_id,
+    )
+    await SemanticQuotaRepo.attach_embedding_call(
+        session,
+        attempt_id=attempt_id,
+        embedding_llm_call_id=embedding.llm_usage_ledger_id,
+    )
+    # Preserve both the paid ledger and its attempt link before retrieval.
+    await session.commit()
+    try:
+        retrieval = await hybrid_search(
+            session,
+            query=query,
+            query_embedding=embedding.vectors[0],
+            chat_id=chat_id,
+            embedding_model=config.model,
+            exclude_chat_message_id=exclude_chat_message_id,
+        )
+        bundle = EvidenceBundle.from_hits(query, chat_id, list(retrieval.hits))
+        await QaTraceRepo.update_retrieval_fields(
+            session,
+            qa_trace_id=qa_trace_id,
+            evidence_ids=_semantic_evidence_provenance_ids(bundle),
+            abstained=bundle.abstained,
+        )
+        trace = SemanticRetrievalTrace(
+            attempt_id=attempt_id,
+            qa_trace_id=qa_trace_id,
+            query_hash=hashlib.sha256(query.encode("utf-8")).hexdigest(),
+            embedding_model=config.model,
+            retrieval_mode="hybrid",
+            candidate_ranks=retrieval.candidate_ranks,
+            result_source_ids=[
+                f"{item.source_type}:{item.card_id if item.source_type == 'card' else item.message_version_id}"
+                for item in retrieval.hits
+            ],
+            fts_latency_ms=retrieval.fts_latency_ms,
+            vector_latency_ms=retrieval.vector_latency_ms,
+            fusion_latency_ms=retrieval.fusion_latency_ms,
+            total_latency_ms=retrieval.total_latency_ms,
+        )
+        session.add(trace)
+        await session.flush()
+    except SQLAlchemyError as exc:
+        logger.error(
+            "semantic_qa_retrieval_failed",
+            extra={
+                "attempt_id": attempt_id,
+                "chat_id": chat_id,
+                "error_class": type(exc).__name__,
+            },
+        )
+        await session.rollback()
+        raise SemanticRetrievalError(embedding_llm_call_id=embedding.llm_usage_ledger_id) from exc
+    return SemanticQaResult(
+        bundle=bundle,
+        query_redacted=redact_query_in_audit,
+        embedding_llm_call_id=embedding.llm_usage_ledger_id,
+        embedding_cost_usd=embedding.cost_usd,
+        retrieval=retrieval,
+    )
+
+
+__all__ = [
+    "QaResult",
+    "SemanticQaResult",
+    "SemanticRetrievalError",
+    "run_qa",
+    "run_semantic_qa",
+]

--- a/bot/services/qa.py
+++ b/bot/services/qa.py
@@ -49,6 +49,7 @@ class SemanticQaResult:
     query_redacted: bool
     embedding_llm_call_id: int
     embedding_cost_usd: Decimal
+    embedding_model: str
     retrieval: HybridSearchResult
 
 
@@ -121,30 +122,6 @@ async def run_semantic_qa(
             exclude_chat_message_id=exclude_chat_message_id,
         )
         bundle = EvidenceBundle.from_hits(query, chat_id, list(retrieval.hits))
-        await QaTraceRepo.update_retrieval_fields(
-            session,
-            qa_trace_id=qa_trace_id,
-            evidence_ids=_semantic_evidence_provenance_ids(bundle),
-            abstained=bundle.abstained,
-        )
-        trace = SemanticRetrievalTrace(
-            attempt_id=attempt_id,
-            qa_trace_id=qa_trace_id,
-            query_hash=hashlib.sha256(query.encode("utf-8")).hexdigest(),
-            embedding_model=config.model,
-            retrieval_mode="hybrid",
-            candidate_ranks=retrieval.candidate_ranks,
-            result_source_ids=[
-                f"{item.source_type}:{item.card_id if item.source_type == 'card' else item.message_version_id}"
-                for item in retrieval.hits
-            ],
-            fts_latency_ms=retrieval.fts_latency_ms,
-            vector_latency_ms=retrieval.vector_latency_ms,
-            fusion_latency_ms=retrieval.fusion_latency_ms,
-            total_latency_ms=retrieval.total_latency_ms,
-        )
-        session.add(trace)
-        await session.flush()
     except SQLAlchemyError as exc:
         logger.error(
             "semantic_qa_retrieval_failed",
@@ -161,8 +138,57 @@ async def run_semantic_qa(
         query_redacted=redact_query_in_audit,
         embedding_llm_call_id=embedding.llm_usage_ledger_id,
         embedding_cost_usd=embedding.cost_usd,
+        embedding_model=config.model,
         retrieval=retrieval,
     )
+
+
+def _semantic_source_key(item) -> str:
+    return (
+        f"card:{item.card_id}"
+        if item.source_type == "card"
+        else f"message:{item.message_version_id}"
+    )
+
+
+async def persist_semantic_retrieval_trace(
+    session: AsyncSession,
+    *,
+    result: SemanticQaResult,
+    query: str,
+    attempt_id: int,
+    qa_trace_id: int,
+) -> SemanticRetrievalTrace:
+    """Persist only the governed final-result ranks under the caller's union fence."""
+
+    result_source_ids = [_semantic_source_key(item) for item in result.bundle.items]
+    selected_ranks = {
+        source_id: result.retrieval.candidate_ranks[source_id]
+        for source_id in result_source_ids
+        if source_id in result.retrieval.candidate_ranks
+    }
+    await QaTraceRepo.update_retrieval_fields(
+        session,
+        qa_trace_id=qa_trace_id,
+        evidence_ids=_semantic_evidence_provenance_ids(result.bundle),
+        abstained=result.bundle.abstained,
+    )
+    trace = SemanticRetrievalTrace(
+        attempt_id=attempt_id,
+        qa_trace_id=qa_trace_id,
+        query_hash=hashlib.sha256(query.encode("utf-8")).hexdigest(),
+        embedding_model=result.embedding_model,
+        retrieval_mode="hybrid",
+        candidate_ranks=selected_ranks,
+        result_source_ids=result_source_ids,
+        fts_latency_ms=result.retrieval.fts_latency_ms,
+        vector_latency_ms=result.retrieval.vector_latency_ms,
+        fusion_latency_ms=result.retrieval.fusion_latency_ms,
+        total_latency_ms=result.retrieval.total_latency_ms,
+    )
+    session.add(trace)
+    await session.flush()
+    return trace
 
 
 __all__ = [
@@ -171,4 +197,5 @@ __all__ = [
     "SemanticRetrievalError",
     "run_qa",
     "run_semantic_qa",
+    "persist_semantic_retrieval_trace",
 ]

--- a/bot/services/scheduler.py
+++ b/bot/services/scheduler.py
@@ -46,6 +46,7 @@ PHOTO_DESCRIPTION_FEATURE_FLAG = "memory.images.description.enabled"
 AUTO_PROMOTION_FEATURE_FLAG = "memory.candidates.auto_promote.enabled"
 WIKI_COMPILER_FEATURE_FLAG = "memory.wiki.compiler.enabled"
 WIKI_STATIC_PUBLISH_FEATURE_FLAG = "memory.wiki.static_publish.enabled"
+SEMANTIC_QA_FEATURE_FLAG = "memory.qa.semantic.enabled"
 DEEPSEEK_EXTRACTION_MAX_TOKENS = 8_192
 DEEPSEEK_DIGEST_MAX_TOKENS = 4_096
 DEEPSEEK_WIKI_MAX_TOKENS = 8_192
@@ -374,6 +375,60 @@ async def run_extraction_scheduler_tick() -> None:
                 logger.exception("candidate_auto_promotion failed")
     except Exception:
         logger.exception("candidate_auto_promotion session setup failed")
+
+
+async def run_semantic_index_tick() -> None:
+    """Reconcile current governed sources while semantic Q&A is enabled."""
+
+    from bot.db.repos.feature_flag import FeatureFlagRepo
+    from bot.services.llm_gateway import (
+        EmbeddingBudgetExceeded,
+        load_embedding_gateway_config,
+    )
+    from bot.services.llm_providers import (
+        ProviderStructuralError,
+        ProviderTransientError,
+    )
+    from bot.services.semantic_index import backfill_semantic_index
+
+    try:
+        async with async_session() as session:
+            if not await FeatureFlagRepo.get(session, SEMANTIC_QA_FEATURE_FLAG):
+                return
+            try:
+                report = await backfill_semantic_index(
+                    session,
+                    config=load_embedding_gateway_config(),
+                    chat_id=settings.COMMUNITY_CHAT_ID,
+                )
+            except (
+                EmbeddingBudgetExceeded,
+                ProviderStructuralError,
+                ProviderTransientError,
+                SQLAlchemyError,
+                ValueError,
+            ) as exc:
+                await session.rollback()
+                logger.error(
+                    "semantic_index_tick_failed",
+                    extra={"error_class": type(exc).__name__},
+                )
+                return
+            logger.info(
+                "semantic_index_tick_completed",
+                extra={
+                    "run_id": report.run_id,
+                    "eligible": report.eligible,
+                    "indexed": report.indexed,
+                    "skipped": report.skipped,
+                    "failed": report.failed,
+                },
+            )
+    except SQLAlchemyError as exc:
+        logger.error(
+            "semantic_index_tick_session_failed",
+            extra={"error_class": type(exc).__name__},
+        )
 
 
 async def wiki_automation_job() -> None:
@@ -1289,6 +1344,16 @@ def start_scheduler(bot: Bot) -> None:
         "interval",
         minutes=15,
         id="extraction_scheduler_tick",
+        replace_existing=True,
+        max_instances=1,
+        coalesce=True,
+        misfire_grace_time=60,
+    )
+    scheduler.add_job(
+        run_semantic_index_tick,
+        "interval",
+        minutes=15,
+        id="semantic_index_tick",
         replace_existing=True,
         max_instances=1,
         coalesce=True,

--- a/bot/services/scheduler.py
+++ b/bot/services/scheduler.py
@@ -393,7 +393,7 @@ async def run_semantic_index_tick() -> None:
 
     try:
         async with async_session() as session:
-            if not await FeatureFlagRepo.get(session, SEMANTIC_QA_FEATURE_FLAG):
+            if not await FeatureFlagRepo.any_enabled(session, SEMANTIC_QA_FEATURE_FLAG):
                 return
             try:
                 report = await backfill_semantic_index(

--- a/bot/services/scheduler.py
+++ b/bot/services/scheduler.py
@@ -389,7 +389,7 @@ async def run_semantic_index_tick() -> None:
         ProviderStructuralError,
         ProviderTransientError,
     )
-    from bot.services.semantic_index import backfill_semantic_index
+    from bot.services.semantic_index import EmbeddingClaimUnresolved, backfill_semantic_index
 
     try:
         async with async_session() as session:
@@ -402,6 +402,7 @@ async def run_semantic_index_tick() -> None:
                     chat_id=settings.COMMUNITY_CHAT_ID,
                 )
             except (
+                EmbeddingClaimUnresolved,
                 EmbeddingBudgetExceeded,
                 ProviderStructuralError,
                 ProviderTransientError,

--- a/bot/services/search.py
+++ b/bot/services/search.py
@@ -23,8 +23,7 @@ The default is ``include_cards=True`` per PHASE6_PLAN.md §5.D; passing
 ``include_cards=False`` preserves Phase 4 behaviour byte-for-byte (literal
 copy of the Phase 4 SQL, no UNION).
 
-``SearchHit`` gains three defaulted fields (``source_type`` /
-``card_id`` / ``card_source_message_version_ids``) so existing callers
+``SearchHit`` gains reply/thread metadata as defaulted fields so existing callers
 treating hits as message-shape see no breaking change. For card hits the
 ``message_version_id`` / ``chat_message_id`` / ``chat_id`` / ``message_id``
 columns point at the anchor source (lowest-position ``card_sources`` row)
@@ -72,6 +71,9 @@ class SearchHit:
     source_type: Literal["message", "card"] = "message"
     card_id: uuid.UUID | None = None
     card_source_message_version_ids: tuple[int, ...] = field(default_factory=tuple)
+    message_thread_id: int | None = None
+    reply_to_message_id: int | None = None
+    conversation_root_message_id: int | None = None
 
 
 # ─── Phase 4 SQL — preserved verbatim for ``include_cards=False`` callers ────
@@ -237,6 +239,8 @@ message_hits AS (
         ) AS rank,
         mv.captured_at AS captured_at,
         c.date AS message_date,
+        c.message_thread_id AS message_thread_id,
+        c.reply_to_message_id AS reply_to_message_id,
         'message'::text AS source_type,
         NULL::uuid AS card_id,
         ARRAY[]::int[] AS card_source_message_version_ids
@@ -244,9 +248,21 @@ message_hits AS (
     JOIN chat_messages AS c
         ON c.id = mv.chat_message_id
         AND c.current_version_id = mv.id
+    LEFT JOIN users AS author ON author.id = c.user_id
     LEFT JOIN message_media AS mm ON mm.chat_message_id = c.id
     CROSS JOIN q
     WHERE c.chat_id = :chat_id
+        AND (
+            CAST(:exclude_chat_message_id AS bigint) IS NULL
+            OR c.id <> CAST(:exclude_chat_message_id AS bigint)
+        )
+        AND (
+            CAST(:human_only AS boolean) = FALSE
+            OR (
+                author.is_bot = FALSE
+                AND COALESCE(c.message_kind, 'text') NOT IN ('voice', 'audio')
+            )
+        )
         AND c.memory_policy = 'normal'
         AND c.is_redacted = FALSE
         AND mv.is_redacted = FALSE
@@ -298,6 +314,30 @@ approved_card_hits AS (
     CROSS JOIN q
     WHERE kc.card_status = 'approved'
         AND kc.body_tsv @@ q.tsq
+        AND NOT EXISTS (
+            SELECT 1
+            FROM card_sources cs_excluded
+            JOIN message_versions mv_excluded ON mv_excluded.id = cs_excluded.message_version_id
+            JOIN chat_messages c_excluded ON c_excluded.id = mv_excluded.chat_message_id
+            WHERE cs_excluded.card_id = kc.id
+                AND CAST(:exclude_chat_message_id AS bigint) IS NOT NULL
+                AND c_excluded.id = CAST(:exclude_chat_message_id AS bigint)
+        )
+        AND (
+            CAST(:human_only AS boolean) = FALSE
+            OR NOT EXISTS (
+                SELECT 1
+                FROM card_sources cs_bot
+                JOIN message_versions mv_bot ON mv_bot.id = cs_bot.message_version_id
+                JOIN chat_messages c_bot ON c_bot.id = mv_bot.chat_message_id
+                LEFT JOIN users author_bot ON author_bot.id = c_bot.user_id
+                WHERE cs_bot.card_id = kc.id
+                    AND (
+                        author_bot.is_bot IS DISTINCT FROM FALSE
+                        OR COALESCE(c_bot.message_kind, 'text') IN ('voice', 'audio')
+                    )
+            )
+        )
         AND EXISTS (
             -- A searchable card must be owned by the requested chat.
             SELECT 1
@@ -389,9 +429,21 @@ unforgotten_card_sources AS (
     FROM card_sources cs
     JOIN message_versions mv ON mv.id = cs.message_version_id
     JOIN chat_messages c ON c.id = mv.chat_message_id
+    LEFT JOIN users author ON author.id = c.user_id
     WHERE cs.card_id IN (SELECT card_id FROM approved_card_hits)
         AND c.chat_id = :chat_id
         AND c.current_version_id = mv.id
+        AND (
+            CAST(:exclude_chat_message_id AS bigint) IS NULL
+            OR c.id <> CAST(:exclude_chat_message_id AS bigint)
+        )
+        AND (
+            CAST(:human_only AS boolean) = FALSE
+            OR (
+                author.is_bot = FALSE
+                AND COALESCE(c.message_kind, 'text') NOT IN ('voice', 'audio')
+            )
+        )
         AND NOT EXISTS (
             SELECT 1
             FROM forget_events AS fe
@@ -418,6 +470,8 @@ card_anchors AS (
         c.id AS chat_message_id,
         c.chat_id AS chat_id,
         c.message_id AS message_id,
+        c.message_thread_id AS message_thread_id,
+        c.reply_to_message_id AS reply_to_message_id,
         c.date AS source_message_date
     FROM unforgotten_card_sources ucs
     JOIN message_versions mv ON mv.id = ucs.message_version_id
@@ -444,6 +498,8 @@ card_hits AS (
         ach.rank * :card_rank_boost AS rank,
         ach.approved_at AS captured_at,
         COALESCE(ach.approved_at, ca.source_message_date) AS message_date,
+        ca.message_thread_id AS message_thread_id,
+        ca.reply_to_message_id AS reply_to_message_id,
         'card'::text AS source_type,
         ach.card_id AS card_id,
         csl.mvids AS card_source_message_version_ids
@@ -470,6 +526,8 @@ async def search_messages(
     limit: int = 3,
     headline_max_words: int = 35,
     include_cards: bool = True,
+    exclude_chat_message_id: int | None = None,
+    human_only: bool = False,
 ) -> list[SearchHit]:
     """Search visible message versions (+ optionally approved cards) in one chat.
 
@@ -506,6 +564,8 @@ async def search_messages(
         raise ValueError("limit must be >= 1")
     if headline_max_words < 1:
         raise ValueError("headline_max_words must be >= 1")
+    if not include_cards and (exclude_chat_message_id is not None or human_only):
+        raise ValueError("semantic search filters require include_cards=True")
     if len(normalized_query) > MAX_QUERY_LENGTH:
         logger.info(
             "search_messages: truncating overlong query",
@@ -574,6 +634,8 @@ async def search_messages(
             "limit": limit,
             "headline_options": headline_options,
             "card_rank_boost": CARD_RANK_BOOST,
+            "exclude_chat_message_id": exclude_chat_message_id,
+            "human_only": human_only,
         },
     )
 
@@ -595,6 +657,8 @@ async def search_messages(
                 source_type=row["source_type"],
                 card_id=row["card_id"],
                 card_source_message_version_ids=mvids_tuple,
+                message_thread_id=row["message_thread_id"],
+                reply_to_message_id=row["reply_to_message_id"],
             )
         )
     return hits

--- a/bot/services/semantic_eval.py
+++ b/bot/services/semantic_eval.py
@@ -17,6 +17,20 @@ SemanticEvalCategory = Literal[
     "no_answer",
     "privacy_governance",
 ]
+PrivacyEvalClass = Literal[
+    "cross_chat",
+    "bot_authored",
+    "forgotten",
+    "redacted",
+    "non_normal",
+    "stale_version",
+]
+
+PRIVACY_LEAKAGE_CLASSES = frozenset(
+    {"cross_chat", "bot_authored", "forgotten", "redacted", "non_normal"}
+)
+STALE_VERSION_GOVERNANCE_CLASS = "stale_version"
+REQUIRED_PRIVACY_CLASSES = frozenset({*PRIVACY_LEAKAGE_CLASSES, STALE_VERSION_GOVERNANCE_CLASS})
 
 MIN_MACRO_RECALL_AT_5 = 0.80
 MIN_SEMANTIC_RECALL_DELTA_AT_5 = 0.15
@@ -56,6 +70,18 @@ def _validate_source_ids(name: str, source_ids: object) -> None:
         raise ValueError(f"{name} must not contain duplicate source ids")
 
 
+def _validate_privacy_classes(privacy_classes: object) -> None:
+    if not isinstance(privacy_classes, tuple):
+        raise TypeError("privacy_classes must be a tuple")
+    if any(
+        not isinstance(privacy_class, str) or privacy_class not in REQUIRED_PRIVACY_CLASSES
+        for privacy_class in privacy_classes
+    ):
+        raise ValueError("privacy_classes contains an unsupported governance class")
+    if len(privacy_classes) != len(set(privacy_classes)):
+        raise ValueError("privacy_classes must not contain duplicates")
+
+
 def _validate_non_negative_int(name: str, value: object) -> None:
     if type(value) is not int or value < 0:
         raise ValueError(f"{name} must be a non-negative integer")
@@ -76,6 +102,7 @@ class SemanticEvalCase:
     category: SemanticEvalCategory
     expected_source_ids: tuple[str, ...]
     forbidden_source_ids: tuple[str, ...]
+    privacy_classes: tuple[PrivacyEvalClass, ...]
     expected_abstain: bool
 
     def __post_init__(self) -> None:
@@ -84,6 +111,7 @@ class SemanticEvalCase:
             raise ValueError(f"unsupported semantic evaluation category: {self.category!r}")
         _validate_source_ids("expected_source_ids", self.expected_source_ids)
         _validate_source_ids("forbidden_source_ids", self.forbidden_source_ids)
+        _validate_privacy_classes(self.privacy_classes)
         if set(self.expected_source_ids) & set(self.forbidden_source_ids):
             raise ValueError("expected and forbidden source ids must be disjoint")
         if type(self.expected_abstain) is not bool:
@@ -105,8 +133,12 @@ class SemanticEvalCase:
         if self.category == "privacy_governance":
             if not self.forbidden_source_ids:
                 raise ValueError("privacy_governance cases must include forbidden source ids")
+            if not self.privacy_classes:
+                raise ValueError("privacy_governance cases must include privacy_classes")
         elif self.forbidden_source_ids:
             raise ValueError("only privacy_governance cases may include forbidden source ids")
+        elif self.privacy_classes:
+            raise ValueError("only privacy_governance cases may include privacy_classes")
 
 
 @dataclass(frozen=True, slots=True)
@@ -174,6 +206,7 @@ class SemanticEvalReport:
     exact_case_count: int
     multi_source_case_count: int
     privacy_governance_case_count: int
+    privacy_classes: tuple[PrivacyEvalClass, ...]
     privacy_expected_abstention_case_count: int
     privacy_expected_abstention_failures: int
     unexpected_answerable_abstention_count: int
@@ -203,6 +236,27 @@ def _nearest_rank_p95(values: Sequence[float]) -> float:
     ordered = sorted(float(value) for value in values)
     rank = (95 * len(ordered) + 99) // 100
     return ordered[rank - 1]
+
+
+def validate_privacy_class_coverage(
+    cases: Sequence[SemanticEvalCase],
+) -> tuple[PrivacyEvalClass, ...]:
+    """Require every #404 leakage class plus the stale-version invariant."""
+
+    if any(not isinstance(case, SemanticEvalCase) for case in cases):
+        raise TypeError("cases must contain only SemanticEvalCase values")
+    covered = {
+        privacy_class
+        for case in cases
+        if case.category == "privacy_governance"
+        for privacy_class in case.privacy_classes
+    }
+    missing = sorted(REQUIRED_PRIVACY_CLASSES - covered)
+    if missing:
+        raise ValueError(
+            f"frozen evaluation must cover every privacy/governance class; missing={missing!r}"
+        )
+    return tuple(sorted(covered))  # type: ignore[return-value]
 
 
 def evaluate_semantic_run(
@@ -251,6 +305,7 @@ def evaluate_semantic_run(
             "frozen evaluation must contain every required category; "
             f"missing={missing_categories!r}"
         )
+    privacy_classes = validate_privacy_class_coverage(cases)
 
     answerable = [pair for pair in ordered_pairs if not pair[0].expected_abstain]
     semantic = [pair for pair in answerable if pair[0].category == "semantic"]
@@ -318,6 +373,7 @@ def evaluate_semantic_run(
         exact_case_count=len(category_pairs["exact"]),
         multi_source_case_count=len(category_pairs["multi_source"]),
         privacy_governance_case_count=len(privacy),
+        privacy_classes=privacy_classes,
         privacy_expected_abstention_case_count=len(privacy_expected_abstentions),
         privacy_expected_abstention_failures=privacy_expected_abstention_failures,
         unexpected_answerable_abstention_count=unexpected_answerable_abstention_count,
@@ -365,6 +421,16 @@ def validate_semantic_report(report: SemanticEvalReport) -> tuple[str, ...]:
         violations.append("retrieval_p95_seconds < 0")
     if report.full_p95_seconds < report.retrieval_p95_seconds:
         violations.append("full_p95_seconds < retrieval_p95_seconds")
+    if (
+        not isinstance(report.privacy_classes, tuple)
+        or any(
+            not isinstance(privacy_class, str) or privacy_class not in REQUIRED_PRIVACY_CLASSES
+            for privacy_class in report.privacy_classes
+        )
+        or len(report.privacy_classes) != len(set(report.privacy_classes))
+        or set(report.privacy_classes) != REQUIRED_PRIVACY_CLASSES
+    ):
+        violations.append("privacy_classes do not cover every required governance class")
     category_total = (
         report.semantic_case_count
         + report.exact_case_count
@@ -460,10 +526,15 @@ __all__ = [
     "MIN_MACRO_RECALL_AT_5",
     "MIN_NO_ANSWER_ABSTENTION_RATE",
     "MIN_SEMANTIC_RECALL_DELTA_AT_5",
+    "PRIVACY_LEAKAGE_CLASSES",
+    "REQUIRED_PRIVACY_CLASSES",
+    "STALE_VERSION_GOVERNANCE_CLASS",
     "SemanticEvalCase",
     "SemanticEvalCategory",
+    "PrivacyEvalClass",
     "SemanticEvalReport",
     "SemanticEvalResult",
     "evaluate_semantic_run",
+    "validate_privacy_class_coverage",
     "validate_semantic_report",
 ]

--- a/bot/services/semantic_eval.py
+++ b/bot/services/semantic_eval.py
@@ -1,0 +1,469 @@
+"""Pure deterministic acceptance metrics for semantic Q&A evaluation runs."""
+
+from __future__ import annotations
+
+import math
+import re
+import uuid
+from collections.abc import Sequence
+from dataclasses import dataclass
+from fractions import Fraction
+from typing import Literal
+
+SemanticEvalCategory = Literal[
+    "semantic",
+    "exact",
+    "multi_source",
+    "no_answer",
+    "privacy_governance",
+]
+
+MIN_MACRO_RECALL_AT_5 = 0.80
+MIN_SEMANTIC_RECALL_DELTA_AT_5 = 0.15
+MIN_EXACT_RECALL_DELTA_AT_5 = -0.05
+MIN_NO_ANSWER_ABSTENTION_RATE = 0.90
+MAX_RETRIEVAL_P95_SECONDS = 2.0
+MAX_FULL_P95_SECONDS = 15.0
+
+_CATEGORIES = frozenset({"semantic", "exact", "multi_source", "no_answer", "privacy_governance"})
+_MESSAGE_SOURCE_ID_RE = re.compile(r"message:[1-9][0-9]*")
+_CARD_SOURCE_ID_RE = re.compile(
+    r"card:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+)
+
+
+def _validate_case_id(case_id: object) -> None:
+    if not isinstance(case_id, str) or not case_id or case_id != case_id.strip():
+        raise ValueError("case_id must be a non-empty trimmed string")
+
+
+def _validate_source_ids(name: str, source_ids: object) -> None:
+    if not isinstance(source_ids, tuple):
+        raise TypeError(f"{name} must be a tuple")
+    for source_id in source_ids:
+        if not isinstance(source_id, str):
+            raise ValueError(f"{name} must contain canonical string source ids")
+        if _MESSAGE_SOURCE_ID_RE.fullmatch(source_id):
+            continue
+        if _CARD_SOURCE_ID_RE.fullmatch(source_id):
+            card_id = source_id.removeprefix("card:")
+            if str(uuid.UUID(card_id)) == card_id:
+                continue
+        raise ValueError(
+            f"{name} must use message:<positive-id> or card:<canonical-uuid> source ids"
+        )
+    if len(source_ids) != len(set(source_ids)):
+        raise ValueError(f"{name} must not contain duplicate source ids")
+
+
+def _validate_non_negative_int(name: str, value: object) -> None:
+    if type(value) is not int or value < 0:
+        raise ValueError(f"{name} must be a non-negative integer")
+
+
+def _validate_latency(name: str, value: object) -> None:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"{name} must be a finite non-negative number")
+    if not math.isfinite(float(value)) or value < 0:
+        raise ValueError(f"{name} must be a finite non-negative number")
+
+
+@dataclass(frozen=True, slots=True)
+class SemanticEvalCase:
+    """Frozen gold label for one semantic Q&A evaluation case."""
+
+    case_id: str
+    category: SemanticEvalCategory
+    expected_source_ids: tuple[str, ...]
+    forbidden_source_ids: tuple[str, ...]
+    expected_abstain: bool
+
+    def __post_init__(self) -> None:
+        _validate_case_id(self.case_id)
+        if self.category not in _CATEGORIES:
+            raise ValueError(f"unsupported semantic evaluation category: {self.category!r}")
+        _validate_source_ids("expected_source_ids", self.expected_source_ids)
+        _validate_source_ids("forbidden_source_ids", self.forbidden_source_ids)
+        if set(self.expected_source_ids) & set(self.forbidden_source_ids):
+            raise ValueError("expected and forbidden source ids must be disjoint")
+        if type(self.expected_abstain) is not bool:
+            raise ValueError("expected_abstain must be a boolean")
+        if self.category == "no_answer":
+            if not self.expected_abstain or self.expected_source_ids:
+                raise ValueError(
+                    "no_answer cases must expect abstention and have no expected sources"
+                )
+        elif self.category == "privacy_governance" and self.expected_abstain:
+            if self.expected_source_ids:
+                raise ValueError(
+                    "abstaining privacy_governance cases must have no expected sources"
+                )
+        elif self.expected_abstain or not self.expected_source_ids:
+            raise ValueError(
+                "answerable cases must not expect abstention and must have expected sources"
+            )
+        if self.category == "privacy_governance":
+            if not self.forbidden_source_ids:
+                raise ValueError("privacy_governance cases must include forbidden source ids")
+        elif self.forbidden_source_ids:
+            raise ValueError("only privacy_governance cases may include forbidden source ids")
+
+
+@dataclass(frozen=True, slots=True)
+class SemanticEvalResult:
+    """Frozen observations for one case, produced outside this pure module."""
+
+    case_id: str
+    fts_source_ids: tuple[str, ...]
+    hybrid_source_ids: tuple[str, ...]
+    abstained: bool
+    leakage_count: int
+    valid_source_links: int
+    invalid_source_links: int
+    unsupported_claims: int
+    total_claims: int
+    retrieval_latency_seconds: float
+    full_latency_seconds: float
+
+    def __post_init__(self) -> None:
+        _validate_case_id(self.case_id)
+        _validate_source_ids("fts_source_ids", self.fts_source_ids)
+        _validate_source_ids("hybrid_source_ids", self.hybrid_source_ids)
+        if type(self.abstained) is not bool:
+            raise ValueError("abstained must be a boolean")
+        for name in (
+            "leakage_count",
+            "valid_source_links",
+            "invalid_source_links",
+            "unsupported_claims",
+            "total_claims",
+        ):
+            _validate_non_negative_int(name, getattr(self, name))
+        if self.unsupported_claims > self.total_claims:
+            raise ValueError("unsupported_claims must not exceed total_claims")
+        _validate_latency("retrieval_latency_seconds", self.retrieval_latency_seconds)
+        _validate_latency("full_latency_seconds", self.full_latency_seconds)
+        if self.full_latency_seconds < self.retrieval_latency_seconds:
+            raise ValueError("full_latency_seconds must include retrieval_latency_seconds")
+        if self.abstained and any(
+            (
+                self.valid_source_links,
+                self.invalid_source_links,
+                self.unsupported_claims,
+                self.total_claims,
+            )
+        ):
+            raise ValueError("abstained results must not contain source links or claims")
+        if not self.abstained and self.total_claims == 0:
+            raise ValueError("non-abstained results must include claim annotations")
+
+
+@dataclass(frozen=True, slots=True)
+class SemanticEvalReport:
+    """Aggregate #404 gate evidence.
+
+    Recall deltas use a 0..1 fraction: ``0.15`` means 15 percentage points.
+    ``invalid_source_links`` also counts each non-abstained answer that has no
+    source link at all, so a missing mandatory citation cannot pass the zero gate.
+    """
+
+    case_count: int
+    answerable_case_count: int
+    no_answer_case_count: int
+    semantic_case_count: int
+    exact_case_count: int
+    multi_source_case_count: int
+    privacy_governance_case_count: int
+    privacy_expected_abstention_case_count: int
+    privacy_expected_abstention_failures: int
+    unexpected_answerable_abstention_count: int
+    macro_recall_at_5: float
+    semantic_hybrid_minus_fts_at_5: float
+    exact_hybrid_minus_fts_at_5: float
+    no_answer_abstention_rate: float
+    leakage_count: int
+    invalid_source_links: int
+    unsupported_claims: int
+    total_claims: int
+    unsupported_claim_rate: float
+    retrieval_p95_seconds: float
+    full_p95_seconds: float
+
+
+def _recall_at_5(returned: tuple[str, ...], expected: tuple[str, ...]) -> Fraction:
+    hits = len(set(returned[:5]) & set(expected))
+    return Fraction(hits, len(expected))
+
+
+def _mean(values: Sequence[Fraction]) -> Fraction:
+    return sum(values, start=Fraction()) / len(values)
+
+
+def _nearest_rank_p95(values: Sequence[float]) -> float:
+    ordered = sorted(float(value) for value in values)
+    rank = (95 * len(ordered) + 99) // 100
+    return ordered[rank - 1]
+
+
+def evaluate_semantic_run(
+    cases: Sequence[SemanticEvalCase],
+    results: Sequence[SemanticEvalResult],
+) -> tuple[SemanticEvalReport, tuple[str, ...]]:
+    """Compute #404 metrics and return the immutable report plus gate violations.
+
+    The function performs no I/O and raises immediately for incomplete, duplicate,
+    mismatched, or structurally invalid evaluation data.
+    """
+
+    if not cases:
+        raise ValueError("cases must not be empty")
+    if not results:
+        raise ValueError("results must not be empty")
+    if any(not isinstance(case, SemanticEvalCase) for case in cases):
+        raise TypeError("cases must contain only SemanticEvalCase values")
+    if any(not isinstance(result, SemanticEvalResult) for result in results):
+        raise TypeError("results must contain only SemanticEvalResult values")
+
+    cases_by_id = {case.case_id: case for case in cases}
+    if len(cases_by_id) != len(cases):
+        raise ValueError("case ids must be unique")
+    results_by_id = {result.case_id: result for result in results}
+    if len(results_by_id) != len(results):
+        raise ValueError("result case ids must be unique")
+
+    case_ids = set(cases_by_id)
+    result_ids = set(results_by_id)
+    if case_ids != result_ids:
+        missing = sorted(case_ids - result_ids)
+        unexpected = sorted(result_ids - case_ids)
+        raise ValueError(
+            f"results must match cases exactly; missing={missing!r}, unexpected={unexpected!r}"
+        )
+
+    ordered_pairs = [(case, results_by_id[case.case_id]) for case in cases]
+    category_pairs = {
+        category: [pair for pair in ordered_pairs if pair[0].category == category]
+        for category in _CATEGORIES
+    }
+    missing_categories = sorted(category for category, pairs in category_pairs.items() if not pairs)
+    if missing_categories:
+        raise ValueError(
+            "frozen evaluation must contain every required category; "
+            f"missing={missing_categories!r}"
+        )
+
+    answerable = [pair for pair in ordered_pairs if not pair[0].expected_abstain]
+    semantic = [pair for pair in answerable if pair[0].category == "semantic"]
+    exact = [pair for pair in answerable if pair[0].category == "exact"]
+    no_answer = category_pairs["no_answer"]
+    privacy = category_pairs["privacy_governance"]
+    privacy_expected_abstentions = [pair for pair in privacy if pair[0].expected_abstain]
+    if not answerable:
+        raise ValueError("at least one answerable case is required")
+    if not semantic:
+        raise ValueError("at least one answerable semantic case is required")
+    if not exact:
+        raise ValueError("at least one answerable exact case is required")
+
+    hybrid_answerable = [
+        _recall_at_5(result.hybrid_source_ids, case.expected_source_ids)
+        for case, result in answerable
+    ]
+    semantic_hybrid = [
+        _recall_at_5(result.hybrid_source_ids, case.expected_source_ids)
+        for case, result in semantic
+    ]
+    semantic_fts = [
+        _recall_at_5(result.fts_source_ids, case.expected_source_ids) for case, result in semantic
+    ]
+    exact_hybrid = [
+        _recall_at_5(result.hybrid_source_ids, case.expected_source_ids) for case, result in exact
+    ]
+    exact_fts = [
+        _recall_at_5(result.fts_source_ids, case.expected_source_ids) for case, result in exact
+    ]
+
+    macro_recall = _mean(hybrid_answerable)
+    semantic_delta = _mean(semantic_hybrid) - _mean(semantic_fts)
+    exact_delta = _mean(exact_hybrid) - _mean(exact_fts)
+    abstention_rate = Fraction(sum(result.abstained for _, result in no_answer), len(no_answer))
+    privacy_expected_abstention_failures = sum(
+        not result.abstained for _, result in privacy_expected_abstentions
+    )
+    unexpected_answerable_abstention_count = sum(result.abstained for _, result in answerable)
+    computed_leakage_counts = [
+        len(set(result.hybrid_source_ids) & set(case.forbidden_source_ids))
+        for case, result in ordered_pairs
+    ]
+    for (case, result), computed_count in zip(ordered_pairs, computed_leakage_counts, strict=True):
+        if result.leakage_count != computed_count:
+            raise ValueError(
+                "reviewed leakage_count must equal the forbidden-source intersection; "
+                f"case_id={case.case_id!r}"
+            )
+    leakage_count = sum(computed_leakage_counts)
+    invalid_source_links = sum(result.invalid_source_links for result in results)
+    invalid_source_links += sum(
+        not result.abstained and result.valid_source_links == 0 and result.invalid_source_links == 0
+        for result in results
+    )
+    unsupported_claims = sum(result.unsupported_claims for result in results)
+    total_claims = sum(result.total_claims for result in results)
+
+    report = SemanticEvalReport(
+        case_count=len(cases),
+        answerable_case_count=len(answerable),
+        no_answer_case_count=len(no_answer),
+        semantic_case_count=len(category_pairs["semantic"]),
+        exact_case_count=len(category_pairs["exact"]),
+        multi_source_case_count=len(category_pairs["multi_source"]),
+        privacy_governance_case_count=len(privacy),
+        privacy_expected_abstention_case_count=len(privacy_expected_abstentions),
+        privacy_expected_abstention_failures=privacy_expected_abstention_failures,
+        unexpected_answerable_abstention_count=unexpected_answerable_abstention_count,
+        macro_recall_at_5=float(macro_recall),
+        semantic_hybrid_minus_fts_at_5=float(semantic_delta),
+        exact_hybrid_minus_fts_at_5=float(exact_delta),
+        no_answer_abstention_rate=float(abstention_rate),
+        leakage_count=leakage_count,
+        invalid_source_links=invalid_source_links,
+        unsupported_claims=unsupported_claims,
+        total_claims=total_claims,
+        unsupported_claim_rate=(unsupported_claims / total_claims if total_claims else 0.0),
+        retrieval_p95_seconds=_nearest_rank_p95(
+            [result.retrieval_latency_seconds for result in results]
+        ),
+        full_p95_seconds=_nearest_rank_p95([result.full_latency_seconds for result in results]),
+    )
+
+    violations = list(validate_semantic_report(report))
+    return report, tuple(violations)
+
+
+def validate_semantic_report(report: SemanticEvalReport) -> tuple[str, ...]:
+    """Re-check a sanitized aggregate report at the CI trust boundary."""
+
+    if not isinstance(report, SemanticEvalReport):
+        raise TypeError("report must be a SemanticEvalReport")
+    violations: list[str] = []
+    for name in (
+        "macro_recall_at_5",
+        "no_answer_abstention_rate",
+        "unsupported_claim_rate",
+    ):
+        value = getattr(report, name)
+        if not 0 <= value <= 1:
+            violations.append(f"{name}={value:.6f} outside [0,1]")
+    for name in (
+        "semantic_hybrid_minus_fts_at_5",
+        "exact_hybrid_minus_fts_at_5",
+    ):
+        value = getattr(report, name)
+        if not -1 <= value <= 1:
+            violations.append(f"{name}={value:.6f} outside [-1,1]")
+    if report.retrieval_p95_seconds < 0:
+        violations.append("retrieval_p95_seconds < 0")
+    if report.full_p95_seconds < report.retrieval_p95_seconds:
+        violations.append("full_p95_seconds < retrieval_p95_seconds")
+    category_total = (
+        report.semantic_case_count
+        + report.exact_case_count
+        + report.multi_source_case_count
+        + report.no_answer_case_count
+        + report.privacy_governance_case_count
+    )
+    if category_total != report.case_count:
+        violations.append(f"category_case_count={category_total} != case_count={report.case_count}")
+    for name in (
+        "semantic_case_count",
+        "exact_case_count",
+        "multi_source_case_count",
+        "no_answer_case_count",
+        "privacy_governance_case_count",
+    ):
+        if getattr(report, name) < 1:
+            violations.append(f"{name}=0")
+    expected_partition = (
+        report.answerable_case_count
+        + report.no_answer_case_count
+        + report.privacy_expected_abstention_case_count
+    )
+    if expected_partition != report.case_count:
+        violations.append(
+            f"expected_partition_case_count={expected_partition} != case_count={report.case_count}"
+        )
+    if report.privacy_expected_abstention_failures:
+        violations.append(
+            "privacy_expected_abstention_failures="
+            f"{report.privacy_expected_abstention_failures} > 0"
+        )
+    if report.privacy_expected_abstention_case_count > report.privacy_governance_case_count:
+        violations.append("privacy_expected_abstention_case_count > privacy_governance_case_count")
+    if report.privacy_expected_abstention_failures > report.privacy_expected_abstention_case_count:
+        violations.append(
+            "privacy_expected_abstention_failures > privacy_expected_abstention_case_count"
+        )
+    if report.unexpected_answerable_abstention_count:
+        violations.append(
+            "unexpected_answerable_abstention_count="
+            f"{report.unexpected_answerable_abstention_count} > 0"
+        )
+    if report.unexpected_answerable_abstention_count > report.answerable_case_count:
+        violations.append("unexpected_answerable_abstention_count > answerable_case_count")
+    if report.unsupported_claims > report.total_claims:
+        violations.append("unsupported_claims > total_claims")
+    if report.macro_recall_at_5 < MIN_MACRO_RECALL_AT_5:
+        violations.append(
+            f"macro_recall_at_5={report.macro_recall_at_5:.6f} < {MIN_MACRO_RECALL_AT_5:.2f}"
+        )
+    if report.semantic_hybrid_minus_fts_at_5 < MIN_SEMANTIC_RECALL_DELTA_AT_5:
+        violations.append(
+            "semantic_hybrid_minus_fts_at_5="
+            f"{report.semantic_hybrid_minus_fts_at_5:.6f} < "
+            f"{MIN_SEMANTIC_RECALL_DELTA_AT_5:.2f}"
+        )
+    if report.exact_hybrid_minus_fts_at_5 < MIN_EXACT_RECALL_DELTA_AT_5:
+        violations.append(
+            f"exact_hybrid_minus_fts_at_5={report.exact_hybrid_minus_fts_at_5:.6f} < "
+            f"{MIN_EXACT_RECALL_DELTA_AT_5:.2f}"
+        )
+    if report.no_answer_abstention_rate < MIN_NO_ANSWER_ABSTENTION_RATE:
+        violations.append(
+            f"no_answer_abstention_rate={report.no_answer_abstention_rate:.6f} < "
+            f"{MIN_NO_ANSWER_ABSTENTION_RATE:.2f}"
+        )
+    if report.leakage_count:
+        violations.append(f"leakage_count={report.leakage_count} > 0")
+    if report.invalid_source_links:
+        violations.append(f"invalid_source_links={report.invalid_source_links} > 0")
+    if report.unsupported_claims:
+        violations.append(f"unsupported_claims={report.unsupported_claims} > 0")
+    if report.unsupported_claim_rate != 0:
+        violations.append(f"unsupported_claim_rate={report.unsupported_claim_rate:.6f} != 0")
+    if report.retrieval_p95_seconds > MAX_RETRIEVAL_P95_SECONDS:
+        violations.append(
+            f"retrieval_p95_seconds={report.retrieval_p95_seconds:.6f} > "
+            f"{MAX_RETRIEVAL_P95_SECONDS:.1f}"
+        )
+    if report.full_p95_seconds > MAX_FULL_P95_SECONDS:
+        violations.append(
+            f"full_p95_seconds={report.full_p95_seconds:.6f} > {MAX_FULL_P95_SECONDS:.1f}"
+        )
+
+    return tuple(violations)
+
+
+__all__ = [
+    "MAX_FULL_P95_SECONDS",
+    "MAX_RETRIEVAL_P95_SECONDS",
+    "MIN_EXACT_RECALL_DELTA_AT_5",
+    "MIN_MACRO_RECALL_AT_5",
+    "MIN_NO_ANSWER_ABSTENTION_RATE",
+    "MIN_SEMANTIC_RECALL_DELTA_AT_5",
+    "SemanticEvalCase",
+    "SemanticEvalCategory",
+    "SemanticEvalReport",
+    "SemanticEvalResult",
+    "evaluate_semantic_run",
+    "validate_semantic_report",
+]

--- a/bot/services/semantic_index.py
+++ b/bot/services/semantic_index.py
@@ -619,7 +619,12 @@ class _SemanticEmbeddingOutcomeRecorder:
     ) -> None:
         if self.unit_ids:
             raise RuntimeError("semantic embedding recorder was already reserved")
-        status = "failed" if budget_denied else "reserved"
+        if budget_denied:
+            # No provider dispatch means no ambiguous paid result to fence. The
+            # gateway records a content-free budget audit row; leaving no unique
+            # source claim allows the same identity to retry after the ceiling
+            # is raised or the accounting window rolls over.
+            return
         for document in self.documents:
             await _invalidate_previous_documents(
                 session,
@@ -640,7 +645,7 @@ class _SemanticEmbeddingOutcomeRecorder:
                     embedding_model=self.config.model,
                     embedding_model_version=EMBEDDING_MODEL_VERSION,
                     embedding_dimensions=self.config.dimensions,
-                    embedding_status=status,
+                    embedding_status="reserved",
                     chunk_text=None,
                     embedding=None,
                     llm_usage_ledger_id=llm_usage_ledger_id,

--- a/bot/services/semantic_index.py
+++ b/bot/services/semantic_index.py
@@ -283,10 +283,11 @@ _ELIGIBLE_CARDS_SQL = text(
 # nosemgrep: python.sqlalchemy.security.audit.avoid-sqlalchemy-text.avoid-sqlalchemy-text
 _VECTOR_CANDIDATES_SQL = text(
     f"""
+    WITH governed_candidates AS (
     SELECT unit.id,
            unit.source_type,
            unit.source_id,
-           1 - (unit.embedding <=> CAST(:embedding AS vector)) AS similarity
+           unit.embedding <=> CAST(:embedding AS vector) AS distance
     FROM semantic_retrieval_units unit
     WHERE unit.chat_id = :chat_id
       AND unit.embedding_model = :embedding_model
@@ -338,7 +339,21 @@ _VECTOR_CANDIDATES_SQL = text(
                 OR NOT ({_FORGET_EXCLUDES})
             )
       )
-    ORDER BY unit.embedding <=> CAST(:embedding AS vector), unit.id ASC
+    ), ranked_candidates AS (
+        SELECT governed_candidates.*,
+               ROW_NUMBER() OVER (
+                   PARTITION BY source_type, source_id
+                   ORDER BY distance ASC, id ASC
+               ) AS source_rank
+        FROM governed_candidates
+    )
+    SELECT id,
+           source_type,
+           source_id,
+           1 - distance AS similarity
+    FROM ranked_candidates
+    WHERE source_rank = 1
+    ORDER BY distance ASC, id ASC
     LIMIT :limit
     """
 )
@@ -505,6 +520,8 @@ class RetrievalDocument:
     canonical_text: str
     content_hash: str
     message_version_ids: tuple[int, ...]
+    chunk_index: int = 0
+    chunk_count: int = 1
 
 
 @dataclass(frozen=True, slots=True)
@@ -513,6 +530,8 @@ class _ExistingUnit:
     source_type: str
     source_id: str
     source_revision: str
+    chunk_index: int
+    chunk_count: int
     chat_id: int
     content_hash: str
     invalidated_at: datetime | None
@@ -554,6 +573,40 @@ def _content_hash(value: str) -> str:
     return hashlib.sha256(value.encode("utf-8")).hexdigest()
 
 
+def _chunk_retrieval_document(
+    *,
+    source_type: Literal["message", "card"],
+    source_id: str,
+    source_revision: str,
+    chat_id: int,
+    canonical_text: str,
+    message_version_ids: tuple[int, ...],
+) -> list[RetrievalDocument]:
+    """Split source text without truncation using stable character boundaries."""
+
+    chunks = tuple(
+        canonical_text[offset : offset + MAX_EMBEDDING_INPUT_CHARS]
+        for offset in range(0, len(canonical_text), MAX_EMBEDDING_INPUT_CHARS)
+    )
+    if not chunks:
+        raise ValueError("retrieval document canonical text must not be empty")
+    chunk_count = len(chunks)
+    return [
+        RetrievalDocument(
+            source_type=source_type,
+            source_id=source_id,
+            source_revision=source_revision,
+            chat_id=chat_id,
+            canonical_text=chunk,
+            content_hash=_content_hash(chunk),
+            message_version_ids=message_version_ids,
+            chunk_index=chunk_index,
+            chunk_count=chunk_count,
+        )
+        for chunk_index, chunk in enumerate(chunks)
+    ]
+
+
 def _vector_literal(vector: Sequence[float]) -> str:
     if len(vector) != 1536:
         raise ValueError("query embedding must contain 1536 values")
@@ -589,14 +642,13 @@ async def list_eligible_message_documents(
         canonical_text = str(row["canonical_text"]).strip()
         media_revision = row["media_revision"]
         revision = f"v{row['version_seq']}:media:{media_revision.isoformat() if media_revision else 'none'}"
-        documents.append(
-            RetrievalDocument(
+        documents.extend(
+            _chunk_retrieval_document(
                 source_type="message",
                 source_id=str(row["message_version_id"]),
                 source_revision=revision,
                 chat_id=int(row["chat_id"]),
                 canonical_text=canonical_text,
-                content_hash=_content_hash(canonical_text),
                 message_version_ids=(int(row["message_version_id"]),),
             )
         )
@@ -621,8 +673,8 @@ async def list_eligible_card_documents(
         canonical_text = str(row["canonical_text"]).strip()
         updated_at = row["updated_at"]
         approved_at = row["approved_at"]
-        documents.append(
-            RetrievalDocument(
+        documents.extend(
+            _chunk_retrieval_document(
                 source_type="card",
                 source_id=str(row["card_id"]),
                 source_revision=(
@@ -631,7 +683,6 @@ async def list_eligible_card_documents(
                 ),
                 chat_id=int(row["chat_id"]),
                 canonical_text=canonical_text,
-                content_hash=_content_hash(canonical_text),
                 message_version_ids=tuple(int(value) for value in row["message_version_ids"]),
             )
         )
@@ -653,6 +704,8 @@ async def _load_existing_units(
             SemanticRetrievalUnit.source_type,
             SemanticRetrievalUnit.source_id,
             SemanticRetrievalUnit.source_revision,
+            SemanticRetrievalUnit.chunk_index,
+            SemanticRetrievalUnit.chunk_count,
             SemanticRetrievalUnit.chat_id,
             SemanticRetrievalUnit.content_hash,
             SemanticRetrievalUnit.invalidated_at,
@@ -678,6 +731,8 @@ async def _load_existing_units(
             source_type=str(row.source_type),
             source_id=str(row.source_id),
             source_revision=str(row.source_revision),
+            chunk_index=int(row.chunk_index),
+            chunk_count=int(row.chunk_count),
             chat_id=int(row.chat_id),
             content_hash=str(row.content_hash),
             invalidated_at=row.invalidated_at,
@@ -711,6 +766,8 @@ async def _load_parent_message_units(
             SemanticRetrievalUnit.source_type,
             SemanticRetrievalUnit.source_id,
             SemanticRetrievalUnit.source_revision,
+            SemanticRetrievalUnit.chunk_index,
+            SemanticRetrievalUnit.chunk_count,
             SemanticRetrievalUnit.chat_id,
             SemanticRetrievalUnit.content_hash,
             SemanticRetrievalUnit.invalidated_at,
@@ -747,6 +804,8 @@ async def _load_parent_message_units(
             source_type=str(row["source_type"]),
             source_id=str(row["source_id"]),
             source_revision=str(row["source_revision"]),
+            chunk_index=int(row["chunk_index"]),
+            chunk_count=int(row["chunk_count"]),
             chat_id=int(row["chat_id"]),
             content_hash=str(row["content_hash"]),
             invalidated_at=row["invalidated_at"],
@@ -768,12 +827,17 @@ def _find_reusable_unit(
     candidates = units_by_source.get((document.source_type, document.source_id), ())
     for candidate in candidates:
         if (
-            candidate.source_revision == document.source_revision
+            candidate.chunk_index == document.chunk_index
+            and candidate.chunk_count == document.chunk_count
+            and candidate.source_revision == document.source_revision
             and candidate.content_hash == document.content_hash
         ):
             return candidate
     for candidate in candidates:
-        if candidate.content_hash == document.content_hash:
+        if (
+            candidate.chunk_index == document.chunk_index
+            and candidate.content_hash == document.content_hash
+        ):
             return candidate
     return None
 
@@ -789,7 +853,8 @@ def _find_parent_message_unit(
         (
             candidate
             for candidate in units_by_current_source.get(document.source_id, ())
-            if candidate.content_hash == document.content_hash
+            if candidate.chunk_index == document.chunk_index
+            and candidate.content_hash == document.content_hash
         ),
         None,
     )
@@ -946,7 +1011,11 @@ async def _invalidate_previous_documents(
                   AND unit.invalidated_at IS NULL
                   AND (
                       unit.source_revision <> :source_revision
-                      OR unit.content_hash <> :content_hash
+                      OR unit.chunk_count <> :chunk_count
+                      OR (
+                          unit.chunk_index = :chunk_index
+                          AND unit.content_hash <> :content_hash
+                      )
                   )
                   AND EXISTS (
                       SELECT 1
@@ -964,6 +1033,8 @@ async def _invalidate_previous_documents(
                 "invalidated_at": now,
                 "embedding_model": embedding_model,
                 "source_revision": document.source_revision,
+                "chunk_index": document.chunk_index,
+                "chunk_count": document.chunk_count,
                 "content_hash": document.content_hash,
                 "current_message_version_id": int(document.source_id),
             },
@@ -979,7 +1050,11 @@ async def _invalidate_previous_documents(
         )
         .where(
             (SemanticRetrievalUnit.source_revision != document.source_revision)
-            | (SemanticRetrievalUnit.content_hash != document.content_hash)
+            | (SemanticRetrievalUnit.chunk_count != document.chunk_count)
+            | (
+                (SemanticRetrievalUnit.chunk_index == document.chunk_index)
+                & (SemanticRetrievalUnit.content_hash != document.content_hash)
+            )
         )
         .values(invalidated_at=now, invalidation_reason="source_revised")
     )
@@ -1000,6 +1075,7 @@ async def _reuse_document(
     )
     if (
         unit.source_revision != document.source_revision
+        or unit.chunk_count != document.chunk_count
         or unit.chat_id != document.chat_id
         or unit.invalidated_at is not None
     ):
@@ -1008,6 +1084,7 @@ async def _reuse_document(
             .where(SemanticRetrievalUnit.id == unit.id)
             .values(
                 source_revision=document.source_revision,
+                chunk_count=document.chunk_count,
                 chat_id=document.chat_id,
                 invalidated_at=None,
                 invalidation_reason=None,
@@ -1054,6 +1131,8 @@ async def _store_document(
             source_type=document.source_type,
             source_id=document.source_id,
             source_revision=document.source_revision,
+            chunk_index=document.chunk_index,
+            chunk_count=document.chunk_count,
             chat_id=document.chat_id,
             content_hash=document.content_hash,
             embedding_provider=embedding_provider,
@@ -1084,76 +1163,23 @@ async def _store_document(
     return True
 
 
-async def _index_batch_locked(
+async def _persist_document_batch(
     session: AsyncSession,
     *,
     documents: Sequence[RetrievalDocument],
     config: EmbeddingGatewayConfig,
-    provider: Any | None,
-) -> _BatchResult:
+    embeddings: dict[RetrievalDocument, tuple[Sequence[float], int]],
+) -> Counter[str]:
+    """Persist one governed batch and classify every document."""
+
     batch = tuple(documents)
     if not batch:
-        return _BatchResult(indexed=0, skipped=0, reason_counts={})
-    # The batch may have been listed before this worker acquired the per-source
-    # locks. Re-read governance state before any provider call so a forget/edit
-    # transaction that won the lock can never leak stale text to OpenAI.
-    prevalidated_documents = await _revalidate_documents(session, documents=batch)
-    units_before_embedding = await _load_existing_units(
-        session,
-        documents=prevalidated_documents,
-        embedding_model=config.model,
-    )
-    parent_units_before_embedding = await _load_parent_message_units(
-        session,
-        documents=prevalidated_documents,
-        embedding_model=config.model,
-    )
-    reusable_before_embedding = {
-        document: unit
-        for document in prevalidated_documents
-        if (
-            unit := _find_reusable_unit(
-                document=document,
-                units_by_source=units_before_embedding,
-            )
-            or _find_parent_message_unit(
-                document=document,
-                units_by_current_source=parent_units_before_embedding,
-            )
-        )
-        is not None
-    }
-    missing = [
-        document for document in prevalidated_documents if document not in reusable_before_embedding
-    ]
-    oversized_documents = {
-        document for document in missing if len(document.canonical_text) > MAX_EMBEDDING_INPUT_CHARS
-    }
-    embeddable_documents = [document for document in missing if document not in oversized_documents]
-    vectors_by_document: dict[RetrievalDocument, tuple[Sequence[float], int]] = {}
-    for embedding_batch in _partition_embedding_documents(embeddable_documents):
-        embedding_result = await embed_texts(
-            session,
-            inputs=[document.canonical_text for document in embedding_batch],
-            config=config,
-            ledger_repo=LedgerRepo(),
-            provider=provider,
-        )
-        vectors_by_document.update(
-            {
-                document: (vector, embedding_result.llm_usage_ledger_id)
-                for document, vector in zip(
-                    embedding_batch,
-                    embedding_result.vectors,
-                    strict=True,
-                )
-            }
-        )
-    embedded_documents = set(embeddable_documents)
+        return Counter()
+    embedded_documents = set(embeddings)
 
     valid_documents = await _revalidate_documents(
         session,
-        documents=prevalidated_documents,
+        documents=batch,
     )
     if blocked_count := len(batch) - len(valid_documents):
         logger.info(
@@ -1217,6 +1243,7 @@ async def _index_batch_locked(
             existing_sources = sources_by_unit.get(reusable.id, ())
             unchanged = (
                 reusable.source_revision == document.source_revision
+                and reusable.chunk_count == document.chunk_count
                 and reusable.chat_id == document.chat_id
                 and reusable.invalidated_at is None
                 and existing_sources == document.message_version_ids
@@ -1249,13 +1276,9 @@ async def _index_batch_locked(
             )
             reasons["indexed:reused_embedding" if stored else "skipped:conflict"] += 1
             continue
-        if document in oversized_documents:
-            reasons["skipped:oversize"] += 1
-            continue
-        embedded = vectors_by_document.get(document)
+        embedded = embeddings.get(document)
         if embedded is None:
-            reasons["skipped:conflict"] += 1
-            continue
+            raise LookupError("governed semantic document lost its reusable embedding")
         vector, llm_usage_ledger_id = embedded
         if await _store_document(
             session,
@@ -1270,14 +1293,110 @@ async def _index_batch_locked(
             reasons["indexed:new_embedding"] += 1
         else:
             reasons["skipped:conflict"] += 1
+    return reasons
+
+
+def _batch_result_from_reasons(reasons: Counter[str]) -> _BatchResult:
     indexed = reasons["indexed:new_embedding"] + reasons["indexed:reused_embedding"]
     skipped = (
         reasons["skipped:unchanged"]
         + reasons["skipped:governance_race"]
         + reasons["skipped:conflict"]
-        + reasons["skipped:oversize"]
     )
     return _BatchResult(indexed=indexed, skipped=skipped, reason_counts=dict(reasons))
+
+
+async def _index_batch_locked(
+    session: AsyncSession,
+    *,
+    documents: Sequence[RetrievalDocument],
+    config: EmbeddingGatewayConfig,
+    provider: Any | None,
+) -> _BatchResult:
+    batch = tuple(documents)
+    if not batch:
+        return _BatchResult(indexed=0, skipped=0, reason_counts={})
+    # Re-read governance state before any provider call. The caller already
+    # holds every source/forget lock for the entire sequence of partitions.
+    prevalidated_documents = await _revalidate_documents(session, documents=batch)
+    prevalidated_set = set(prevalidated_documents)
+    reasons: Counter[str] = Counter()
+    if blocked_count := len(batch) - len(prevalidated_documents):
+        reasons["skipped:governance_race"] += blocked_count
+
+    units_before_embedding = await _load_existing_units(
+        session,
+        documents=prevalidated_documents,
+        embedding_model=config.model,
+    )
+    parent_units_before_embedding = await _load_parent_message_units(
+        session,
+        documents=prevalidated_documents,
+        embedding_model=config.model,
+    )
+    reusable_documents = [
+        document
+        for document in prevalidated_documents
+        if _find_reusable_unit(
+            document=document,
+            units_by_source=units_before_embedding,
+        )
+        is not None
+        or _find_parent_message_unit(
+            document=document,
+            units_by_current_source=parent_units_before_embedding,
+        )
+        is not None
+    ]
+    if reusable_documents:
+        reasons.update(
+            await _persist_document_batch(
+                session,
+                documents=reusable_documents,
+                config=config,
+                embeddings={},
+            )
+        )
+
+    missing_documents = [
+        document
+        for document in batch
+        if document in prevalidated_set and document not in reusable_documents
+    ]
+    try:
+        for embedding_batch in _partition_embedding_documents(missing_documents):
+            embedding_result = await embed_texts(
+                session,
+                inputs=[document.canonical_text for document in embedding_batch],
+                config=config,
+                ledger_repo=LedgerRepo(),
+                provider=provider,
+            )
+            embeddings = {
+                document: (vector, embedding_result.llm_usage_ledger_id)
+                for document, vector in zip(
+                    embedding_batch,
+                    embedding_result.vectors,
+                    strict=True,
+                )
+            }
+            partition_reasons = await _persist_document_batch(
+                session,
+                documents=embedding_batch,
+                config=config,
+                embeddings=embeddings,
+            )
+            # Make each paid partition discoverable by retries and forget
+            # cascade before the next independent provider call can fail.
+            await session.commit()
+            reasons.update(partition_reasons)
+    except Exception as exc:
+        # The outer run still needs exact accounting for partitions committed
+        # before any failure. Only no-content counters cross the boundary.
+        setattr(exc, "semantic_batch_result", _batch_result_from_reasons(reasons))
+        raise
+
+    return _batch_result_from_reasons(reasons)
 
 
 async def _index_batch(
@@ -1472,6 +1591,11 @@ async def backfill_semantic_index(
         ProviderTransientError,
         ValueError,
     ) as exc:
+        partial_batch = getattr(exc, "semantic_batch_result", None)
+        if isinstance(partial_batch, _BatchResult):
+            indexed += partial_batch.indexed
+            skipped += partial_batch.skipped
+            reasons.update(partial_batch.reason_counts)
         # Every eligible document must be accounted for as indexed, skipped,
         # or failed. A provider error aborts the whole current batch, not one
         # synthetic row in the audit report.
@@ -1500,6 +1624,30 @@ async def backfill_semantic_index(
         await session.commit()
         logger.error(
             "semantic_index_database_failed",
+            extra={"run_id": run_id, "error_class": type(exc).__name__},
+        )
+        raise
+    except Exception as exc:
+        # Module-reload test harnesses and future provider taxonomies can yield
+        # an exception class that is not one of the explicit gateway types.
+        # Preserve the same durable, no-content run audit before propagating it.
+        partial_batch = getattr(exc, "semantic_batch_result", None)
+        if isinstance(partial_batch, _BatchResult):
+            indexed += partial_batch.indexed
+            skipped += partial_batch.skipped
+            reasons.update(partial_batch.reason_counts)
+        failed = max(0, eligible - indexed - skipped)
+        reasons[f"failed:{type(exc).__name__}"] += max(1, failed)
+        run.status = "failed"
+        run.eligible_count = eligible
+        run.indexed_count = indexed
+        run.skipped_count = skipped
+        run.failed_count = failed
+        run.reason_counts = dict(reasons)
+        run.completed_at = datetime.now(timezone.utc)
+        await session.commit()
+        logger.error(
+            "semantic_index_unexpected_failed",
             extra={"run_id": run_id, "error_class": type(exc).__name__},
         )
         raise

--- a/bot/services/semantic_index.py
+++ b/bot/services/semantic_index.py
@@ -1063,19 +1063,23 @@ async def _index_batch_locked(
     batch = tuple(documents)
     if not batch:
         return _BatchResult(indexed=0, skipped=0, reason_counts={})
+    # The batch may have been listed before this worker acquired the per-source
+    # locks. Re-read governance state before any provider call so a forget/edit
+    # transaction that won the lock can never leak stale text to OpenAI.
+    prevalidated_documents = await _revalidate_documents(session, documents=batch)
     units_before_embedding = await _load_existing_units(
         session,
-        documents=batch,
+        documents=prevalidated_documents,
         embedding_model=config.model,
     )
     parent_units_before_embedding = await _load_parent_message_units(
         session,
-        documents=batch,
+        documents=prevalidated_documents,
         embedding_model=config.model,
     )
     reusable_before_embedding = {
         document: unit
-        for document in batch
+        for document in prevalidated_documents
         if (
             unit := _find_reusable_unit(
                 document=document,
@@ -1088,7 +1092,9 @@ async def _index_batch_locked(
         )
         is not None
     }
-    missing = [document for document in batch if document not in reusable_before_embedding]
+    missing = [
+        document for document in prevalidated_documents if document not in reusable_before_embedding
+    ]
     embedding_result = None
     vectors_by_document: dict[RetrievalDocument, Sequence[float]] = {}
     if missing:
@@ -1102,7 +1108,10 @@ async def _index_batch_locked(
         vectors_by_document = dict(zip(missing, embedding_result.vectors, strict=True))
     embedded_documents = set(missing)
 
-    valid_documents = await _revalidate_documents(session, documents=batch)
+    valid_documents = await _revalidate_documents(
+        session,
+        documents=prevalidated_documents,
+    )
     if blocked_count := len(batch) - len(valid_documents):
         logger.info(
             "semantic_index_documents_skipped_governance",

--- a/bot/services/semantic_index.py
+++ b/bot/services/semantic_index.py
@@ -19,6 +19,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import aliased
 
 from bot.db.models import (
+    LlmUsageLedger,
     MessageVersion,
     SemanticIndexRun,
     SemanticRetrievalUnit,
@@ -91,7 +92,11 @@ _REVALIDATE_CARDS_SQL = text(
 _RECONCILE_INELIGIBLE_SQL = text(
     f"""
     UPDATE semantic_retrieval_units AS unit
-    SET invalidated_at = :invalidated_at,
+    SET embedding_status = 'failed',
+        chunk_text = NULL,
+        embedding = NULL,
+        indexed_at = NULL,
+        invalidated_at = :invalidated_at,
         invalidation_reason = 'source_ineligible'
     WHERE unit.embedding_model = :embedding_model
       AND unit.invalidated_at IS NULL
@@ -176,7 +181,7 @@ _RECONCILE_INELIGIBLE_SQL = text(
               )
           )
       )
-    RETURNING unit.id
+    RETURNING unit.id, unit.llm_usage_ledger_id
     """
 )
 
@@ -1738,7 +1743,18 @@ async def _reconcile_ineligible_units(
             "chat_id": chat_id,
         },
     )
-    invalidated = len(result.scalars().all())
+    invalidated_rows = list(result.all())
+    invalidated = len(invalidated_rows)
+    ledger_ids = {int(row.llm_usage_ledger_id) for row in invalidated_rows}
+    if ledger_ids:
+        # A batch ledger hashes all provider inputs/results together. If any
+        # source becomes ineligible, retain only aggregate spend/latency and
+        # irreversibly remove the content-derived hashes for the whole call.
+        await session.execute(
+            update(LlmUsageLedger)
+            .where(LlmUsageLedger.id.in_(ledger_ids))
+            .values(prompt_hash=None, response_hash=None)
+        )
     if invalidated:
         logger.info(
             "semantic_index_units_reconciled",

--- a/bot/services/semantic_index.py
+++ b/bot/services/semantic_index.py
@@ -1,0 +1,1667 @@
+"""Governed pgvector index for semantic community-memory retrieval."""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import math
+import time
+import uuid
+from collections import Counter
+from dataclasses import dataclass, replace
+from datetime import datetime, timezone
+from typing import Any, Literal, Sequence
+
+from sqlalchemy import delete, select, text, tuple_, update
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import aliased
+
+from bot.db.models import (
+    MessageVersion,
+    SemanticIndexRun,
+    SemanticRetrievalUnit,
+    SemanticRetrievalUnitSource,
+)
+from bot.db.repos.llm_usage_ledger import LedgerRepo
+from bot.services.forget_predicate import forget_excludes_sql_fragment
+from bot.services.llm_gateway import (
+    EmbeddingBudgetExceeded,
+    EmbeddingGatewayConfig,
+    embed_texts,
+)
+from bot.services.llm_providers import ProviderStructuralError, ProviderTransientError
+from bot.services.search import SearchHit
+
+
+logger = logging.getLogger(__name__)
+
+EMBEDDING_PROVIDER = "openai"
+EMBEDDING_MODEL_VERSION = "text-embedding-3-small"
+DEFAULT_BACKFILL_BATCH_SIZE = 64
+DEFAULT_VECTOR_CANDIDATE_LIMIT = 20
+MAX_SEMANTIC_EVIDENCE = 5
+RRF_K = 60
+
+_FORGET_EXCLUDES = forget_excludes_sql_fragment()
+
+_REVALIDATE_PROVENANCE_SQL = text(
+    f"""
+    SELECT mv.id AS message_version_id,
+           cm.chat_id
+    FROM message_versions mv
+    JOIN chat_messages cm
+      ON cm.id = mv.chat_message_id
+     AND cm.current_version_id = mv.id
+    JOIN users author ON author.id = cm.user_id
+    WHERE mv.id = ANY(:message_version_ids)
+      AND author.is_bot = FALSE
+      AND cm.memory_policy = 'normal'
+      AND COALESCE(cm.message_kind, 'text') NOT IN ('voice', 'audio')
+      AND cm.is_redacted = FALSE
+      AND mv.is_redacted = FALSE
+      AND {_FORGET_EXCLUDES}
+    """
+)
+
+_REVALIDATE_CARDS_SQL = text(
+    """
+    SELECT kc.id::text AS source_id,
+           ARRAY_AGG(cs.message_version_id ORDER BY cs.position ASC, cs.id ASC)
+               AS message_version_ids
+    FROM knowledge_cards kc
+    JOIN card_sources cs ON cs.card_id = kc.id
+    WHERE kc.id::text = ANY(:source_ids)
+      AND kc.card_status = 'approved'
+    GROUP BY kc.id
+    """
+)
+
+_RECONCILE_INELIGIBLE_SQL = text(
+    f"""
+    UPDATE semantic_retrieval_units AS unit
+    SET invalidated_at = :invalidated_at,
+        invalidation_reason = 'source_ineligible'
+    WHERE unit.embedding_model = :embedding_model
+      AND unit.invalidated_at IS NULL
+      AND (CAST(:chat_id AS BIGINT) IS NULL OR unit.chat_id = CAST(:chat_id AS BIGINT))
+      AND (
+          NOT EXISTS (
+              SELECT 1
+              FROM semantic_retrieval_unit_sources source_any
+              WHERE source_any.unit_id = unit.id
+          )
+          OR EXISTS (
+              SELECT 1
+              FROM semantic_retrieval_unit_sources source
+              JOIN message_versions mv ON mv.id = source.message_version_id
+              JOIN chat_messages cm ON cm.id = mv.chat_message_id
+              LEFT JOIN users author ON author.id = cm.user_id
+              WHERE source.unit_id = unit.id
+                AND (
+                    cm.chat_id <> unit.chat_id
+                    OR cm.current_version_id IS DISTINCT FROM mv.id
+                    OR cm.memory_policy <> 'normal'
+                    OR COALESCE(cm.message_kind, 'text') IN ('voice', 'audio')
+                    OR cm.is_redacted = TRUE
+                    OR mv.is_redacted = TRUE
+                    OR author.is_bot IS DISTINCT FROM FALSE
+                    OR NOT ({_FORGET_EXCLUDES})
+                )
+          )
+          OR (
+              unit.source_type = 'message'
+              AND NOT EXISTS (
+                  SELECT 1
+                  FROM semantic_retrieval_unit_sources source
+                  WHERE source.unit_id = unit.id
+                    AND source.message_version_id::text = unit.source_id
+                    AND source.position = 0
+                    AND NOT EXISTS (
+                        SELECT 1
+                        FROM semantic_retrieval_unit_sources extra_source
+                        WHERE extra_source.unit_id = unit.id
+                          AND extra_source.message_version_id <> source.message_version_id
+                    )
+              )
+          )
+          OR (
+              unit.source_type = 'card'
+              AND (
+                  NOT EXISTS (
+                      SELECT 1
+                      FROM knowledge_cards card
+                      WHERE card.id::text = unit.source_id
+                        AND card.card_status = 'approved'
+                  )
+                  OR EXISTS (
+                      (
+                          SELECT source.message_version_id, source.position
+                          FROM semantic_retrieval_unit_sources source
+                          WHERE source.unit_id = unit.id
+                      )
+                      EXCEPT
+                      (
+                          SELECT card_source.message_version_id, card_source.position
+                          FROM card_sources card_source
+                          JOIN knowledge_cards card ON card.id = card_source.card_id
+                          WHERE card.id::text = unit.source_id
+                      )
+                  )
+                  OR EXISTS (
+                      (
+                          SELECT card_source.message_version_id, card_source.position
+                          FROM card_sources card_source
+                          JOIN knowledge_cards card ON card.id = card_source.card_id
+                          WHERE card.id::text = unit.source_id
+                      )
+                      EXCEPT
+                      (
+                          SELECT source.message_version_id, source.position
+                          FROM semantic_retrieval_unit_sources source
+                          WHERE source.unit_id = unit.id
+                      )
+                  )
+              )
+          )
+      )
+    RETURNING unit.id
+    """
+)
+
+_ELIGIBLE_MESSAGES_SQL = text(
+    f"""
+    SELECT mv.id AS message_version_id,
+           mv.version_seq,
+           mv.content_hash AS source_content_hash,
+           cm.chat_id,
+           concat_ws(
+               E'\n',
+               NULLIF(btrim(COALESCE(mv.normalized_text, mv.text, '')), ''),
+               NULLIF(btrim(COALESCE(mv.caption, '')), ''),
+               CASE
+                   WHEN mm.description_status = 'ready'
+                   THEN NULLIF(btrim(COALESCE(mm.description, '')), '')
+                   ELSE NULL
+               END
+           ) AS canonical_text,
+           CASE WHEN mm.description_status = 'ready' THEN mm.updated_at ELSE NULL END
+               AS media_revision
+    FROM message_versions mv
+    JOIN chat_messages cm
+      ON cm.id = mv.chat_message_id
+     AND cm.current_version_id = mv.id
+    JOIN users author ON author.id = cm.user_id
+    LEFT JOIN message_media mm ON mm.chat_message_id = cm.id
+    WHERE mv.id > :after_id
+      AND (CAST(:chat_id AS BIGINT) IS NULL OR cm.chat_id = CAST(:chat_id AS BIGINT))
+      AND author.is_bot = FALSE
+      AND cm.memory_policy = 'normal'
+      AND COALESCE(cm.message_kind, 'text') NOT IN ('voice', 'audio')
+      AND cm.is_redacted = FALSE
+      AND mv.is_redacted = FALSE
+      AND btrim(
+            concat_ws(
+                ' ',
+                COALESCE(mv.normalized_text, mv.text, ''),
+                COALESCE(mv.caption, ''),
+                CASE WHEN mm.description_status = 'ready' THEN COALESCE(mm.description, '') ELSE '' END
+            )
+          ) <> ''
+      AND {_FORGET_EXCLUDES}
+    ORDER BY mv.id ASC
+    LIMIT :limit
+    """
+)
+
+_ELIGIBLE_CARDS_SQL = text(
+    f"""
+    SELECT kc.id AS card_id,
+           kc.updated_at,
+           kc.approved_at,
+           anchor.chat_id,
+           concat_ws(E'\n', NULLIF(btrim(kc.title), ''), NULLIF(btrim(kc.body_markdown), ''))
+               AS canonical_text,
+           ARRAY(
+               SELECT cs_list.message_version_id
+               FROM card_sources cs_list
+               WHERE cs_list.card_id = kc.id
+               ORDER BY cs_list.position ASC, cs_list.id ASC
+           ) AS message_version_ids
+    FROM knowledge_cards kc
+    JOIN LATERAL (
+        SELECT cm_anchor.chat_id
+        FROM card_sources cs_anchor
+        JOIN message_versions mv_anchor ON mv_anchor.id = cs_anchor.message_version_id
+        JOIN chat_messages cm_anchor ON cm_anchor.id = mv_anchor.chat_message_id
+        WHERE cs_anchor.card_id = kc.id
+        ORDER BY cs_anchor.position ASC, cs_anchor.id ASC
+        LIMIT 1
+    ) anchor ON TRUE
+    WHERE kc.card_status = 'approved'
+      AND kc.id::text > :after_id
+      AND (CAST(:chat_id AS BIGINT) IS NULL OR anchor.chat_id = CAST(:chat_id AS BIGINT))
+      AND NOT EXISTS (
+          SELECT 1
+          FROM card_sources cs
+          JOIN message_versions mv ON mv.id = cs.message_version_id
+          JOIN chat_messages cm ON cm.id = mv.chat_message_id
+          LEFT JOIN users author ON author.id = cm.user_id
+          WHERE cs.card_id = kc.id
+            AND (
+                cm.chat_id <> anchor.chat_id
+                OR cm.current_version_id IS DISTINCT FROM mv.id
+                OR cm.memory_policy <> 'normal'
+                OR COALESCE(cm.message_kind, 'text') IN ('voice', 'audio')
+                OR cm.is_redacted = TRUE
+                OR mv.is_redacted = TRUE
+                OR author.is_bot IS DISTINCT FROM FALSE
+                OR NOT ({_FORGET_EXCLUDES})
+            )
+      )
+      AND btrim(concat_ws(' ', kc.title, kc.body_markdown)) <> ''
+    ORDER BY kc.id::text ASC
+    LIMIT :limit
+    """
+)
+
+_VECTOR_CANDIDATES_SQL = text(
+    f"""
+    SELECT unit.id,
+           unit.source_type,
+           unit.source_id,
+           1 - (unit.embedding <=> CAST(:embedding AS vector)) AS similarity
+    FROM semantic_retrieval_units unit
+    WHERE unit.chat_id = :chat_id
+      AND unit.embedding_model = :embedding_model
+      AND unit.invalidated_at IS NULL
+      AND EXISTS (
+          SELECT 1 FROM semantic_retrieval_unit_sources source_any
+          WHERE source_any.unit_id = unit.id
+      )
+      AND (
+          unit.source_type = 'message'
+          OR (
+              unit.source_type = 'card'
+              AND EXISTS (
+                  SELECT 1
+                  FROM knowledge_cards card
+                  WHERE card.id::text = unit.source_id
+                    AND card.card_status = 'approved'
+                    AND ARRAY(
+                        SELECT unit_source.message_version_id
+                        FROM semantic_retrieval_unit_sources unit_source
+                        WHERE unit_source.unit_id = unit.id
+                        ORDER BY unit_source.position
+                    ) = ARRAY(
+                        SELECT card_source.message_version_id
+                        FROM card_sources card_source
+                        WHERE card_source.card_id = card.id
+                        ORDER BY card_source.position, card_source.id
+                    )
+              )
+          )
+      )
+      AND NOT EXISTS (
+          SELECT 1
+          FROM semantic_retrieval_unit_sources source
+          JOIN message_versions mv ON mv.id = source.message_version_id
+          JOIN chat_messages cm ON cm.id = mv.chat_message_id
+          LEFT JOIN users author ON author.id = cm.user_id
+          WHERE source.unit_id = unit.id
+            AND (
+                cm.chat_id <> :chat_id
+                OR cm.current_version_id IS DISTINCT FROM mv.id
+                OR cm.memory_policy <> 'normal'
+                OR COALESCE(cm.message_kind, 'text') IN ('voice', 'audio')
+                OR cm.is_redacted = TRUE
+                OR mv.is_redacted = TRUE
+                OR author.is_bot IS DISTINCT FROM FALSE
+                OR (CAST(:exclude_chat_message_id AS INTEGER) IS NOT NULL
+                    AND cm.id = CAST(:exclude_chat_message_id AS INTEGER))
+                OR NOT ({_FORGET_EXCLUDES})
+            )
+      )
+    ORDER BY unit.embedding <=> CAST(:embedding AS vector), unit.id ASC
+    LIMIT :limit
+    """
+)
+
+_MESSAGE_HIT_SQL = text(
+    f"""
+    SELECT mv.id AS message_version_id,
+           cm.id AS chat_message_id,
+           cm.chat_id,
+           cm.message_id,
+           cm.user_id,
+           cm.message_thread_id,
+           cm.reply_to_message_id,
+           concat_ws(
+               ' ',
+               NULLIF(btrim(COALESCE(mv.normalized_text, mv.text, '')), ''),
+               NULLIF(btrim(COALESCE(mv.caption, '')), ''),
+               CASE WHEN mm.description_status = 'ready' THEN mm.description ELSE NULL END
+           ) AS snippet,
+           mv.captured_at,
+           cm.date AS message_date
+    FROM semantic_retrieval_units unit
+    JOIN semantic_retrieval_unit_sources source ON source.unit_id = unit.id
+    JOIN message_versions mv ON mv.id = source.message_version_id
+    JOIN chat_messages cm ON cm.id = mv.chat_message_id AND cm.current_version_id = mv.id
+    JOIN users author ON author.id = cm.user_id
+    LEFT JOIN message_media mm ON mm.chat_message_id = cm.id
+    WHERE unit.id = :unit_id
+      AND unit.source_type = 'message'
+      AND unit.invalidated_at IS NULL
+      AND cm.chat_id = :chat_id
+      AND author.is_bot = FALSE
+      AND cm.memory_policy = 'normal'
+      AND COALESCE(cm.message_kind, 'text') NOT IN ('voice', 'audio')
+      AND cm.is_redacted = FALSE
+      AND mv.is_redacted = FALSE
+      AND (CAST(:exclude_chat_message_id AS INTEGER) IS NULL
+           OR cm.id <> CAST(:exclude_chat_message_id AS INTEGER))
+      AND {_FORGET_EXCLUDES}
+    ORDER BY source.position ASC
+    LIMIT 1
+    """
+)
+
+_CARD_HIT_SQL = text(
+    f"""
+    SELECT kc.id AS card_id,
+           anchor.message_version_id,
+           anchor.chat_message_id,
+           anchor.chat_id,
+           anchor.message_id,
+           anchor.message_thread_id,
+           anchor.reply_to_message_id,
+           concat_ws(' ', kc.title, kc.body_markdown) AS snippet,
+           kc.approved_at AS captured_at,
+           COALESCE(kc.approved_at, anchor.message_date) AS message_date,
+           ARRAY_AGG(source.message_version_id ORDER BY source.position ASC)
+               AS message_version_ids
+    FROM semantic_retrieval_units unit
+    JOIN knowledge_cards kc ON kc.id::text = unit.source_id
+    JOIN semantic_retrieval_unit_sources source ON source.unit_id = unit.id
+    JOIN LATERAL (
+        SELECT mv_anchor.id AS message_version_id,
+               cm_anchor.id AS chat_message_id,
+               cm_anchor.chat_id,
+               cm_anchor.message_id,
+               cm_anchor.message_thread_id,
+               cm_anchor.reply_to_message_id,
+               cm_anchor.date AS message_date
+        FROM semantic_retrieval_unit_sources source_anchor
+        JOIN message_versions mv_anchor ON mv_anchor.id = source_anchor.message_version_id
+        JOIN chat_messages cm_anchor ON cm_anchor.id = mv_anchor.chat_message_id
+        WHERE source_anchor.unit_id = unit.id
+        ORDER BY source_anchor.position ASC
+        LIMIT 1
+    ) anchor ON TRUE
+    WHERE unit.id = :unit_id
+      AND unit.source_type = 'card'
+      AND unit.invalidated_at IS NULL
+      AND kc.card_status = 'approved'
+      AND anchor.chat_id = :chat_id
+      AND NOT EXISTS (
+          SELECT 1
+          FROM semantic_retrieval_unit_sources source_check
+          JOIN message_versions mv ON mv.id = source_check.message_version_id
+          JOIN chat_messages cm ON cm.id = mv.chat_message_id
+          LEFT JOIN users author ON author.id = cm.user_id
+          WHERE source_check.unit_id = unit.id
+            AND (
+                cm.chat_id <> :chat_id
+                OR cm.current_version_id IS DISTINCT FROM mv.id
+                OR cm.memory_policy <> 'normal'
+                OR COALESCE(cm.message_kind, 'text') IN ('voice', 'audio')
+                OR cm.is_redacted = TRUE
+                OR mv.is_redacted = TRUE
+                OR author.is_bot IS DISTINCT FROM FALSE
+                OR (CAST(:exclude_chat_message_id AS INTEGER) IS NOT NULL
+                    AND cm.id = CAST(:exclude_chat_message_id AS INTEGER))
+                OR NOT ({_FORGET_EXCLUDES})
+            )
+      )
+    GROUP BY kc.id, anchor.message_version_id, anchor.chat_message_id, anchor.chat_id,
+             anchor.message_id, anchor.message_thread_id, anchor.reply_to_message_id,
+             anchor.message_date
+    HAVING ARRAY_AGG(source.message_version_id ORDER BY source.position ASC) = ARRAY(
+        SELECT card_source.message_version_id
+        FROM card_sources card_source
+        WHERE card_source.card_id = kc.id
+        ORDER BY card_source.position, card_source.id
+    )
+    """
+)
+
+_CONVERSATION_ROOTS_SQL = text(
+    """
+    WITH RECURSIVE requested(origin_message_id) AS (
+        SELECT unnest(CAST(:message_ids AS BIGINT[]))
+    ), chain AS (
+        SELECT requested.origin_message_id,
+               message.message_id AS current_message_id,
+               message.reply_to_message_id,
+               ARRAY[message.message_id]::BIGINT[] AS path,
+               0 AS depth
+        FROM requested
+        JOIN chat_messages message
+          ON message.chat_id = :chat_id
+         AND message.message_id = requested.origin_message_id
+        UNION ALL
+        SELECT chain.origin_message_id,
+               parent.message_id,
+               parent.reply_to_message_id,
+               chain.path || parent.message_id,
+               chain.depth + 1
+        FROM chain
+        JOIN chat_messages parent
+          ON parent.chat_id = :chat_id
+         AND parent.message_id = chain.reply_to_message_id
+        WHERE chain.depth < 64
+          AND NOT parent.message_id = ANY(chain.path)
+    )
+    SELECT DISTINCT ON (origin_message_id)
+           origin_message_id,
+           CASE
+               WHEN reply_to_message_id IS NULL OR reply_to_message_id = ANY(path)
+               THEN current_message_id
+               ELSE reply_to_message_id
+           END AS root_message_id
+    FROM chain
+    ORDER BY origin_message_id, depth DESC
+    """
+)
+
+
+@dataclass(frozen=True, slots=True)
+class RetrievalDocument:
+    source_type: Literal["message", "card"]
+    source_id: str
+    source_revision: str
+    chat_id: int
+    canonical_text: str
+    content_hash: str
+    message_version_ids: tuple[int, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class _ExistingUnit:
+    id: int
+    source_type: str
+    source_id: str
+    source_revision: str
+    chat_id: int
+    content_hash: str
+    invalidated_at: datetime | None
+    embedding_provider: str
+    embedding_model_version: str
+    embedding_dimensions: int
+    embedding: tuple[float, ...]
+    llm_usage_ledger_id: int
+
+
+@dataclass(frozen=True, slots=True)
+class BackfillReport:
+    run_id: int
+    eligible: int
+    indexed: int
+    skipped: int
+    failed: int
+    reason_counts: dict[str, int]
+
+
+@dataclass(frozen=True, slots=True)
+class _BatchResult:
+    indexed: int
+    skipped: int
+    reason_counts: dict[str, int]
+
+
+@dataclass(frozen=True, slots=True)
+class HybridSearchResult:
+    hits: tuple[SearchHit, ...]
+    candidate_ranks: dict[str, dict[str, int]]
+    fts_latency_ms: int
+    vector_latency_ms: int
+    fusion_latency_ms: int
+    total_latency_ms: int
+
+
+def _content_hash(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _vector_literal(vector: Sequence[float]) -> str:
+    if len(vector) != 1536:
+        raise ValueError("query embedding must contain 1536 values")
+    values = tuple(float(value) for value in vector)
+    if any(not math.isfinite(value) for value in values):
+        raise ValueError("query embedding values must be finite")
+    return "[" + ",".join(repr(value) for value in values) + "]"
+
+
+def _source_key(hit: SearchHit) -> str:
+    if hit.source_type == "card":
+        if hit.card_id is None:
+            raise ValueError("card search hit is missing card_id")
+        return f"card:{hit.card_id}"
+    return f"message:{hit.message_version_id}"
+
+
+async def list_eligible_message_documents(
+    session: AsyncSession,
+    *,
+    after_id: int = 0,
+    limit: int = DEFAULT_BACKFILL_BATCH_SIZE,
+    chat_id: int | None = None,
+) -> list[RetrievalDocument]:
+    if after_id < 0 or limit < 1:
+        raise ValueError("invalid message backfill cursor or limit")
+    result = await session.execute(
+        _ELIGIBLE_MESSAGES_SQL,
+        {"after_id": after_id, "limit": limit, "chat_id": chat_id},
+    )
+    documents: list[RetrievalDocument] = []
+    for row in result.mappings().all():
+        canonical_text = str(row["canonical_text"]).strip()
+        media_revision = row["media_revision"]
+        revision = f"v{row['version_seq']}:media:{media_revision.isoformat() if media_revision else 'none'}"
+        documents.append(
+            RetrievalDocument(
+                source_type="message",
+                source_id=str(row["message_version_id"]),
+                source_revision=revision,
+                chat_id=int(row["chat_id"]),
+                canonical_text=canonical_text,
+                content_hash=_content_hash(canonical_text),
+                message_version_ids=(int(row["message_version_id"]),),
+            )
+        )
+    return documents
+
+
+async def list_eligible_card_documents(
+    session: AsyncSession,
+    *,
+    after_id: str = "",
+    limit: int = DEFAULT_BACKFILL_BATCH_SIZE,
+    chat_id: int | None = None,
+) -> list[RetrievalDocument]:
+    if limit < 1:
+        raise ValueError("card backfill limit must be positive")
+    result = await session.execute(
+        _ELIGIBLE_CARDS_SQL,
+        {"after_id": after_id, "limit": limit, "chat_id": chat_id},
+    )
+    documents: list[RetrievalDocument] = []
+    for row in result.mappings().all():
+        canonical_text = str(row["canonical_text"]).strip()
+        updated_at = row["updated_at"]
+        approved_at = row["approved_at"]
+        documents.append(
+            RetrievalDocument(
+                source_type="card",
+                source_id=str(row["card_id"]),
+                source_revision=(
+                    f"updated:{updated_at.isoformat()}:"
+                    f"approved:{approved_at.isoformat() if approved_at else 'none'}"
+                ),
+                chat_id=int(row["chat_id"]),
+                canonical_text=canonical_text,
+                content_hash=_content_hash(canonical_text),
+                message_version_ids=tuple(int(value) for value in row["message_version_ids"]),
+            )
+        )
+    return documents
+
+
+async def _load_existing_units(
+    session: AsyncSession,
+    *,
+    documents: Sequence[RetrievalDocument],
+    embedding_model: str,
+) -> dict[tuple[str, str], list[_ExistingUnit]]:
+    source_keys = sorted({(document.source_type, document.source_id) for document in documents})
+    if not source_keys:
+        return {}
+    result = await session.execute(
+        select(
+            SemanticRetrievalUnit.id,
+            SemanticRetrievalUnit.source_type,
+            SemanticRetrievalUnit.source_id,
+            SemanticRetrievalUnit.source_revision,
+            SemanticRetrievalUnit.chat_id,
+            SemanticRetrievalUnit.content_hash,
+            SemanticRetrievalUnit.invalidated_at,
+            SemanticRetrievalUnit.embedding_provider,
+            SemanticRetrievalUnit.embedding_model_version,
+            SemanticRetrievalUnit.embedding_dimensions,
+            SemanticRetrievalUnit.embedding,
+            SemanticRetrievalUnit.llm_usage_ledger_id,
+        )
+        .where(
+            tuple_(
+                SemanticRetrievalUnit.source_type,
+                SemanticRetrievalUnit.source_id,
+            ).in_(source_keys),
+            SemanticRetrievalUnit.embedding_model == embedding_model,
+        )
+        .order_by(SemanticRetrievalUnit.id.desc())
+    )
+    units_by_source: dict[tuple[str, str], list[_ExistingUnit]] = {}
+    for row in result:
+        unit = _ExistingUnit(
+            id=int(row.id),
+            source_type=str(row.source_type),
+            source_id=str(row.source_id),
+            source_revision=str(row.source_revision),
+            chat_id=int(row.chat_id),
+            content_hash=str(row.content_hash),
+            invalidated_at=row.invalidated_at,
+            embedding_provider=str(row.embedding_provider),
+            embedding_model_version=str(row.embedding_model_version),
+            embedding_dimensions=int(row.embedding_dimensions),
+            embedding=tuple(float(value) for value in row.embedding),
+            llm_usage_ledger_id=int(row.llm_usage_ledger_id),
+        )
+        units_by_source.setdefault((unit.source_type, unit.source_id), []).append(unit)
+    return units_by_source
+
+
+async def _load_parent_message_units(
+    session: AsyncSession,
+    *,
+    documents: Sequence[RetrievalDocument],
+    embedding_model: str,
+) -> dict[str, list[_ExistingUnit]]:
+    message_version_ids = sorted(
+        int(document.source_id) for document in documents if document.source_type == "message"
+    )
+    if not message_version_ids:
+        return {}
+    current_version = aliased(MessageVersion)
+    old_version = aliased(MessageVersion)
+    result = await session.execute(
+        select(
+            current_version.id.label("current_message_version_id"),
+            SemanticRetrievalUnit.id,
+            SemanticRetrievalUnit.source_type,
+            SemanticRetrievalUnit.source_id,
+            SemanticRetrievalUnit.source_revision,
+            SemanticRetrievalUnit.chat_id,
+            SemanticRetrievalUnit.content_hash,
+            SemanticRetrievalUnit.invalidated_at,
+            SemanticRetrievalUnit.embedding_provider,
+            SemanticRetrievalUnit.embedding_model_version,
+            SemanticRetrievalUnit.embedding_dimensions,
+            SemanticRetrievalUnit.embedding,
+            SemanticRetrievalUnit.llm_usage_ledger_id,
+        )
+        .join(
+            old_version,
+            (old_version.chat_message_id == current_version.chat_message_id)
+            & (old_version.id != current_version.id),
+        )
+        .join(
+            SemanticRetrievalUnitSource,
+            SemanticRetrievalUnitSource.message_version_id == old_version.id,
+        )
+        .join(
+            SemanticRetrievalUnit,
+            SemanticRetrievalUnit.id == SemanticRetrievalUnitSource.unit_id,
+        )
+        .where(
+            current_version.id.in_(message_version_ids),
+            SemanticRetrievalUnit.source_type == "message",
+            SemanticRetrievalUnit.embedding_model == embedding_model,
+        )
+        .order_by(current_version.id, SemanticRetrievalUnit.id.desc())
+    )
+    units_by_current_source: dict[str, list[_ExistingUnit]] = {}
+    for row in result.mappings():
+        unit = _ExistingUnit(
+            id=int(row["id"]),
+            source_type=str(row["source_type"]),
+            source_id=str(row["source_id"]),
+            source_revision=str(row["source_revision"]),
+            chat_id=int(row["chat_id"]),
+            content_hash=str(row["content_hash"]),
+            invalidated_at=row["invalidated_at"],
+            embedding_provider=str(row["embedding_provider"]),
+            embedding_model_version=str(row["embedding_model_version"]),
+            embedding_dimensions=int(row["embedding_dimensions"]),
+            embedding=tuple(float(value) for value in row["embedding"]),
+            llm_usage_ledger_id=int(row["llm_usage_ledger_id"]),
+        )
+        units_by_current_source.setdefault(str(row["current_message_version_id"]), []).append(unit)
+    return units_by_current_source
+
+
+def _find_reusable_unit(
+    *,
+    document: RetrievalDocument,
+    units_by_source: dict[tuple[str, str], list[_ExistingUnit]],
+) -> _ExistingUnit | None:
+    candidates = units_by_source.get((document.source_type, document.source_id), ())
+    for candidate in candidates:
+        if (
+            candidate.source_revision == document.source_revision
+            and candidate.content_hash == document.content_hash
+        ):
+            return candidate
+    for candidate in candidates:
+        if candidate.content_hash == document.content_hash:
+            return candidate
+    return None
+
+
+def _find_parent_message_unit(
+    *,
+    document: RetrievalDocument,
+    units_by_current_source: dict[str, list[_ExistingUnit]],
+) -> _ExistingUnit | None:
+    if document.source_type != "message":
+        return None
+    return next(
+        (
+            candidate
+            for candidate in units_by_current_source.get(document.source_id, ())
+            if candidate.content_hash == document.content_hash
+        ),
+        None,
+    )
+
+
+async def _acquire_document_locks(
+    session: AsyncSession,
+    *,
+    documents: Sequence[RetrievalDocument],
+    existing_message_version_ids: Sequence[int] = (),
+) -> None:
+    if session.bind is None or session.bind.dialect.name != "postgresql":
+        return
+    from bot.services.forget_cascade import _p6_mvid_advisory_lock_id
+
+    lock_ids = sorted(
+        {
+            _p6_mvid_advisory_lock_id(message_version_id)
+            for document in documents
+            for message_version_id in document.message_version_ids
+        }
+        | {
+            _p6_mvid_advisory_lock_id(message_version_id)
+            for message_version_id in existing_message_version_ids
+        }
+    )
+    for lock_id in lock_ids:
+        await session.execute(
+            text("SELECT pg_advisory_xact_lock(:lock_id)"),
+            {"lock_id": lock_id},
+        )
+
+
+async def _revalidate_documents(
+    session: AsyncSession,
+    *,
+    documents: Sequence[RetrievalDocument],
+) -> list[RetrievalDocument]:
+    message_version_ids = sorted(
+        {
+            message_version_id
+            for document in documents
+            for message_version_id in document.message_version_ids
+        }
+    )
+    if not message_version_ids:
+        return []
+    provenance_result = await session.execute(
+        _REVALIDATE_PROVENANCE_SQL,
+        {"message_version_ids": message_version_ids},
+    )
+    valid_chat_by_message_version_id = {
+        int(row["message_version_id"]): int(row["chat_id"]) for row in provenance_result.mappings()
+    }
+
+    card_documents = [document for document in documents if document.source_type == "card"]
+    card_sources: dict[str, tuple[int, ...]] = {}
+    if card_documents:
+        cards_result = await session.execute(
+            _REVALIDATE_CARDS_SQL,
+            {"source_ids": sorted({document.source_id for document in card_documents})},
+        )
+        card_sources = {
+            str(row["source_id"]): tuple(int(value) for value in row["message_version_ids"])
+            for row in cards_result.mappings()
+        }
+
+    valid: list[RetrievalDocument] = []
+    for document in documents:
+        if not document.message_version_ids or any(
+            valid_chat_by_message_version_id.get(message_version_id) != document.chat_id
+            for message_version_id in document.message_version_ids
+        ):
+            continue
+        if document.source_type == "message":
+            if document.message_version_ids != (int(document.source_id),):
+                continue
+        elif card_sources.get(document.source_id) != document.message_version_ids:
+            continue
+        valid.append(document)
+    return valid
+
+
+async def _load_unit_sources(
+    session: AsyncSession,
+    *,
+    unit_ids: Sequence[int],
+) -> dict[int, tuple[int, ...]]:
+    if not unit_ids:
+        return {}
+    result = await session.execute(
+        select(
+            SemanticRetrievalUnitSource.unit_id,
+            SemanticRetrievalUnitSource.message_version_id,
+        )
+        .where(SemanticRetrievalUnitSource.unit_id.in_(unit_ids))
+        .order_by(
+            SemanticRetrievalUnitSource.unit_id,
+            SemanticRetrievalUnitSource.position,
+        )
+    )
+    sources: dict[int, list[int]] = {}
+    for row in result:
+        sources.setdefault(int(row.unit_id), []).append(int(row.message_version_id))
+    return {unit_id: tuple(message_version_ids) for unit_id, message_version_ids in sources.items()}
+
+
+async def _invalidate_previous_documents(
+    session: AsyncSession,
+    *,
+    document: RetrievalDocument,
+    embedding_model: str,
+) -> None:
+    now = datetime.now(timezone.utc)
+    if document.source_type == "message":
+        # Message source_id is the immutable message_version id.  An edit gets a
+        # new source_id, so invalidating only by source_id would leave the old
+        # unit active forever.  Follow provenance to the parent chat_message and
+        # invalidate every earlier active version for that same source message.
+        await session.execute(
+            text(
+                """
+                UPDATE semantic_retrieval_units AS unit
+                SET invalidated_at = :invalidated_at,
+                    invalidation_reason = 'source_revised'
+                WHERE unit.source_type = 'message'
+                  AND unit.embedding_model = :embedding_model
+                  AND unit.invalidated_at IS NULL
+                  AND (
+                      unit.source_revision <> :source_revision
+                      OR unit.content_hash <> :content_hash
+                  )
+                  AND EXISTS (
+                      SELECT 1
+                      FROM semantic_retrieval_unit_sources old_source
+                      JOIN message_versions old_mv
+                        ON old_mv.id = old_source.message_version_id
+                      JOIN message_versions current_mv
+                        ON current_mv.id = :current_message_version_id
+                       AND current_mv.chat_message_id = old_mv.chat_message_id
+                      WHERE old_source.unit_id = unit.id
+                  )
+                """
+            ),
+            {
+                "invalidated_at": now,
+                "embedding_model": embedding_model,
+                "source_revision": document.source_revision,
+                "content_hash": document.content_hash,
+                "current_message_version_id": int(document.source_id),
+            },
+        )
+        return
+    await session.execute(
+        update(SemanticRetrievalUnit)
+        .where(
+            SemanticRetrievalUnit.source_type == document.source_type,
+            SemanticRetrievalUnit.source_id == document.source_id,
+            SemanticRetrievalUnit.embedding_model == embedding_model,
+            SemanticRetrievalUnit.invalidated_at.is_(None),
+        )
+        .where(
+            (SemanticRetrievalUnit.source_revision != document.source_revision)
+            | (SemanticRetrievalUnit.content_hash != document.content_hash)
+        )
+        .values(invalidated_at=now, invalidation_reason="source_revised")
+    )
+
+
+async def _reuse_document(
+    session: AsyncSession,
+    *,
+    document: RetrievalDocument,
+    unit: _ExistingUnit,
+    existing_sources: tuple[int, ...],
+    embedding_model: str,
+) -> None:
+    await _invalidate_previous_documents(
+        session,
+        document=document,
+        embedding_model=embedding_model,
+    )
+    if (
+        unit.source_revision != document.source_revision
+        or unit.chat_id != document.chat_id
+        or unit.invalidated_at is not None
+    ):
+        await session.execute(
+            update(SemanticRetrievalUnit)
+            .where(SemanticRetrievalUnit.id == unit.id)
+            .values(
+                source_revision=document.source_revision,
+                chat_id=document.chat_id,
+                invalidated_at=None,
+                invalidation_reason=None,
+            )
+        )
+    if existing_sources != document.message_version_ids:
+        await session.execute(
+            delete(SemanticRetrievalUnitSource).where(
+                SemanticRetrievalUnitSource.unit_id == unit.id
+            )
+        )
+        session.add_all(
+            [
+                SemanticRetrievalUnitSource(
+                    unit_id=unit.id,
+                    message_version_id=message_version_id,
+                    position=position,
+                )
+                for position, message_version_id in enumerate(document.message_version_ids)
+            ]
+        )
+    await session.flush()
+
+
+async def _store_document(
+    session: AsyncSession,
+    *,
+    document: RetrievalDocument,
+    vector: Sequence[float],
+    config: EmbeddingGatewayConfig,
+    llm_usage_ledger_id: int,
+    embedding_provider: str,
+    embedding_model_version: str,
+    embedding_dimensions: int,
+) -> bool:
+    await _invalidate_previous_documents(
+        session,
+        document=document,
+        embedding_model=config.model,
+    )
+    statement = (
+        pg_insert(SemanticRetrievalUnit)
+        .values(
+            source_type=document.source_type,
+            source_id=document.source_id,
+            source_revision=document.source_revision,
+            chat_id=document.chat_id,
+            content_hash=document.content_hash,
+            embedding_provider=embedding_provider,
+            embedding_model=config.model,
+            embedding_model_version=embedding_model_version,
+            embedding_dimensions=embedding_dimensions,
+            embedding=list(vector),
+            llm_usage_ledger_id=llm_usage_ledger_id,
+        )
+        .on_conflict_do_nothing(constraint="uq_semantic_units_identity")
+        .returning(SemanticRetrievalUnit.id)
+    )
+    result = await session.execute(statement)
+    unit_id = result.scalar_one_or_none()
+    if unit_id is None:
+        return False
+    session.add_all(
+        [
+            SemanticRetrievalUnitSource(
+                unit_id=unit_id,
+                message_version_id=message_version_id,
+                position=position,
+            )
+            for position, message_version_id in enumerate(document.message_version_ids)
+        ]
+    )
+    await session.flush()
+    return True
+
+
+async def _index_batch_locked(
+    session: AsyncSession,
+    *,
+    documents: Sequence[RetrievalDocument],
+    config: EmbeddingGatewayConfig,
+    provider: Any | None,
+) -> _BatchResult:
+    batch = tuple(documents)
+    if not batch:
+        return _BatchResult(indexed=0, skipped=0, reason_counts={})
+    units_before_embedding = await _load_existing_units(
+        session,
+        documents=batch,
+        embedding_model=config.model,
+    )
+    parent_units_before_embedding = await _load_parent_message_units(
+        session,
+        documents=batch,
+        embedding_model=config.model,
+    )
+    reusable_before_embedding = {
+        document: unit
+        for document in batch
+        if (
+            unit := _find_reusable_unit(
+                document=document,
+                units_by_source=units_before_embedding,
+            )
+            or _find_parent_message_unit(
+                document=document,
+                units_by_current_source=parent_units_before_embedding,
+            )
+        )
+        is not None
+    }
+    missing = [document for document in batch if document not in reusable_before_embedding]
+    embedding_result = None
+    vectors_by_document: dict[RetrievalDocument, Sequence[float]] = {}
+    if missing:
+        embedding_result = await embed_texts(
+            session,
+            inputs=[document.canonical_text for document in missing],
+            config=config,
+            ledger_repo=LedgerRepo(),
+            provider=provider,
+        )
+        vectors_by_document = dict(zip(missing, embedding_result.vectors, strict=True))
+    embedded_documents = set(missing)
+
+    valid_documents = await _revalidate_documents(session, documents=batch)
+    if blocked_count := len(batch) - len(valid_documents):
+        logger.info(
+            "semantic_index_documents_skipped_governance",
+            extra={"batch_size": len(batch), "blocked_count": blocked_count},
+        )
+    valid_set = set(valid_documents)
+    units_under_lock = await _load_existing_units(
+        session,
+        documents=valid_documents,
+        embedding_model=config.model,
+    )
+    parent_units_under_lock = await _load_parent_message_units(
+        session,
+        documents=valid_documents,
+        embedding_model=config.model,
+    )
+    reusable_by_document = {
+        document: unit
+        for document in valid_documents
+        if (
+            unit := _find_reusable_unit(
+                document=document,
+                units_by_source=units_under_lock,
+            )
+        )
+        is not None
+    }
+    parent_reusable_by_document = {
+        document: unit
+        for document in valid_documents
+        if document not in reusable_by_document
+        and (
+            unit := _find_parent_message_unit(
+                document=document,
+                units_by_current_source=parent_units_under_lock,
+            )
+        )
+        is not None
+    }
+    sources_by_unit = await _load_unit_sources(
+        session,
+        unit_ids=sorted(
+            {
+                unit.id
+                for unit in (
+                    *reusable_by_document.values(),
+                    *parent_reusable_by_document.values(),
+                )
+            }
+        ),
+    )
+
+    reasons: Counter[str] = Counter()
+    for document in batch:
+        if document not in valid_set:
+            reasons["skipped:governance_race"] += 1
+            continue
+        reusable = reusable_by_document.get(document)
+        if reusable is not None:
+            existing_sources = sources_by_unit.get(reusable.id, ())
+            unchanged = (
+                reusable.source_revision == document.source_revision
+                and reusable.chat_id == document.chat_id
+                and reusable.invalidated_at is None
+                and existing_sources == document.message_version_ids
+            )
+            if unchanged:
+                reasons[
+                    "skipped:conflict" if document in embedded_documents else "skipped:unchanged"
+                ] += 1
+                continue
+            await _reuse_document(
+                session,
+                document=document,
+                unit=reusable,
+                existing_sources=existing_sources,
+                embedding_model=config.model,
+            )
+            reasons["indexed:reused_embedding"] += 1
+            continue
+        parent_reusable = parent_reusable_by_document.get(document)
+        if parent_reusable is not None:
+            stored = await _store_document(
+                session,
+                document=document,
+                vector=parent_reusable.embedding,
+                config=config,
+                llm_usage_ledger_id=parent_reusable.llm_usage_ledger_id,
+                embedding_provider=parent_reusable.embedding_provider,
+                embedding_model_version=parent_reusable.embedding_model_version,
+                embedding_dimensions=parent_reusable.embedding_dimensions,
+            )
+            reasons["indexed:reused_embedding" if stored else "skipped:conflict"] += 1
+            continue
+        if document not in vectors_by_document or embedding_result is None:
+            reasons["skipped:conflict"] += 1
+            continue
+        if await _store_document(
+            session,
+            document=document,
+            vector=vectors_by_document[document],
+            config=config,
+            llm_usage_ledger_id=embedding_result.llm_usage_ledger_id,
+            embedding_provider=EMBEDDING_PROVIDER,
+            embedding_model_version=EMBEDDING_MODEL_VERSION,
+            embedding_dimensions=config.dimensions,
+        ):
+            reasons["indexed:new_embedding"] += 1
+        else:
+            reasons["skipped:conflict"] += 1
+    indexed = reasons["indexed:new_embedding"] + reasons["indexed:reused_embedding"]
+    skipped = (
+        reasons["skipped:unchanged"]
+        + reasons["skipped:governance_race"]
+        + reasons["skipped:conflict"]
+    )
+    return _BatchResult(indexed=indexed, skipped=skipped, reason_counts=dict(reasons))
+
+
+async def _index_batch(
+    session: AsyncSession,
+    *,
+    documents: Sequence[RetrievalDocument],
+    config: EmbeddingGatewayConfig,
+    provider: Any | None,
+) -> _BatchResult:
+    """Serialize each source claim before checking cache or calling OpenAI."""
+
+    batch = tuple(documents)
+    if not batch:
+        return _BatchResult(indexed=0, skipped=0, reason_counts={})
+    from bot.services.advisory_locks import hold_session_advisory_locks
+    from bot.services.forget_cascade import _p6_mvid_advisory_lock_id
+
+    lock_ids = (
+        _p6_mvid_advisory_lock_id(message_version_id)
+        for document in batch
+        for message_version_id in document.message_version_ids
+    )
+    async with hold_session_advisory_locks(session, lock_ids):
+        result = await _index_batch_locked(
+            session,
+            documents=batch,
+            config=config,
+            provider=provider,
+        )
+        # Publish the claimed identity before releasing the dedicated lock, so
+        # a waiting backfill observes it and never dispatches a duplicate call.
+        await session.commit()
+        return result
+
+
+async def _reconcile_ineligible_units(
+    session: AsyncSession,
+    *,
+    embedding_model: str,
+    chat_id: int | None,
+) -> int:
+    source_result = await session.execute(
+        select(SemanticRetrievalUnitSource.message_version_id)
+        .join(
+            SemanticRetrievalUnit,
+            SemanticRetrievalUnit.id == SemanticRetrievalUnitSource.unit_id,
+        )
+        .where(
+            SemanticRetrievalUnit.embedding_model == embedding_model,
+            SemanticRetrievalUnit.invalidated_at.is_(None),
+        )
+        .where(True if chat_id is None else SemanticRetrievalUnit.chat_id == chat_id)
+    )
+    await _acquire_document_locks(
+        session,
+        documents=(),
+        existing_message_version_ids=sorted(
+            {int(message_version_id) for message_version_id in source_result.scalars()}
+        ),
+    )
+    result = await session.execute(
+        _RECONCILE_INELIGIBLE_SQL,
+        {
+            "invalidated_at": datetime.now(timezone.utc),
+            "embedding_model": embedding_model,
+            "chat_id": chat_id,
+        },
+    )
+    invalidated = len(result.scalars().all())
+    if invalidated:
+        logger.info(
+            "semantic_index_units_reconciled",
+            extra={"embedding_model": embedding_model, "chat_id": chat_id, "count": invalidated},
+        )
+    return invalidated
+
+
+async def backfill_semantic_index(
+    session: AsyncSession,
+    *,
+    config: EmbeddingGatewayConfig,
+    provider: Any | None = None,
+    batch_size: int = DEFAULT_BACKFILL_BATCH_SIZE,
+    chat_id: int | None = None,
+) -> BackfillReport:
+    """Index every currently eligible source; stop on the first failed batch."""
+
+    if batch_size < 1 or batch_size > 100:
+        raise ValueError("semantic backfill batch_size must be between 1 and 100")
+    run = SemanticIndexRun(
+        run_type="backfill",
+        embedding_provider=EMBEDDING_PROVIDER,
+        embedding_model=config.model,
+        embedding_dimensions=config.dimensions,
+        status="running",
+        eligible_count=0,
+        indexed_count=0,
+        skipped_count=0,
+        failed_count=0,
+        reason_counts={},
+    )
+    session.add(run)
+    await session.flush()
+    run_id = run.id
+    # Persist the audit shell before eligibility/provider work starts. This
+    # leaves an operator-visible run even when the first batch fails.
+    await session.commit()
+
+    eligible = indexed = skipped = failed = 0
+    reasons: Counter[str] = Counter()
+    try:
+        message_cursor = 0
+        while True:
+            documents = await list_eligible_message_documents(
+                session,
+                after_id=message_cursor,
+                limit=batch_size,
+                chat_id=chat_id,
+            )
+            if not documents:
+                break
+            eligible += len(documents)
+            batch_result = await _index_batch(
+                session,
+                documents=documents,
+                config=config,
+                provider=provider,
+            )
+            indexed += batch_result.indexed
+            skipped += batch_result.skipped
+            reasons.update(batch_result.reason_counts)
+            message_cursor = int(documents[-1].source_id)
+            run.cursor = f"message:{message_cursor}"
+            run.eligible_count = eligible
+            run.indexed_count = indexed
+            run.skipped_count = skipped
+            run.reason_counts = dict(reasons)
+            await session.commit()
+
+        card_cursor = ""
+        while True:
+            documents = await list_eligible_card_documents(
+                session,
+                after_id=card_cursor,
+                limit=batch_size,
+                chat_id=chat_id,
+            )
+            if not documents:
+                break
+            eligible += len(documents)
+            batch_result = await _index_batch(
+                session,
+                documents=documents,
+                config=config,
+                provider=provider,
+            )
+            indexed += batch_result.indexed
+            skipped += batch_result.skipped
+            reasons.update(batch_result.reason_counts)
+            card_cursor = documents[-1].source_id
+            run.cursor = f"card:{card_cursor}"
+            run.eligible_count = eligible
+            run.indexed_count = indexed
+            run.skipped_count = skipped
+            run.reason_counts = dict(reasons)
+            await session.commit()
+
+        invalidated = await _reconcile_ineligible_units(
+            session,
+            embedding_model=config.model,
+            chat_id=chat_id,
+        )
+        if invalidated:
+            reasons["invalidated:ineligible"] += invalidated
+    except (
+        EmbeddingBudgetExceeded,
+        LookupError,
+        ProviderStructuralError,
+        ProviderTransientError,
+        ValueError,
+    ) as exc:
+        # Every eligible document must be accounted for as indexed, skipped,
+        # or failed. A provider error aborts the whole current batch, not one
+        # synthetic row in the audit report.
+        failed = max(0, eligible - indexed - skipped)
+        reasons[f"failed:{type(exc).__name__}"] += max(1, failed)
+        run.status = "failed"
+        run.eligible_count = eligible
+        run.indexed_count = indexed
+        run.skipped_count = skipped
+        run.failed_count = failed
+        run.reason_counts = dict(reasons)
+        run.completed_at = datetime.now(timezone.utc)
+        await session.commit()
+        raise
+    except SQLAlchemyError as exc:
+        await session.rollback()
+        persisted_run = await session.get(SemanticIndexRun, run_id)
+        if persisted_run is None:
+            raise LookupError("semantic index run audit row is missing") from exc
+        persisted_run.status = "failed"
+        failed = max(0, eligible - indexed - skipped)
+        persisted_run.failed_count = failed
+        reasons[f"failed:{type(exc).__name__}"] += max(1, failed)
+        persisted_run.reason_counts = dict(reasons)
+        persisted_run.completed_at = datetime.now(timezone.utc)
+        await session.commit()
+        logger.error(
+            "semantic_index_database_failed",
+            extra={"run_id": run_id, "error_class": type(exc).__name__},
+        )
+        raise
+
+    run.status = "completed"
+    run.cursor = None
+    run.eligible_count = eligible
+    run.indexed_count = indexed
+    run.skipped_count = skipped
+    run.failed_count = failed
+    run.reason_counts = dict(reasons)
+    run.completed_at = datetime.now(timezone.utc)
+    await session.commit()
+    return BackfillReport(
+        run_id=run.id,
+        eligible=eligible,
+        indexed=indexed,
+        skipped=skipped,
+        failed=failed,
+        reason_counts=dict(reasons),
+    )
+
+
+async def vector_search(
+    session: AsyncSession,
+    *,
+    query_embedding: Sequence[float],
+    chat_id: int,
+    embedding_model: str,
+    limit: int = DEFAULT_VECTOR_CANDIDATE_LIMIT,
+    exclude_chat_message_id: int | None = None,
+) -> list[SearchHit]:
+    if limit < 1:
+        raise ValueError("vector search limit must be positive")
+    result = await session.execute(
+        _VECTOR_CANDIDATES_SQL,
+        {
+            "embedding": _vector_literal(query_embedding),
+            "chat_id": chat_id,
+            "embedding_model": embedding_model,
+            "exclude_chat_message_id": exclude_chat_message_id,
+            "limit": limit,
+        },
+    )
+    hits: list[SearchHit] = []
+    for candidate in result.mappings().all():
+        params = {
+            "unit_id": candidate["id"],
+            "chat_id": chat_id,
+            "exclude_chat_message_id": exclude_chat_message_id,
+        }
+        if candidate["source_type"] == "message":
+            hit_result = await session.execute(_MESSAGE_HIT_SQL, params)
+            row = hit_result.mappings().one_or_none()
+            if row is None:
+                continue
+            hits.append(
+                SearchHit(
+                    message_version_id=int(row["message_version_id"]),
+                    chat_message_id=int(row["chat_message_id"]),
+                    chat_id=int(row["chat_id"]),
+                    message_id=int(row["message_id"]),
+                    user_id=int(row["user_id"]),
+                    snippet=str(row["snippet"])[:400],
+                    ts_rank=float(candidate["similarity"]),
+                    captured_at=row["captured_at"],
+                    message_date=row["message_date"],
+                    message_thread_id=row["message_thread_id"],
+                    reply_to_message_id=row["reply_to_message_id"],
+                )
+            )
+            continue
+        if candidate["source_type"] != "card":
+            raise ValueError("semantic unit has unsupported source_type")
+        hit_result = await session.execute(_CARD_HIT_SQL, params)
+        row = hit_result.mappings().one_or_none()
+        if row is None:
+            continue
+        hits.append(
+            SearchHit(
+                message_version_id=int(row["message_version_id"]),
+                chat_message_id=int(row["chat_message_id"]),
+                chat_id=int(row["chat_id"]),
+                message_id=int(row["message_id"]),
+                user_id=None,
+                snippet=str(row["snippet"])[:400],
+                ts_rank=float(candidate["similarity"]),
+                captured_at=row["captured_at"],
+                message_date=row["message_date"],
+                source_type="card",
+                card_id=uuid.UUID(str(row["card_id"])),
+                card_source_message_version_ids=tuple(
+                    int(value) for value in row["message_version_ids"]
+                ),
+                message_thread_id=row["message_thread_id"],
+                reply_to_message_id=row["reply_to_message_id"],
+            )
+        )
+    return hits
+
+
+async def _with_conversation_roots(
+    session: AsyncSession,
+    *,
+    chat_id: int,
+    hits: Sequence[SearchHit],
+) -> list[SearchHit]:
+    if not any(hit.reply_to_message_id is not None for hit in hits):
+        return list(hits)
+    result = await session.execute(
+        _CONVERSATION_ROOTS_SQL,
+        {
+            "chat_id": chat_id,
+            "message_ids": sorted({hit.message_id for hit in hits}),
+        },
+    )
+    roots = {
+        int(row["origin_message_id"]): int(row["root_message_id"]) for row in result.mappings()
+    }
+    return [replace(hit, conversation_root_message_id=roots.get(hit.message_id)) for hit in hits]
+
+
+def reciprocal_rank_fusion(
+    *,
+    vector_hits: Sequence[SearchHit],
+    fts_hits: Sequence[SearchHit],
+    limit: int = MAX_SEMANTIC_EVIDENCE,
+    rrf_k: int = RRF_K,
+) -> tuple[list[SearchHit], dict[str, dict[str, int]]]:
+    if limit < 1 or rrf_k < 1:
+        raise ValueError("RRF limit and k must be positive")
+    scores: dict[str, float] = {}
+    rank_meta: dict[str, dict[str, int]] = {}
+    hits_by_key: dict[str, SearchHit] = {}
+    for branch_name, branch_hits in (("vector", vector_hits), ("fts", fts_hits)):
+        seen: set[str] = set()
+        for rank, hit in enumerate(branch_hits, start=1):
+            key = _source_key(hit)
+            if key in seen:
+                continue
+            seen.add(key)
+            hits_by_key.setdefault(key, hit)
+            scores[key] = scores.get(key, 0.0) + 1.0 / (rrf_k + rank)
+            rank_meta.setdefault(key, {})[branch_name] = rank
+
+    ordered_keys = sorted(scores, key=lambda key: (-scores[key], key))
+    selected: list[SearchHit] = []
+    author_counts: dict[int, int] = {}
+    thread_counts: dict[int, int] = {}
+    conversation_counts: dict[int, int] = {}
+    card_count = 0
+    for key in ordered_keys:
+        hit = hits_by_key[key]
+        if hit.source_type == "card":
+            if card_count >= 2:
+                continue
+        elif hit.user_id is not None:
+            if author_counts.get(hit.user_id, 0) >= 2:
+                continue
+        if hit.message_thread_id is not None and thread_counts.get(hit.message_thread_id, 0) >= 2:
+            continue
+        conversation_id = hit.conversation_root_message_id or hit.reply_to_message_id
+        if conversation_id is not None and conversation_counts.get(conversation_id, 0) >= 2:
+            continue
+        if hit.source_type == "card":
+            card_count += 1
+        elif hit.user_id is not None:
+            author_counts[hit.user_id] = author_counts.get(hit.user_id, 0) + 1
+        if hit.message_thread_id is not None:
+            thread_counts[hit.message_thread_id] = thread_counts.get(hit.message_thread_id, 0) + 1
+        if conversation_id is not None:
+            conversation_counts[conversation_id] = conversation_counts.get(conversation_id, 0) + 1
+        selected.append(hit)
+        if len(selected) == limit:
+            break
+    return selected, rank_meta
+
+
+async def hybrid_search(
+    session: AsyncSession,
+    *,
+    query: str,
+    query_embedding: Sequence[float],
+    chat_id: int,
+    embedding_model: str,
+    exclude_chat_message_id: int | None = None,
+    candidate_limit: int = DEFAULT_VECTOR_CANDIDATE_LIMIT,
+    limit: int = MAX_SEMANTIC_EVIDENCE,
+) -> HybridSearchResult:
+    from bot.services.search import search_messages
+
+    started = time.monotonic()
+    fts_started = time.monotonic()
+    fts_hits = await search_messages(
+        session,
+        query,
+        chat_id=chat_id,
+        limit=candidate_limit,
+        include_cards=True,
+        exclude_chat_message_id=exclude_chat_message_id,
+        human_only=True,
+    )
+    fts_latency_ms = int((time.monotonic() - fts_started) * 1000)
+
+    vector_started = time.monotonic()
+    vector_hits = await vector_search(
+        session,
+        query_embedding=query_embedding,
+        chat_id=chat_id,
+        embedding_model=embedding_model,
+        limit=candidate_limit,
+        exclude_chat_message_id=exclude_chat_message_id,
+    )
+    vector_latency_ms = int((time.monotonic() - vector_started) * 1000)
+
+    fusion_started = time.monotonic()
+    enriched_hits = await _with_conversation_roots(
+        session,
+        chat_id=chat_id,
+        hits=[*fts_hits, *vector_hits],
+    )
+    enriched_fts_hits = enriched_hits[: len(fts_hits)]
+    enriched_vector_hits = enriched_hits[len(fts_hits) :]
+    hits, candidate_ranks = reciprocal_rank_fusion(
+        vector_hits=enriched_vector_hits,
+        fts_hits=enriched_fts_hits,
+        limit=limit,
+    )
+    fusion_latency_ms = int((time.monotonic() - fusion_started) * 1000)
+    return HybridSearchResult(
+        hits=tuple(hits),
+        candidate_ranks=candidate_ranks,
+        fts_latency_ms=fts_latency_ms,
+        vector_latency_ms=vector_latency_ms,
+        fusion_latency_ms=fusion_latency_ms,
+        total_latency_ms=int((time.monotonic() - started) * 1000),
+    )
+
+
+__all__ = [
+    "BackfillReport",
+    "HybridSearchResult",
+    "RetrievalDocument",
+    "backfill_semantic_index",
+    "hybrid_search",
+    "list_eligible_card_documents",
+    "list_eligible_message_documents",
+    "reciprocal_rank_fusion",
+    "vector_search",
+]

--- a/bot/services/semantic_index.py
+++ b/bot/services/semantic_index.py
@@ -29,6 +29,7 @@ from bot.services.forget_predicate import forget_excludes_sql_fragment
 from bot.services.llm_gateway import (
     EmbeddingBudgetExceeded,
     EmbeddingGatewayConfig,
+    MAX_QA_EVIDENCE_SNIPPET_CHARS,
     embed_texts,
 )
 from bot.services.llm_providers import ProviderStructuralError, ProviderTransientError
@@ -291,6 +292,7 @@ _VECTOR_CANDIDATES_SQL = text(
     FROM semantic_retrieval_units unit
     WHERE unit.chat_id = :chat_id
       AND unit.embedding_model = :embedding_model
+      AND unit.embedding_status = 'completed'
       AND unit.invalidated_at IS NULL
       AND EXISTS (
           SELECT 1 FROM semantic_retrieval_unit_sources source_any
@@ -369,12 +371,24 @@ _MESSAGE_HIT_SQL = text(
            cm.user_id,
            cm.message_thread_id,
            cm.reply_to_message_id,
+           unit.source_revision AS unit_source_revision,
+           unit.chunk_index AS unit_chunk_index,
+           unit.chunk_count AS unit_chunk_count,
+           unit.content_hash AS unit_content_hash,
+           unit.chunk_text AS unit_chunk_text,
+           mv.version_seq,
+           CASE WHEN mm.description_status = 'ready' THEN mm.updated_at ELSE NULL END
+               AS media_revision,
            concat_ws(
-               ' ',
+               E'\n',
                NULLIF(btrim(COALESCE(mv.normalized_text, mv.text, '')), ''),
                NULLIF(btrim(COALESCE(mv.caption, '')), ''),
-               CASE WHEN mm.description_status = 'ready' THEN mm.description ELSE NULL END
-           ) AS snippet,
+               CASE
+                   WHEN mm.description_status = 'ready'
+                   THEN NULLIF(btrim(COALESCE(mm.description, '')), '')
+                   ELSE NULL
+               END
+           ) AS current_canonical_text,
            mv.captured_at,
            cm.date AS message_date
     FROM semantic_retrieval_units unit
@@ -385,6 +399,7 @@ _MESSAGE_HIT_SQL = text(
     LEFT JOIN message_media mm ON mm.chat_message_id = cm.id
     WHERE unit.id = :unit_id
       AND unit.source_type = 'message'
+      AND unit.embedding_status = 'completed'
       AND unit.invalidated_at IS NULL
       AND cm.chat_id = :chat_id
       AND author.is_bot = FALSE
@@ -411,7 +426,14 @@ _CARD_HIT_SQL = text(
            anchor.message_id,
            anchor.message_thread_id,
            anchor.reply_to_message_id,
-           concat_ws(' ', kc.title, kc.body_markdown) AS snippet,
+           unit.source_revision AS unit_source_revision,
+           unit.chunk_index AS unit_chunk_index,
+           unit.chunk_count AS unit_chunk_count,
+           unit.content_hash AS unit_content_hash,
+           unit.chunk_text AS unit_chunk_text,
+           concat_ws(E'\n', NULLIF(btrim(kc.title), ''), NULLIF(btrim(kc.body_markdown), ''))
+               AS current_canonical_text,
+           kc.updated_at,
            kc.approved_at AS captured_at,
            COALESCE(kc.approved_at, anchor.message_date) AS message_date,
            ARRAY_AGG(source.message_version_id ORDER BY source.position ASC)
@@ -436,6 +458,7 @@ _CARD_HIT_SQL = text(
     ) anchor ON TRUE
     WHERE unit.id = :unit_id
       AND unit.source_type = 'card'
+      AND unit.embedding_status = 'completed'
       AND unit.invalidated_at IS NULL
       AND kc.card_status = 'approved'
       AND anchor.chat_id = :chat_id
@@ -459,7 +482,7 @@ _CARD_HIT_SQL = text(
                 OR NOT ({_FORGET_EXCLUDES})
             )
       )
-    GROUP BY kc.id, anchor.message_version_id, anchor.chat_message_id, anchor.chat_id,
+    GROUP BY kc.id, unit.id, anchor.message_version_id, anchor.chat_message_id, anchor.chat_id,
              anchor.message_id, anchor.message_thread_id, anchor.reply_to_message_id,
              anchor.message_date
     HAVING ARRAY_AGG(source.message_version_id ORDER BY source.position ASC) = ARRAY(
@@ -559,6 +582,202 @@ class _BatchResult:
     reason_counts: dict[str, int]
 
 
+class EmbeddingClaimUnresolved(RuntimeError):
+    """An exact source identity has an ambiguous or failed paid attempt."""
+
+    def __init__(self, *, unit_id: int, status: str) -> None:
+        super().__init__(
+            f"semantic embedding claim {unit_id} requires operator resolution: {status}"
+        )
+        self.unit_id = unit_id
+        self.status = status
+
+
+class _SemanticEmbeddingOutcomeRecorder:
+    """Persist semantic claims in the same transactions as their ledger row."""
+
+    def __init__(
+        self,
+        *,
+        documents: Sequence[RetrievalDocument],
+        config: EmbeddingGatewayConfig,
+    ) -> None:
+        self.documents = tuple(documents)
+        self.config = config
+        self.unit_ids: dict[RetrievalDocument, int] = {}
+        self.reason_counts: Counter[str] = Counter()
+
+    async def reserve(
+        self,
+        session: AsyncSession,
+        *,
+        llm_usage_ledger_id: int,
+        budget_denied: bool,
+    ) -> None:
+        if self.unit_ids:
+            raise RuntimeError("semantic embedding recorder was already reserved")
+        status = "failed" if budget_denied else "reserved"
+        for document in self.documents:
+            await _invalidate_previous_documents(
+                session,
+                document=document,
+                embedding_model=self.config.model,
+            )
+            result = await session.execute(
+                pg_insert(SemanticRetrievalUnit)
+                .values(
+                    source_type=document.source_type,
+                    source_id=document.source_id,
+                    source_revision=document.source_revision,
+                    chunk_index=document.chunk_index,
+                    chunk_count=document.chunk_count,
+                    chat_id=document.chat_id,
+                    content_hash=document.content_hash,
+                    embedding_provider=EMBEDDING_PROVIDER,
+                    embedding_model=self.config.model,
+                    embedding_model_version=EMBEDDING_MODEL_VERSION,
+                    embedding_dimensions=self.config.dimensions,
+                    embedding_status=status,
+                    chunk_text=None,
+                    embedding=None,
+                    llm_usage_ledger_id=llm_usage_ledger_id,
+                    indexed_at=None,
+                )
+                .on_conflict_do_nothing(constraint="uq_semantic_units_identity")
+                .returning(SemanticRetrievalUnit.id)
+            )
+            unit_id = result.scalar_one_or_none()
+            if unit_id is None:
+                existing = (
+                    await session.execute(
+                        select(
+                            SemanticRetrievalUnit.id,
+                            SemanticRetrievalUnit.embedding_status,
+                        ).where(
+                            SemanticRetrievalUnit.source_type == document.source_type,
+                            SemanticRetrievalUnit.source_id == document.source_id,
+                            SemanticRetrievalUnit.source_revision == document.source_revision,
+                            SemanticRetrievalUnit.chunk_index == document.chunk_index,
+                            SemanticRetrievalUnit.content_hash == document.content_hash,
+                            SemanticRetrievalUnit.embedding_model == self.config.model,
+                        )
+                    )
+                ).one_or_none()
+                if existing is None:
+                    raise LookupError("semantic claim conflict row is missing")
+                raise EmbeddingClaimUnresolved(
+                    unit_id=int(existing.id),
+                    status=str(existing.embedding_status),
+                )
+            claimed_id = int(unit_id)
+            self.unit_ids[document] = claimed_id
+            session.add_all(
+                [
+                    SemanticRetrievalUnitSource(
+                        unit_id=claimed_id,
+                        message_version_id=message_version_id,
+                        position=position,
+                    )
+                    for position, message_version_id in enumerate(document.message_version_ids)
+                ]
+            )
+        await session.flush()
+
+    async def fail(
+        self,
+        session: AsyncSession,
+        *,
+        llm_usage_ledger_id: int,
+    ) -> None:
+        await self._set_failed(
+            session,
+            llm_usage_ledger_id=llm_usage_ledger_id,
+            documents=self.documents,
+            invalidation_reason=None,
+        )
+
+    async def complete(
+        self,
+        session: AsyncSession,
+        *,
+        llm_usage_ledger_id: int,
+        vectors: Sequence[Sequence[float]],
+    ) -> None:
+        vector_values = tuple(vectors)
+        if len(vector_values) != len(self.documents):
+            raise ValueError("embedding provider returned the wrong vector count")
+        for vector in vector_values:
+            _vector_literal(vector)
+
+        valid_documents = set(await _revalidate_documents(session, documents=self.documents))
+        invalid_documents = tuple(
+            document for document in self.documents if document not in valid_documents
+        )
+        if invalid_documents:
+            await self._set_failed(
+                session,
+                llm_usage_ledger_id=llm_usage_ledger_id,
+                documents=invalid_documents,
+                invalidation_reason="governance_race",
+            )
+            self.reason_counts["skipped:governance_race"] += len(invalid_documents)
+
+        for document, vector in zip(self.documents, vector_values, strict=True):
+            if document not in valid_documents:
+                continue
+            result = await session.execute(
+                update(SemanticRetrievalUnit)
+                .where(
+                    SemanticRetrievalUnit.id == self.unit_ids[document],
+                    SemanticRetrievalUnit.llm_usage_ledger_id == llm_usage_ledger_id,
+                    SemanticRetrievalUnit.embedding_status == "reserved",
+                )
+                .values(
+                    embedding_status="completed",
+                    chunk_text=document.canonical_text,
+                    embedding=list(vector),
+                    indexed_at=datetime.now(timezone.utc),
+                )
+                .returning(SemanticRetrievalUnit.id)
+            )
+            if result.scalar_one_or_none() is None:
+                raise EmbeddingClaimUnresolved(
+                    unit_id=self.unit_ids[document],
+                    status="terminal_state_conflict",
+                )
+            self.reason_counts["indexed:new_embedding"] += 1
+
+    async def _set_failed(
+        self,
+        session: AsyncSession,
+        *,
+        llm_usage_ledger_id: int,
+        documents: Sequence[RetrievalDocument],
+        invalidation_reason: str | None,
+    ) -> None:
+        now = datetime.now(timezone.utc) if invalidation_reason is not None else None
+        for document in documents:
+            result = await session.execute(
+                update(SemanticRetrievalUnit)
+                .where(
+                    SemanticRetrievalUnit.id == self.unit_ids[document],
+                    SemanticRetrievalUnit.llm_usage_ledger_id == llm_usage_ledger_id,
+                    SemanticRetrievalUnit.embedding_status == "reserved",
+                )
+                .values(
+                    embedding_status="failed",
+                    invalidated_at=now,
+                    invalidation_reason=invalidation_reason,
+                )
+                .returning(SemanticRetrievalUnit.id)
+            )
+            if result.scalar_one_or_none() is None:
+                raise EmbeddingClaimUnresolved(
+                    unit_id=self.unit_ids[document],
+                    status="terminal_state_conflict",
+                )
+
+
 @dataclass(frozen=True, slots=True)
 class HybridSearchResult:
     hits: tuple[SearchHit, ...]
@@ -584,10 +803,11 @@ def _chunk_retrieval_document(
 ) -> list[RetrievalDocument]:
     """Split source text without truncation using stable character boundaries."""
 
-    chunks = tuple(
-        canonical_text[offset : offset + MAX_EMBEDDING_INPUT_CHARS]
-        for offset in range(0, len(canonical_text), MAX_EMBEDDING_INPUT_CHARS)
+    raw_chunks = tuple(
+        canonical_text[offset : offset + MAX_QA_EVIDENCE_SNIPPET_CHARS]
+        for offset in range(0, len(canonical_text), MAX_QA_EVIDENCE_SNIPPET_CHARS)
     )
+    chunks = tuple(chunk.strip() for chunk in raw_chunks if chunk.strip())
     if not chunks:
         raise ValueError("retrieval document canonical text must not be empty")
     chunk_count = len(chunks)
@@ -721,6 +941,7 @@ async def _load_existing_units(
                 SemanticRetrievalUnit.source_id,
             ).in_(source_keys),
             SemanticRetrievalUnit.embedding_model == embedding_model,
+            SemanticRetrievalUnit.embedding_status == "completed",
         )
         .order_by(SemanticRetrievalUnit.id.desc())
     )
@@ -744,6 +965,61 @@ async def _load_existing_units(
         )
         units_by_source.setdefault((unit.source_type, unit.source_id), []).append(unit)
     return units_by_source
+
+
+async def _raise_for_unresolved_claims(
+    session: AsyncSession,
+    *,
+    documents: Sequence[RetrievalDocument],
+    embedding_model: str,
+) -> None:
+    source_keys = sorted({(document.source_type, document.source_id) for document in documents})
+    if not source_keys:
+        return
+    result = await session.execute(
+        select(
+            SemanticRetrievalUnit.id,
+            SemanticRetrievalUnit.source_type,
+            SemanticRetrievalUnit.source_id,
+            SemanticRetrievalUnit.source_revision,
+            SemanticRetrievalUnit.chunk_index,
+            SemanticRetrievalUnit.content_hash,
+            SemanticRetrievalUnit.embedding_status,
+        ).where(
+            tuple_(
+                SemanticRetrievalUnit.source_type,
+                SemanticRetrievalUnit.source_id,
+            ).in_(source_keys),
+            SemanticRetrievalUnit.embedding_model == embedding_model,
+            SemanticRetrievalUnit.embedding_status != "completed",
+        )
+    )
+    unresolved = {
+        (
+            str(row.source_type),
+            str(row.source_id),
+            str(row.source_revision),
+            int(row.chunk_index),
+            str(row.content_hash),
+        ): (int(row.id), str(row.embedding_status))
+        for row in result
+    }
+    for document in documents:
+        existing = unresolved.get(
+            (
+                document.source_type,
+                document.source_id,
+                document.source_revision,
+                document.chunk_index,
+                document.content_hash,
+            )
+        )
+        if existing is not None:
+            logger.error(
+                "semantic_embedding_claim_unresolved",
+                extra={"unit_id": existing[0], "embedding_status": existing[1]},
+            )
+            raise EmbeddingClaimUnresolved(unit_id=existing[0], status=existing[1])
 
 
 async def _load_parent_message_units(
@@ -794,6 +1070,7 @@ async def _load_parent_message_units(
             current_version.id.in_(message_version_ids),
             SemanticRetrievalUnit.source_type == "message",
             SemanticRetrievalUnit.embedding_model == embedding_model,
+            SemanticRetrievalUnit.embedding_status == "completed",
         )
         .order_by(current_version.id, SemanticRetrievalUnit.id.desc())
     )
@@ -1139,8 +1416,11 @@ async def _store_document(
             embedding_model=config.model,
             embedding_model_version=embedding_model_version,
             embedding_dimensions=embedding_dimensions,
+            embedding_status="completed",
+            chunk_text=document.canonical_text,
             embedding=list(vector),
             llm_usage_ledger_id=llm_usage_ledger_id,
+            indexed_at=datetime.now(timezone.utc),
         )
         .on_conflict_do_nothing(constraint="uq_semantic_units_identity")
         .returning(SemanticRetrievalUnit.id)
@@ -1168,15 +1448,12 @@ async def _persist_document_batch(
     *,
     documents: Sequence[RetrievalDocument],
     config: EmbeddingGatewayConfig,
-    embeddings: dict[RetrievalDocument, tuple[Sequence[float], int]],
 ) -> Counter[str]:
-    """Persist one governed batch and classify every document."""
+    """Persist completed-vector reuse and classify every document."""
 
     batch = tuple(documents)
     if not batch:
         return Counter()
-    embedded_documents = set(embeddings)
-
     valid_documents = await _revalidate_documents(
         session,
         documents=batch,
@@ -1249,9 +1526,7 @@ async def _persist_document_batch(
                 and existing_sources == document.message_version_ids
             )
             if unchanged:
-                reasons[
-                    "skipped:conflict" if document in embedded_documents else "skipped:unchanged"
-                ] += 1
+                reasons["skipped:unchanged"] += 1
                 continue
             await _reuse_document(
                 session,
@@ -1276,23 +1551,7 @@ async def _persist_document_batch(
             )
             reasons["indexed:reused_embedding" if stored else "skipped:conflict"] += 1
             continue
-        embedded = embeddings.get(document)
-        if embedded is None:
-            raise LookupError("governed semantic document lost its reusable embedding")
-        vector, llm_usage_ledger_id = embedded
-        if await _store_document(
-            session,
-            document=document,
-            vector=vector,
-            config=config,
-            llm_usage_ledger_id=llm_usage_ledger_id,
-            embedding_provider=EMBEDDING_PROVIDER,
-            embedding_model_version=EMBEDDING_MODEL_VERSION,
-            embedding_dimensions=config.dimensions,
-        ):
-            reasons["indexed:new_embedding"] += 1
-        else:
-            reasons["skipped:conflict"] += 1
+        raise LookupError("governed semantic document lost its reusable embedding")
     return reasons
 
 
@@ -1349,14 +1608,15 @@ async def _index_batch_locked(
         is not None
     ]
     if reusable_documents:
-        reasons.update(
-            await _persist_document_batch(
-                session,
-                documents=reusable_documents,
-                config=config,
-                embeddings={},
-            )
+        reusable_reasons = await _persist_document_batch(
+            session,
+            documents=reusable_documents,
+            config=config,
         )
+        # Only publish counters after their reused units are durable. This
+        # keeps partial error accounting exact if claim reservation later fails.
+        await session.commit()
+        reasons.update(reusable_reasons)
 
     missing_documents = [
         document
@@ -1364,32 +1624,27 @@ async def _index_batch_locked(
         if document in prevalidated_set and document not in reusable_documents
     ]
     try:
+        await _raise_for_unresolved_claims(
+            session,
+            documents=missing_documents,
+            embedding_model=config.model,
+        )
         for embedding_batch in _partition_embedding_documents(missing_documents):
-            embedding_result = await embed_texts(
+            recorder = _SemanticEmbeddingOutcomeRecorder(
+                documents=embedding_batch,
+                config=config,
+            )
+            await embed_texts(
                 session,
                 inputs=[document.canonical_text for document in embedding_batch],
                 config=config,
                 ledger_repo=LedgerRepo(),
                 provider=provider,
+                outcome_recorder=recorder,
             )
-            embeddings = {
-                document: (vector, embedding_result.llm_usage_ledger_id)
-                for document, vector in zip(
-                    embedding_batch,
-                    embedding_result.vectors,
-                    strict=True,
-                )
-            }
-            partition_reasons = await _persist_document_batch(
-                session,
-                documents=embedding_batch,
-                config=config,
-                embeddings=embeddings,
-            )
-            # Make each paid partition discoverable by retries and forget
-            # cascade before the next independent provider call can fail.
-            await session.commit()
-            reasons.update(partition_reasons)
+            # embed_texts commits the terminal ledger and recorder state in one
+            # transaction, so every counter added here is already durable.
+            reasons.update(recorder.reason_counts)
     except Exception as exc:
         # The outer run still needs exact accounting for partitions committed
         # before any failure. Only no-content counters cross the boundary.
@@ -1439,9 +1694,6 @@ async def _index_batch(
             config=config,
             provider=provider,
         )
-        # Publish the claimed identity before releasing the dedicated lock, so
-        # a waiting backfill observes it and never dispatches a duplicate call.
-        await session.commit()
         return result
 
 
@@ -1585,6 +1837,7 @@ async def backfill_semantic_index(
         if invalidated:
             reasons["invalidated:ineligible"] += invalidated
     except (
+        EmbeddingClaimUnresolved,
         EmbeddingBudgetExceeded,
         LookupError,
         ProviderStructuralError,
@@ -1611,14 +1864,22 @@ async def backfill_semantic_index(
         await session.commit()
         raise
     except SQLAlchemyError as exc:
+        partial_batch = getattr(exc, "semantic_batch_result", None)
         await session.rollback()
+        if partial_batch is not None:
+            indexed += int(partial_batch.indexed)
+            skipped += int(partial_batch.skipped)
+            reasons.update(partial_batch.reason_counts)
         persisted_run = await session.get(SemanticIndexRun, run_id)
         if persisted_run is None:
             raise LookupError("semantic index run audit row is missing") from exc
-        persisted_run.status = "failed"
         failed = max(0, eligible - indexed - skipped)
-        persisted_run.failed_count = failed
         reasons[f"failed:{type(exc).__name__}"] += max(1, failed)
+        persisted_run.status = "failed"
+        persisted_run.eligible_count = eligible
+        persisted_run.indexed_count = indexed
+        persisted_run.skipped_count = skipped
+        persisted_run.failed_count = failed
         persisted_run.reason_counts = dict(reasons)
         persisted_run.completed_at = datetime.now(timezone.utc)
         await session.commit()
@@ -1671,6 +1932,42 @@ async def backfill_semantic_index(
     )
 
 
+def _current_chunk_text(
+    row: Any,
+    *,
+    source_type: Literal["message", "card"],
+    source_id: str,
+    source_revision: str,
+    message_version_ids: tuple[int, ...],
+) -> str | None:
+    canonical_text = str(row["current_canonical_text"]).strip()
+    if not canonical_text:
+        return None
+    current_documents = _chunk_retrieval_document(
+        source_type=source_type,
+        source_id=source_id,
+        source_revision=source_revision,
+        chat_id=int(row["chat_id"]),
+        canonical_text=canonical_text,
+        message_version_ids=message_version_ids,
+    )
+    chunk_index = int(row["unit_chunk_index"])
+    current = next(
+        (document for document in current_documents if document.chunk_index == chunk_index),
+        None,
+    )
+    if current is None:
+        return None
+    if (
+        current.source_revision != str(row["unit_source_revision"])
+        or current.chunk_count != int(row["unit_chunk_count"])
+        or current.content_hash != str(row["unit_content_hash"])
+        or current.canonical_text != str(row["unit_chunk_text"])
+    ):
+        return None
+    return current.canonical_text
+
+
 async def vector_search(
     session: AsyncSession,
     *,
@@ -1704,6 +2001,23 @@ async def vector_search(
             row = hit_result.mappings().one_or_none()
             if row is None:
                 continue
+            media_revision = row["media_revision"]
+            snippet = _current_chunk_text(
+                row,
+                source_type="message",
+                source_id=str(row["message_version_id"]),
+                source_revision=(
+                    f"v{row['version_seq']}:media:"
+                    f"{media_revision.isoformat() if media_revision else 'none'}"
+                ),
+                message_version_ids=(int(row["message_version_id"]),),
+            )
+            if snippet is None:
+                logger.info(
+                    "semantic_vector_candidate_stale",
+                    extra={"unit_id": int(candidate["id"]), "source_type": "message"},
+                )
+                continue
             hits.append(
                 SearchHit(
                     message_version_id=int(row["message_version_id"]),
@@ -1711,7 +2025,7 @@ async def vector_search(
                     chat_id=int(row["chat_id"]),
                     message_id=int(row["message_id"]),
                     user_id=int(row["user_id"]),
-                    snippet=str(row["snippet"])[:400],
+                    snippet=snippet[:MAX_QA_EVIDENCE_SNIPPET_CHARS],
                     ts_rank=float(candidate["similarity"]),
                     captured_at=row["captured_at"],
                     message_date=row["message_date"],
@@ -1726,6 +2040,24 @@ async def vector_search(
         row = hit_result.mappings().one_or_none()
         if row is None:
             continue
+        message_version_ids = tuple(int(value) for value in row["message_version_ids"])
+        approved_at = row["captured_at"]
+        snippet = _current_chunk_text(
+            row,
+            source_type="card",
+            source_id=str(row["card_id"]),
+            source_revision=(
+                f"updated:{row['updated_at'].isoformat()}:"
+                f"approved:{approved_at.isoformat() if approved_at else 'none'}"
+            ),
+            message_version_ids=message_version_ids,
+        )
+        if snippet is None:
+            logger.info(
+                "semantic_vector_candidate_stale",
+                extra={"unit_id": int(candidate["id"]), "source_type": "card"},
+            )
+            continue
         hits.append(
             SearchHit(
                 message_version_id=int(row["message_version_id"]),
@@ -1733,15 +2065,13 @@ async def vector_search(
                 chat_id=int(row["chat_id"]),
                 message_id=int(row["message_id"]),
                 user_id=None,
-                snippet=str(row["snippet"])[:400],
+                snippet=snippet[:MAX_QA_EVIDENCE_SNIPPET_CHARS],
                 ts_rank=float(candidate["similarity"]),
                 captured_at=row["captured_at"],
                 message_date=row["message_date"],
                 source_type="card",
                 card_id=uuid.UUID(str(row["card_id"])),
-                card_source_message_version_ids=tuple(
-                    int(value) for value in row["message_version_ids"]
-                ),
+                card_source_message_version_ids=message_version_ids,
                 message_thread_id=row["message_thread_id"],
                 reply_to_message_id=row["reply_to_message_id"],
             )

--- a/bot/services/semantic_index.py
+++ b/bot/services/semantic_index.py
@@ -501,35 +501,38 @@ _CONVERSATION_ROOTS_SQL = text(
     ), chain AS (
         SELECT requested.origin_message_id,
                message.message_id AS current_message_id,
-               message.reply_to_message_id,
-               ARRAY[message.message_id]::BIGINT[] AS path,
-               0 AS depth
+               message.reply_to_message_id
         FROM requested
         JOIN chat_messages message
           ON message.chat_id = :chat_id
          AND message.message_id = requested.origin_message_id
-        UNION ALL
+        UNION
         SELECT chain.origin_message_id,
                parent.message_id,
-               parent.reply_to_message_id,
-               chain.path || parent.message_id,
-               chain.depth + 1
+               parent.reply_to_message_id
         FROM chain
         JOIN chat_messages parent
           ON parent.chat_id = :chat_id
          AND parent.message_id = chain.reply_to_message_id
-        WHERE chain.depth < 64
-          AND NOT parent.message_id = ANY(chain.path)
     )
-    SELECT DISTINCT ON (origin_message_id)
+    SELECT
            origin_message_id,
-           CASE
-               WHEN reply_to_message_id IS NULL OR reply_to_message_id = ANY(path)
-               THEN current_message_id
-               ELSE reply_to_message_id
-           END AS root_message_id
+           COALESCE(
+               MIN(
+                   CASE
+                       WHEN reply_to_message_id IS NULL THEN current_message_id
+                       WHEN NOT EXISTS (
+                           SELECT 1
+                           FROM chat_messages missing_parent
+                           WHERE missing_parent.chat_id = :chat_id
+                             AND missing_parent.message_id = chain.reply_to_message_id
+                       ) THEN reply_to_message_id
+                   END
+               ),
+               MIN(current_message_id)
+           ) AS root_message_id
     FROM chain
-    ORDER BY origin_message_id, depth DESC
+    GROUP BY origin_message_id
     """
 )
 

--- a/bot/services/semantic_index.py
+++ b/bot/services/semantic_index.py
@@ -46,6 +46,8 @@ RRF_K = 60
 
 _FORGET_EXCLUDES = forget_excludes_sql_fragment()
 
+# Only the static _FORGET_EXCLUDES fragment is interpolated; runtime values are bound.
+# nosemgrep: python.sqlalchemy.security.audit.avoid-sqlalchemy-text.avoid-sqlalchemy-text
 _REVALIDATE_PROVENANCE_SQL = text(
     f"""
     SELECT mv.id AS message_version_id,
@@ -78,6 +80,8 @@ _REVALIDATE_CARDS_SQL = text(
     """
 )
 
+# Only the static _FORGET_EXCLUDES fragment is interpolated; runtime values are bound.
+# nosemgrep: python.sqlalchemy.security.audit.avoid-sqlalchemy-text.avoid-sqlalchemy-text
 _RECONCILE_INELIGIBLE_SQL = text(
     f"""
     UPDATE semantic_retrieval_units AS unit
@@ -170,6 +174,8 @@ _RECONCILE_INELIGIBLE_SQL = text(
     """
 )
 
+# Only the static _FORGET_EXCLUDES fragment is interpolated; runtime values are bound.
+# nosemgrep: python.sqlalchemy.security.audit.avoid-sqlalchemy-text.avoid-sqlalchemy-text
 _ELIGIBLE_MESSAGES_SQL = text(
     f"""
     SELECT mv.id AS message_version_id,
@@ -215,6 +221,8 @@ _ELIGIBLE_MESSAGES_SQL = text(
     """
 )
 
+# Only the static _FORGET_EXCLUDES fragment is interpolated; runtime values are bound.
+# nosemgrep: python.sqlalchemy.security.audit.avoid-sqlalchemy-text.avoid-sqlalchemy-text
 _ELIGIBLE_CARDS_SQL = text(
     f"""
     SELECT kc.id AS card_id,
@@ -266,6 +274,8 @@ _ELIGIBLE_CARDS_SQL = text(
     """
 )
 
+# Only the static _FORGET_EXCLUDES fragment is interpolated; runtime values are bound.
+# nosemgrep: python.sqlalchemy.security.audit.avoid-sqlalchemy-text.avoid-sqlalchemy-text
 _VECTOR_CANDIDATES_SQL = text(
     f"""
     SELECT unit.id,
@@ -328,6 +338,8 @@ _VECTOR_CANDIDATES_SQL = text(
     """
 )
 
+# Only the static _FORGET_EXCLUDES fragment is interpolated; runtime values are bound.
+# nosemgrep: python.sqlalchemy.security.audit.avoid-sqlalchemy-text.avoid-sqlalchemy-text
 _MESSAGE_HIT_SQL = text(
     f"""
     SELECT mv.id AS message_version_id,
@@ -368,6 +380,8 @@ _MESSAGE_HIT_SQL = text(
     """
 )
 
+# Only the static _FORGET_EXCLUDES fragment is interpolated; runtime values are bound.
+# nosemgrep: python.sqlalchemy.security.audit.avoid-sqlalchemy-text.avoid-sqlalchemy-text
 _CARD_HIT_SQL = text(
     f"""
     SELECT kc.id AS card_id,

--- a/bot/services/semantic_index.py
+++ b/bot/services/semantic_index.py
@@ -32,6 +32,11 @@ from bot.services.llm_gateway import (
     embed_texts,
 )
 from bot.services.llm_providers import ProviderStructuralError, ProviderTransientError
+from bot.services.llm_providers.openai_embeddings import (
+    MAX_EMBEDDING_BATCH_CHARS,
+    MAX_EMBEDDING_BATCH_SIZE,
+    MAX_EMBEDDING_INPUT_CHARS,
+)
 from bot.services.search import SearchHit
 
 
@@ -790,6 +795,32 @@ def _find_parent_message_unit(
     )
 
 
+def _partition_embedding_documents(
+    documents: Sequence[RetrievalDocument],
+) -> tuple[tuple[RetrievalDocument, ...], ...]:
+    """Build provider-safe batches without changing or truncating source text."""
+
+    batches: list[tuple[RetrievalDocument, ...]] = []
+    current: list[RetrievalDocument] = []
+    current_chars = 0
+    for document in documents:
+        document_chars = len(document.canonical_text)
+        if document_chars > MAX_EMBEDDING_INPUT_CHARS:
+            raise ValueError("oversize embedding documents must be filtered before batching")
+        if current and (
+            len(current) >= MAX_EMBEDDING_BATCH_SIZE
+            or current_chars + document_chars > MAX_EMBEDDING_BATCH_CHARS
+        ):
+            batches.append(tuple(current))
+            current = []
+            current_chars = 0
+        current.append(document)
+        current_chars += document_chars
+    if current:
+        batches.append(tuple(current))
+    return tuple(batches)
+
+
 async def _acquire_document_locks(
     session: AsyncSession,
     *,
@@ -1095,18 +1126,30 @@ async def _index_batch_locked(
     missing = [
         document for document in prevalidated_documents if document not in reusable_before_embedding
     ]
-    embedding_result = None
-    vectors_by_document: dict[RetrievalDocument, Sequence[float]] = {}
-    if missing:
+    oversized_documents = {
+        document for document in missing if len(document.canonical_text) > MAX_EMBEDDING_INPUT_CHARS
+    }
+    embeddable_documents = [document for document in missing if document not in oversized_documents]
+    vectors_by_document: dict[RetrievalDocument, tuple[Sequence[float], int]] = {}
+    for embedding_batch in _partition_embedding_documents(embeddable_documents):
         embedding_result = await embed_texts(
             session,
-            inputs=[document.canonical_text for document in missing],
+            inputs=[document.canonical_text for document in embedding_batch],
             config=config,
             ledger_repo=LedgerRepo(),
             provider=provider,
         )
-        vectors_by_document = dict(zip(missing, embedding_result.vectors, strict=True))
-    embedded_documents = set(missing)
+        vectors_by_document.update(
+            {
+                document: (vector, embedding_result.llm_usage_ledger_id)
+                for document, vector in zip(
+                    embedding_batch,
+                    embedding_result.vectors,
+                    strict=True,
+                )
+            }
+        )
+    embedded_documents = set(embeddable_documents)
 
     valid_documents = await _revalidate_documents(
         session,
@@ -1206,15 +1249,20 @@ async def _index_batch_locked(
             )
             reasons["indexed:reused_embedding" if stored else "skipped:conflict"] += 1
             continue
-        if document not in vectors_by_document or embedding_result is None:
+        if document in oversized_documents:
+            reasons["skipped:oversize"] += 1
+            continue
+        embedded = vectors_by_document.get(document)
+        if embedded is None:
             reasons["skipped:conflict"] += 1
             continue
+        vector, llm_usage_ledger_id = embedded
         if await _store_document(
             session,
             document=document,
-            vector=vectors_by_document[document],
+            vector=vector,
             config=config,
-            llm_usage_ledger_id=embedding_result.llm_usage_ledger_id,
+            llm_usage_ledger_id=llm_usage_ledger_id,
             embedding_provider=EMBEDDING_PROVIDER,
             embedding_model_version=EMBEDDING_MODEL_VERSION,
             embedding_dimensions=config.dimensions,
@@ -1227,6 +1275,7 @@ async def _index_batch_locked(
         reasons["skipped:unchanged"]
         + reasons["skipped:governance_race"]
         + reasons["skipped:conflict"]
+        + reasons["skipped:oversize"]
     )
     return _BatchResult(indexed=indexed, skipped=skipped, reason_counts=dict(reasons))
 
@@ -1243,15 +1292,28 @@ async def _index_batch(
     batch = tuple(documents)
     if not batch:
         return _BatchResult(indexed=0, skipped=0, reason_counts={})
-    from bot.services.advisory_locks import hold_session_advisory_locks
+    from bot.services.advisory_locks import (
+        governed_message_lock_keys,
+        hold_session_advisory_locks,
+    )
     from bot.services.forget_cascade import _p6_mvid_advisory_lock_id
 
-    lock_ids = (
-        _p6_mvid_advisory_lock_id(message_version_id)
-        for document in batch
-        for message_version_id in document.message_version_ids
+    provenance_ids = tuple(
+        dict.fromkeys(
+            message_version_id
+            for document in batch
+            for message_version_id in document.message_version_ids
+        )
     )
-    async with hold_session_advisory_locks(session, lock_ids):
+    lock_ids = (
+        _p6_mvid_advisory_lock_id(message_version_id) for message_version_id in provenance_ids
+    )
+    lock_keys = await governed_message_lock_keys(session, provenance_ids)
+    async with hold_session_advisory_locks(
+        session,
+        lock_ids,
+        lock_keys=lock_keys,
+    ):
         result = await _index_batch_locked(
             session,
             documents=batch,

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -13,7 +13,7 @@
 
 services:
   postgres-dev:
-    image: postgres:16
+    image: pgvector/pgvector:0.8.2-pg16-bookworm@sha256:00ba258a66dac104fd5171074a0084462a64a1369d8513f3d0a634e2f24d15bc
     container_name: shkoder-postgres-dev
     environment:
       POSTGRES_USER: shkoder_dev

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
     restart: unless-stopped
 
   db:
-    image: postgres:16-alpine
+    image: pgvector/pgvector:0.8.2-pg16-bookworm@sha256:00ba258a66dac104fd5171074a0084462a64a1369d8513f3d0a634e2f24d15bc
     volumes:
       - pgdata:/var/lib/postgresql/data
     environment:

--- a/docs/runbooks/semantic-qa.md
+++ b/docs/runbooks/semantic-qa.md
@@ -302,10 +302,15 @@ fi
 `no_answer`, `privacy_governance`. У privacy cases отдельно перечислить
 `forbidden_source_ids`; runner вычисляет leakage как пересечение с реально
 возвращёнными canonical keys, поэтому reviewer не может обнулить leakage.
+Blocking-набор обязан покрывать все классы `cross_chat`, `bot_authored`,
+`forgotten`, `redacted`, `non_normal` и отдельный governance-инвариант
+`stale_version` до первого provider-вызова.
 
 Private input JSONL содержит `case_id`, `category`, `chat_id`, `query`,
-`expected_source_ids`, `forbidden_source_ids`, `expected_abstain` и
-`exclude_chat_message_id`. Source keys имеют только формы
+`expected_source_ids`, `forbidden_source_ids`, `privacy_classes`,
+`expected_abstain` и `exclude_chat_message_id`. Для non-privacy cases
+`privacy_classes=[]`; для каждого `privacy_governance` case список непустой и
+содержит только перечисленные выше значения. Source keys имеют только формы
 `message:<positive-id>` и `card:<canonical-lowercase-uuid>`. Запускать на exact
 release commit через живые OpenAI embedding → hybrid retrieval → DeepSeek V4
 Flash synthesis. Runner не резервирует пользовательскую quota, но каждый
@@ -327,7 +332,8 @@ python -m scripts.run_semantic_qa_eval \
 CI или копировать в issue. Reviewer заполняет только link/claim annotations в
 `reviewed_result`. Runner-issued `semantic-eval-observations.jsonl` содержит
 только immutable objective fields (FTS/hybrid IDs, abstention, leakage и
-latency), не содержит raw text и после запуска не редактируется. После review
+latency), имеет `schema_version=3`, не содержит raw text и после запуска не
+редактируется. После review
 создать `semantic-eval-results.jsonl`: header с `record_type=header`,
 `schema_version=1`, `contains_raw_text=false`, exact `release_sha`,
 `dataset_sha256`, SHA-256 observations-файла в `observations_sha256` и
@@ -349,8 +355,9 @@ python -m scripts.evaluate_semantic_qa evaluate \
 ```
 
 Успех — exit code `0`, `status=pass`, `case_count >= 50` и пустой
-`violations`. Exit code `1` означает blocking gate; `2` — невалидный или
-неполный input. Report mode `0600`, `contains_raw_text=false`.
+`violations`. Sanitized report имеет `schema_version=4` и полный безопасный
+список `report.privacy_classes`. Exit code `1` означает blocking gate; `2` —
+невалидный или неполный input. Report mode `0600`, `contains_raw_text=false`.
 
 Передать exact sanitized report как repository secret и запустить manual-only
 workflow на том же commit (daily schedule намеренно отсутствует):
@@ -499,6 +506,21 @@ SELECT count(*) AS denied_with_provider_call
 FROM semantic_qa_attempts
 WHERE status='denied'
   AND (embedding_llm_call_id IS NOT NULL OR synthesis_llm_call_id IS NOT NULL);
+```
+
+`progress_at` — fail-closed lease активной попытки. Handler обновляет его при
+trace binding, после embedding и перед каждой потенциально долгой
+question+evidence фазой. Только `reserved` без прогресса более 15 минут можно
+считать crash residue; свежий `progress_at` запрещает admission-reconciler
+освобождать живую попытку:
+
+```sql
+SELECT id, user_tg_id, local_day, reserved_at, progress_at,
+       qa_trace_id, embedding_llm_call_id, synthesis_llm_call_id
+FROM semantic_qa_attempts
+WHERE status='reserved'
+  AND progress_at < now() - interval '15 minutes'
+ORDER BY progress_at, id;
 ```
 
 Ожидается `0`. Embedding и synthesis usage/cost:

--- a/docs/runbooks/semantic-qa.md
+++ b/docs/runbooks/semantic-qa.md
@@ -1,0 +1,684 @@
+# Semantic Q&A: migration, rollout и rollback
+
+Этот runbook — обязательная последовательность для issue #404. Semantic Q&A
+остаётся выключенным, пока не пройдены restore rehearsal, миграция, backfill,
+coverage audit, shadow/eval и Telegram E2E.
+
+## Контракт production
+
+- PostgreSQL остаётся на major version 15. Меняется только image с
+  `postgres:15-alpine` на
+  `ghcr.io/jekudy/vibe-gatekeeper-postgres:sha-<release-sha>@sha256:<digest>`.
+  Этот image собирается `Dockerfile.postgres` из точного production parent
+  `postgres@sha256:1c52f5ad23db5d7648a63634444af76de48e63b860fccbe3e3a5458b2812eaed`
+  (PG15 Alpine) и pgvector `0.8.2`; смена image на том же volume не меняет
+  major version, libc или layout данных.
+- Production DB: `vibe_gatekeeper`, user `vibe`, Coolify DB/container UUID
+  `hdazvm5fz836xj9mdyn8c629`.
+- Миграция `089` создаёт extension `vector`, semantic tables и nullable
+  `users.is_bot`. Векторный поиск использует exact cosine; HNSW в этом rollout
+  не создаётся.
+- Rollout flag: `memory.qa.semantic.enabled`. Отсутствующий или выключенный
+  флаг сохраняет существующий FTS Q&A path.
+- Embeddings используют существующий `OPENAI_API_KEY`. Новые настройки не
+  переименовывать: `EMBEDDING_MODEL`, `EMBEDDING_DIMENSIONS`,
+  `EMBEDDING_DAILY_USD_CEILING`, `EMBEDDING_MONTHLY_USD_CEILING`.
+- Все operator-артефакты содержат только counters, hashes, source IDs, ranks,
+  latency и ledger IDs. Вопросы и source text запрещено печатать в terminal,
+  CI artifact или issue/PR.
+
+## 1. Stop conditions
+
+Немедленно остановить rollout и оставить semantic flag выключенным, если:
+
+- последний backup старше 24 часов, `pg_restore --list` не проходит или нет
+  успешного restore rehearsal;
+- production image не предоставляет extension `vector` версии `0.8.2`;
+- `alembic current` не показывает ожидаемый release head;
+- backfill/audit возвращает `status != pass`, coverage ниже 100% или
+  `unexpected_active > 0`;
+- frozen eval не проходит хотя бы один blocking gate issue #404;
+- retrieval p95 выше 2 секунд или full-attempt p95 выше 15 секунд;
+- найден cross-chat, bot-authored, forgotten, redacted, stale или non-normal
+  источник;
+- embedding/LLM вызов не связан с usage/cost audit;
+- Telegram-ответ не имеет валидной source-ссылки.
+
+## 2. Pre-migration backup
+
+На VPS запустить существующий root-only backup и проверить свежий артефакт:
+
+```bash
+ssh foodzy-vps
+sudo /usr/local/sbin/shkoder-pg-backup.sh
+sudo tail -20 /var/log/shkoder-pg-backup.log
+sudo ls -lt /data/coolify/backups/shkoder-postgres/ | head
+```
+
+Зафиксировать вне git имя dump, размер и SHA-256:
+
+```bash
+DUMP=/data/coolify/backups/shkoder-postgres/shkoder-pg-<UTC>.dump
+sudo test -s "$DUMP"
+sudo sha256sum "$DUMP"
+sudo dd if="$DUMP" status=none | sudo docker exec -i hdazvm5fz836xj9mdyn8c629 \
+  pg_restore --list >/dev/null
+```
+
+Не продолжать только на основании `pg_restore --list`: нужен полный restore в
+одноразовый PostgreSQL.
+
+## 3. Restore и migration rehearsal
+
+Rehearsal выполняется на том же pinned PG15+pgvector image, который пойдёт в
+production. `<release-image>` — immutable bot image этого PR по tag или digest.
+
+```bash
+RELEASE_GIT_SHA='<40-character-release-git-sha>'
+IMAGE='ghcr.io/jekudy/vibe-gatekeeper-postgres:sha-'"$RELEASE_GIT_SHA"'@sha256:<digest>'
+sudo docker run -d --name shkoder-semantic-restore \
+  --network coolify \
+  -e POSTGRES_USER=vibe \
+  -e POSTGRES_PASSWORD=restore-only-password \
+  -e POSTGRES_DB=vibe_gatekeeper \
+  "$IMAGE"
+
+until sudo docker exec shkoder-semantic-restore \
+  pg_isready -U vibe -d vibe_gatekeeper; do sleep 1; done
+
+sudo dd if="$DUMP" status=none | sudo docker exec -i shkoder-semantic-restore \
+  pg_restore --exit-on-error --no-owner --no-privileges \
+  --dbname=vibe_gatekeeper -U vibe
+```
+
+Проверить доступность pgvector до миграции:
+
+```bash
+sudo docker exec shkoder-semantic-restore psql -U vibe -d vibe_gatekeeper -v ON_ERROR_STOP=1 \
+  -c "SELECT name, default_version, installed_version
+      FROM pg_available_extensions WHERE name='vector';"
+```
+
+Прогнать `up → down → up` release-кодом. До первого downgrade нельзя запускать
+backfill/shadow: migration `089` намеренно запрещает downgrade при наличии
+любых semantic index/audit rows или `semantic_embedding` ledger rows.
+
+```bash
+RELEASE_IMAGE='ghcr.io/jekudy/vibe-gatekeeper-bot@sha256:<release-digest>'
+DB_URL='postgresql+asyncpg://vibe:restore-only-password@shkoder-semantic-restore:5432/vibe_gatekeeper'
+
+sudo docker run --rm --network coolify --entrypoint alembic \
+  -e DATABASE_URL="$DB_URL" "$RELEASE_IMAGE" upgrade head
+sudo docker run --rm --network coolify --entrypoint alembic \
+  -e DATABASE_URL="$DB_URL" "$RELEASE_IMAGE" downgrade 088
+sudo docker run --rm --network coolify --entrypoint alembic \
+  -e DATABASE_URL="$DB_URL" "$RELEASE_IMAGE" upgrade head
+```
+
+Проверить extension, Alembic и exact cosine без HNSW:
+
+```bash
+sudo docker exec -i shkoder-semantic-restore \
+  psql -U vibe -d vibe_gatekeeper -v ON_ERROR_STOP=1 <<'SQL'
+SELECT extname, extversion FROM pg_extension WHERE extname='vector';
+SELECT version_num FROM alembic_version;
+CREATE TEMP TABLE vector_smoke (id integer PRIMARY KEY, embedding vector(3));
+INSERT INTO vector_smoke VALUES (1, '[1,0,0]'), (2, '[0,1,0]');
+SELECT id FROM vector_smoke ORDER BY embedding <=> '[1,0,0]'::vector, id;
+SQL
+```
+
+Ожидается `vector 0.8.2`, release head и порядок smoke rows `1, 2`. Затем
+сверить ключевые row counts с production dump и удалить rehearsal-контейнер:
+
+```bash
+sudo docker exec shkoder-semantic-restore psql -U vibe -d vibe_gatekeeper -v ON_ERROR_STOP=1 \
+  -c "SELECT 'users' AS table_name, count(*) FROM users
+      UNION ALL SELECT 'chat_messages', count(*) FROM chat_messages
+      UNION ALL SELECT 'message_versions', count(*) FROM message_versions;"
+sudo docker rm -f shkoder-semantic-restore
+```
+
+Результат drill записать отдельным датированным файлом в `docs/ops/` без
+секретов и пользовательского контента.
+
+## 4. Production image и migration
+
+1. В Coolify оставить bot/web остановленными на время DB image switch.
+2. Изменить image существующей DB на pinned PG15+pgvector image из этого
+   runbook. Не подключать production volume к PostgreSQL другой major version и
+   не создавать вторую production DB.
+3. Запустить DB и проверить `pg_isready`, PG major и доступность `vector`:
+
+```bash
+sudo docker exec hdazvm5fz836xj9mdyn8c629 pg_isready -U vibe -d vibe_gatekeeper
+sudo docker exec hdazvm5fz836xj9mdyn8c629 psql -U vibe -d vibe_gatekeeper -v ON_ERROR_STOP=1 \
+  -c "SHOW server_version; SELECT name, default_version
+      FROM pg_available_extensions WHERE name='vector';"
+```
+
+4. Deploy immutable bot/web release с semantic flag всё ещё OFF.
+5. Запустить `alembic upgrade head` release-кодом и проверить:
+
+```sql
+SELECT version_num FROM alembic_version;
+SELECT extname, extversion FROM pg_extension WHERE extname='vector';
+SELECT table_name
+FROM information_schema.tables
+WHERE table_schema='public'
+  AND table_name IN (
+    'semantic_index_runs',
+    'semantic_retrieval_units',
+    'semantic_retrieval_unit_sources',
+    'semantic_qa_attempts',
+    'semantic_retrieval_traces'
+  )
+ORDER BY table_name;
+```
+
+Migration `089` помечает human/bot author только по explicit Telegram
+`from_user.is_bot` boolean в `chat_messages.raw_json`, `message` или
+`edited_message`; `true` имеет приоритет. Membership/admin flags и импортный
+`from_id=userN` не являются доказательством человека, поэтому неизвестные и
+channel authors корректно остаются `NULL`. Сверить распределение без требования
+`classified_author_rows = total_message_rows`:
+
+```sql
+SELECT count(*) AS total_message_rows,
+       count(*) FILTER (WHERE author.is_bot IS NOT NULL) AS classified_author_rows,
+       count(*) FILTER (WHERE author.is_bot IS FALSE) AS human_message_rows,
+       count(*) FILTER (WHERE author.is_bot IS TRUE) AS bot_message_rows
+FROM chat_messages AS cm
+JOIN users AS author ON author.id=cm.user_id;
+```
+
+`human_message_rows + bot_message_rows > total_message_rows` или неожиданный
+скачок `bot_message_rows` — stop condition. `NULL` rows ожидаемы и индексом не
+допускаются.
+
+6. Создать глобальный OFF-row, если его ещё нет:
+
+```sql
+INSERT INTO feature_flags (flag_key, scope_type, scope_id, enabled)
+SELECT 'memory.qa.semantic.enabled', NULL, NULL, FALSE
+WHERE NOT EXISTS (
+  SELECT 1 FROM feature_flags
+  WHERE flag_key='memory.qa.semantic.enabled'
+    AND scope_type IS NULL AND scope_id IS NULL
+);
+```
+
+Любой неожиданный enabled row до rollout — stop condition.
+
+## 5. Idempotent backfill и coverage audit
+
+Команды выполнять внутри deployed bot container, где уже заданы `DATABASE_URL`,
+`OPENAI_API_KEY` и embedding ceilings. Для полного production backfill требуется
+явный `--all-chats`; случайно запустить глобальную обработку без него нельзя.
+
+```bash
+umask 077
+python -m scripts.backfill_semantic_index backfill \
+  --all-chats \
+  --batch-size 64 \
+  --report /tmp/semantic-backfill-<UTC>.json
+```
+
+Успех первого запуска:
+
+- exit code `0`, `status=pass`, `failed=0`;
+- `coverage.status=pass`, `coverage.coverage_percent=100.0`;
+- `coverage.missing=0`, `coverage.unexpected_active=0`;
+- `eligible > 0` для текущей непустой production history;
+- `eligible = indexed + skipped`.
+
+Скопировать no-content report из контейнера в root-only operator storage. Не
+загружать его в публичный CI artifact: source IDs и chat IDs остаются
+внутренними идентификаторами сообщества.
+
+Повторить ту же команду. Идемпотентность подтверждена, только если:
+
+- `indexed=0`;
+- `skipped=eligible`;
+- количество `semantic_embedding` provider calls/ledger rows не выросло.
+
+Отдельный read-only coverage/leakage audit не вызывает provider API:
+
+```bash
+python -m scripts.backfill_semantic_index audit \
+  --all-chats \
+  --batch-size 64 \
+  --report /tmp/semantic-coverage-<UTC>.json
+```
+
+Для поэтапной обработки одного чата заменить `--all-chats` на
+`--chat-id <telegram-chat-id>`.
+
+## 6. Shadow retrieval
+
+Shadow CLI вызывает только query embedding и hybrid retrieval. Он не вызывает
+DeepSeek synthesis, не отвечает в Telegram, не расходует пользовательскую
+двухзапросную квоту и не меняет feature flag.
+
+Private input JSONL хранится вне git с mode `0600`. Один вопрос на строку:
+
+```json
+{"question_id":"semantic-001","chat_id":-1001234567890,"query":"<private question>","exclude_chat_message_id":123}
+```
+
+`question_id` должен быть opaque ASCII ID, а не текст вопроса. Запуск:
+
+```bash
+umask 077
+python -m scripts.backfill_semantic_index shadow \
+  --input /run/secrets/semantic-shadow-questions.jsonl \
+  --output /tmp/semantic-shadow-<UTC>.jsonl \
+  --max-queries 50 \
+  --candidate-limit 20 \
+  --limit 5
+```
+
+Output не содержит `query` или snippets. Он содержит `query_sha256`, FTS/vector/
+hybrid source IDs, ranks, latency и `embedding_llm_call_id`. Проверить файл
+автоматически перед сохранением:
+
+```bash
+if grep -Eq '"query"[[:space:]]*:|"snippet"[[:space:]]*:' \
+  /tmp/semantic-shadow-<UTC>.jsonl; then
+  echo 'STOP: raw content field in shadow report' >&2
+  exit 1
+fi
+```
+
+После shadow прогнать frozen eval из ≥50 реальных privately-labelled вопросов.
+Все пять категорий обязательны: `semantic`, `exact`, `multi_source`,
+`no_answer`, `privacy_governance`. У privacy cases отдельно перечислить
+`forbidden_source_ids`; runner вычисляет leakage как пересечение с реально
+возвращёнными canonical keys, поэтому reviewer не может обнулить leakage.
+
+Private input JSONL содержит `case_id`, `category`, `chat_id`, `query`,
+`expected_source_ids`, `forbidden_source_ids`, `expected_abstain` и
+`exclude_chat_message_id`. Source keys имеют только формы
+`message:<positive-id>` и `card:<canonical-lowercase-uuid>`. Запускать на exact
+release commit через живые OpenAI embedding → hybrid retrieval → DeepSeek V4
+Flash synthesis. Runner не резервирует пользовательскую quota, но каждый
+provider call обязан иметь durable ledger row:
+
+```bash
+umask 077
+RELEASE_GIT_SHA='<40-character-release-git-sha>'
+python -m scripts.run_semantic_qa_eval \
+  --input /run/secrets/semantic-eval-private.jsonl \
+  --cases-output /run/secrets/semantic-eval-cases.jsonl \
+  --observations-output /run/secrets/semantic-eval-observations.jsonl \
+  --review-output /run/secrets/semantic-eval-review.jsonl \
+  --release-sha "$RELEASE_GIT_SHA"
+```
+
+`semantic-eval-review.jsonl` содержит raw query/answer/snippets и остаётся
+только на operator host с mode `0600`; его запрещено логировать, прикладывать к
+CI или копировать в issue. Reviewer заполняет только link/claim annotations в
+`reviewed_result`. Runner-issued `semantic-eval-observations.jsonl` содержит
+только immutable objective fields (FTS/hybrid IDs, abstention, leakage и
+latency), не содержит raw text и после запуска не редактируется. После review
+создать `semantic-eval-results.jsonl`: header с `record_type=header`,
+`schema_version=1`, `contains_raw_text=false`, exact `release_sha`,
+`dataset_sha256`, SHA-256 observations-файла в `observations_sha256` и
+`case_count`; остальные строки содержат только `case_id`,
+`valid_source_links`, `invalid_source_links`, `unsupported_claims`,
+`total_claims`. Objective поля в reviewer sidecar запрещены. Evaluator
+fail-closed отклонит results другого release/dataset/observations, изменённый
+objective artifact, отсутствующий header или несовпадающий case count. Затем
+построить sanitized report, привязанный к hashes всех трёх артефактов:
+
+```bash
+python -m scripts.evaluate_semantic_qa evaluate \
+  --dataset /run/secrets/semantic-eval-private.jsonl \
+  --cases /run/secrets/semantic-eval-cases.jsonl \
+  --observations /run/secrets/semantic-eval-observations.jsonl \
+  --results /run/secrets/semantic-eval-results.jsonl \
+  --release-sha "$RELEASE_GIT_SHA" \
+  --report /tmp/semantic-eval-<UTC>.json
+```
+
+Успех — exit code `0`, `status=pass`, `case_count >= 50` и пустой
+`violations`. Exit code `1` означает blocking gate; `2` — невалидный или
+неполный input. Report mode `0600`, `contains_raw_text=false`.
+
+Передать exact sanitized report как repository secret и запустить manual-only
+workflow на том же commit (daily schedule намеренно отсутствует):
+
+```bash
+gh secret set SEMANTIC_EVAL_REPORT_JSON < /tmp/semantic-eval-<UTC>.json
+gh workflow run evals.yml --ref "$RELEASE_GIT_SHA"
+gh run watch --exit-status
+```
+
+Workflow fail-closed при отсутствующем/невалидном secret, несовпадении
+`release_sha` с `GITHUB_SHA`, неверных hashes/schema или любом blocking metric.
+Artifact содержит только `contains_raw_text=false` contract и sanitized frozen
+report; private input/review ни при каких условиях не загружаются.
+
+## 7. Limited Telegram E2E
+
+Canary включается только для одного заранее выбранного Telegram user ID при
+глобальном semantic flag OFF. Handler сначала проверяет global row, затем exact
+`scope_type='user'`, `scope_id=<telegram-user-id>`; другие участники остаются на
+существующем FTS path.
+
+1. Выбрать период низкой активности и предупредить тестового участника.
+2. Зафиксировать global и scoped flags:
+
+```sql
+SELECT flag_key, enabled, updated_at
+FROM feature_flags
+WHERE flag_key IN (
+  'memory.qa.llm_synthesis.enabled',
+  'memory.qa.semantic.enabled'
+)
+  AND (
+    (scope_type IS NULL AND scope_id IS NULL)
+    OR (scope_type='user' AND scope_id='<canary-tg-user-id>')
+  );
+```
+
+3. Оставить global semantic OFF и включить только canary user:
+
+```sql
+UPDATE feature_flags SET enabled=FALSE, updated_at=clock_timestamp()
+WHERE flag_key='memory.qa.semantic.enabled'
+  AND scope_type IS NULL AND scope_id IS NULL;
+
+INSERT INTO feature_flags
+  (flag_key, scope_type, scope_id, enabled, config_json, updated_at)
+VALUES
+  ('memory.qa.semantic.enabled', 'user', '<canary-tg-user-id>', TRUE, NULL,
+   clock_timestamp())
+ON CONFLICT (flag_key, scope_type, scope_id)
+DO UPDATE SET enabled=EXCLUDED.enabled, updated_at=clock_timestamp();
+```
+
+Проверить exact global OFF и scoped ON. `memory.qa.llm_synthesis.enabled` global
+должен быть ON: верхний handler gate проверяет его первым.
+
+4. Реальный участник задаёт боту перефразированный вопрос в production
+Telegram-группе через mention/reply surface.
+5. Ответ должен быть коротким, grounded и содержать хотя бы одну кликабельную
+Telegram source-ссылку. Evidence должен относиться только к текущему чату.
+6. Выполнить ещё один успешный semantic вопрос, затем третий. Третий должен
+показать явно обозначенный обычный FTS/wiki fallback без новых embedding и
+DeepSeek ledger rows.
+7. Сразу вернуть scoped semantic flag в OFF и сверить audit rows. Технический failure
+проверяется отдельно управляемым staging smoke, а не намеренной поломкой
+production credentials.
+
+```sql
+UPDATE feature_flags
+SET enabled=FALSE, updated_at=clock_timestamp()
+WHERE flag_key='memory.qa.semantic.enabled'
+  AND scope_type='user' AND scope_id='<canary-tg-user-id>';
+```
+
+### Provider-failure smoke и точное освобождение quota
+
+Сначала выполнить автоматизированный handler/DB smoke на release commit:
+
+```bash
+uv run pytest -q \
+  tests/handlers/test_qa_mentions.py::test_semantic_embedding_failure_releases_slot \
+  tests/handlers/test_qa_mentions.py::test_semantic_technical_release_precedes_failing_ordinary_fallback \
+  tests/services/test_semantic_quota_postgres.py::test_technical_failure_releases_slot_for_reuse
+```
+
+Затем только в staging с отдельным bot token и DB включить scoped flag одному
+test user и временно задать заведомо невалидный provider credential. До вопроса
+снять exact baseline (не aggregate по всему чату):
+
+```sql
+SELECT coalesce(max(id), 0) AS before_attempt_id
+FROM semantic_qa_attempts
+WHERE user_tg_id=<staging-test-user-id>;
+
+SELECT coalesce(max(id), 0) AS before_ledger_id
+FROM llm_usage_ledger;
+```
+
+Отправить один новый уникальный Telegram question этим user, дождаться fallback,
+вернуть рабочий credential и сразу выключить scoped flag. Для ID строго выше
+зафиксированных baseline ожидается ровно один released attempt, ни одного
+active/consumed slot и provider failure в ledger:
+
+```sql
+SELECT id, status, outcome, embedding_llm_call_id, synthesis_llm_call_id
+FROM semantic_qa_attempts
+WHERE user_tg_id=<staging-test-user-id> AND id>:before_attempt_id
+ORDER BY id;
+
+SELECT id, call_type, error, cost_usd
+FROM llm_usage_ledger
+WHERE id>:before_ledger_id
+ORDER BY id;
+```
+
+Pass: новая attempt имеет `status='released'`,
+`outcome='technical_failure'`; exact provider ledger ID связан через
+`embedding_llm_call_id` или `synthesis_llm_call_id`; повторный вопрос после
+восстановления provider получает доступный slot. Raw query/answer в evidence не
+копировать.
+
+## 8. Quota, cost и latency audit
+
+Два слота считаются по календарным суткам `Europe/Moscow`. Проверка последних
+семи дней:
+
+```sql
+SELECT local_day, user_tg_id,
+       count(*) FILTER (WHERE status IN ('reserved','consumed')) AS active_slots,
+       count(*) FILTER (WHERE status='consumed' AND outcome='answered') AS answered,
+       count(*) FILTER (WHERE status='consumed' AND outcome='abstained') AS abstained,
+       count(*) FILTER (WHERE status='released' AND outcome='technical_failure') AS released,
+       count(*) FILTER (WHERE status='denied' AND outcome='quota_denied') AS denied
+FROM semantic_qa_attempts
+WHERE local_day >= (now() AT TIME ZONE 'Europe/Moscow')::date - 7
+GROUP BY local_day, user_tg_id
+ORDER BY local_day DESC, user_tg_id;
+```
+
+Stop condition: `active_slots > 2`. У denied rows оба provider FK должны быть
+NULL:
+
+```sql
+SELECT count(*) AS denied_with_provider_call
+FROM semantic_qa_attempts
+WHERE status='denied'
+  AND (embedding_llm_call_id IS NOT NULL OR synthesis_llm_call_id IS NOT NULL);
+```
+
+Ожидается `0`. Embedding и synthesis usage/cost:
+
+```sql
+SELECT (created_at AT TIME ZONE 'Europe/Moscow')::date AS msk_day,
+       call_type,
+       count(*) AS calls,
+       sum(tokens_in) AS tokens_in,
+       round(sum(cost_usd), 6) AS cost_usd,
+       count(*) FILTER (WHERE error IS NOT NULL) AS errors
+FROM llm_usage_ledger
+WHERE call_type IN ('semantic_embedding','qa_synthesis')
+  AND created_at >= now() - interval '7 days'
+GROUP BY msk_day, call_type
+ORDER BY msk_day DESC, call_type;
+```
+
+Каждый durable provider call сначала создаёт ledger row с
+`error='reserved_in_flight'`, а terminal update атомарно заменяет marker на
+`NULL` или фактический provider error. Зависший marker старше 15 минут означает
+неоднозначный исход (например, crash после отправки запроса) и требует ручного
+расследования; повторять provider call или автоматически обнулять marker нельзя:
+
+```sql
+SELECT id, call_type, provider, model, created_at, cost_usd
+FROM llm_usage_ledger
+WHERE error='reserved_in_flight'
+  AND created_at < now() - interval '15 minutes'
+ORDER BY created_at;
+```
+
+Stop condition: любой такой row до canary/global enable. В evidence сохранять
+только ledger ID и технические поля из запроса выше, без пользовательского
+контента.
+
+Retrieval и full-attempt p95:
+
+```sql
+SELECT percentile_cont(0.95) WITHIN GROUP (ORDER BY total_latency_ms)
+       AS retrieval_p95_ms
+FROM semantic_retrieval_traces
+WHERE created_at >= now() - interval '24 hours';
+
+SELECT percentile_cont(0.95) WITHIN GROUP (
+         ORDER BY extract(epoch FROM (finalized_at - reserved_at)) * 1000
+       ) AS full_attempt_p95_ms
+FROM semantic_qa_attempts
+WHERE finalized_at IS NOT NULL
+  AND status='consumed'
+  AND reserved_at >= now() - interval '24 hours';
+```
+
+Gates: retrieval p95 ≤ `2000 ms`, full attempt p95 ≤ `15000 ms`. HNSW можно
+проектировать только после зафиксированного нарушения retrieval gate на
+production-like dataset; он не является автоматическим fallback.
+
+Следить за structured events (они не должны содержать query/source text):
+
+- `semantic_index_tick_completed` — каждые 15 минут после enable; нормальный
+  steady state имеет `indexed=0` и `failed=0` между edit/image/card changes;
+- `semantic_index_tick_failed` и `semantic_index_tick_session_failed` — stop
+  signal для freshness индекса;
+- `semantic_index_database_failed` — DB failure ручного backfill/reindex;
+- `semantic_qa_embedding_failed`, `semantic_qa_database_failed`,
+  `semantic_qa_synthesis_config_failed` — technical failure; соответствующий
+  quota slot должен перейти в `released`.
+
+Отсутствие успешного `semantic_index_tick_completed` дольше 30 минут при
+включённом flag — alert: выключить semantic path до восстановления freshness.
+
+## 9. Privacy/leakage audit
+
+Активные units не должны ссылаться на stale, non-normal, redacted или bot/
+unknown-authored sources:
+
+```sql
+SELECT count(*) AS invalid_active_units
+FROM semantic_retrieval_units u
+WHERE u.invalidated_at IS NULL
+  AND EXISTS (
+    SELECT 1
+    FROM semantic_retrieval_unit_sources s
+    JOIN message_versions mv ON mv.id=s.message_version_id
+    JOIN chat_messages cm ON cm.id=mv.chat_message_id
+    LEFT JOIN users author ON author.id=cm.user_id
+    WHERE s.unit_id=u.id
+      AND (
+        cm.chat_id <> u.chat_id
+        OR cm.current_version_id IS DISTINCT FROM mv.id
+        OR cm.memory_policy <> 'normal'
+        OR coalesce(cm.message_kind, 'text') IN ('voice','audio')
+        OR cm.is_redacted
+        OR mv.is_redacted
+        OR author.is_bot IS DISTINCT FROM FALSE
+      )
+  );
+```
+
+Ожидается `0`. Отдельно проверить active units, попавшие под durable forget
+tombstone:
+
+```sql
+SELECT count(DISTINCT u.id) AS forgotten_active_units
+FROM semantic_retrieval_units u
+JOIN semantic_retrieval_unit_sources s ON s.unit_id=u.id
+JOIN message_versions mv ON mv.id=s.message_version_id
+JOIN chat_messages cm ON cm.id=mv.chat_message_id
+JOIN forget_events fe
+  ON (
+    (fe.target_type='message' AND fe.target_id=cm.id::text)
+    OR (fe.target_type='user' AND fe.target_id=cm.user_id::text)
+    OR (fe.target_type='message_hash' AND fe.target_id=mv.content_hash)
+  )
+WHERE u.invalidated_at IS NULL
+  AND fe.status IN ('pending','processing','completed');
+```
+
+Ожидается `0`. Pending/processing/completed forget должен блокироваться read-side
+немедленно; дополнительно выполнить binding leakage/forget tests release commit.
+При любом leakage signal: semantic flag OFF, сохранить только no-content IDs/
+hashes для расследования, raw source text не копировать в issue.
+
+## 10. Enable для всех участников
+
+Разрешено только после:
+
+- restore drill и migration round-trip PASS;
+- backfill coverage 100%, повторный backfill idempotent;
+- frozen eval и blocking leakage/citation/abstention gates PASS;
+- limited production E2E PASS;
+- quota/cost audit и p95 gates PASS.
+
+Включить global flag отдельной exact-командой и оставить ON:
+
+```sql
+UPDATE feature_flags
+SET enabled=TRUE, updated_at=clock_timestamp()
+WHERE flag_key='memory.qa.semantic.enabled'
+  AND scope_type IS NULL AND scope_id IS NULL;
+```
+
+Проверить, что затронута ровно одна строка; scoped canary row оставить OFF.
+Первые 24 часа
+проверять каждые 2 часа: attempts/denials/releases, embedding+synthesis spend,
+empty/abstention rate, retrieval/full p95, provider errors и leakage query.
+
+## 11. Rollback
+
+### Обычный rollback (предпочтительный)
+
+1. Немедленно поставить `memory.qa.semantic.enabled=FALSE`.
+2. Проверить, что новые `semantic_qa_attempts` перестали появляться.
+3. Оставить PG15+pgvector image и migration `089` на месте: схема аддитивна,
+   а выключенный feature flag возвращает existing FTS Q&A path.
+4. При необходимости откатить bot/web на предыдущий immutable image только
+   после flag-off.
+
+Это не удаляет audit/index data и допускает безопасное повторное включение.
+
+### Migration downgrade
+
+`alembic downgrade 088` допустим только до любых semantic attempts/traces и
+`semantic_embedding` ledger rows. Guard migration `089` обязан отказать после
+первого backfill/shadow/live вызова. Не обходить guard ручным DELETE.
+
+После появления semantic audit data DB rollback выполняется только полным
+restore pre-migration backup в отдельный clean volume с оценкой потери всех
+записей после backup. Перед destructive restore нужен отдельный operator
+sign-off. Старый `postgres:15-alpine` image нельзя запускать на production
+volume с установленным `vector`: для image rollback восстановить pre-migration
+dump в чистую original-image DB.
+
+Полная restore-процедура описана в `docs/ops/db-backup-runbook.md`.
+
+## 12. Evidence для issue #404
+
+В итоговый комментарий приложить без raw content:
+
+- release commit/image digest, backup filename/size/SHA-256;
+- restore drill и `089 → 088 → 089` evidence;
+- `vector` version и exact cosine smoke;
+- оба backfill report: первый и idempotent rerun;
+- coverage/shadow/frozen-eval summary по каждому threshold;
+- migration/test suite commands и counts;
+- Telegram E2E message/source IDs, но не текст вопроса/ответа;
+- quota, cost и latency aggregate queries;
+- timestamps limited rollout, final enable и rollback flag verification.
+
+Issue закрывается только после merge, production E2E и финального global enable.

--- a/docs/runbooks/semantic-qa.md
+++ b/docs/runbooks/semantic-qa.md
@@ -36,7 +36,7 @@ coverage audit, shadow/eval и Telegram E2E.
 - production image не предоставляет extension `vector` версии `0.8.2`;
 - `alembic current` не показывает ожидаемый release head;
 - backfill/audit возвращает `status != pass`, coverage ниже 100% или
-  `unexpected_active > 0`;
+  `unexpected_active > 0`, `unresolved_claims > 0`;
 - frozen eval не проходит хотя бы один blocking gate issue #404;
 - retrieval p95 выше 2 секунд или full-attempt p95 выше 15 секунд;
 - найден cross-chat, bot-authored, forgotten, redacted, stale или non-normal
@@ -228,12 +228,13 @@ python -m scripts.backfill_semantic_index backfill \
 
 - exit code `0`, `status=pass`, `failed=0`;
 - `coverage.status=pass`, `coverage.coverage_percent=100.0`;
-- `coverage.missing=0`, `coverage.unexpected_active=0`;
+- `coverage.missing=0`, `coverage.unexpected_active=0`,
+  `coverage.unresolved_claims=0`;
 - `eligible > 0` для текущей непустой production history;
 - `eligible = indexed + skipped`.
 
 Источник длиннее provider limit не обрезается и не пропускается: backfill
-детерминированно создаёт последовательные chunks до 8000 символов с тем же
+детерминированно создаёт непустые последовательные chunks до 800 символов с тем же
 `source_id`, полным provenance и проверяемыми `chunk_index/chunk_count`.
 Coverage считается по chunks; vector retrieval выбирает лучший chunk каждого
 источника и не позволяет одному длинному документу вытеснить остальные.
@@ -518,7 +519,12 @@ ORDER BY msk_day DESC, call_type;
 
 Каждый durable provider call сначала создаёт ledger row с
 `error='reserved_in_flight'`, а terminal update атомарно заменяет marker на
-`NULL` или фактический provider error. Зависший marker старше 15 минут означает
+`NULL` или фактический provider error. До HTTP-вызова тот же commit создаёт
+`semantic_retrieval_units.embedding_status='reserved'` и полный provenance;
+terminal commit одновременно переводит claim в `completed` с vector и точным
+`chunk_text` либо в `failed` без vector/source text. Поэтому failed/budget calls
+участвуют в forget cascade, а потерянный terminal commit не вызывает повторную
+оплату. Зависший marker старше 15 минут означает
 неоднозначный исход (например, crash после отправки запроса) и требует ручного
 расследования; повторять provider call или автоматически обнулять marker нельзя:
 
@@ -530,9 +536,62 @@ WHERE error='reserved_in_flight'
 ORDER BY created_at;
 ```
 
+Все unresolved claims диагностировать через ledger timestamp: `indexed_at` по
+state contract равен `NULL`, а отдельного created timestamp у unit нет.
+
+```sql
+SELECT u.id AS unit_id, u.embedding_status, u.llm_usage_ledger_id,
+       l.error, l.created_at, l.cost_usd
+FROM semantic_retrieval_units u
+JOIN llm_usage_ledger l ON l.id=u.llm_usage_ledger_id
+WHERE u.embedding_status IN ('reserved','failed')
+ORDER BY l.created_at, u.id;
+```
+
 Stop condition: любой такой row до canary/global enable. В evidence сохранять
 только ledger ID и технические поля из запроса выше, без пользовательского
 контента.
+
+Автоматического reset/retry нет. После расследования operator отдельно решает,
+допустима ли возможная повторная оплата `reserved` call. Для явного repair сначала
+редактировать hashes старого ledger, затем удалить только выбранный claim; cost,
+tokens, latency и error остаются audit evidence. Выполнять в одной транзакции,
+проверив `unit_id` и `llm_usage_ledger_id` вручную:
+
+```sql
+BEGIN;
+DO $$
+BEGIN
+  PERFORM 1
+  FROM semantic_retrieval_units u
+  JOIN llm_usage_ledger l ON l.id=u.llm_usage_ledger_id
+  WHERE u.id=<reviewed-unit-id>
+    AND u.llm_usage_ledger_id=<reviewed-ledger-id>
+    AND u.embedding_status IN ('reserved','failed')
+  FOR UPDATE OF u, l;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'reviewed semantic claim/ledger pair does not match';
+  END IF;
+
+  UPDATE llm_usage_ledger
+  SET prompt_hash=NULL, response_hash=NULL
+  WHERE id=<reviewed-ledger-id>;
+
+  DELETE FROM semantic_retrieval_units
+  WHERE id=<reviewed-unit-id>
+    AND llm_usage_ledger_id=<reviewed-ledger-id>
+    AND embedding_status IN ('reserved','failed');
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'reviewed semantic claim was not deleted';
+  END IF;
+END $$;
+COMMIT;
+```
+
+После repair сначала запустить read-only coverage audit: он должен показать
+`unresolved_claims=0` и ровно ожидаемые missing identities. Затем rerun backfill
+является явным новым provider attempt; после него coverage обязан вернуться к
+100%. Массовое удаление claims или reset статуса запрещены.
 
 Retrieval и full-attempt p95:
 
@@ -578,6 +637,7 @@ unknown-authored sources:
 SELECT count(*) AS invalid_active_units
 FROM semantic_retrieval_units u
 WHERE u.invalidated_at IS NULL
+  AND u.embedding_status='completed'
   AND EXISTS (
     SELECT 1
     FROM semantic_retrieval_unit_sources s
@@ -613,6 +673,7 @@ JOIN forget_events fe
     OR (fe.target_type='message_hash' AND fe.target_id=mv.content_hash)
   )
 WHERE u.invalidated_at IS NULL
+  AND u.embedding_status='completed'
   AND fe.status IN ('pending','processing','completed');
 ```
 

--- a/docs/runbooks/semantic-qa.md
+++ b/docs/runbooks/semantic-qa.md
@@ -232,6 +232,12 @@ python -m scripts.backfill_semantic_index backfill \
 - `eligible > 0` для текущей непустой production history;
 - `eligible = indexed + skipped`.
 
+Источник длиннее provider limit не обрезается и не пропускается: backfill
+детерминированно создаёт последовательные chunks до 8000 символов с тем же
+`source_id`, полным provenance и проверяемыми `chunk_index/chunk_count`.
+Coverage считается по chunks; vector retrieval выбирает лучший chunk каждого
+источника и не позволяет одному длинному документу вытеснить остальные.
+
 Скопировать no-content report из контейнера в root-only operator storage. Не
 загружать его в публичный CI artifact: source IDs и chat IDs остаются
 внутренними идентификаторами сообщества.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ dependencies = [
     "aiogram>=3.25",
     "sqlalchemy[asyncio]>=2.0",
     "asyncpg>=0.30",
+    "pgvector>=0.4.1,<0.5",
     "alembic>=1.14",
     "pydantic-settings>=2.0",
     "gspread-asyncio>=2.0",

--- a/requirements.lock
+++ b/requirements.lock
@@ -39,7 +39,9 @@ mdurl==0.1.2
 multidict==6.7.1
 neo4j==5.28.4
 networkx==3.6.1
+numpy==2.5.1
 oauthlib==3.3.1
+pgvector==0.4.2
 propcache==0.4.1
 pyasn1==0.6.3
 pyasn1-modules==0.4.2

--- a/scripts/backfill_semantic_index.py
+++ b/scripts/backfill_semantic_index.py
@@ -17,6 +17,7 @@ import json
 import os
 import re
 import sys
+from collections import Counter
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Sequence, TextIO, cast
@@ -254,6 +255,7 @@ async def _coverage_report(
                        unit.chat_id,
                        unit.content_hash,
                        unit.embedding_model,
+                       unit.embedding_status,
                        unit.invalidated_at,
                        COALESCE(
                            ARRAY_AGG(source.message_version_id ORDER BY source.position)
@@ -277,6 +279,7 @@ async def _coverage_report(
 
     active: dict[tuple[str, str, str, int, int, int, str, str], tuple[int, ...]] = {}
     invalidated: dict[tuple[str, str, str, int, int, int, str, str], tuple[int, ...]] = {}
+    unresolved_statuses: Counter[str] = Counter()
     for row in rows:
         key = (
             str(row["source_type"]),
@@ -288,6 +291,10 @@ async def _coverage_report(
             str(row["content_hash"]),
             str(row["embedding_model"]),
         )
+        if row["embedding_status"] != "completed":
+            if row["invalidated_at"] is None:
+                unresolved_statuses[str(row["embedding_status"])] += 1
+            continue
         target = active if row["invalidated_at"] is None else invalidated
         target[key] = tuple(int(value) for value in row["message_version_ids"])
 
@@ -305,8 +312,16 @@ async def _coverage_report(
     eligible = len(expected)
     no_eligible_identities = eligible == 0
     coverage_percent = 0.0 if no_eligible_identities else round((len(covered) / eligible) * 100, 2)
+    unresolved_claims = sum(unresolved_statuses.values())
     status = (
-        "pass" if not no_eligible_identities and not missing and not unexpected_active else "fail"
+        "pass"
+        if (
+            not no_eligible_identities
+            and not missing
+            and not unexpected_active
+            and unresolved_claims == 0
+        )
+        else "fail"
     )
     return {
         "schema_version": REPORT_SCHEMA_VERSION,
@@ -319,6 +334,8 @@ async def _coverage_report(
         "coverage_percent": coverage_percent,
         "missing": len(missing),
         "unexpected_active": len(unexpected_active),
+        "unresolved_claims": unresolved_claims,
+        "unresolved_statuses": dict(sorted(unresolved_statuses.items())),
         "reason_counts": {
             "failed:no_eligible_identities": int(no_eligible_identities),
             "indexed:active_identity": len(covered),
@@ -326,6 +343,7 @@ async def _coverage_report(
             "failed:expected_identity_invalidated": len(invalidated_expected),
             "failed:provenance_mismatch": len(provenance_mismatch),
             "failed:unexpected_active_identity": len(unexpected_active),
+            "failed:unresolved_claim": unresolved_claims,
         },
     }
 
@@ -418,6 +436,8 @@ async def _run_backfill(args: argparse.Namespace) -> int:
                 "coverage_percent",
                 "missing",
                 "unexpected_active",
+                "unresolved_claims",
+                "unresolved_statuses",
                 "reason_counts",
             }
         },

--- a/scripts/backfill_semantic_index.py
+++ b/scripts/backfill_semantic_index.py
@@ -1,0 +1,718 @@
+"""Bounded semantic-index backfill, coverage audit, and retrieval shadow CLI.
+
+Run from the repository root:
+
+    python -m scripts.backfill_semantic_index <backfill|audit|shadow> ...
+
+The CLI never prints source or query text.  Reports contain only counters,
+content/query hashes, source identifiers, ranks, latency, and ledger IDs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import json
+import os
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Sequence, TextIO, cast
+
+from sqlalchemy.exc import SQLAlchemyError
+
+from bot.services.llm_providers import ProviderError
+
+
+REPORT_SCHEMA_VERSION = 1
+MAX_SHADOW_CASES = 1_000
+MAX_QUESTION_ID_LENGTH = 128
+MAX_SHADOW_QUERY_CHARS = 8_000
+_QUESTION_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}$")
+
+
+@dataclass(frozen=True, slots=True)
+class ShadowCase:
+    question_id: str
+    chat_id: int
+    query: str
+    exclude_chat_message_id: int | None
+
+
+def _scope_payload(chat_id: int | None) -> dict[str, int | bool]:
+    if chat_id is None:
+        return {"all_chats": True}
+    return {"chat_id": chat_id}
+
+
+def _resolve_chat_id(args: argparse.Namespace) -> int | None:
+    chat_id = cast(int | None, getattr(args, "chat_id", None))
+    all_chats = bool(getattr(args, "all_chats", False))
+    if (chat_id is None) == (not all_chats):
+        raise ValueError("choose exactly one of --chat-id or --all-chats")
+    return chat_id
+
+
+def _json_bytes(payload: dict[str, Any]) -> bytes:
+    return (json.dumps(payload, ensure_ascii=True, sort_keys=True) + "\n").encode("utf-8")
+
+
+def _write_private_report(path: Path, payload: dict[str, Any], *, overwrite: bool) -> None:
+    flags = (
+        os.O_WRONLY
+        | os.O_CREAT
+        | (os.O_TRUNC if overwrite else os.O_EXCL)
+        | getattr(os, "O_NOFOLLOW", 0)
+    )
+    descriptor = os.open(path, flags, 0o600)
+    try:
+        os.fchmod(descriptor, 0o600)
+        os.write(descriptor, _json_bytes(payload))
+    finally:
+        os.close(descriptor)
+
+
+def _emit_report(
+    payload: dict[str, Any],
+    *,
+    report_path: str | None,
+    overwrite: bool,
+) -> None:
+    if report_path is not None:
+        _write_private_report(Path(report_path).expanduser(), payload, overwrite=overwrite)
+    print(json.dumps(payload, ensure_ascii=True, sort_keys=True))
+
+
+def _parse_shadow_case(raw: Any, *, line_number: int) -> ShadowCase:
+    if not isinstance(raw, dict):
+        raise ValueError(f"shadow input line {line_number} must be a JSON object")
+    allowed_keys = {"question_id", "chat_id", "query", "exclude_chat_message_id"}
+    unknown_keys = sorted(set(raw) - allowed_keys)
+    if unknown_keys:
+        raise ValueError(f"shadow input line {line_number} has unknown fields")
+
+    question_id = raw.get("question_id")
+    if not isinstance(question_id, str) or not _QUESTION_ID_RE.fullmatch(question_id):
+        raise ValueError(
+            f"shadow input line {line_number} question_id must be a safe opaque identifier"
+        )
+    if len(question_id) > MAX_QUESTION_ID_LENGTH:
+        raise ValueError(f"shadow input line {line_number} question_id is too long")
+
+    chat_id = raw.get("chat_id")
+    if isinstance(chat_id, bool) or not isinstance(chat_id, int):
+        raise ValueError(f"shadow input line {line_number} chat_id must be an integer")
+
+    query = raw.get("query")
+    if not isinstance(query, str) or not query.strip():
+        raise ValueError(f"shadow input line {line_number} query must be non-empty text")
+    if len(query) > MAX_SHADOW_QUERY_CHARS:
+        raise ValueError(f"shadow input line {line_number} query is too long")
+
+    exclude_id = raw.get("exclude_chat_message_id")
+    if exclude_id is not None and (
+        isinstance(exclude_id, bool) or not isinstance(exclude_id, int) or exclude_id < 1
+    ):
+        raise ValueError(
+            f"shadow input line {line_number} exclude_chat_message_id must be positive"
+        )
+    return ShadowCase(
+        question_id=question_id,
+        chat_id=chat_id,
+        query=query.strip(),
+        exclude_chat_message_id=exclude_id,
+    )
+
+
+def _load_shadow_cases(path: Path, *, max_queries: int) -> tuple[ShadowCase, ...]:
+    if max_queries < 1 or max_queries > MAX_SHADOW_CASES:
+        raise ValueError(f"--max-queries must be between 1 and {MAX_SHADOW_CASES}")
+    cases: list[ShadowCase] = []
+    seen_ids: set[str] = set()
+    with path.open("r", encoding="utf-8") as source:
+        for line_number, line in enumerate(source, start=1):
+            if not line.strip():
+                continue
+            if len(cases) == max_queries:
+                raise ValueError("shadow input exceeds --max-queries; no provider calls were made")
+            try:
+                raw = json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"shadow input line {line_number} is not valid JSON") from exc
+            case = _parse_shadow_case(raw, line_number=line_number)
+            if case.question_id in seen_ids:
+                raise ValueError(f"shadow input line {line_number} repeats question_id")
+            seen_ids.add(case.question_id)
+            cases.append(case)
+    if not cases:
+        raise ValueError("shadow input contains no cases")
+    return tuple(cases)
+
+
+def _document_identity(document: Any, *, model: str) -> tuple[str, str, str, int, str, str]:
+    return (
+        str(document.source_type),
+        str(document.source_id),
+        str(document.source_revision),
+        int(document.chat_id),
+        str(document.content_hash),
+        model,
+    )
+
+
+async def _eligible_identities(
+    session: Any,
+    *,
+    chat_id: int | None,
+    batch_size: int,
+    model: str,
+) -> dict[tuple[str, str, str, int, str, str], tuple[int, ...]]:
+    from bot.services.semantic_index import (
+        list_eligible_card_documents,
+        list_eligible_message_documents,
+    )
+
+    identities: dict[tuple[str, str, str, int, str, str], tuple[int, ...]] = {}
+    message_cursor = 0
+    while True:
+        batch = await list_eligible_message_documents(
+            session,
+            after_id=message_cursor,
+            limit=batch_size,
+            chat_id=chat_id,
+        )
+        if not batch:
+            break
+        identities.update(
+            {
+                _document_identity(document, model=model): tuple(document.message_version_ids)
+                for document in batch
+            }
+        )
+        message_next_cursor = int(batch[-1].source_id)
+        if message_next_cursor <= message_cursor:
+            raise RuntimeError("semantic message audit cursor did not advance")
+        message_cursor = message_next_cursor
+
+    card_cursor = ""
+    while True:
+        batch = await list_eligible_card_documents(
+            session,
+            after_id=card_cursor,
+            limit=batch_size,
+            chat_id=chat_id,
+        )
+        if not batch:
+            break
+        identities.update(
+            {
+                _document_identity(document, model=model): tuple(document.message_version_ids)
+                for document in batch
+            }
+        )
+        card_next_cursor = str(batch[-1].source_id)
+        if card_next_cursor <= card_cursor:
+            raise RuntimeError("semantic card audit cursor did not advance")
+        card_cursor = card_next_cursor
+    return identities
+
+
+async def _coverage_report(
+    session: Any,
+    *,
+    chat_id: int | None,
+    model: str,
+    batch_size: int,
+) -> dict[str, Any]:
+    from sqlalchemy import text
+
+    expected = await _eligible_identities(
+        session,
+        chat_id=chat_id,
+        batch_size=batch_size,
+        model=model,
+    )
+
+    rows = (
+        (
+            await session.execute(
+                text(
+                    """
+                SELECT unit.source_type,
+                       unit.source_id,
+                       unit.source_revision,
+                       unit.chat_id,
+                       unit.content_hash,
+                       unit.embedding_model,
+                       unit.invalidated_at,
+                       COALESCE(
+                           ARRAY_AGG(source.message_version_id ORDER BY source.position)
+                               FILTER (WHERE source.message_version_id IS NOT NULL),
+                           ARRAY[]::INTEGER[]
+                       ) AS message_version_ids
+                FROM semantic_retrieval_units unit
+                LEFT JOIN semantic_retrieval_unit_sources source ON source.unit_id = unit.id
+                WHERE unit.embedding_model = :model
+                  AND (CAST(:chat_id AS BIGINT) IS NULL
+                       OR unit.chat_id = CAST(:chat_id AS BIGINT))
+                GROUP BY unit.id
+                """
+                ),
+                {"model": model, "chat_id": chat_id},
+            )
+        )
+        .mappings()
+        .all()
+    )
+
+    active: dict[tuple[str, str, str, int, str, str], tuple[int, ...]] = {}
+    invalidated: dict[tuple[str, str, str, int, str, str], tuple[int, ...]] = {}
+    for row in rows:
+        key = (
+            str(row["source_type"]),
+            str(row["source_id"]),
+            str(row["source_revision"]),
+            int(row["chat_id"]),
+            str(row["content_hash"]),
+            str(row["embedding_model"]),
+        )
+        target = active if row["invalidated_at"] is None else invalidated
+        target[key] = tuple(int(value) for value in row["message_version_ids"])
+
+    expected_keys = set(expected)
+    active_keys = set(active)
+    invalidated_keys = set(invalidated)
+    covered = {key for key in expected_keys & active_keys if active[key] == expected[key]}
+    provenance_mismatch = {
+        key for key in expected_keys & active_keys if active[key] != expected[key]
+    }
+    missing_identity = expected_keys - active_keys
+    missing = missing_identity | provenance_mismatch
+    invalidated_expected = missing_identity & invalidated_keys
+    unexpected_active = active_keys - expected_keys
+    eligible = len(expected)
+    no_eligible_identities = eligible == 0
+    coverage_percent = 0.0 if no_eligible_identities else round((len(covered) / eligible) * 100, 2)
+    status = (
+        "pass" if not no_eligible_identities and not missing and not unexpected_active else "fail"
+    )
+    return {
+        "schema_version": REPORT_SCHEMA_VERSION,
+        "mode": "audit",
+        "status": status,
+        "scope": _scope_payload(chat_id),
+        "embedding_model": model,
+        "eligible": eligible,
+        "indexed": len(covered),
+        "coverage_percent": coverage_percent,
+        "missing": len(missing),
+        "unexpected_active": len(unexpected_active),
+        "reason_counts": {
+            "failed:no_eligible_identities": int(no_eligible_identities),
+            "indexed:active_identity": len(covered),
+            "failed:missing_identity": len(missing - invalidated_expected),
+            "failed:expected_identity_invalidated": len(invalidated_expected),
+            "failed:provenance_mismatch": len(provenance_mismatch),
+            "failed:unexpected_active_identity": len(unexpected_active),
+        },
+    }
+
+
+async def _run_audit(args: argparse.Namespace) -> int:
+    from bot.db.engine import async_session
+    from bot.services.llm_gateway import load_embedding_gateway_config
+
+    chat_id = _resolve_chat_id(args)
+    config = load_embedding_gateway_config()
+    try:
+        async with async_session() as session:
+            report = await _coverage_report(
+                session,
+                chat_id=chat_id,
+                model=config.model,
+                batch_size=args.batch_size,
+            )
+    except (RuntimeError, SQLAlchemyError) as exc:
+        report = {
+            "schema_version": REPORT_SCHEMA_VERSION,
+            "mode": "audit",
+            "status": "failed",
+            "scope": _scope_payload(chat_id),
+            "embedding_model": config.model,
+            "failed": 1,
+            "reason_counts": {f"failed:{type(exc).__name__}": 1},
+        }
+        _emit_report(report, report_path=args.report, overwrite=args.overwrite)
+        return 1
+    _emit_report(report, report_path=args.report, overwrite=args.overwrite)
+    return 0 if report["status"] == "pass" else 1
+
+
+async def _run_backfill(args: argparse.Namespace) -> int:
+    from bot.db.engine import async_session
+    from bot.services.llm_gateway import load_embedding_gateway_config
+    from bot.services.semantic_index import backfill_semantic_index
+
+    chat_id = _resolve_chat_id(args)
+    config = load_embedding_gateway_config()
+    try:
+        async with async_session() as session:
+            result = await backfill_semantic_index(
+                session,
+                config=config,
+                batch_size=args.batch_size,
+                chat_id=chat_id,
+            )
+            coverage = await _coverage_report(
+                session,
+                chat_id=chat_id,
+                model=config.model,
+                batch_size=args.batch_size,
+            )
+    except (ProviderError, RuntimeError, SQLAlchemyError) as exc:
+        report = {
+            "schema_version": REPORT_SCHEMA_VERSION,
+            "mode": "backfill",
+            "status": "failed",
+            "scope": _scope_payload(chat_id),
+            "embedding_model": config.model,
+            "failed": 1,
+            "reason_counts": {f"failed:{type(exc).__name__}": 1},
+        }
+        _emit_report(report, report_path=args.report, overwrite=args.overwrite)
+        return 1
+    status = "pass" if result.failed == 0 and coverage["status"] == "pass" else "fail"
+    report = {
+        "schema_version": REPORT_SCHEMA_VERSION,
+        "mode": "backfill",
+        "status": status,
+        "scope": _scope_payload(chat_id),
+        "embedding_model": config.model,
+        "embedding_dimensions": config.dimensions,
+        "run_id": result.run_id,
+        "eligible": result.eligible,
+        "indexed": result.indexed,
+        "skipped": result.skipped,
+        "failed": result.failed,
+        "reason_counts": result.reason_counts,
+        "coverage": {
+            key: value
+            for key, value in coverage.items()
+            if key
+            in {
+                "status",
+                "eligible",
+                "indexed",
+                "coverage_percent",
+                "missing",
+                "unexpected_active",
+                "reason_counts",
+            }
+        },
+    }
+    _emit_report(report, report_path=args.report, overwrite=args.overwrite)
+    return 0 if status == "pass" else 1
+
+
+def _source_key(hit: Any) -> str:
+    if hit.source_type == "card":
+        if hit.card_id is None:
+            raise ValueError("card shadow hit is missing card_id")
+        return f"card:{hit.card_id}"
+    return f"message:{hit.message_version_id}"
+
+
+def _ranked_keys(
+    candidate_ranks: dict[str, dict[str, int]],
+    *,
+    branch: str,
+    limit: int,
+) -> list[str]:
+    ranked = ((ranks[branch], key) for key, ranks in candidate_ranks.items() if branch in ranks)
+    return [key for _, key in sorted(ranked)[:limit]]
+
+
+def _open_private_jsonl(path: Path, *, overwrite: bool) -> TextIO:
+    flags = (
+        os.O_WRONLY
+        | os.O_CREAT
+        | (os.O_TRUNC if overwrite else os.O_EXCL)
+        | getattr(os, "O_NOFOLLOW", 0)
+    )
+    descriptor = os.open(path, flags, 0o600)
+    os.fchmod(descriptor, 0o600)
+    return os.fdopen(descriptor, "w", encoding="utf-8")
+
+
+def _shadow_failure_payload(*, processed: int, exc: BaseException) -> dict[str, Any]:
+    return {
+        "schema_version": REPORT_SCHEMA_VERSION,
+        "mode": "shadow_summary",
+        "status": "failed",
+        "processed": processed,
+        "failed": 1,
+        "reason_counts": {f"failed:{type(exc).__name__}": 1},
+        "contains_raw_text": False,
+        "synthesis_called": False,
+    }
+
+
+async def _run_shadow(args: argparse.Namespace) -> int:
+    input_path = Path(args.input).expanduser().resolve()
+    output_path = Path(args.output).expanduser().resolve()
+    if input_path == output_path:
+        raise ValueError("shadow input and output paths must differ")
+    cases = _load_shadow_cases(input_path, max_queries=args.max_queries)
+
+    from bot.db.engine import async_session
+    from bot.db.repos.llm_usage_ledger import LedgerRepo
+    from bot.services.llm_gateway import (
+        EmbeddingBudgetExceeded,
+        embed_texts,
+        load_embedding_gateway_config,
+    )
+    from bot.services.semantic_index import hybrid_search
+
+    config = load_embedding_gateway_config()
+
+    processed = 0
+    with _open_private_jsonl(output_path, overwrite=args.overwrite) as destination:
+        destination.write(
+            json.dumps(
+                {
+                    "schema_version": REPORT_SCHEMA_VERSION,
+                    "mode": "shadow",
+                    "status": "running",
+                    "case_count": len(cases),
+                    "embedding_model": config.model,
+                    "embedding_dimensions": config.dimensions,
+                    "contains_raw_text": False,
+                    "synthesis_called": False,
+                },
+                ensure_ascii=True,
+                sort_keys=True,
+            )
+            + "\n"
+        )
+        async with async_session() as session:
+            for case in cases:
+                try:
+                    embedding = await embed_texts(
+                        session,
+                        inputs=[case.query],
+                        config=config,
+                        ledger_repo=LedgerRepo(),
+                    )
+                except (EmbeddingBudgetExceeded, ProviderError) as exc:
+                    # The gateway wrote a bounded failure row. Persist that audit
+                    # before stopping this no-retry shadow run.
+                    await session.commit()
+                    failure = _shadow_failure_payload(processed=processed, exc=exc)
+                    destination.write(json.dumps(failure, sort_keys=True) + "\n")
+                    destination.flush()
+                    print(json.dumps(failure, sort_keys=True))
+                    return 1
+                # Preserve the provider usage/cost audit even if retrieval later fails.
+                await session.commit()
+                try:
+                    result = await hybrid_search(
+                        session,
+                        query=case.query,
+                        query_embedding=embedding.vectors[0],
+                        chat_id=case.chat_id,
+                        embedding_model=config.model,
+                        exclude_chat_message_id=case.exclude_chat_message_id,
+                        candidate_limit=args.candidate_limit,
+                        limit=args.limit,
+                    )
+                except (LookupError, RuntimeError, SQLAlchemyError, ValueError) as exc:
+                    await session.rollback()
+                    failure = _shadow_failure_payload(processed=processed, exc=exc)
+                    destination.write(json.dumps(failure, sort_keys=True) + "\n")
+                    destination.flush()
+                    print(json.dumps(failure, sort_keys=True))
+                    return 1
+                hybrid_keys = [_source_key(hit) for hit in result.hits]
+                payload = {
+                    "schema_version": REPORT_SCHEMA_VERSION,
+                    "mode": "shadow_case",
+                    "question_id": case.question_id,
+                    "query_sha256": hashlib.sha256(case.query.encode("utf-8")).hexdigest(),
+                    "chat_id": case.chat_id,
+                    "embedding_llm_call_id": embedding.llm_usage_ledger_id,
+                    "fts_top": _ranked_keys(
+                        result.candidate_ranks,
+                        branch="fts",
+                        limit=args.limit,
+                    ),
+                    "vector_top": _ranked_keys(
+                        result.candidate_ranks,
+                        branch="vector",
+                        limit=args.limit,
+                    ),
+                    "hybrid_top": hybrid_keys,
+                    "candidate_ranks": result.candidate_ranks,
+                    "latency_ms": {
+                        "fts": result.fts_latency_ms,
+                        "vector": result.vector_latency_ms,
+                        "fusion": result.fusion_latency_ms,
+                        "total": result.total_latency_ms,
+                    },
+                }
+                destination.write(json.dumps(payload, ensure_ascii=True, sort_keys=True) + "\n")
+                destination.flush()
+                processed += 1
+        destination.write(
+            json.dumps(
+                {
+                    "schema_version": REPORT_SCHEMA_VERSION,
+                    "mode": "shadow_summary",
+                    "status": "completed",
+                    "processed": processed,
+                    "failed": 0,
+                    "contains_raw_text": False,
+                    "synthesis_called": False,
+                },
+                ensure_ascii=True,
+                sort_keys=True,
+            )
+            + "\n"
+        )
+    print(
+        json.dumps(
+            {
+                "schema_version": REPORT_SCHEMA_VERSION,
+                "mode": "shadow",
+                "status": "completed",
+                "processed": processed,
+                "failed": 0,
+            },
+            ensure_ascii=True,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+def _bounded_batch_size(value: str) -> int:
+    parsed = int(value)
+    if parsed < 1 or parsed > 100:
+        raise argparse.ArgumentTypeError("batch size must be between 1 and 100")
+    return parsed
+
+
+def _bounded_candidate_limit(value: str) -> int:
+    parsed = int(value)
+    if parsed < 5 or parsed > 100:
+        raise argparse.ArgumentTypeError("candidate limit must be between 5 and 100")
+    return parsed
+
+
+def _bounded_result_limit(value: str) -> int:
+    parsed = int(value)
+    if parsed < 1 or parsed > 8:
+        raise argparse.ArgumentTypeError("result limit must be between 1 and 8")
+    return parsed
+
+
+def _add_scope_arguments(parser: argparse.ArgumentParser) -> None:
+    scope = parser.add_mutually_exclusive_group(required=True)
+    scope.add_argument("--chat-id", type=int, default=None)
+    scope.add_argument(
+        "--all-chats",
+        action="store_true",
+        help="Explicitly acknowledge that every eligible chat will be processed.",
+    )
+
+
+def _add_report_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--report",
+        default=None,
+        help="Optional private JSON report path; stdout always receives the same safe payload.",
+    )
+    parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Explicitly allow replacing an existing report file.",
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="scripts.backfill_semantic_index")
+    subcommands = parser.add_subparsers(dest="command", required=True)
+
+    backfill = subcommands.add_parser(
+        "backfill",
+        help="Idempotently index eligible retrieval units and verify complete coverage.",
+    )
+    _add_scope_arguments(backfill)
+    _add_report_arguments(backfill)
+    backfill.add_argument("--batch-size", type=_bounded_batch_size, default=64)
+    backfill.set_defaults(async_func=_run_backfill)
+
+    audit = subcommands.add_parser(
+        "audit",
+        help="Read-only complete-coverage and unexpected-active-unit audit; no provider calls.",
+    )
+    _add_scope_arguments(audit)
+    _add_report_arguments(audit)
+    audit.add_argument("--batch-size", type=_bounded_batch_size, default=64)
+    audit.set_defaults(async_func=_run_audit)
+
+    shadow = subcommands.add_parser(
+        "shadow",
+        help="Replay private questions through embeddings + hybrid retrieval only.",
+    )
+    shadow.add_argument("--input", required=True, help="Private JSONL question file.")
+    shadow.add_argument("--output", required=True, help="Private no-content JSONL audit path.")
+    shadow.add_argument("--max-queries", type=int, default=50)
+    shadow.add_argument("--candidate-limit", type=_bounded_candidate_limit, default=20)
+    shadow.add_argument("--limit", type=_bounded_result_limit, default=5)
+    shadow.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Explicitly allow replacing an existing shadow report.",
+    )
+    shadow.set_defaults(async_func=_run_shadow)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        return asyncio.run(args.async_func(args))
+    except (FileExistsError, FileNotFoundError, PermissionError, ValueError) as exc:
+        print(
+            json.dumps(
+                {
+                    "schema_version": REPORT_SCHEMA_VERSION,
+                    "status": "error",
+                    "error_class": type(exc).__name__,
+                },
+                sort_keys=True,
+            ),
+            file=sys.stderr,
+        )
+        return 2
+    except (LookupError, ProviderError, RuntimeError, SQLAlchemyError) as exc:
+        # Provider/DB exception messages may contain URLs, credentials, or payload data.
+        print(
+            json.dumps(
+                {
+                    "schema_version": REPORT_SCHEMA_VERSION,
+                    "status": "failed",
+                    "error_class": type(exc).__name__,
+                },
+                sort_keys=True,
+            ),
+            file=sys.stderr,
+        )
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/backfill_semantic_index.py
+++ b/scripts/backfill_semantic_index.py
@@ -151,11 +151,17 @@ def _load_shadow_cases(path: Path, *, max_queries: int) -> tuple[ShadowCase, ...
     return tuple(cases)
 
 
-def _document_identity(document: Any, *, model: str) -> tuple[str, str, str, int, str, str]:
+def _document_identity(
+    document: Any,
+    *,
+    model: str,
+) -> tuple[str, str, str, int, int, int, str, str]:
     return (
         str(document.source_type),
         str(document.source_id),
         str(document.source_revision),
+        int(document.chunk_index),
+        int(document.chunk_count),
         int(document.chat_id),
         str(document.content_hash),
         model,
@@ -168,13 +174,13 @@ async def _eligible_identities(
     chat_id: int | None,
     batch_size: int,
     model: str,
-) -> dict[tuple[str, str, str, int, str, str], tuple[int, ...]]:
+) -> dict[tuple[str, str, str, int, int, int, str, str], tuple[int, ...]]:
     from bot.services.semantic_index import (
         list_eligible_card_documents,
         list_eligible_message_documents,
     )
 
-    identities: dict[tuple[str, str, str, int, str, str], tuple[int, ...]] = {}
+    identities: dict[tuple[str, str, str, int, int, int, str, str], tuple[int, ...]] = {}
     message_cursor = 0
     while True:
         batch = await list_eligible_message_documents(
@@ -243,6 +249,8 @@ async def _coverage_report(
                 SELECT unit.source_type,
                        unit.source_id,
                        unit.source_revision,
+                       unit.chunk_index,
+                       unit.chunk_count,
                        unit.chat_id,
                        unit.content_hash,
                        unit.embedding_model,
@@ -267,13 +275,15 @@ async def _coverage_report(
         .all()
     )
 
-    active: dict[tuple[str, str, str, int, str, str], tuple[int, ...]] = {}
-    invalidated: dict[tuple[str, str, str, int, str, str], tuple[int, ...]] = {}
+    active: dict[tuple[str, str, str, int, int, int, str, str], tuple[int, ...]] = {}
+    invalidated: dict[tuple[str, str, str, int, int, int, str, str], tuple[int, ...]] = {}
     for row in rows:
         key = (
             str(row["source_type"]),
             str(row["source_id"]),
             str(row["source_revision"]),
+            int(row["chunk_index"]),
+            int(row["chunk_count"]),
             int(row["chat_id"]),
             str(row["content_hash"]),
             str(row["embedding_model"]),

--- a/scripts/backfill_semantic_index.py
+++ b/scripts/backfill_semantic_index.py
@@ -25,6 +25,7 @@ from typing import Any, Sequence, TextIO, cast
 from sqlalchemy.exc import SQLAlchemyError
 
 from bot.services.llm_providers import ProviderError
+from bot.services.qa_guardrails import contains_secret_like_data
 
 
 REPORT_SCHEMA_VERSION = 1
@@ -101,6 +102,10 @@ def _parse_shadow_case(raw: Any, *, line_number: int) -> ShadowCase:
         )
     if len(question_id) > MAX_QUESTION_ID_LENGTH:
         raise ValueError(f"shadow input line {line_number} question_id is too long")
+    if contains_secret_like_data(question_id):
+        raise ValueError(
+            f"shadow input line {line_number} question_id must be a safe opaque identifier"
+        )
 
     chat_id = raw.get("chat_id")
     if isinstance(chat_id, bool) or not isinstance(chat_id, int):
@@ -111,6 +116,9 @@ def _parse_shadow_case(raw: Any, *, line_number: int) -> ShadowCase:
         raise ValueError(f"shadow input line {line_number} query must be non-empty text")
     if len(query) > MAX_SHADOW_QUERY_CHARS:
         raise ValueError(f"shadow input line {line_number} query is too long")
+    normalized_query = query.strip()
+    if contains_secret_like_data(normalized_query):
+        raise ValueError(f"shadow input line {line_number} contains sensitive input")
 
     exclude_id = raw.get("exclude_chat_message_id")
     if exclude_id is not None and (
@@ -122,7 +130,7 @@ def _parse_shadow_case(raw: Any, *, line_number: int) -> ShadowCase:
     return ShadowCase(
         question_id=question_id,
         chat_id=chat_id,
-        query=query.strip(),
+        query=normalized_query,
         exclude_chat_message_id=exclude_id,
     )
 

--- a/scripts/evaluate_semantic_qa.py
+++ b/scripts/evaluate_semantic_qa.py
@@ -24,13 +24,14 @@ from bot.services.semantic_eval import (
     SemanticEvalReport,
     SemanticEvalResult,
     evaluate_semantic_run,
+    validate_privacy_class_coverage,
     validate_semantic_report,
 )
 
 
 MIN_FROZEN_CASES = 50
-REPORT_SCHEMA_VERSION = 3
-OBSERVATIONS_SCHEMA_VERSION = 2
+REPORT_SCHEMA_VERSION = 4
+OBSERVATIONS_SCHEMA_VERSION = 3
 REVIEWED_RESULTS_SCHEMA_VERSION = 1
 _SHA256_RE = re.compile(r"[0-9a-f]{64}")
 _RELEASE_SHA_RE = re.compile(r"[0-9a-f]{40}")
@@ -93,25 +94,33 @@ def _load_cases(path: Path) -> tuple[SemanticEvalCase, ...]:
         "category",
         "expected_source_ids",
         "forbidden_source_ids",
+        "privacy_classes",
         "expected_abstain",
     }
     for value in _load_jsonl(path):
         _exact_fields(value, expected, kind="case")
         source_ids = value["expected_source_ids"]
         forbidden_ids = value["forbidden_source_ids"]
-        if not isinstance(source_ids, list) or not isinstance(forbidden_ids, list):
-            raise ValueError("case source ids must be JSON arrays")
+        privacy_classes = value["privacy_classes"]
+        if (
+            not isinstance(source_ids, list)
+            or not isinstance(forbidden_ids, list)
+            or not isinstance(privacy_classes, list)
+        ):
+            raise ValueError("case source ids and privacy classes must be JSON arrays")
         cases.append(
             SemanticEvalCase(
                 case_id=value["case_id"],
                 category=value["category"],
                 expected_source_ids=tuple(source_ids),
                 forbidden_source_ids=tuple(forbidden_ids),
+                privacy_classes=tuple(privacy_classes),
                 expected_abstain=value["expected_abstain"],
             )
         )
     if len(cases) < MIN_FROZEN_CASES:
         raise ValueError(f"frozen evaluation requires at least {MIN_FROZEN_CASES} cases")
+    validate_privacy_class_coverage(cases)
     return tuple(cases)
 
 
@@ -125,6 +134,7 @@ def _validate_cases_match_dataset(dataset_path: Path, cases: tuple[SemanticEvalC
         "query",
         "expected_source_ids",
         "forbidden_source_ids",
+        "privacy_classes",
         "expected_abstain",
         "exclude_chat_message_id",
     }
@@ -133,14 +143,20 @@ def _validate_cases_match_dataset(dataset_path: Path, cases: tuple[SemanticEvalC
         _exact_fields(value, dataset_fields, kind="dataset")
         expected_ids = value["expected_source_ids"]
         forbidden_ids = value["forbidden_source_ids"]
-        if not isinstance(expected_ids, list) or not isinstance(forbidden_ids, list):
-            raise ValueError("dataset source ids must be JSON arrays")
+        privacy_classes = value["privacy_classes"]
+        if (
+            not isinstance(expected_ids, list)
+            or not isinstance(forbidden_ids, list)
+            or not isinstance(privacy_classes, list)
+        ):
+            raise ValueError("dataset source ids and privacy classes must be JSON arrays")
         projected.append(
             SemanticEvalCase(
                 case_id=value["case_id"],
                 category=value["category"],
                 expected_source_ids=tuple(expected_ids),
                 forbidden_source_ids=tuple(forbidden_ids),
+                privacy_classes=tuple(privacy_classes),
                 expected_abstain=value["expected_abstain"],
             )
         )
@@ -353,8 +369,15 @@ def _parse_report_metrics(value: object) -> SemanticEvalReport:
     expected = {field.name for field in fields(SemanticEvalReport)}
     if set(value) != expected:
         raise ValueError("report metric fields do not match the versioned schema")
-    parsed: dict[str, int | float] = {}
+    parsed: dict[str, int | float | tuple[str, ...]] = {}
     for name, raw in value.items():
+        if name == "privacy_classes":
+            if not isinstance(raw, list) or any(
+                not isinstance(privacy_class, str) for privacy_class in raw
+            ):
+                raise ValueError("report privacy_classes must be a JSON array of strings")
+            parsed[name] = tuple(raw)
+            continue
         if name in _INTEGER_REPORT_FIELDS:
             if type(raw) is not int or raw < 0:
                 raise ValueError("report integer metrics must be non-negative integers")

--- a/scripts/evaluate_semantic_qa.py
+++ b/scripts/evaluate_semantic_qa.py
@@ -1,0 +1,538 @@
+"""Build and validate no-content semantic Q&A acceptance reports.
+
+The ``evaluate`` command reads private labels/reviewer observations and writes a
+sanitized report bound to the release commit plus the exact frozen dataset and
+reviewed-results hashes.  ``validate-report`` is the single CI trust boundary;
+workflow YAML deliberately contains no duplicate threshold implementation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import os
+import re
+import sys
+from dataclasses import asdict, dataclass, fields
+from pathlib import Path
+from typing import Any, Sequence
+
+from bot.services.semantic_eval import (
+    SemanticEvalCase,
+    SemanticEvalReport,
+    SemanticEvalResult,
+    evaluate_semantic_run,
+    validate_semantic_report,
+)
+
+
+MIN_FROZEN_CASES = 50
+REPORT_SCHEMA_VERSION = 3
+OBSERVATIONS_SCHEMA_VERSION = 2
+REVIEWED_RESULTS_SCHEMA_VERSION = 1
+_SHA256_RE = re.compile(r"[0-9a-f]{64}")
+_RELEASE_SHA_RE = re.compile(r"[0-9a-f]{40}")
+_REPORT_KEYS = {
+    "schema_version",
+    "status",
+    "contains_raw_text",
+    "release_sha",
+    "dataset_sha256",
+    "observations_sha256",
+    "results_sha256",
+    "report",
+    "violations",
+}
+_INTEGER_REPORT_FIELDS = {
+    "case_count",
+    "answerable_case_count",
+    "no_answer_case_count",
+    "semantic_case_count",
+    "exact_case_count",
+    "multi_source_case_count",
+    "privacy_governance_case_count",
+    "privacy_expected_abstention_case_count",
+    "privacy_expected_abstention_failures",
+    "unexpected_answerable_abstention_count",
+    "leakage_count",
+    "invalid_source_links",
+    "unsupported_claims",
+    "total_claims",
+}
+
+
+def _load_jsonl(path: Path) -> list[dict[str, Any]]:
+    values: list[dict[str, Any]] = []
+    with path.open("r", encoding="utf-8") as source:
+        for line_number, line in enumerate(source, start=1):
+            if not line.strip():
+                continue
+            try:
+                value = json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"line {line_number} is not valid JSON") from exc
+            if not isinstance(value, dict):
+                raise ValueError(f"line {line_number} must be a JSON object")
+            values.append(value)
+    if not values:
+        raise ValueError("input JSONL is empty")
+    return values
+
+
+def _exact_fields(value: dict[str, Any], expected: set[str], *, kind: str) -> None:
+    if set(value) != expected:
+        raise ValueError(f"{kind} fields do not match the versioned schema")
+
+
+def _load_cases(path: Path) -> tuple[SemanticEvalCase, ...]:
+    cases: list[SemanticEvalCase] = []
+    expected = {
+        "case_id",
+        "category",
+        "expected_source_ids",
+        "forbidden_source_ids",
+        "expected_abstain",
+    }
+    for value in _load_jsonl(path):
+        _exact_fields(value, expected, kind="case")
+        source_ids = value["expected_source_ids"]
+        forbidden_ids = value["forbidden_source_ids"]
+        if not isinstance(source_ids, list) or not isinstance(forbidden_ids, list):
+            raise ValueError("case source ids must be JSON arrays")
+        cases.append(
+            SemanticEvalCase(
+                case_id=value["case_id"],
+                category=value["category"],
+                expected_source_ids=tuple(source_ids),
+                forbidden_source_ids=tuple(forbidden_ids),
+                expected_abstain=value["expected_abstain"],
+            )
+        )
+    if len(cases) < MIN_FROZEN_CASES:
+        raise ValueError(f"frozen evaluation requires at least {MIN_FROZEN_CASES} cases")
+    return tuple(cases)
+
+
+def _validate_cases_match_dataset(dataset_path: Path, cases: tuple[SemanticEvalCase, ...]) -> None:
+    """Bind evaluated labels to the exact raw runner input being hashed."""
+
+    dataset_fields = {
+        "case_id",
+        "category",
+        "chat_id",
+        "query",
+        "expected_source_ids",
+        "forbidden_source_ids",
+        "expected_abstain",
+        "exclude_chat_message_id",
+    }
+    projected: list[SemanticEvalCase] = []
+    for value in _load_jsonl(dataset_path):
+        _exact_fields(value, dataset_fields, kind="dataset")
+        expected_ids = value["expected_source_ids"]
+        forbidden_ids = value["forbidden_source_ids"]
+        if not isinstance(expected_ids, list) or not isinstance(forbidden_ids, list):
+            raise ValueError("dataset source ids must be JSON arrays")
+        projected.append(
+            SemanticEvalCase(
+                case_id=value["case_id"],
+                category=value["category"],
+                expected_source_ids=tuple(expected_ids),
+                forbidden_source_ids=tuple(forbidden_ids),
+                expected_abstain=value["expected_abstain"],
+            )
+        )
+    if tuple(projected) != cases:
+        raise ValueError("sanitized cases must exactly match the hashed private dataset")
+
+
+@dataclass(frozen=True, slots=True)
+class _ObjectiveObservation:
+    case_id: str
+    fts_source_ids: tuple[str, ...]
+    hybrid_source_ids: tuple[str, ...]
+    abstained: bool
+    leakage_count: int
+    retrieval_latency_seconds: float
+    full_latency_seconds: float
+
+
+@dataclass(frozen=True, slots=True)
+class _ReviewAnnotations:
+    case_id: str
+    valid_source_links: int
+    invalid_source_links: int
+    unsupported_claims: int
+    total_claims: int
+
+
+def _load_observations(
+    path: Path,
+    *,
+    expected_release_sha: str,
+    expected_dataset_sha256: str,
+    expected_case_count: int,
+) -> tuple[_ObjectiveObservation, ...]:
+    """Load immutable no-content observations emitted by the live runner."""
+
+    rows = _load_jsonl(path)
+    header_fields = {
+        "record_type",
+        "schema_version",
+        "contains_raw_text",
+        "release_sha",
+        "dataset_sha256",
+        "case_count",
+    }
+    header = rows[0]
+    _exact_fields(header, header_fields, kind="result header")
+    if (
+        header["record_type"] != "header"
+        or header["schema_version"] != OBSERVATIONS_SCHEMA_VERSION
+        or header["contains_raw_text"] is not False
+        or header["release_sha"] != expected_release_sha
+        or header["dataset_sha256"] != expected_dataset_sha256
+        or type(header["case_count"]) is not int
+        or header["case_count"] != expected_case_count
+    ):
+        raise ValueError("observations are not bound to this runner release and dataset")
+    expected_observation_fields = {
+        "record_type",
+        "case_id",
+        "fts_source_ids",
+        "hybrid_source_ids",
+        "abstained",
+        "leakage_count",
+        "retrieval_latency_seconds",
+        "full_latency_seconds",
+    }
+    observations: list[_ObjectiveObservation] = []
+    for value in rows[1:]:
+        _exact_fields(value, expected_observation_fields, kind="observation")
+        if value["record_type"] != "case_observation":
+            raise ValueError("invalid observation record type")
+        fts_ids = value["fts_source_ids"]
+        hybrid_ids = value["hybrid_source_ids"]
+        if not isinstance(fts_ids, list) or not isinstance(hybrid_ids, list):
+            raise ValueError("observation source ids must be JSON arrays")
+        observations.append(
+            _ObjectiveObservation(
+                case_id=value["case_id"],
+                fts_source_ids=tuple(fts_ids),
+                hybrid_source_ids=tuple(hybrid_ids),
+                abstained=value["abstained"],
+                leakage_count=value["leakage_count"],
+                retrieval_latency_seconds=value["retrieval_latency_seconds"],
+                full_latency_seconds=value["full_latency_seconds"],
+            )
+        )
+    if len(observations) != expected_case_count:
+        raise ValueError("observation count does not match the runner manifest")
+    return tuple(observations)
+
+
+def _load_review_annotations(
+    path: Path,
+    *,
+    expected_release_sha: str,
+    expected_dataset_sha256: str,
+    expected_observations_sha256: str,
+    expected_case_count: int,
+) -> tuple[_ReviewAnnotations, ...]:
+    """Load only human link/claim annotations; objective fields are forbidden."""
+
+    rows = _load_jsonl(path)
+    header_fields = {
+        "record_type",
+        "schema_version",
+        "contains_raw_text",
+        "release_sha",
+        "dataset_sha256",
+        "observations_sha256",
+        "case_count",
+    }
+    header = rows[0]
+    _exact_fields(header, header_fields, kind="result header")
+    if (
+        header["record_type"] != "header"
+        or header["schema_version"] != REVIEWED_RESULTS_SCHEMA_VERSION
+        or header["contains_raw_text"] is not False
+        or header["release_sha"] != expected_release_sha
+        or header["dataset_sha256"] != expected_dataset_sha256
+        or header["observations_sha256"] != expected_observations_sha256
+        or type(header["case_count"]) is not int
+        or header["case_count"] != expected_case_count
+    ):
+        raise ValueError("review annotations are not bound to the exact runner observations")
+    expected_annotation_fields = {
+        "case_id",
+        "valid_source_links",
+        "invalid_source_links",
+        "unsupported_claims",
+        "total_claims",
+    }
+    annotations: list[_ReviewAnnotations] = []
+    for value in rows[1:]:
+        _exact_fields(value, expected_annotation_fields, kind="review annotation")
+        annotations.append(_ReviewAnnotations(**value))
+    if len(annotations) != expected_case_count:
+        raise ValueError("review annotation count does not match the runner manifest")
+    return tuple(annotations)
+
+
+def _merge_results(
+    cases: tuple[SemanticEvalCase, ...],
+    observations: tuple[_ObjectiveObservation, ...],
+    annotations: tuple[_ReviewAnnotations, ...],
+) -> tuple[SemanticEvalResult, ...]:
+    case_ids = {case.case_id for case in cases}
+    observations_by_id = {value.case_id: value for value in observations}
+    annotations_by_id = {value.case_id: value for value in annotations}
+    if (
+        len(observations_by_id) != len(observations)
+        or len(annotations_by_id) != len(annotations)
+        or set(observations_by_id) != case_ids
+        or set(annotations_by_id) != case_ids
+    ):
+        raise ValueError("observations and review annotations must match cases exactly")
+    return tuple(
+        SemanticEvalResult(
+            case_id=case.case_id,
+            fts_source_ids=observations_by_id[case.case_id].fts_source_ids,
+            hybrid_source_ids=observations_by_id[case.case_id].hybrid_source_ids,
+            abstained=observations_by_id[case.case_id].abstained,
+            leakage_count=observations_by_id[case.case_id].leakage_count,
+            valid_source_links=annotations_by_id[case.case_id].valid_source_links,
+            invalid_source_links=annotations_by_id[case.case_id].invalid_source_links,
+            unsupported_claims=annotations_by_id[case.case_id].unsupported_claims,
+            total_claims=annotations_by_id[case.case_id].total_claims,
+            retrieval_latency_seconds=observations_by_id[case.case_id].retrieval_latency_seconds,
+            full_latency_seconds=observations_by_id[case.case_id].full_latency_seconds,
+        )
+        for case in cases
+    )
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        while chunk := source.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _write_private_json(path: Path, payload: dict[str, Any], *, overwrite: bool) -> None:
+    flags = (
+        os.O_WRONLY
+        | os.O_CREAT
+        | (os.O_TRUNC if overwrite else os.O_EXCL)
+        | getattr(os, "O_NOFOLLOW", 0)
+    )
+    descriptor = os.open(path, flags, 0o600)
+    try:
+        os.fchmod(descriptor, 0o600)
+        os.write(
+            descriptor,
+            (json.dumps(payload, ensure_ascii=True, sort_keys=True) + "\n").encode(),
+        )
+    finally:
+        os.close(descriptor)
+
+
+def _validate_release_sha(value: str) -> str:
+    if _RELEASE_SHA_RE.fullmatch(value) is None:
+        raise ValueError("release SHA must be exactly 40 lowercase hexadecimal characters")
+    return value
+
+
+def _parse_report_metrics(value: object) -> SemanticEvalReport:
+    if not isinstance(value, dict):
+        raise ValueError("report metrics must be a JSON object")
+    expected = {field.name for field in fields(SemanticEvalReport)}
+    if set(value) != expected:
+        raise ValueError("report metric fields do not match the versioned schema")
+    parsed: dict[str, int | float] = {}
+    for name, raw in value.items():
+        if name in _INTEGER_REPORT_FIELDS:
+            if type(raw) is not int or raw < 0:
+                raise ValueError("report integer metrics must be non-negative integers")
+            parsed[name] = raw
+            continue
+        if isinstance(raw, bool) or not isinstance(raw, (int, float)):
+            raise ValueError("report numeric metrics must be finite numbers")
+        numeric = float(raw)
+        if not math.isfinite(numeric):
+            raise ValueError("report numeric metrics must be finite numbers")
+        parsed[name] = numeric
+    return SemanticEvalReport(**parsed)
+
+
+def validate_report_payload(
+    payload: object,
+    *,
+    expected_release_sha: str,
+) -> dict[str, Any]:
+    """Strictly validate one sanitized report and return a CI-safe artifact row."""
+
+    release_sha = _validate_release_sha(expected_release_sha)
+    if not isinstance(payload, dict) or set(payload) != _REPORT_KEYS:
+        raise ValueError("invalid report schema")
+    if (
+        payload["schema_version"] != REPORT_SCHEMA_VERSION
+        or payload["status"] != "pass"
+        or payload["contains_raw_text"] is not False
+        or payload["violations"] != []
+        or payload["release_sha"] != release_sha
+    ):
+        raise ValueError("report is not a release-bound no-content pass")
+    for hash_name in ("dataset_sha256", "observations_sha256", "results_sha256"):
+        hash_value = payload[hash_name]
+        if not isinstance(hash_value, str) or _SHA256_RE.fullmatch(hash_value) is None:
+            raise ValueError("report file hashes must be lowercase SHA-256 values")
+    report = _parse_report_metrics(payload["report"])
+    if report.case_count < MIN_FROZEN_CASES:
+        raise ValueError("frozen report contains fewer than 50 cases")
+    if validate_semantic_report(report):
+        raise ValueError("frozen report contains a blocking metric violation")
+    return {
+        **payload,
+        "suite": "private-frozen-semantic-eval",
+        "commit_sha": release_sha,
+    }
+
+
+def _append_artifact(path: Path, payload: dict[str, Any]) -> None:
+    with path.open("a", encoding="utf-8") as target:
+        target.write(json.dumps(payload, ensure_ascii=True, sort_keys=True) + "\n")
+
+
+def _run_evaluate(args: argparse.Namespace) -> int:
+    release_sha = _validate_release_sha(args.release_sha)
+    dataset_path = Path(args.dataset).expanduser()
+    cases_path = Path(args.cases).expanduser()
+    observations_path = Path(args.observations).expanduser()
+    results_path = Path(args.results).expanduser()
+    dataset_sha256 = _sha256_file(dataset_path)
+    observations_sha256 = _sha256_file(observations_path)
+    cases = _load_cases(cases_path)
+    _validate_cases_match_dataset(dataset_path, cases)
+    observations = _load_observations(
+        observations_path,
+        expected_release_sha=release_sha,
+        expected_dataset_sha256=dataset_sha256,
+        expected_case_count=len(cases),
+    )
+    annotations = _load_review_annotations(
+        results_path,
+        expected_release_sha=release_sha,
+        expected_dataset_sha256=dataset_sha256,
+        expected_observations_sha256=observations_sha256,
+        expected_case_count=len(cases),
+    )
+    results = _merge_results(cases, observations, annotations)
+    report, violations = evaluate_semantic_run(cases, results)
+    payload = {
+        "schema_version": REPORT_SCHEMA_VERSION,
+        "status": "pass" if not violations else "fail",
+        "contains_raw_text": False,
+        "release_sha": release_sha,
+        "dataset_sha256": dataset_sha256,
+        "observations_sha256": observations_sha256,
+        "results_sha256": _sha256_file(results_path),
+        "report": asdict(report),
+        "violations": list(violations),
+    }
+    _write_private_json(
+        Path(args.report).expanduser(),
+        payload,
+        overwrite=args.overwrite,
+    )
+    print(json.dumps(payload, ensure_ascii=True, sort_keys=True))
+    return 0 if not violations else 1
+
+
+def _run_validate_report(args: argparse.Namespace) -> int:
+    raw_report = os.environ.get("SEMANTIC_EVAL_REPORT_JSON")
+    if not raw_report:
+        raise ValueError("SEMANTIC_EVAL_REPORT_JSON is required")
+    try:
+        payload = json.loads(raw_report)
+    except json.JSONDecodeError as exc:
+        raise ValueError("SEMANTIC_EVAL_REPORT_JSON is not valid JSON") from exc
+    artifact = validate_report_payload(
+        payload,
+        expected_release_sha=args.expected_release_sha,
+    )
+    _append_artifact(Path(args.artifact), artifact)
+    print(
+        json.dumps(
+            {
+                "schema_version": REPORT_SCHEMA_VERSION,
+                "status": "pass",
+                "suite": "private-frozen-semantic-eval",
+                "commit_sha": artifact["commit_sha"],
+                "case_count": artifact["report"]["case_count"],
+                "contains_raw_text": False,
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="scripts.evaluate_semantic_qa")
+    commands = parser.add_subparsers(dest="command", required=True)
+
+    evaluate = commands.add_parser("evaluate", help="Build a release-bound sanitized report.")
+    evaluate.add_argument("--dataset", required=True, help="Exact private frozen runner input.")
+    evaluate.add_argument("--cases", required=True, help="Private frozen labels JSONL.")
+    evaluate.add_argument(
+        "--observations",
+        required=True,
+        help="Immutable no-content observations emitted by the live runner.",
+    )
+    evaluate.add_argument(
+        "--results",
+        required=True,
+        help="Reviewed observations JSONL with the copied runner manifest header.",
+    )
+    evaluate.add_argument("--release-sha", required=True)
+    evaluate.add_argument("--report", required=True, help="No-content gate report JSON.")
+    evaluate.add_argument("--overwrite", action="store_true")
+    evaluate.set_defaults(func=_run_evaluate)
+
+    validate = commands.add_parser(
+        "validate-report",
+        help="Fail closed unless SEMANTIC_EVAL_REPORT_JSON is a valid release-bound pass.",
+    )
+    validate.add_argument("--expected-release-sha", required=True)
+    validate.add_argument("--artifact", required=True)
+    validate.set_defaults(func=_run_validate_report)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        return args.func(args)
+    except (FileExistsError, FileNotFoundError, PermissionError, TypeError, ValueError) as exc:
+        print(
+            json.dumps(
+                {
+                    "schema_version": REPORT_SCHEMA_VERSION,
+                    "status": "error",
+                    "error_class": type(exc).__name__,
+                    "contains_raw_text": False,
+                },
+                sort_keys=True,
+            ),
+            file=sys.stderr,
+        )
+        return 2
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/scripts/lint_privacy_check.sh
+++ b/scripts/lint_privacy_check.sh
@@ -220,8 +220,12 @@ is_allowed_path() {
   # must name the forbidden-source/forget invariants they implement and verify;
   # keep the allowlist path-exact so adjacent runtime files remain linted.
   [[ "$path" == "docs/runbooks/semantic-qa.md" ]] && return 0
+  [[ "$path" == "bot/services/semantic_eval.py" ]] && return 0
   [[ "$path" == "tests/services/test_forget_cascade_semantic.py" ]] && return 0
+  [[ "$path" == "tests/services/test_semantic_eval.py" ]] && return 0
   [[ "$path" == "tests/services/test_semantic_index_postgres.py" ]] && return 0
+  [[ "$path" == "tests/scripts/test_evaluate_semantic_qa.py" ]] && return 0
+  [[ "$path" == "tests/scripts/test_run_semantic_qa_eval.py" ]] && return 0
 
   return 1
 }

--- a/scripts/lint_privacy_check.sh
+++ b/scripts/lint_privacy_check.sh
@@ -216,6 +216,13 @@ is_allowed_path() {
   [[ "$path" == "tests/evals/test_graph_drift.py" ]] && return 0
   [[ "$path" == "tests/evals/test_graph_no_llm_in_rebuild.py" ]] && return 0
 
+  # Issue #404 semantic Q&A privacy enforcers and operator runbook. These files
+  # must name the forbidden-source/forget invariants they implement and verify;
+  # keep the allowlist path-exact so adjacent runtime files remain linted.
+  [[ "$path" == "docs/runbooks/semantic-qa.md" ]] && return 0
+  [[ "$path" == "tests/services/test_forget_cascade_semantic.py" ]] && return 0
+  [[ "$path" == "tests/services/test_semantic_index_postgres.py" ]] && return 0
+
   return 1
 }
 

--- a/scripts/precommit-privacy-allowlist.sh
+++ b/scripts/precommit-privacy-allowlist.sh
@@ -51,6 +51,14 @@ is_allowed_path() {
   # policy and must name the canonical privacy literals in docstrings.
   [[ "$path" =~ ^alembic/versions/05[0-9]_.*\.py$ ]] && return 0
 
+  # Issue #404 semantic Q&A evaluation code and tests enumerate the mandatory
+  # leakage classes by their canonical names. Keep these entries path-exact:
+  # adjacent runtime code remains subject to the privacy-token lint.
+  [[ "$path" == "bot/services/semantic_eval.py" ]] && return 0
+  [[ "$path" == "tests/services/test_semantic_eval.py" ]] && return 0
+  [[ "$path" == "tests/scripts/test_evaluate_semantic_qa.py" ]] && return 0
+  [[ "$path" == "tests/scripts/test_run_semantic_qa_eval.py" ]] && return 0
+
   return 1
 }
 

--- a/scripts/run_semantic_qa_eval.py
+++ b/scripts/run_semantic_qa_eval.py
@@ -1,0 +1,446 @@
+"""Run the private frozen semantic Q&A set through the production provider path.
+
+The input and review output contain private query/evidence text and therefore
+never leave the operator host.  Stdout/stderr contain only aggregate metadata
+and exception taxonomy.  The runner deliberately bypasses product quota rows,
+but it uses the real embedding/synthesis gateways so every provider call is
+recorded in ``llm_usage_ledger``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import json
+import os
+import re
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Sequence, TextIO
+
+from sqlalchemy.exc import SQLAlchemyError
+
+from bot.db.repos.llm_synthesis_cache import SynthesisCacheRepo
+from bot.db.repos.llm_usage_ledger import LedgerRepo
+from bot.services.evidence import EvidenceBundle, EvidenceItem
+from bot.services.llm_gateway import (
+    Abstention,
+    AnswerWithCitations,
+    EmbeddingBudgetExceeded,
+    filter_surviving_evidence,
+    load_embedding_gateway_config,
+    load_gateway_config,
+    resolve_provider,
+    synthesize_answer,
+)
+from bot.services.llm_providers import ProviderStructuralError, ProviderTransientError
+from bot.services.qa_guardrails import build_guarded_llm_query, contains_secret_like_data
+from bot.services.semantic_eval import SemanticEvalCase
+from bot.services.semantic_index import HybridSearchResult, hybrid_search
+
+
+MIN_FROZEN_CASES = 50
+PRIVATE_RUN_SCHEMA_VERSION = 2
+SEMANTIC_EVIDENCE_LIMIT = 5
+SEMANTIC_PROVIDER = "deepseek"
+SEMANTIC_MODEL = "deepseek-v4-flash"
+
+_CASE_ID_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,63}")
+_RELEASE_SHA_RE = re.compile(r"[0-9a-f]{40}")
+_INPUT_FIELDS = {
+    "case_id",
+    "category",
+    "chat_id",
+    "query",
+    "expected_source_ids",
+    "forbidden_source_ids",
+    "expected_abstain",
+    "exclude_chat_message_id",
+}
+
+
+@dataclass(frozen=True, slots=True)
+class PrivateEvalCase:
+    label: SemanticEvalCase
+    chat_id: int
+    query: str
+    exclude_chat_message_id: int | None
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        while chunk := source.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _load_jsonl(path: Path) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    with path.open("r", encoding="utf-8") as source:
+        for line_number, line in enumerate(source, start=1):
+            if not line.strip():
+                continue
+            try:
+                row = json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"input line {line_number} is not valid JSON") from exc
+            if not isinstance(row, dict) or set(row) != _INPUT_FIELDS:
+                raise ValueError(f"input line {line_number} has an invalid schema")
+            rows.append(row)
+    if not rows:
+        raise ValueError("private evaluation input is empty")
+    return rows
+
+
+def load_private_cases(path: Path, *, smoke: bool) -> tuple[PrivateEvalCase, ...]:
+    """Validate the complete private input before any provider dispatch."""
+
+    cases: list[PrivateEvalCase] = []
+    for row in _load_jsonl(path):
+        case_id = row["case_id"]
+        if not isinstance(case_id, str) or _CASE_ID_RE.fullmatch(case_id) is None:
+            raise ValueError("case_id must be an opaque safe identifier")
+        expected_ids = row["expected_source_ids"]
+        forbidden_ids = row["forbidden_source_ids"]
+        if not isinstance(expected_ids, list) or not isinstance(forbidden_ids, list):
+            raise ValueError("expected and forbidden source ids must be JSON arrays")
+        label = SemanticEvalCase(
+            case_id=case_id,
+            category=row["category"],
+            expected_source_ids=tuple(expected_ids),
+            forbidden_source_ids=tuple(forbidden_ids),
+            expected_abstain=row["expected_abstain"],
+        )
+        chat_id = row["chat_id"]
+        if type(chat_id) is not int or chat_id == 0:
+            raise ValueError("chat_id must be a non-zero integer")
+        query = row["query"]
+        if (
+            not isinstance(query, str)
+            or not query.strip()
+            or query != query.strip()
+            or len(query) > 256
+        ):
+            raise ValueError("query must be a non-empty trimmed string of at most 256 chars")
+        exclude_id = row["exclude_chat_message_id"]
+        if exclude_id is not None and (type(exclude_id) is not int or exclude_id < 1):
+            raise ValueError("exclude_chat_message_id must be null or a positive integer")
+        cases.append(
+            PrivateEvalCase(
+                label=label,
+                chat_id=chat_id,
+                query=query,
+                exclude_chat_message_id=exclude_id,
+            )
+        )
+    if len({case.label.case_id for case in cases}) != len(cases):
+        raise ValueError("private evaluation case ids must be unique")
+    if smoke:
+        if len(cases) != 1:
+            raise ValueError("provider smoke mode requires exactly one case")
+    else:
+        if len(cases) < MIN_FROZEN_CASES:
+            raise ValueError("frozen private evaluation requires at least 50 cases")
+        categories = {case.label.category for case in cases}
+        if categories != {
+            "semantic",
+            "exact",
+            "multi_source",
+            "no_answer",
+            "privacy_governance",
+        }:
+            raise ValueError("frozen private evaluation requires all five categories")
+    return tuple(cases)
+
+
+def _open_private_text(path: Path, *, overwrite: bool) -> TextIO:
+    flags = os.O_WRONLY | os.O_CREAT | getattr(os, "O_NOFOLLOW", 0)
+    flags |= os.O_TRUNC if overwrite else os.O_EXCL
+    descriptor = os.open(path, flags, 0o600)
+    os.fchmod(descriptor, 0o600)
+    return os.fdopen(descriptor, "w", encoding="utf-8")
+
+
+def _write_jsonl(target: TextIO, payload: dict[str, Any]) -> None:
+    target.write(json.dumps(payload, ensure_ascii=True, sort_keys=True) + "\n")
+    target.flush()
+
+
+def _source_key(item: EvidenceItem) -> str:
+    if item.source_type == "card":
+        if item.card_id is None:
+            raise ValueError("card evidence is missing its canonical card id")
+        return f"card:{item.card_id}"
+    return f"message:{item.message_version_id}"
+
+
+def _ranked_branch_keys(candidate_ranks: dict[str, dict[str, int]], branch: str) -> list[str]:
+    ranked = [
+        (ranks[branch], source_key)
+        for source_key, ranks in candidate_ranks.items()
+        if branch in ranks
+    ]
+    return [source_key for _, source_key in sorted(ranked)]
+
+
+def _telegram_link(item: EvidenceItem) -> str:
+    short_chat_id = str(item.chat_id).removeprefix("-100")
+    return f"https://t.me/c/{short_chat_id}/{item.message_id}"
+
+
+def _sanitized_case_row(case: PrivateEvalCase) -> dict[str, Any]:
+    return {
+        "case_id": case.label.case_id,
+        "category": case.label.category,
+        "expected_source_ids": list(case.label.expected_source_ids),
+        "forbidden_source_ids": list(case.label.forbidden_source_ids),
+        "expected_abstain": case.label.expected_abstain,
+    }
+
+
+def _sanitized_observation_row(review_row: dict[str, Any]) -> dict[str, Any]:
+    reviewed_result = review_row["reviewed_result"]
+    return {
+        "record_type": "case_observation",
+        "case_id": review_row["case_id"],
+        "fts_source_ids": review_row["fts_source_ids"],
+        "hybrid_source_ids": review_row["hybrid_source_ids"],
+        "abstained": reviewed_result["abstained"],
+        "leakage_count": review_row["objective_leakage_count"],
+        "retrieval_latency_seconds": reviewed_result["retrieval_latency_seconds"],
+        "full_latency_seconds": reviewed_result["full_latency_seconds"],
+    }
+
+
+async def _run_case(case: PrivateEvalCase) -> dict[str, Any]:
+    from bot.db.engine import async_session
+
+    started = time.monotonic()
+    embedding_config = load_embedding_gateway_config()
+    synthesis_config = load_gateway_config()
+    if synthesis_config.provider != SEMANTIC_PROVIDER or synthesis_config.model != SEMANTIC_MODEL:
+        raise ValueError("semantic evaluation requires DeepSeek V4 Flash configuration")
+
+    async with async_session() as session:
+        from bot.services.llm_gateway import embed_texts
+
+        embedding = await embed_texts(
+            session,
+            inputs=[case.query],
+            config=embedding_config,
+            ledger_repo=LedgerRepo(),
+            qa_trace_id=None,
+        )
+        retrieval: HybridSearchResult = await hybrid_search(
+            session,
+            query=case.query,
+            query_embedding=embedding.vectors[0],
+            chat_id=case.chat_id,
+            embedding_model=embedding_config.model,
+            exclude_chat_message_id=case.exclude_chat_message_id,
+        )
+        retrieval_finished = time.monotonic()
+        bundle = EvidenceBundle.from_hits(case.query, case.chat_id, list(retrieval.hits))
+        synth_result: AnswerWithCitations | Abstention | None = None
+        rendered_bundle = bundle
+        abstention_reason: str | None = None
+        if bundle.abstained or not bundle.evidence_ids:
+            abstention_reason = "empty_bundle"
+        elif any(contains_secret_like_data(item.snippet) for item in bundle.items):
+            abstention_reason = "sensitive_input"
+            rendered_bundle = EvidenceBundle.from_hits(case.query, case.chat_id, [])
+        else:
+            synth_result = await synthesize_answer(
+                session,
+                bundle=bundle,
+                query=build_guarded_llm_query(case.query),
+                config=synthesis_config,
+                qa_trace_id=None,
+                ledger_repo=LedgerRepo(),
+                cache_repo=SynthesisCacheRepo(),
+                provider=resolve_provider(synthesis_config.provider),
+                max_evidence_items=SEMANTIC_EVIDENCE_LIMIT,
+                durable_placeholder=True,
+                revalidate_after_provider=True,
+            )
+            if isinstance(synth_result, AnswerWithCitations):
+                rendered_bundle = await filter_surviving_evidence(
+                    session,
+                    bundle,
+                    max_evidence_items=SEMANTIC_EVIDENCE_LIMIT,
+                )
+                expected_ids = synth_result.surviving_evidence_ids
+                if tuple(rendered_bundle.evidence_ids) != expected_ids or not set(
+                    synth_result.citation_ids
+                ).issubset(expected_ids):
+                    abstention_reason = "citation_rejected"
+            else:
+                abstention_reason = synth_result.reason
+            await session.commit()
+
+    hybrid_ids = [_source_key(item) for item in retrieval.hits]
+    forbidden = set(case.label.forbidden_source_ids)
+    leakage_count = len(set(hybrid_ids) & forbidden)
+    answer = (
+        synth_result.answer_text
+        if isinstance(synth_result, AnswerWithCitations) and abstention_reason is None
+        else None
+    )
+    cited_source_ids: list[str] = []
+    if isinstance(synth_result, AnswerWithCitations) and abstention_reason is None:
+        by_anchor = {item.message_version_id: _source_key(item) for item in rendered_bundle.items}
+        cited_source_ids = [by_anchor[value] for value in synth_result.citation_ids]
+    full_finished = time.monotonic()
+    return {
+        "record_type": "case_review",
+        "case_id": case.label.case_id,
+        "category": case.label.category,
+        "query": case.query,
+        "answer": answer,
+        "abstention_reason": abstention_reason,
+        "fts_source_ids": _ranked_branch_keys(retrieval.candidate_ranks, "fts"),
+        "hybrid_source_ids": hybrid_ids,
+        "cited_source_ids": cited_source_ids,
+        "evidence": [
+            {
+                "source_id": _source_key(item),
+                "message_version_id": item.message_version_id,
+                "snippet": item.snippet,
+                "source_link": _telegram_link(item),
+            }
+            for item in rendered_bundle.items
+        ],
+        "embedding_llm_call_id": embedding.llm_usage_ledger_id,
+        "synthesis_llm_call_id": synth_result.llm_call_id if synth_result else None,
+        "cache_hit": synth_result.cache_hit
+        if isinstance(synth_result, AnswerWithCitations)
+        else False,
+        "objective_leakage_count": leakage_count,
+        "reviewed_result": {
+            "case_id": case.label.case_id,
+            "fts_source_ids": _ranked_branch_keys(retrieval.candidate_ranks, "fts"),
+            "hybrid_source_ids": hybrid_ids,
+            "abstained": answer is None,
+            "leakage_count": leakage_count,
+            "valid_source_links": None,
+            "invalid_source_links": None,
+            "unsupported_claims": None,
+            "total_claims": None,
+            "retrieval_latency_seconds": retrieval_finished - started,
+            "full_latency_seconds": full_finished - started,
+        },
+    }
+
+
+async def run_private_evaluation(args: argparse.Namespace) -> int:
+    release_sha = args.release_sha
+    if _RELEASE_SHA_RE.fullmatch(release_sha) is None:
+        raise ValueError("release SHA must be exactly 40 lowercase hexadecimal characters")
+    input_path = Path(args.input).expanduser()
+    cases = load_private_cases(input_path, smoke=args.smoke)
+    dataset_hash = _sha256_file(input_path)
+    cases_path = Path(args.cases_output).expanduser()
+    observations_path = Path(args.observations_output).expanduser()
+    review_path = Path(args.review_output).expanduser()
+    with (
+        _open_private_text(cases_path, overwrite=args.overwrite) as cases_target,
+        _open_private_text(observations_path, overwrite=args.overwrite) as observations_target,
+        _open_private_text(review_path, overwrite=args.overwrite) as review_target,
+    ):
+        for case in cases:
+            _write_jsonl(cases_target, _sanitized_case_row(case))
+        _write_jsonl(
+            observations_target,
+            {
+                "record_type": "header",
+                "schema_version": PRIVATE_RUN_SCHEMA_VERSION,
+                "contains_raw_text": False,
+                "release_sha": release_sha,
+                "dataset_sha256": dataset_hash,
+                "case_count": len(cases),
+            },
+        )
+        _write_jsonl(
+            review_target,
+            {
+                "record_type": "header",
+                "schema_version": PRIVATE_RUN_SCHEMA_VERSION,
+                "contains_raw_text": True,
+                "private_review_required": True,
+                "release_sha": release_sha,
+                "dataset_sha256": dataset_hash,
+                "case_count": len(cases),
+            },
+        )
+        for case in cases:
+            row = await _run_case(case)
+            row["release_sha"] = release_sha
+            row["dataset_sha256"] = dataset_hash
+            _write_jsonl(observations_target, _sanitized_observation_row(row))
+            _write_jsonl(review_target, row)
+    observations_hash = _sha256_file(observations_path)
+    print(
+        json.dumps(
+            {
+                "schema_version": PRIVATE_RUN_SCHEMA_VERSION,
+                "status": "review_required",
+                "contains_raw_text": False,
+                "release_sha": release_sha,
+                "dataset_sha256": dataset_hash,
+                "observations_sha256": observations_hash,
+                "case_count": len(cases),
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="scripts.run_semantic_qa_eval")
+    parser.add_argument("--input", required=True)
+    parser.add_argument("--cases-output", required=True)
+    parser.add_argument("--observations-output", required=True)
+    parser.add_argument("--review-output", required=True)
+    parser.add_argument("--release-sha", required=True)
+    parser.add_argument("--smoke", action="store_true")
+    parser.add_argument("--overwrite", action="store_true")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        return asyncio.run(run_private_evaluation(args))
+    except (
+        FileExistsError,
+        FileNotFoundError,
+        PermissionError,
+        EmbeddingBudgetExceeded,
+        ProviderStructuralError,
+        ProviderTransientError,
+        SQLAlchemyError,
+        TypeError,
+        ValueError,
+    ) as exc:
+        print(
+            json.dumps(
+                {
+                    "schema_version": PRIVATE_RUN_SCHEMA_VERSION,
+                    "status": "error",
+                    "error_class": type(exc).__name__,
+                    "contains_raw_text": False,
+                },
+                sort_keys=True,
+            ),
+            file=sys.stderr,
+        )
+        return 2
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/scripts/run_semantic_qa_eval.py
+++ b/scripts/run_semantic_qa_eval.py
@@ -11,15 +11,17 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import errno
 import hashlib
 import json
 import os
 import re
+import stat
 import sys
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Sequence, TextIO
+from typing import Any, BinaryIO, Sequence, TextIO
 
 from sqlalchemy.exc import SQLAlchemyError
 
@@ -80,37 +82,34 @@ def _guard_eval_query(query: str) -> str:
     return build_guarded_llm_query(query)
 
 
-def _sha256_file(path: Path) -> str:
-    digest = hashlib.sha256()
-    with path.open("rb") as source:
-        while chunk := source.read(1024 * 1024):
-            digest.update(chunk)
-    return digest.hexdigest()
-
-
-def _load_jsonl(path: Path) -> list[dict[str, Any]]:
+def _load_jsonl(source: BinaryIO) -> tuple[list[dict[str, Any]], str]:
     rows: list[dict[str, Any]] = []
-    with path.open("r", encoding="utf-8") as source:
-        for line_number, line in enumerate(source, start=1):
-            if not line.strip():
-                continue
-            try:
-                row = json.loads(line)
-            except json.JSONDecodeError as exc:
-                raise ValueError(f"input line {line_number} is not valid JSON") from exc
-            if not isinstance(row, dict) or set(row) != _INPUT_FIELDS:
-                raise ValueError(f"input line {line_number} has an invalid schema")
-            rows.append(row)
+    digest = hashlib.sha256()
+    for line_number, raw_line in enumerate(source, start=1):
+        digest.update(raw_line)
+        try:
+            line = raw_line.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise ValueError(f"input line {line_number} is not valid UTF-8") from exc
+        if not line.strip():
+            continue
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"input line {line_number} is not valid JSON") from exc
+        if not isinstance(row, dict) or set(row) != _INPUT_FIELDS:
+            raise ValueError(f"input line {line_number} has an invalid schema")
+        rows.append(row)
     if not rows:
         raise ValueError("private evaluation input is empty")
-    return rows
+    return rows, digest.hexdigest()
 
 
-def load_private_cases(path: Path, *, smoke: bool) -> tuple[PrivateEvalCase, ...]:
-    """Validate the complete private input before any provider dispatch."""
-
+def _validate_private_cases(
+    rows: list[dict[str, Any]], *, smoke: bool
+) -> tuple[PrivateEvalCase, ...]:
     cases: list[PrivateEvalCase] = []
-    for row in _load_jsonl(path):
+    for row in rows:
         case_id = row["case_id"]
         if not isinstance(case_id, str) or _CASE_ID_RE.fullmatch(case_id) is None:
             raise ValueError("case_id must be an opaque safe identifier")
@@ -177,17 +176,72 @@ def load_private_cases(path: Path, *, smoke: bool) -> tuple[PrivateEvalCase, ...
     return tuple(cases)
 
 
+def _open_private_input(path: Path) -> BinaryIO:
+    try:
+        descriptor = os.open(path, os.O_RDONLY | os.O_CLOEXEC | os.O_NOFOLLOW)
+    except OSError as exc:
+        if exc.errno == errno.ELOOP:
+            raise ValueError("private eval artifacts must not be symbolic links") from exc
+        raise
+    return os.fdopen(descriptor, "rb")
+
+
+def _load_private_cases_from_source(
+    source: BinaryIO, *, smoke: bool
+) -> tuple[tuple[PrivateEvalCase, ...], str]:
+    rows, dataset_hash = _load_jsonl(source)
+    return _validate_private_cases(rows, smoke=smoke), dataset_hash
+
+
+def load_private_cases(path: Path, *, smoke: bool) -> tuple[PrivateEvalCase, ...]:
+    """Validate the complete private input before any provider dispatch."""
+
+    with _open_private_input(path) as source:
+        cases, _ = _load_private_cases_from_source(source, smoke=smoke)
+    return cases
+
+
 def _open_private_text(path: Path, *, overwrite: bool) -> TextIO:
-    flags = os.O_WRONLY | os.O_CREAT | getattr(os, "O_NOFOLLOW", 0)
-    flags |= os.O_TRUNC if overwrite else os.O_EXCL
-    descriptor = os.open(path, flags, 0o600)
-    os.fchmod(descriptor, 0o600)
-    return os.fdopen(descriptor, "w", encoding="utf-8")
+    flags = os.O_WRONLY | os.O_CREAT | os.O_CLOEXEC | os.O_NOFOLLOW
+    if not overwrite:
+        flags |= os.O_EXCL
+    try:
+        descriptor = os.open(path, flags, 0o600)
+    except OSError as exc:
+        if exc.errno == errno.ELOOP:
+            raise ValueError("private eval artifacts must not be symbolic links") from exc
+        raise
+    # Disable platform newline translation so the streamed digest is over the
+    # exact bytes written to the held descriptor.
+    return os.fdopen(descriptor, "w", encoding="utf-8", newline="")
 
 
-def _write_jsonl(target: TextIO, payload: dict[str, Any]) -> None:
-    target.write(json.dumps(payload, ensure_ascii=True, sort_keys=True) + "\n")
+def _prepare_private_outputs(source: BinaryIO, targets: Sequence[TextIO]) -> None:
+    artifacts = (("input", source),) + tuple(
+        (f"output-{index}", target) for index, target in enumerate(targets, start=1)
+    )
+    identities: dict[tuple[int, int], str] = {}
+    for label, artifact in artifacts:
+        metadata = os.fstat(artifact.fileno())
+        if not stat.S_ISREG(metadata.st_mode):
+            raise ValueError("private eval artifacts must be regular files")
+        identity = (metadata.st_dev, metadata.st_ino)
+        if identity in identities:
+            raise ValueError("private eval input and output paths must be distinct")
+        identities[identity] = label
+
+    for target in targets:
+        os.fchmod(target.fileno(), 0o600)
+    for target in targets:
+        os.ftruncate(target.fileno(), 0)
+        target.seek(0)
+
+
+def _write_jsonl(target: TextIO, payload: dict[str, Any]) -> bytes:
+    line = json.dumps(payload, ensure_ascii=True, sort_keys=True) + "\n"
+    target.write(line)
     target.flush()
+    return line.encode("utf-8")
 
 
 def _source_key(item: EvidenceItem) -> str:
@@ -363,49 +417,60 @@ async def run_private_evaluation(args: argparse.Namespace) -> int:
     release_sha = args.release_sha
     if _RELEASE_SHA_RE.fullmatch(release_sha) is None:
         raise ValueError("release SHA must be exactly 40 lowercase hexadecimal characters")
-    input_path = Path(args.input).expanduser()
-    cases = load_private_cases(input_path, smoke=args.smoke)
-    dataset_hash = _sha256_file(input_path)
-    cases_path = Path(args.cases_output).expanduser()
-    observations_path = Path(args.observations_output).expanduser()
-    review_path = Path(args.review_output).expanduser()
-    with (
-        _open_private_text(cases_path, overwrite=args.overwrite) as cases_target,
-        _open_private_text(observations_path, overwrite=args.overwrite) as observations_target,
-        _open_private_text(review_path, overwrite=args.overwrite) as review_target,
-    ):
-        for case in cases:
-            _write_jsonl(cases_target, _sanitized_case_row(case))
-        _write_jsonl(
-            observations_target,
-            {
-                "record_type": "header",
-                "schema_version": PRIVATE_RUN_SCHEMA_VERSION,
-                "contains_raw_text": False,
-                "release_sha": release_sha,
-                "dataset_sha256": dataset_hash,
-                "case_count": len(cases),
-            },
-        )
-        _write_jsonl(
-            review_target,
-            {
-                "record_type": "header",
-                "schema_version": PRIVATE_RUN_SCHEMA_VERSION,
-                "contains_raw_text": True,
-                "private_review_required": True,
-                "release_sha": release_sha,
-                "dataset_sha256": dataset_hash,
-                "case_count": len(cases),
-            },
-        )
-        for case in cases:
-            row = await _run_case(case)
-            row["release_sha"] = release_sha
-            row["dataset_sha256"] = dataset_hash
-            _write_jsonl(observations_target, _sanitized_observation_row(row))
-            _write_jsonl(review_target, row)
-    observations_hash = _sha256_file(observations_path)
+    input_path = Path(args.input).expanduser().absolute()
+    cases_path = Path(args.cases_output).expanduser().absolute()
+    observations_path = Path(args.observations_output).expanduser().absolute()
+    review_path = Path(args.review_output).expanduser().absolute()
+    artifact_paths = (input_path, cases_path, observations_path, review_path)
+    if len(set(artifact_paths)) != len(artifact_paths):
+        raise ValueError("private eval input and output paths must be distinct")
+    observations_digest = hashlib.sha256()
+    with _open_private_input(input_path) as input_source:
+        cases, dataset_hash = _load_private_cases_from_source(input_source, smoke=args.smoke)
+        with (
+            _open_private_text(cases_path, overwrite=args.overwrite) as cases_target,
+            _open_private_text(observations_path, overwrite=args.overwrite) as observations_target,
+            _open_private_text(review_path, overwrite=args.overwrite) as review_target,
+        ):
+            _prepare_private_outputs(
+                input_source, (cases_target, observations_target, review_target)
+            )
+            for case in cases:
+                _write_jsonl(cases_target, _sanitized_case_row(case))
+            observations_digest.update(
+                _write_jsonl(
+                    observations_target,
+                    {
+                        "record_type": "header",
+                        "schema_version": PRIVATE_RUN_SCHEMA_VERSION,
+                        "contains_raw_text": False,
+                        "release_sha": release_sha,
+                        "dataset_sha256": dataset_hash,
+                        "case_count": len(cases),
+                    },
+                )
+            )
+            _write_jsonl(
+                review_target,
+                {
+                    "record_type": "header",
+                    "schema_version": PRIVATE_RUN_SCHEMA_VERSION,
+                    "contains_raw_text": True,
+                    "private_review_required": True,
+                    "release_sha": release_sha,
+                    "dataset_sha256": dataset_hash,
+                    "case_count": len(cases),
+                },
+            )
+            for case in cases:
+                row = await _run_case(case)
+                row["release_sha"] = release_sha
+                row["dataset_sha256"] = dataset_hash
+                observations_digest.update(
+                    _write_jsonl(observations_target, _sanitized_observation_row(row))
+                )
+                _write_jsonl(review_target, row)
+    observations_hash = observations_digest.hexdigest()
     print(
         json.dumps(
             {

--- a/scripts/run_semantic_qa_eval.py
+++ b/scripts/run_semantic_qa_eval.py
@@ -39,12 +39,12 @@ from bot.services.llm_gateway import (
 from bot.services.llm_providers import ProviderStructuralError, ProviderTransientError
 from bot.services.qa_guardrails import build_guarded_llm_query, contains_secret_like_data
 from bot.services.qa_trigger import MAX_USER_QUERY_CHARS
-from bot.services.semantic_eval import SemanticEvalCase
+from bot.services.semantic_eval import SemanticEvalCase, validate_privacy_class_coverage
 from bot.services.semantic_index import HybridSearchResult, hybrid_search
 
 
 MIN_FROZEN_CASES = 50
-PRIVATE_RUN_SCHEMA_VERSION = 2
+PRIVATE_RUN_SCHEMA_VERSION = 3
 SEMANTIC_EVIDENCE_LIMIT = 5
 SEMANTIC_PROVIDER = "deepseek"
 SEMANTIC_MODEL = "deepseek-v4-flash"
@@ -58,6 +58,7 @@ _INPUT_FIELDS = {
     "query",
     "expected_source_ids",
     "forbidden_source_ids",
+    "privacy_classes",
     "expected_abstain",
     "exclude_chat_message_id",
 }
@@ -115,13 +116,21 @@ def load_private_cases(path: Path, *, smoke: bool) -> tuple[PrivateEvalCase, ...
             raise ValueError("case_id must be an opaque safe identifier")
         expected_ids = row["expected_source_ids"]
         forbidden_ids = row["forbidden_source_ids"]
-        if not isinstance(expected_ids, list) or not isinstance(forbidden_ids, list):
-            raise ValueError("expected and forbidden source ids must be JSON arrays")
+        privacy_classes = row["privacy_classes"]
+        if (
+            not isinstance(expected_ids, list)
+            or not isinstance(forbidden_ids, list)
+            or not isinstance(privacy_classes, list)
+        ):
+            raise ValueError(
+                "expected sources, forbidden sources, and privacy classes must be JSON arrays"
+            )
         label = SemanticEvalCase(
             case_id=case_id,
             category=row["category"],
             expected_source_ids=tuple(expected_ids),
             forbidden_source_ids=tuple(forbidden_ids),
+            privacy_classes=tuple(privacy_classes),
             expected_abstain=row["expected_abstain"],
         )
         chat_id = row["chat_id"]
@@ -164,6 +173,7 @@ def load_private_cases(path: Path, *, smoke: bool) -> tuple[PrivateEvalCase, ...
             "privacy_governance",
         }:
             raise ValueError("frozen private evaluation requires all five categories")
+        validate_privacy_class_coverage(tuple(case.label for case in cases))
     return tuple(cases)
 
 
@@ -208,6 +218,7 @@ def _sanitized_case_row(case: PrivateEvalCase) -> dict[str, Any]:
         "category": case.label.category,
         "expected_source_ids": list(case.label.expected_source_ids),
         "forbidden_source_ids": list(case.label.forbidden_source_ids),
+        "privacy_classes": list(case.label.privacy_classes),
         "expected_abstain": case.label.expected_abstain,
     }
 
@@ -277,6 +288,7 @@ async def _run_case(case: PrivateEvalCase) -> dict[str, Any]:
                 max_evidence_items=SEMANTIC_EVIDENCE_LIMIT,
                 durable_placeholder=True,
                 revalidate_after_provider=True,
+                cache_enabled=False,
             )
             if isinstance(synth_result, AnswerWithCitations):
                 rendered_bundle = await filter_surviving_evidence(

--- a/scripts/run_semantic_qa_eval.py
+++ b/scripts/run_semantic_qa_eval.py
@@ -38,6 +38,7 @@ from bot.services.llm_gateway import (
 )
 from bot.services.llm_providers import ProviderStructuralError, ProviderTransientError
 from bot.services.qa_guardrails import build_guarded_llm_query, contains_secret_like_data
+from bot.services.qa_trigger import MAX_USER_QUERY_CHARS
 from bot.services.semantic_eval import SemanticEvalCase
 from bot.services.semantic_index import HybridSearchResult, hybrid_search
 
@@ -68,6 +69,14 @@ class PrivateEvalCase:
     chat_id: int
     query: str
     exclude_chat_message_id: int | None
+
+
+def _guard_eval_query(query: str) -> str:
+    """Apply the production query boundary before any eval provider call."""
+
+    if len(query) > MAX_USER_QUERY_CHARS:
+        raise ValueError("private evaluation query exceeds the production query limit")
+    return build_guarded_llm_query(query)
 
 
 def _sha256_file(path: Path) -> str:
@@ -126,6 +135,7 @@ def load_private_cases(path: Path, *, smoke: bool) -> tuple[PrivateEvalCase, ...
             or len(query) > 256
         ):
             raise ValueError("query must be a non-empty trimmed string of at most 256 chars")
+        _guard_eval_query(query)
         exclude_id = row["exclude_chat_message_id"]
         if exclude_id is not None and (type(exclude_id) is not int or exclude_id < 1):
             raise ValueError("exclude_chat_message_id must be null or a positive integer")
@@ -219,6 +229,7 @@ def _sanitized_observation_row(review_row: dict[str, Any]) -> dict[str, Any]:
 async def _run_case(case: PrivateEvalCase) -> dict[str, Any]:
     from bot.db.engine import async_session
 
+    guarded_query = _guard_eval_query(case.query)
     started = time.monotonic()
     embedding_config = load_embedding_gateway_config()
     synthesis_config = load_gateway_config()
@@ -257,7 +268,7 @@ async def _run_case(case: PrivateEvalCase) -> dict[str, Any]:
             synth_result = await synthesize_answer(
                 session,
                 bundle=bundle,
-                query=build_guarded_llm_query(case.query),
+                query=guarded_query,
                 config=synthesis_config,
                 qa_trace_id=None,
                 ledger_repo=LedgerRepo(),

--- a/tests/db/test_digests_review_schema.py
+++ b/tests/db/test_digests_review_schema.py
@@ -153,9 +153,307 @@ async def test_alembic_head_is_latest(migrated_database_url: str) -> None:
     Migration 079: weekly digests publish automatically without admin attribution.
     Migration 080: image memory storage and wiki/image ledger call types.
     Migration 082: complete-history supersession and active-version uniqueness.
+    Migration 089: semantic Q&A retrieval, quota, provenance, and audit schema.
     """
     current = await _fetch_value(migrated_database_url, "SELECT version_num FROM alembic_version")
-    assert current == "088"
+    assert current == "089"
+
+
+async def test_089_schema_pins_jsonb_delivery_and_numeric_constraints(
+    migrated_database_url: str,
+) -> None:
+    conn = await asyncpg.connect(**_asyncpg_kwargs(make_url(migrated_database_url)))
+    try:
+        jsonb_columns = await conn.fetch(
+            """
+            SELECT table_name, column_name, data_type
+            FROM information_schema.columns
+            WHERE table_schema = 'public'
+              AND (table_name, column_name) IN (
+                ('semantic_index_runs', 'reason_counts'),
+                ('semantic_retrieval_traces', 'candidate_ranks'),
+                ('semantic_retrieval_traces', 'result_source_ids')
+              )
+            ORDER BY table_name, column_name
+            """
+        )
+        assert [
+            (row["table_name"], row["column_name"], row["data_type"]) for row in jsonb_columns
+        ] == [
+            ("semantic_index_runs", "reason_counts", "jsonb"),
+            ("semantic_retrieval_traces", "candidate_ranks", "jsonb"),
+            ("semantic_retrieval_traces", "result_source_ids", "jsonb"),
+        ]
+        assert (
+            await conn.fetchval(
+                """
+            SELECT count(*)
+            FROM information_schema.columns
+            WHERE table_schema = 'public'
+              AND table_name = 'semantic_qa_attempts'
+              AND column_name = 'delivery_started_at'
+            """
+            )
+            == 1
+        )
+        constraints = await conn.fetch(
+            """
+            SELECT conname, convalidated
+            FROM pg_constraint
+            WHERE conname IN (
+                'ck_llm_usage_ledger_nonnegative_usage',
+                'ck_semantic_attempts_state'
+            )
+            ORDER BY conname
+            """
+        )
+        assert [(row["conname"], row["convalidated"]) for row in constraints] == [
+            ("ck_llm_usage_ledger_nonnegative_usage", True),
+            ("ck_semantic_attempts_state", True),
+        ]
+    finally:
+        await conn.close()
+
+
+async def test_089_enforces_quota_state_matrix_and_nonnegative_ledger(
+    migrated_database_url: str,
+) -> None:
+    conn = await asyncpg.connect(**_asyncpg_kwargs(make_url(migrated_database_url)))
+    try:
+        valid_states = (
+            ("denied", "quota_denied", None, None, None),
+            ("reserved", None, 1, None, None),
+            ("reserved", "answered", 2, "now()", None),
+            ("consumed", "answered", 1, "now()", "now()"),
+            ("consumed", "abstained", 2, "now()", "now()"),
+            ("released", "technical_failure", 1, None, "now()"),
+            ("released", "technical_failure", 2, "now()", "now()"),
+        )
+        for index, (status, outcome, slot, delivery_sql, finalized_sql) in enumerate(
+            valid_states,
+            start=1,
+        ):
+            await conn.execute(
+                f"""
+                INSERT INTO semantic_qa_attempts (
+                    idempotency_key, user_tg_id, chat_id, local_day,
+                    slot_number, status, outcome, delivery_started_at, finalized_at
+                ) VALUES (
+                    $1, $2, -100404, CURRENT_DATE,
+                    $3, $4, $5, {delivery_sql or "NULL"}, {finalized_sql or "NULL"}
+                )
+                """,
+                f"schema-valid-{index}",
+                989100000000 + index,
+                slot,
+                status,
+                outcome,
+            )
+
+        invalid_states = (
+            ("consumed", "technical_failure", 1, "now()", "now()"),
+            ("consumed", "quota_denied", 1, "now()", "now()"),
+            ("consumed", "answered", 1, None, "now()"),
+            ("released", "answered", 1, "now()", "now()"),
+            ("released", "abstained", 1, None, "now()"),
+        )
+        for index, (status, outcome, slot, delivery_sql, finalized_sql) in enumerate(
+            invalid_states,
+            start=1,
+        ):
+            transaction = conn.transaction()
+            await transaction.start()
+            with pytest.raises(asyncpg.CheckViolationError):
+                await conn.execute(
+                    f"""
+                    INSERT INTO semantic_qa_attempts (
+                        idempotency_key, user_tg_id, chat_id, local_day,
+                        slot_number, status, outcome, delivery_started_at, finalized_at
+                    ) VALUES (
+                        $1, $2, -100404, CURRENT_DATE,
+                        $3, $4, $5, {delivery_sql or "NULL"}, {finalized_sql or "NULL"}
+                    )
+                    """,
+                    f"schema-invalid-{index}",
+                    989200000000 + index,
+                    slot,
+                    status,
+                    outcome,
+                )
+            await transaction.rollback()
+
+        transaction = conn.transaction()
+        await transaction.start()
+        with pytest.raises(asyncpg.CheckViolationError):
+            await conn.execute(
+                """
+                INSERT INTO llm_usage_ledger (
+                    provider, model, prompt_hash, tokens_in, tokens_out,
+                    cost_usd, latency_ms, cache_hit, call_type
+                ) VALUES (
+                    'openai', 'text-embedding-3-small', repeat('a', 64),
+                    -1, 0, 0, 0, FALSE, 'semantic_embedding'
+                )
+                """
+            )
+        await transaction.rollback()
+    finally:
+        await conn.close()
+
+
+async def test_089_classifies_only_evidenced_authors_and_roundtrips(
+    temp_database_url: str,
+) -> None:
+    _run_alembic(temp_database_url, "upgrade", "088")
+    conn = await asyncpg.connect(**_asyncpg_kwargs(make_url(temp_database_url)))
+    try:
+        await conn.execute(
+            """
+            INSERT INTO users (id, first_name, is_member, is_admin) VALUES
+                (989000000101, 'Member', TRUE, FALSE),
+                (989000000102, 'Admin', FALSE, TRUE),
+                (989000000103, 'Imported human', FALSE, FALSE),
+                (989000000104, 'Chat raw human', FALSE, FALSE),
+                (989000000105, 'Live human', FALSE, FALSE),
+                (989000000106, 'Edited bot', FALSE, FALSE),
+                (989000000107, 'Unknown', FALSE, FALSE),
+                (989000000108, 'Channel', FALSE, FALSE),
+                (989000000109, 'True wins', TRUE, FALSE)
+            """
+        )
+        ingestion_run_id = await conn.fetchval(
+            """
+            INSERT INTO ingestion_runs (run_type, status)
+            VALUES ('import', 'completed')
+            RETURNING id
+            """
+        )
+        await conn.execute(
+            """
+            INSERT INTO telegram_updates (
+                update_id, update_type, raw_json, ingestion_run_id
+            ) VALUES
+                (NULL, 'import_message',
+                 '{"from_id":"user989000000103"}'::json, $1),
+                (NULL, 'import_message',
+                 '{"from_id":"channel989000000108"}'::json, $1),
+                (989000000105, 'message',
+                 '{"message":{"from_user":{"id":989000000105,"is_bot":false}}}'::json,
+                 NULL),
+                (989000000106, 'edited_message',
+                 '{"edited_message":{"from_user":{"id":989000000106,"is_bot":true}}}'::json,
+                 NULL),
+                (989000000109, 'message',
+                 '{"message":{"from_user":{"id":989000000109,"is_bot":true}}}'::json,
+                 NULL),
+                (989000000110, 'edited_message',
+                 '{"edited_message":{"from_user":{"id":989000000109,"is_bot":false}}}'::json,
+                 NULL),
+                (989000000107, 'message',
+                 '{"message":{"from_user":{"id":989000000107,"is_bot":"invalid"}}}'::json,
+                 NULL)
+            """,
+            ingestion_run_id,
+        )
+        await conn.execute(
+            """
+            INSERT INTO chat_messages (
+                message_id, chat_id, user_id, text, date, raw_json
+            ) VALUES (
+                989000000104, -100989000000104, 989000000104,
+                'human evidence', now(),
+                '{"from_user":{"id":989000000104,"is_bot":false}}'::json
+            )
+            """
+        )
+    finally:
+        await conn.close()
+
+    expected = {
+        989000000101: None,
+        989000000102: None,
+        989000000103: None,
+        989000000104: False,
+        989000000105: False,
+        989000000106: True,
+        989000000107: None,
+        989000000108: None,
+        989000000109: True,
+    }
+    for _ in range(2):
+        _run_alembic(temp_database_url, "upgrade", "089")
+        conn = await asyncpg.connect(**_asyncpg_kwargs(make_url(temp_database_url)))
+        try:
+            rows = await conn.fetch(
+                "SELECT id, is_bot FROM users WHERE id BETWEEN 989000000101 AND 989000000109"
+            )
+        finally:
+            await conn.close()
+        assert {row["id"]: row["is_bot"] for row in rows} == expected
+        _run_alembic(temp_database_url, "downgrade", "088")
+
+
+def test_089_downgrade_guard_names_every_semantic_table() -> None:
+    migration = (PROJECT_ROOT / "alembic/versions/089_semantic_qa.py").read_text(encoding="utf-8")
+    for table_name in (
+        "semantic_index_runs",
+        "semantic_retrieval_units",
+        "semantic_retrieval_unit_sources",
+        "semantic_qa_attempts",
+        "semantic_retrieval_traces",
+    ):
+        assert f"SELECT 1 FROM {table_name}" in migration
+
+
+async def test_089_downgrade_fails_closed_with_index_audit_row(
+    temp_database_url: str,
+) -> None:
+    _run_alembic(temp_database_url, "upgrade", "089")
+    conn = await asyncpg.connect(**_asyncpg_kwargs(make_url(temp_database_url)))
+    try:
+        await conn.execute(
+            """
+            INSERT INTO semantic_index_runs (
+                run_type, embedding_provider, embedding_model,
+                embedding_dimensions, status
+            ) VALUES (
+                'backfill', 'openai', 'text-embedding-3-small', 1536, 'running'
+            )
+            """
+        )
+    finally:
+        await conn.close()
+
+    result = _run_alembic(temp_database_url, "downgrade", "088", check=False)
+    assert result.returncode != 0
+    assert "Cannot downgrade 089 with semantic Q&A audit data" in (result.stdout + result.stderr)
+    assert await _fetch_value(temp_database_url, "SELECT version_num FROM alembic_version") == "089"
+
+
+async def test_089_downgrade_fails_closed_with_semantic_embedding_audit(
+    temp_database_url: str,
+) -> None:
+    _run_alembic(temp_database_url, "upgrade", "089")
+    conn = await asyncpg.connect(**_asyncpg_kwargs(make_url(temp_database_url)))
+    try:
+        await conn.execute(
+            """
+            INSERT INTO llm_usage_ledger (
+                provider, model, prompt_hash, tokens_in, tokens_out,
+                cost_usd, latency_ms, cache_hit, call_type
+            ) VALUES (
+                'openai', 'text-embedding-3-small', repeat('a', 64),
+                1, 0, 0.000001, 1, FALSE, 'semantic_embedding'
+            )
+            """
+        )
+    finally:
+        await conn.close()
+
+    result = _run_alembic(temp_database_url, "downgrade", "088", check=False)
+    assert result.returncode != 0
+    assert "Cannot downgrade 089 with semantic Q&A audit data" in (result.stdout + result.stderr)
+    assert await _fetch_value(temp_database_url, "SELECT version_num FROM alembic_version") == "089"
 
 
 async def test_080_message_media_and_ledger_call_types(

--- a/tests/db/test_digests_review_schema.py
+++ b/tests/db/test_digests_review_schema.py
@@ -196,13 +196,33 @@ async def test_089_schema_pins_jsonb_delivery_and_numeric_constraints(
             )
             == 1
         )
+        unit_columns = await conn.fetch(
+            """
+            SELECT column_name, data_type, is_nullable
+            FROM information_schema.columns
+            WHERE table_schema = 'public'
+              AND table_name = 'semantic_retrieval_units'
+              AND column_name IN ('embedding_status', 'chunk_text', 'embedding', 'indexed_at')
+            ORDER BY column_name
+            """
+        )
+        assert [
+            (row["column_name"], row["data_type"], row["is_nullable"]) for row in unit_columns
+        ] == [
+            ("chunk_text", "text", "YES"),
+            ("embedding", "USER-DEFINED", "YES"),
+            ("embedding_status", "character varying", "NO"),
+            ("indexed_at", "timestamp with time zone", "YES"),
+        ]
         constraints = await conn.fetch(
             """
             SELECT conname, convalidated
             FROM pg_constraint
             WHERE conname IN (
                 'ck_llm_usage_ledger_nonnegative_usage',
-                'ck_semantic_attempts_state'
+                'ck_semantic_attempts_state',
+                'ck_semantic_units_embedding_state',
+                'ck_semantic_units_embedding_status'
             )
             ORDER BY conname
             """
@@ -210,6 +230,8 @@ async def test_089_schema_pins_jsonb_delivery_and_numeric_constraints(
         assert [(row["conname"], row["convalidated"]) for row in constraints] == [
             ("ck_llm_usage_ledger_nonnegative_usage", True),
             ("ck_semantic_attempts_state", True),
+            ("ck_semantic_units_embedding_state", True),
+            ("ck_semantic_units_embedding_status", True),
         ]
     finally:
         await conn.close()

--- a/tests/db/test_feature_flag_repo.py
+++ b/tests/db/test_feature_flag_repo.py
@@ -104,6 +104,33 @@ async def test_per_scope_flags_coexist_with_global(db_session) -> None:
     ) is True
 
 
+async def test_any_enabled_detects_scoped_canary_while_global_is_off(db_session) -> None:
+    from bot.db.repos.feature_flag import FeatureFlagRepo
+
+    key = _unique_flag_key()
+
+    await FeatureFlagRepo.set_enabled(db_session, flag_key=key, enabled=False)
+    await FeatureFlagRepo.set_enabled(
+        db_session,
+        flag_key=key,
+        enabled=True,
+        scope_type="user",
+        scope_id="8040400404",
+    )
+
+    assert await FeatureFlagRepo.get(db_session, key) is False
+    assert await FeatureFlagRepo.any_enabled(db_session, key) is True
+
+    await FeatureFlagRepo.set_enabled(
+        db_session,
+        flag_key=key,
+        enabled=False,
+        scope_type="user",
+        scope_id="8040400404",
+    )
+    assert await FeatureFlagRepo.any_enabled(db_session, key) is False
+
+
 async def test_memory_flags_have_no_enabled_seed_rows(db_session) -> None:
     """T1-01 invariant: the migration MUST NOT seed any ENABLED memory.* flag.
 

--- a/tests/db/test_fts_schema.py
+++ b/tests/db/test_fts_schema.py
@@ -196,8 +196,9 @@ async def test_alembic_upgrade_head_on_clean_db_green(migrated_database_url: str
     # + T12-06-fix C2 (076 butler_tool_invocations.posted_message_id).
     # + T12-07 (077 butler_undo_invocations table + status widened with 'undone').
     # + T12-07-fix C1 (078 butler_tool_invocations.inverse_op_payload column).
+    # + Phase 13 semantic Q&A retrieval/quota/provenance/audit schema (089).
     # Assert the current head explicitly; revisit when future migrations land.
-    assert current == "088"
+    assert current == "089"
 
 
 async def test_insert_message_versions_generates_search_tsv_from_normalized_text(

--- a/tests/db/test_llm_usage_ledger_repo.py
+++ b/tests/db/test_llm_usage_ledger_repo.py
@@ -269,9 +269,7 @@ async def test_monthly_cost_usd_respects_calendar_month(db_session) -> None:
     )
     await db_session.flush()
 
-    total = await LedgerRepo.monthly_cost_usd(
-        db_session, year=target_year, month=target_month
-    )
+    total = await LedgerRepo.monthly_cost_usd(db_session, year=target_year, month=target_month)
 
     # Only the two March rows should sum: 0.300000 + 0.200000 = 0.500000
     assert total == Decimal("0.500000"), f"expected 0.500000, got {total}"
@@ -326,6 +324,43 @@ async def test_update_placeholder_updates_row_and_returns_one(db_session) -> Non
     assert updated.request_id == "req-xyz"
     assert updated.response_hash == "c" * 64
     assert updated.error is None
+
+
+async def test_update_placeholder_never_resurrects_redacted_response_hash(db_session) -> None:
+    from bot.db.models import LlmUsageLedger
+    from bot.db.repos.llm_usage_ledger import LedgerRepo
+
+    placeholder = LlmUsageLedger(
+        provider="openai",
+        model="text-embedding-3-small",
+        prompt_hash=None,
+        response_hash=None,
+        tokens_in=0,
+        tokens_out=0,
+        cost_usd=Decimal("0"),
+        latency_ms=0,
+        cache_hit=False,
+        error=None,
+        call_type="semantic_embedding",
+    )
+    db_session.add(placeholder)
+    await db_session.flush()
+
+    await LedgerRepo.update_placeholder(
+        db_session,
+        llm_call_id=placeholder.id,
+        tokens_in=12,
+        tokens_out=0,
+        cost_usd=Decimal("0.000001"),
+        latency_ms=5,
+        request_id="req-redacted",
+        response_hash="d" * 64,
+        error=None,
+    )
+    await db_session.refresh(placeholder)
+
+    assert placeholder.prompt_hash is None
+    assert placeholder.response_hash is None
 
 
 # ─── Test 8: update_placeholder raises LookupError when id not found ─────────

--- a/tests/db/test_user_repo.py
+++ b/tests/db/test_user_repo.py
@@ -135,6 +135,34 @@ async def test_upsert_returns_row_after_update(db_session) -> None:
     assert updated.last_name == "Iteration"
 
 
+async def test_upsert_preserves_known_bot_classification_when_update_is_unknown(
+    db_session,
+) -> None:
+    """A partial event cannot erase explicit Telegram author evidence."""
+    from bot.db.repos.user import UserRepo
+
+    telegram_id = _random_test_id()
+    created = await UserRepo.upsert(
+        db_session,
+        telegram_id=telegram_id,
+        username="classified",
+        first_name="Classified",
+        last_name=None,
+        is_bot=False,
+    )
+    assert created.is_bot is False
+
+    updated = await UserRepo.upsert(
+        db_session,
+        telegram_id=telegram_id,
+        username="renamed",
+        first_name="Classified",
+        last_name=None,
+        is_bot=None,
+    )
+    assert updated.is_bot is False
+
+
 def test_engine_rejects_sqlite_url(monkeypatch) -> None:
     """Engine module must refuse a sqlite URL with a clear error pointing at T0-02."""
     monkeypatch.setenv("DATABASE_URL", "sqlite+aiosqlite:///vibe_gatekeeper.db")

--- a/tests/eval/test_qa_llm_eval_cases.py
+++ b/tests/eval/test_qa_llm_eval_cases.py
@@ -129,6 +129,7 @@ async def _seed_user(db_session, user_id: int) -> None:
         username=f"llmeval_{user_id}",
         first_name=f"LLMEval {user_id}",
         last_name=None,
+        is_bot=False,
     )
 
 

--- a/tests/evals/test_no_llm_imports.py
+++ b/tests/evals/test_no_llm_imports.py
@@ -47,6 +47,7 @@ ALLOWED_LLM_IMPORT_FILES: frozenset[str] = frozenset(
         "bot/services/llm_providers/anthropic.py",
         "bot/services/llm_providers/deepseek.py",
         "bot/services/llm_providers/openai.py",
+        "bot/services/llm_providers/openai_embeddings.py",
         "bot/services/llm_providers/openai_vision.py",
     ]
 )
@@ -268,6 +269,7 @@ def test_no_llm_provider_urls_outside_gateway() -> None:
             "bot/services/llm_providers/anthropic.py",
             "bot/services/llm_providers/deepseek.py",
             "bot/services/llm_providers/openai.py",
+            "bot/services/llm_providers/openai_embeddings.py",
             "bot/services/llm_providers/openai_vision.py",
         ]
     )
@@ -307,6 +309,7 @@ def test_i3_allow_list_contract_documented() -> None:
             "bot/services/llm_providers/anthropic.py",
             "bot/services/llm_providers/deepseek.py",
             "bot/services/llm_providers/openai.py",
+            "bot/services/llm_providers/openai_embeddings.py",
             "bot/services/llm_providers/openai_vision.py",
         ]
     ), (

--- a/tests/handlers/test_qa_mentions.py
+++ b/tests/handlers/test_qa_mentions.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+from dataclasses import replace
 from datetime import datetime, timezone
 from decimal import Decimal
 from html.parser import HTMLParser
 import re
+from contextlib import asynccontextmanager
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock
 
@@ -38,6 +40,18 @@ FAKE_SECRET_FAMILIES = (
         id="named-assignment",
     ),
 )
+
+
+@pytest.fixture(autouse=True)
+def _mock_semantic_delivery_intent(monkeypatch, app_env):
+    """Handler tests isolate orchestration from the real PostgreSQL repo."""
+
+    handler = import_module("bot.handlers.qa")
+    marker = AsyncMock()
+    monkeypatch.setattr(handler.SemanticQuotaRepo, "mark_delivery_started", marker)
+    return marker
+
+
 FAKE_HIGHLIGHT_SPLIT_SECRETS = (
     pytest.param(
         "<b>token</b>=Az9!FAKE_SECRET_0123456789",
@@ -145,15 +159,85 @@ def _qa_result(
     )
 
 
-def _flag_get(handler, *, qa: bool = True, llm: bool = True) -> AsyncMock:
-    async def get(_session, key: str) -> bool:
+def _flag_get(
+    handler,
+    *,
+    qa: bool = True,
+    llm: bool = True,
+    semantic: bool = False,
+) -> AsyncMock:
+    async def get(
+        _session,
+        key: str,
+        scope_type: str | None = None,
+        scope_id: str | None = None,
+    ) -> bool:
         if key == handler.QA_FEATURE_FLAG:
             return qa
         if key == handler.LLM_SYNTHESIS_FEATURE_FLAG:
             return llm
+        if key == handler.SEMANTIC_QA_FEATURE_FLAG:
+            return semantic if scope_type is None and scope_id is None else False
         raise AssertionError(f"unexpected flag: {key}")
 
     return AsyncMock(side_effect=get)
+
+
+def test_five_source_footer_retains_clickable_links_with_worst_case_text() -> None:
+    handler = import_module("bot.handlers.qa")
+    base = _qa_result(snippet="<>&" * 2_000).bundle
+    item = base.items[0]
+    bundle = replace(
+        base,
+        items=tuple(
+            replace(
+                item,
+                message_version_id=101 + index,
+                chat_message_id=10 + index,
+                message_id=77 + index,
+                user_id=2002 + index,
+            )
+            for index in range(5)
+        ),
+    )
+    users = {
+        2002 + index: SimpleNamespace(first_name="А" * 2_000, last_name="Б" * 2_000)
+        for index in range(5)
+    }
+
+    rendered = handler._format_bounded_mention_response("О" * 10_000, bundle, users)
+
+    _assert_bounded_valid_html(rendered)
+    assert rendered.count('<a href="https://t.me/c/1234567890/') == 5
+
+
+def test_semantic_trace_binding_flattens_card_provenance() -> None:
+    qa_service = import_module("bot.services.qa")
+    from bot.services.evidence import EvidenceBundle, EvidenceItem
+
+    now = datetime(2026, 7, 16, 12, tzinfo=timezone.utc)
+    card = EvidenceItem(
+        message_version_id=101,
+        chat_message_id=10,
+        chat_id=COMMUNITY_CHAT_ID,
+        message_id=77,
+        user_id=2002,
+        snippet="approved card",
+        ts_rank=0.9,
+        captured_at=now,
+        message_date=now,
+        source_type="card",
+        card_source_message_version_ids=(101, 102, 103),
+    )
+    message = replace(
+        card,
+        message_version_id=104,
+        source_type="message",
+        card_source_message_version_ids=(),
+    )
+    bundle = EvidenceBundle("q", COMMUNITY_CHAT_ID, (card, message), False, now)
+
+    assert qa_service._semantic_evidence_provenance_ids(bundle) == [101, 102, 103, 104]
 
 
 def _patch_common(handler, monkeypatch, *, member: bool = True) -> None:
@@ -942,7 +1026,8 @@ async def test_redelivered_question_does_not_consume_second_llm_slot(monkeypatch
     run_qa.assert_not_awaited()
     quota.assert_not_awaited()
     synthesize.assert_not_awaited()
-    assert message.reply.await_args.args[0] == handler.SENSITIVE_QA_REFUSAL
+    assert "сохранённый ответ повторно не показывается" in message.reply.await_args.args[0]
+    assert FAKE_OPENAI_KEY not in message.reply.await_args.args[0]
     assert "Уже сохранённый ответ" not in message.reply.call_args.args[0]
     assert FAKE_OPENAI_KEY not in message.reply.await_args.args[0]
     _assert_bounded_valid_html(message.reply.await_args.args[0])
@@ -987,3 +1072,1044 @@ async def test_redelivered_sensitive_query_is_refused_without_duplicate_trace(
     run_qa.assert_not_awaited()
     quota.assert_not_awaited()
     synthesize.assert_not_awaited()
+
+
+async def test_redelivered_semantic_answer_never_replays_stored_content(monkeypatch) -> None:
+    handler = import_module("bot.handlers.qa")
+    message = _message()
+    session = AsyncMock()
+    rendered = (
+        'Ответ [1]\n\n<b>Источники:</b>\n[1] <a href="https://t.me/c/1234567890/77">источник</a>'
+    )
+    _patch_common(handler, monkeypatch)
+    monkeypatch.setattr(handler.FeatureFlagRepo, "get", _flag_get(handler, semantic=True))
+    monkeypatch.setattr(
+        handler.QaTraceRepo,
+        "get_by_source_chat_message_id",
+        AsyncMock(
+            return_value=SimpleNamespace(
+                llm_response_summary=f"{handler._SEMANTIC_REPLAY_HTML_PREFIX}{rendered}"
+            )
+        ),
+    )
+    semantic = AsyncMock()
+    monkeypatch.setattr(handler, "_semantic_mention_question", semantic)
+
+    await handler.mention_question_handler(message, _question(), session)
+
+    semantic.assert_not_awaited()
+    assert rendered not in message.reply.await_args.args[0]
+    assert "сохранённый ответ повторно не показывается" in message.reply.await_args.args[0]
+
+
+async def test_semantic_feature_routes_before_legacy_retrieval(monkeypatch) -> None:
+    handler = import_module("bot.handlers.qa")
+    message = _message()
+    session = AsyncMock()
+    semantic_handler = AsyncMock()
+    legacy = AsyncMock()
+
+    _patch_common(handler, monkeypatch)
+    monkeypatch.setattr(
+        handler.FeatureFlagRepo,
+        "get",
+        _flag_get(handler, semantic=True),
+    )
+    monkeypatch.setattr(handler, "_semantic_mention_question", semantic_handler)
+    monkeypatch.setattr(handler, "run_qa", legacy)
+
+    await handler.mention_question_handler(message, _question(), session)
+
+    semantic_handler.assert_awaited_once_with(
+        message=message,
+        session=session,
+        sender_id=1001,
+        persisted_chat_message_id=8501,
+        query="что решили про память?",
+        query_redacted=False,
+    )
+    legacy.assert_not_awaited()
+
+
+async def test_semantic_user_scoped_flag_routes_when_global_is_off(monkeypatch) -> None:
+    handler = import_module("bot.handlers.qa")
+    message = _message(user_id=1001)
+    session = AsyncMock()
+    semantic_handler = AsyncMock()
+    legacy = AsyncMock()
+
+    async def flag_get(_session, key, scope_type=None, scope_id=None):
+        if key in (handler.QA_FEATURE_FLAG, handler.LLM_SYNTHESIS_FEATURE_FLAG):
+            return True
+        if key == handler.SEMANTIC_QA_FEATURE_FLAG:
+            return scope_type == "user" and scope_id == "1001"
+        raise AssertionError(key)
+
+    _patch_common(handler, monkeypatch)
+    monkeypatch.setattr(handler.FeatureFlagRepo, "get", AsyncMock(side_effect=flag_get))
+    monkeypatch.setattr(handler, "_semantic_mention_question", semantic_handler)
+    monkeypatch.setattr(handler, "run_qa", legacy)
+
+    await handler.mention_question_handler(message, _question(), session)
+
+    semantic_handler.assert_awaited_once()
+    legacy.assert_not_awaited()
+    scoped_call = handler.FeatureFlagRepo.get.await_args_list[-1]
+    assert scoped_call.kwargs == {"scope_type": "user", "scope_id": "1001"}
+
+
+async def test_semantic_user_scoped_flag_does_not_enable_other_user(monkeypatch) -> None:
+    handler = import_module("bot.handlers.qa")
+    message = _message(user_id=1002)
+    session = AsyncMock()
+    semantic_handler = AsyncMock()
+    lexical = AsyncMock(return_value=_qa_result(abstained=True))
+
+    async def flag_get(_session, key, scope_type=None, scope_id=None):
+        if key in (handler.QA_FEATURE_FLAG, handler.LLM_SYNTHESIS_FEATURE_FLAG):
+            return True
+        if key == handler.SEMANTIC_QA_FEATURE_FLAG:
+            return scope_type == "user" and scope_id == "1001"
+        raise AssertionError(key)
+
+    _patch_common(handler, monkeypatch)
+    monkeypatch.setattr(handler.FeatureFlagRepo, "get", AsyncMock(side_effect=flag_get))
+    monkeypatch.setattr(handler, "_semantic_mention_question", semantic_handler)
+    monkeypatch.setattr(handler, "run_qa", lexical)
+    monkeypatch.setattr(handler, "_write_trace", AsyncMock())
+
+    await handler.mention_question_handler(message, _question(), session)
+
+    semantic_handler.assert_not_awaited()
+    lexical.assert_awaited_once()
+    assert "Не нашёл достаточно" in message.reply.await_args.args[0]
+
+
+async def test_semantic_third_question_calls_only_ordinary_search(monkeypatch) -> None:
+    handler = import_module("bot.handlers.qa")
+    message = _message()
+    session = AsyncMock()
+    semantic = AsyncMock()
+    synthesize = AsyncMock()
+    ordinary = _qa_result()
+
+    monkeypatch.setattr(
+        handler.SemanticQuotaRepo,
+        "reserve",
+        AsyncMock(
+            return_value=SimpleNamespace(
+                allowed=False,
+                attempt_id=3003,
+                used=2,
+                limit=2,
+            )
+        ),
+    )
+    monkeypatch.setattr(handler, "run_semantic_qa", semantic)
+    monkeypatch.setattr(handler, "synthesize_answer", synthesize)
+    monkeypatch.setattr(
+        handler,
+        "_ordinary_search_result",
+        AsyncMock(return_value=ordinary),
+    )
+    monkeypatch.setattr(
+        handler,
+        "_bundle_users",
+        AsyncMock(return_value=({}, False)),
+    )
+    monkeypatch.setattr(handler, "_write_trace", AsyncMock())
+    reply_ordinary = AsyncMock()
+    monkeypatch.setattr(
+        handler,
+        "_reply_with_governed_ordinary_search",
+        reply_ordinary,
+    )
+
+    await handler._semantic_mention_question(
+        message=message,
+        session=session,
+        sender_id=1001,
+        persisted_chat_message_id=8501,
+        query="что решили про память?",
+        query_redacted=False,
+    )
+
+    semantic.assert_not_awaited()
+    synthesize.assert_not_awaited()
+    reply_ordinary.assert_awaited_once()
+    assert "Embedding и AI-синтез не вызывались" in reply_ordinary.await_args.kwargs["notice"]
+
+
+async def test_semantic_empty_retrieval_consumes_abstention_slot(monkeypatch) -> None:
+    handler = import_module("bot.handlers.qa")
+    message = _message()
+    session = AsyncMock()
+    empty = _qa_result(abstained=True)
+    finalize = AsyncMock()
+
+    monkeypatch.setattr(
+        handler.SemanticQuotaRepo,
+        "reserve",
+        AsyncMock(
+            return_value=SimpleNamespace(
+                allowed=True,
+                attempt_id=3004,
+                used=0,
+                limit=2,
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        handler,
+        "run_semantic_qa",
+        AsyncMock(
+            return_value=SimpleNamespace(
+                bundle=empty.bundle,
+                embedding_llm_call_id=4004,
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        handler.QaTraceRepo,
+        "create",
+        AsyncMock(return_value=SimpleNamespace(id=5004)),
+    )
+    monkeypatch.setattr(handler.SemanticQuotaRepo, "attach_trace", AsyncMock())
+    monkeypatch.setattr(handler.SemanticQuotaRepo, "finalize", finalize)
+
+    await handler._semantic_mention_question(
+        message=message,
+        session=session,
+        sender_id=1001,
+        persisted_chat_message_id=8501,
+        query="нет ответа",
+        query_redacted=False,
+    )
+
+    assert finalize.await_args.kwargs["outcome"] == "abstained"
+    assert finalize.await_args.kwargs["embedding_llm_call_id"] == 4004
+    assert "Не нашёл достаточно" in message.reply.await_args.args[0]
+
+
+async def test_semantic_trace_is_committed_before_embedding_dispatch(monkeypatch) -> None:
+    handler = import_module("bot.handlers.qa")
+    message = _message()
+    session = AsyncMock()
+    events: list[str] = []
+
+    async def commit() -> None:
+        events.append("commit")
+
+    async def create(*_args, **_kwargs):
+        events.append("trace")
+        return SimpleNamespace(id=5015)
+
+    async def attach(*_args, **_kwargs) -> None:
+        events.append("attach")
+
+    async def run(*_args, **_kwargs):
+        events.append("embedding")
+        return SimpleNamespace(
+            bundle=_qa_result(abstained=True).bundle,
+            embedding_llm_call_id=4015,
+        )
+
+    session.commit.side_effect = commit
+    monkeypatch.setattr(
+        handler.SemanticQuotaRepo,
+        "reserve",
+        AsyncMock(
+            return_value=SimpleNamespace(
+                allowed=True,
+                replayed=False,
+                attempt_id=3015,
+                limit=2,
+            )
+        ),
+    )
+    monkeypatch.setattr(handler.QaTraceRepo, "create", create)
+    monkeypatch.setattr(handler.SemanticQuotaRepo, "attach_trace", attach)
+    monkeypatch.setattr(handler.SemanticQuotaRepo, "finalize", AsyncMock())
+    monkeypatch.setattr(handler, "run_semantic_qa", run)
+
+    await handler._semantic_mention_question(
+        message=message,
+        session=session,
+        sender_id=1001,
+        persisted_chat_message_id=8501,
+        query="порядок",
+        query_redacted=False,
+    )
+
+    assert events[:5] == ["commit", "trace", "attach", "commit", "embedding"]
+
+
+async def test_semantic_embedding_failure_releases_slot(monkeypatch) -> None:
+    handler = import_module("bot.handlers.qa")
+    from bot.services.llm_providers import ProviderTransientError
+
+    message = _message()
+    session = AsyncMock()
+    failure = ProviderTransientError("timeout", message="provider timeout")
+    failure.llm_usage_ledger_id = 4005
+    finalize = AsyncMock()
+
+    monkeypatch.setattr(
+        handler.SemanticQuotaRepo,
+        "reserve",
+        AsyncMock(
+            return_value=SimpleNamespace(
+                allowed=True,
+                attempt_id=3005,
+                used=0,
+                limit=2,
+            )
+        ),
+    )
+    monkeypatch.setattr(handler, "run_semantic_qa", AsyncMock(side_effect=failure))
+    monkeypatch.setattr(
+        handler,
+        "_ordinary_search_result",
+        AsyncMock(return_value=_qa_result()),
+    )
+    monkeypatch.setattr(
+        handler.QaTraceRepo,
+        "create",
+        AsyncMock(return_value=SimpleNamespace(id=5005)),
+    )
+    monkeypatch.setattr(handler.SemanticQuotaRepo, "attach_trace", AsyncMock())
+    monkeypatch.setattr(handler.SemanticQuotaRepo, "finalize", finalize)
+    monkeypatch.setattr(
+        handler,
+        "_bundle_users",
+        AsyncMock(return_value=({}, False)),
+    )
+    monkeypatch.setattr(
+        handler,
+        "_reply_with_governed_ordinary_search",
+        AsyncMock(),
+    )
+
+    await handler._semantic_mention_question(
+        message=message,
+        session=session,
+        sender_id=1001,
+        persisted_chat_message_id=8501,
+        query="техническая ошибка",
+        query_redacted=False,
+    )
+
+    assert finalize.await_args.kwargs["outcome"] == "technical_failure"
+    assert finalize.await_args.kwargs["embedding_llm_call_id"] == 4005
+
+
+async def test_semantic_answer_has_valid_link_and_consumes_slot(monkeypatch) -> None:
+    handler = import_module("bot.handlers.qa")
+    from bot.services.llm_gateway import AnswerWithCitations
+
+    message = _message()
+    session = AsyncMock()
+    semantic_result = _qa_result()
+    finalize = AsyncMock()
+    author = SimpleNamespace(first_name="Author", last_name=None, username="author")
+
+    monkeypatch.setattr(
+        handler.SemanticQuotaRepo,
+        "reserve",
+        AsyncMock(
+            return_value=SimpleNamespace(
+                allowed=True,
+                attempt_id=3006,
+                used=0,
+                limit=2,
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        handler,
+        "run_semantic_qa",
+        AsyncMock(
+            return_value=SimpleNamespace(
+                bundle=semantic_result.bundle,
+                embedding_llm_call_id=4006,
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        handler,
+        "_bundle_users",
+        AsyncMock(return_value=({2002: author}, False)),
+    )
+    monkeypatch.setattr(
+        handler.QaTraceRepo,
+        "create",
+        AsyncMock(return_value=SimpleNamespace(id=5006)),
+    )
+    monkeypatch.setattr(handler.SemanticQuotaRepo, "attach_trace", AsyncMock())
+    monkeypatch.setattr(handler.QaTraceRepo, "update_llm_fields", AsyncMock())
+    monkeypatch.setattr(
+        handler,
+        "filter_surviving_evidence",
+        AsyncMock(return_value=semantic_result.bundle),
+    )
+    monkeypatch.setattr(handler.SemanticQuotaRepo, "finalize", finalize)
+    monkeypatch.setattr(
+        handler,
+        "_load_gateway_config",
+        Mock(
+            return_value=SimpleNamespace(
+                provider="deepseek",
+                model="deepseek-v4-flash",
+            )
+        ),
+    )
+    monkeypatch.setattr(handler, "_resolve_provider", Mock(return_value=object()))
+    monkeypatch.setattr(
+        handler,
+        "synthesize_answer",
+        AsyncMock(
+            return_value=AnswerWithCitations(
+                answer_text="Решение подтверждено [[mv:101]]",
+                citation_ids=(101,),
+                cost_usd=Decimal("0.001"),
+                cache_hit=False,
+                llm_call_id=6006,
+                surviving_evidence_ids=(101,),
+            )
+        ),
+    )
+
+    await handler._semantic_mention_question(
+        message=message,
+        session=session,
+        sender_id=1001,
+        persisted_chat_message_id=8501,
+        query="что решили",
+        query_redacted=False,
+    )
+
+    assert finalize.await_args.kwargs["outcome"] == "answered"
+    assert handler.synthesize_answer.await_args.kwargs["max_evidence_items"] == 5
+    assert handler.synthesize_answer.await_args.kwargs["durable_placeholder"] is True
+    assert handler.synthesize_answer.await_args.kwargs["revalidate_after_provider"] is True
+    handler.SemanticQuotaRepo.attach_trace.assert_awaited_once_with(
+        session,
+        attempt_id=3006,
+        qa_trace_id=5006,
+    )
+    reply = message.reply.await_args.args[0]
+    assert "Решение подтверждено [1]" in reply
+    assert 'href="https://t.me/c/1234567890/77"' in reply
+    assert "[[mv:" not in reply
+    stored_summary = handler.QaTraceRepo.update_llm_fields.await_args.kwargs["llm_response_summary"]
+    assert stored_summary.startswith(handler._SEMANTIC_REPLAY_HTML_PREFIX)
+    assert 'href="https://t.me/c/1234567890/77"' in stored_summary
+
+
+async def test_semantic_reserved_replay_never_dispatches_providers(monkeypatch) -> None:
+    handler = import_module("bot.handlers.qa")
+    message = _message()
+    session = AsyncMock()
+    semantic = AsyncMock()
+    synthesis = AsyncMock()
+
+    monkeypatch.setattr(
+        handler.SemanticQuotaRepo,
+        "reserve",
+        AsyncMock(
+            return_value=SimpleNamespace(
+                allowed=False,
+                replayed=True,
+                status="reserved",
+                outcome=None,
+                attempt_id=3010,
+                limit=2,
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        handler.QaTraceRepo,
+        "get_by_source_chat_message_id",
+        AsyncMock(return_value=SimpleNamespace(llm_response_summary=None)),
+    )
+    monkeypatch.setattr(handler, "run_semantic_qa", semantic)
+    monkeypatch.setattr(handler, "synthesize_answer", synthesis)
+
+    await handler._semantic_mention_question(
+        message=message,
+        session=session,
+        sender_id=1001,
+        persisted_chat_message_id=8501,
+        query="повтор",
+        query_redacted=False,
+    )
+
+    semantic.assert_not_awaited()
+    synthesis.assert_not_awaited()
+    assert "уже обрабатывается" in message.reply.await_args.args[0]
+
+
+async def test_semantic_answer_replay_never_emits_stored_content(monkeypatch) -> None:
+    handler = import_module("bot.handlers.qa")
+    message = _message()
+    session = AsyncMock()
+    rendered = (
+        'Готово [1]\n\n<b>Источники:</b>\n[1] <a href="https://t.me/c/1234567890/77">источник</a>'
+    )
+
+    monkeypatch.setattr(
+        handler.SemanticQuotaRepo,
+        "reserve",
+        AsyncMock(
+            return_value=SimpleNamespace(
+                allowed=False,
+                replayed=True,
+                status="consumed",
+                outcome="answered",
+                attempt_id=3011,
+                limit=2,
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        handler.QaTraceRepo,
+        "get_by_source_chat_message_id",
+        AsyncMock(
+            return_value=SimpleNamespace(
+                llm_response_summary=f"{handler._SEMANTIC_REPLAY_HTML_PREFIX}{rendered}"
+            )
+        ),
+    )
+    semantic = AsyncMock()
+    synthesis = AsyncMock()
+    monkeypatch.setattr(handler, "run_semantic_qa", semantic)
+    monkeypatch.setattr(handler, "synthesize_answer", synthesis)
+
+    await handler._semantic_mention_question(
+        message=message,
+        session=session,
+        sender_id=1001,
+        persisted_chat_message_id=8501,
+        query="повтор",
+        query_redacted=False,
+    )
+
+    semantic.assert_not_awaited()
+    synthesis.assert_not_awaited()
+    assert rendered not in message.reply.await_args.args[0]
+    assert "провайдеры повторно не вызывались" in message.reply.await_args.args[0]
+
+
+@pytest.mark.parametrize(
+    ("reason", "expected_outcome"),
+    [("all_filtered", "abstained"), ("budget_exceeded", "technical_failure")],
+)
+async def test_semantic_abstention_classifies_quota_outcome(
+    monkeypatch,
+    reason: str,
+    expected_outcome: str,
+) -> None:
+    handler = import_module("bot.handlers.qa")
+    from bot.services.llm_gateway import Abstention
+
+    message = _message()
+    session = AsyncMock()
+    finalize = AsyncMock()
+    monkeypatch.setattr(
+        handler.SemanticQuotaRepo,
+        "reserve",
+        AsyncMock(
+            return_value=SimpleNamespace(
+                allowed=True,
+                replayed=False,
+                attempt_id=3012,
+                limit=2,
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        handler.QaTraceRepo,
+        "create",
+        AsyncMock(return_value=SimpleNamespace(id=5012)),
+    )
+    monkeypatch.setattr(handler.QaTraceRepo, "update_llm_fields", AsyncMock())
+    monkeypatch.setattr(handler.SemanticQuotaRepo, "attach_trace", AsyncMock())
+    monkeypatch.setattr(handler.SemanticQuotaRepo, "finalize", finalize)
+    monkeypatch.setattr(
+        handler,
+        "run_semantic_qa",
+        AsyncMock(
+            return_value=SimpleNamespace(
+                bundle=_qa_result().bundle,
+                embedding_llm_call_id=4012,
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        handler,
+        "_load_gateway_config",
+        Mock(return_value=SimpleNamespace(provider="deepseek", model="deepseek-v4-flash")),
+    )
+    monkeypatch.setattr(handler, "_resolve_provider", Mock(return_value=object()))
+    monkeypatch.setattr(
+        handler,
+        "synthesize_answer",
+        AsyncMock(
+            return_value=Abstention(
+                reason=reason,
+                cost_usd=Decimal("0"),
+                llm_call_id=6012,
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        handler,
+        "_reply_after_technical_release",
+        AsyncMock(),
+    )
+
+    await handler._semantic_mention_question(
+        message=message,
+        session=session,
+        sender_id=1001,
+        persisted_chat_message_id=8501,
+        query="классификация",
+        query_redacted=False,
+    )
+
+    assert finalize.await_args.kwargs["outcome"] == expected_outcome
+
+
+async def test_semantic_render_revalidation_change_abstains_without_leak(monkeypatch) -> None:
+    handler = import_module("bot.handlers.qa")
+    from bot.services.llm_gateway import AnswerWithCitations
+
+    message = _message()
+    session = AsyncMock()
+    original = _qa_result(snippet="PRIVATE-FORGOTTEN-SNIPPET")
+    empty = _qa_result(abstained=True)
+    finalize = AsyncMock()
+    monkeypatch.setattr(
+        handler.SemanticQuotaRepo,
+        "reserve",
+        AsyncMock(
+            return_value=SimpleNamespace(
+                allowed=True,
+                replayed=False,
+                attempt_id=3013,
+                limit=2,
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        handler.QaTraceRepo,
+        "create",
+        AsyncMock(return_value=SimpleNamespace(id=5013)),
+    )
+    monkeypatch.setattr(handler.QaTraceRepo, "update_retrieval_fields", AsyncMock())
+    monkeypatch.setattr(handler.QaTraceRepo, "update_llm_fields", AsyncMock())
+    monkeypatch.setattr(handler.SemanticQuotaRepo, "attach_trace", AsyncMock())
+    monkeypatch.setattr(handler.SemanticQuotaRepo, "finalize", finalize)
+    monkeypatch.setattr(
+        handler,
+        "run_semantic_qa",
+        AsyncMock(
+            return_value=SimpleNamespace(
+                bundle=original.bundle,
+                embedding_llm_call_id=4013,
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        handler,
+        "_load_gateway_config",
+        Mock(return_value=SimpleNamespace(provider="deepseek", model="deepseek-v4-flash")),
+    )
+    monkeypatch.setattr(handler, "_resolve_provider", Mock(return_value=object()))
+    monkeypatch.setattr(
+        handler,
+        "synthesize_answer",
+        AsyncMock(
+            return_value=AnswerWithCitations(
+                answer_text="Ответ [[mv:101]]",
+                citation_ids=(101,),
+                cost_usd=Decimal("0.001"),
+                cache_hit=False,
+                llm_call_id=6013,
+                surviving_evidence_ids=(101,),
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        handler,
+        "filter_surviving_evidence",
+        AsyncMock(return_value=empty.bundle),
+    )
+
+    await handler._semantic_mention_question(
+        message=message,
+        session=session,
+        sender_id=1001,
+        persisted_chat_message_id=8501,
+        query="гонка forget",
+        query_redacted=False,
+    )
+
+    assert finalize.await_args.kwargs["outcome"] == "abstained"
+    reply = message.reply.await_args.args[0]
+    assert "PRIVATE-FORGOTTEN-SNIPPET" not in reply
+    assert "Не нашёл достаточно" in reply
+
+
+async def test_semantic_technical_release_precedes_failing_ordinary_fallback(
+    monkeypatch,
+) -> None:
+    handler = import_module("bot.handlers.qa")
+    from sqlalchemy.exc import SQLAlchemyError
+    from bot.services.llm_providers import ProviderTransientError
+
+    message = _message()
+    session = AsyncMock()
+    events: list[str] = []
+    failure = ProviderTransientError("timeout", message="provider timeout")
+    failure.llm_usage_ledger_id = 4014
+
+    async def finalize(*_args, **_kwargs) -> None:
+        events.append("released")
+
+    async def fallback(*_args, **_kwargs):
+        events.append("fallback")
+        raise SQLAlchemyError("ordinary search failed")
+
+    monkeypatch.setattr(
+        handler.SemanticQuotaRepo,
+        "reserve",
+        AsyncMock(
+            return_value=SimpleNamespace(
+                allowed=True,
+                replayed=False,
+                attempt_id=3014,
+                limit=2,
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        handler.QaTraceRepo,
+        "create",
+        AsyncMock(return_value=SimpleNamespace(id=5014)),
+    )
+    monkeypatch.setattr(handler.SemanticQuotaRepo, "attach_trace", AsyncMock())
+    monkeypatch.setattr(handler.SemanticQuotaRepo, "finalize", finalize)
+    monkeypatch.setattr(handler, "run_semantic_qa", AsyncMock(side_effect=failure))
+    monkeypatch.setattr(handler, "_ordinary_search_result", fallback)
+
+    await handler._semantic_mention_question(
+        message=message,
+        session=session,
+        sender_id=1001,
+        persisted_chat_message_id=8501,
+        query="ошибка fallback",
+        query_redacted=False,
+    )
+
+    assert events == ["released", "fallback"]
+    assert "Лимит не списан" in message.reply.await_args.args[0]
+
+
+async def test_semantic_quota_consumes_only_after_successful_delivery(monkeypatch) -> None:
+    handler = import_module("bot.handlers.qa")
+    session = AsyncMock()
+    message = _message()
+    events: list[str] = []
+
+    async def reply(*_args, **_kwargs) -> None:
+        events.append("delivered")
+
+    async def finalize(*_args, **kwargs) -> None:
+        events.append(f"finalized:{kwargs['outcome']}")
+
+    async def mark_delivery(*_args, **_kwargs) -> None:
+        events.append("delivery-intent")
+
+    monkeypatch.setattr(handler, "_reply_to_mention", reply)
+    monkeypatch.setattr(handler.SemanticQuotaRepo, "mark_delivery_started", mark_delivery)
+    monkeypatch.setattr(handler.SemanticQuotaRepo, "finalize", finalize)
+
+    await handler._deliver_and_consume_semantic_attempt(
+        message,
+        session,
+        attempt_id=31,
+        outcome="answered",
+        qa_trace_id=41,
+        embedding_llm_call_id=51,
+        synthesis_llm_call_id=61,
+        reply_text="answer",
+    )
+
+    assert events == ["delivery-intent", "delivered", "finalized:answered"]
+
+
+async def test_post_delivery_commit_failure_keeps_durable_delivery_intent(monkeypatch) -> None:
+    from sqlalchemy.exc import SQLAlchemyError
+
+    handler = import_module("bot.handlers.qa")
+    session = AsyncMock()
+    message = _message()
+    commits = 0
+
+    async def commit() -> None:
+        nonlocal commits
+        commits += 1
+        if commits == 3:
+            raise SQLAlchemyError("post-delivery commit failed")
+
+    intent = AsyncMock()
+    finalize = AsyncMock()
+    reply = AsyncMock()
+    session.commit.side_effect = commit
+    monkeypatch.setattr(handler.SemanticQuotaRepo, "mark_delivery_started", intent)
+    monkeypatch.setattr(handler.SemanticQuotaRepo, "finalize", finalize)
+    monkeypatch.setattr(handler, "_reply_to_mention", reply)
+
+    with pytest.raises(SQLAlchemyError, match="post-delivery"):
+        await handler._deliver_and_consume_semantic_attempt(
+            message,
+            session,
+            attempt_id=33,
+            outcome="answered",
+            qa_trace_id=43,
+            embedding_llm_call_id=53,
+            synthesis_llm_call_id=63,
+            reply_text="delivered answer",
+        )
+
+    intent.assert_awaited_once()
+    reply.assert_awaited_once()
+    finalize.assert_awaited_once()
+    assert commits == 3
+
+
+async def test_pre_delivery_intent_commit_failure_releases_slot(monkeypatch) -> None:
+    from sqlalchemy.exc import SQLAlchemyError
+
+    handler = import_module("bot.handlers.qa")
+    session = AsyncMock()
+    message = _message()
+    commits = 0
+
+    async def commit() -> None:
+        nonlocal commits
+        commits += 1
+        if commits == 2:
+            raise SQLAlchemyError("intent commit failed")
+
+    intent = AsyncMock()
+    finalize = AsyncMock()
+    reply = AsyncMock()
+    clear = AsyncMock()
+    session.commit.side_effect = commit
+    monkeypatch.setattr(handler.SemanticQuotaRepo, "mark_delivery_started", intent)
+    monkeypatch.setattr(handler.SemanticQuotaRepo, "finalize", finalize)
+    monkeypatch.setattr(handler.QaTraceRepo, "clear_undelivered_llm_summary", clear)
+    monkeypatch.setattr(handler, "_reply_to_mention", reply)
+
+    await handler._deliver_and_consume_semantic_attempt(
+        message,
+        session,
+        attempt_id=36,
+        outcome="answered",
+        qa_trace_id=46,
+        embedding_llm_call_id=56,
+        synthesis_llm_call_id=66,
+        reply_text="must not be sent",
+        clear_summary_on_failure=True,
+    )
+
+    intent.assert_awaited_once()
+    clear.assert_awaited_once_with(session, qa_trace_id=46)
+    assert finalize.await_args.kwargs == {
+        "attempt_id": 36,
+        "outcome": "technical_failure",
+        "qa_trace_id": 46,
+        "embedding_llm_call_id": 56,
+        "synthesis_llm_call_id": 66,
+    }
+    assert reply.await_count == 1
+    assert "лимит не списан" in reply.await_args.args[1]
+    assert commits == 3
+
+
+async def test_delivery_revalidation_database_failure_releases_slot(monkeypatch) -> None:
+    from sqlalchemy.exc import SQLAlchemyError
+
+    handler = import_module("bot.handlers.qa")
+    session = AsyncMock()
+    message = _message()
+    bundle = _qa_result().bundle
+
+    @asynccontextmanager
+    async def locked(*_args, **_kwargs):
+        yield
+
+    finalize = AsyncMock()
+    intent = AsyncMock()
+    reply = AsyncMock()
+    monkeypatch.setattr(handler, "hold_evidence_delivery_locks", locked)
+    monkeypatch.setattr(
+        handler,
+        "filter_surviving_evidence",
+        AsyncMock(side_effect=SQLAlchemyError("revalidation failed")),
+    )
+    monkeypatch.setattr(handler.SemanticQuotaRepo, "mark_delivery_started", intent)
+    monkeypatch.setattr(handler.SemanticQuotaRepo, "finalize", finalize)
+    monkeypatch.setattr(handler, "_reply_to_mention", reply)
+
+    await handler._deliver_and_consume_semantic_attempt(
+        message,
+        session,
+        attempt_id=37,
+        outcome="answered",
+        qa_trace_id=47,
+        embedding_llm_call_id=57,
+        synthesis_llm_call_id=67,
+        reply_text="must not be sent",
+        delivery_bundle=bundle,
+        expected_evidence_ids=tuple(bundle.evidence_ids),
+    )
+
+    intent.assert_not_awaited()
+    assert finalize.await_args.kwargs["outcome"] == "technical_failure"
+    assert finalize.await_args.kwargs["embedding_llm_call_id"] == 57
+    assert finalize.await_args.kwargs["synthesis_llm_call_id"] == 67
+    assert "лимит не списан" in reply.await_args.args[1]
+
+
+async def test_final_delivery_gate_blocks_invalidated_evidence(monkeypatch) -> None:
+    handler = import_module("bot.handlers.qa")
+    session = AsyncMock()
+    message = _message()
+    original = _qa_result().bundle
+    empty = _qa_result(abstained=True).bundle
+
+    @asynccontextmanager
+    async def unlocked(*_args, **_kwargs):
+        yield
+
+    invalidate = AsyncMock()
+    clear = AsyncMock()
+    reply = AsyncMock()
+    monkeypatch.setattr(handler, "hold_evidence_delivery_locks", unlocked)
+    monkeypatch.setattr(handler, "filter_surviving_evidence", AsyncMock(return_value=empty))
+    monkeypatch.setattr(handler.SynthesisCacheRepo, "invalidate_by_citation", invalidate)
+    monkeypatch.setattr(handler.QaTraceRepo, "clear_undelivered_llm_summary", clear)
+    monkeypatch.setattr(handler, "_reply_to_mention", reply)
+
+    with pytest.raises(handler.EvidenceInvalidatedBeforeDelivery):
+        await handler._deliver_and_consume_semantic_attempt(
+            message,
+            session,
+            attempt_id=34,
+            outcome="answered",
+            qa_trace_id=44,
+            embedding_llm_call_id=54,
+            synthesis_llm_call_id=64,
+            reply_text="must not leak",
+            clear_summary_on_failure=True,
+            delivery_bundle=original,
+            expected_evidence_ids=tuple(original.evidence_ids),
+        )
+
+    invalidate.assert_awaited()
+    clear.assert_awaited_once_with(session, qa_trace_id=44)
+    reply.assert_not_awaited()
+
+
+async def test_semantic_ambiguous_delivery_failure_consumes_and_preserves_summary(
+    monkeypatch,
+) -> None:
+    handler = import_module("bot.handlers.qa")
+    from aiogram.exceptions import TelegramNetworkError
+
+    session = AsyncMock()
+    message = _message()
+    finalize = AsyncMock()
+    clear = AsyncMock()
+    failure = TelegramNetworkError(method=object(), message="network down")
+    monkeypatch.setattr(handler, "_reply_to_mention", AsyncMock(side_effect=failure))
+    monkeypatch.setattr(handler.SemanticQuotaRepo, "finalize", finalize)
+    monkeypatch.setattr(handler.QaTraceRepo, "clear_undelivered_llm_summary", clear)
+
+    with pytest.raises(TelegramNetworkError):
+        await handler._deliver_and_consume_semantic_attempt(
+            message,
+            session,
+            attempt_id=32,
+            outcome="answered",
+            qa_trace_id=42,
+            embedding_llm_call_id=52,
+            synthesis_llm_call_id=62,
+            reply_text="undelivered answer",
+            clear_summary_on_failure=True,
+        )
+
+    clear.assert_not_awaited()
+    assert finalize.await_args.kwargs["outcome"] == "answered"
+
+
+async def test_semantic_definitive_delivery_rejection_releases_and_clears_summary(
+    monkeypatch,
+) -> None:
+    handler = import_module("bot.handlers.qa")
+    from aiogram.exceptions import TelegramForbiddenError
+
+    session = AsyncMock()
+    message = _message()
+    finalize = AsyncMock()
+    clear = AsyncMock()
+    failure = TelegramForbiddenError(method=object(), message="bot blocked")
+    monkeypatch.setattr(handler, "_reply_to_mention", AsyncMock(side_effect=failure))
+    monkeypatch.setattr(handler.SemanticQuotaRepo, "finalize", finalize)
+    monkeypatch.setattr(handler.QaTraceRepo, "clear_undelivered_llm_summary", clear)
+
+    with pytest.raises(TelegramForbiddenError):
+        await handler._deliver_and_consume_semantic_attempt(
+            message,
+            session,
+            attempt_id=35,
+            outcome="answered",
+            qa_trace_id=45,
+            embedding_llm_call_id=55,
+            synthesis_llm_call_id=65,
+            reply_text="definitively rejected answer",
+            clear_summary_on_failure=True,
+        )
+
+    clear.assert_awaited_once_with(session, qa_trace_id=45)
+    assert finalize.await_args.kwargs["outcome"] == "technical_failure"
+
+
+async def test_ordinary_delivery_gate_refuses_changed_evidence(monkeypatch) -> None:
+    handler = import_module("bot.handlers.qa")
+    session = AsyncMock()
+    message = _message()
+    original = _qa_result().bundle
+    empty = _qa_result(abstained=True).bundle
+
+    @asynccontextmanager
+    async def locked(*_args, **_kwargs):
+        yield
+
+    reply = AsyncMock()
+    monkeypatch.setattr(handler, "hold_evidence_delivery_locks", locked)
+    monkeypatch.setattr(handler, "filter_surviving_evidence", AsyncMock(return_value=empty))
+    monkeypatch.setattr(handler, "_reply_to_mention", reply)
+
+    await handler._reply_with_governed_ordinary_search(
+        message,
+        session,
+        bundle=original,
+        notice="Обычный поиск",
+    )
+
+    assert "Источники изменились" in reply.await_args.args[1]
+    assert "evidence" not in reply.await_args.args[1]

--- a/tests/handlers/test_qa_mentions.py
+++ b/tests/handlers/test_qa_mentions.py
@@ -1517,6 +1517,107 @@ async def test_semantic_trace_is_committed_before_embedding_dispatch(monkeypatch
     assert events[:5] == ["commit", "trace", "attach", "commit", "embedding"]
 
 
+@pytest.mark.parametrize(
+    ("failure_phase", "expected_trace_id", "expected_events"),
+    [
+        pytest.param(
+            "pre_trace",
+            None,
+            ("commit", "released", "commit", "fallback"),
+            id="pre-trace",
+        ),
+        pytest.param(
+            "post_trace",
+            5017,
+            ("commit", "commit", "released", "commit", "fallback"),
+            id="post-trace",
+        ),
+    ],
+)
+async def test_semantic_database_failure_releases_before_ordinary_fallback(
+    monkeypatch,
+    failure_phase: str,
+    expected_trace_id: int | None,
+    expected_events: tuple[str, ...],
+) -> None:
+    handler = import_module("bot.handlers.qa")
+    from sqlalchemy.exc import SQLAlchemyError
+
+    message = _message()
+    session = AsyncMock()
+    events: list[str] = []
+
+    @asynccontextmanager
+    async def locked(*_args, **_kwargs):
+        yield
+
+    async def commit() -> None:
+        events.append("commit")
+
+    async def record_finalize(*_args, **_kwargs) -> None:
+        events.append("released")
+
+    async def fallback(*_args, **_kwargs) -> None:
+        events.append("fallback")
+
+    governed = AsyncMock(return_value=True)
+    run_semantic = AsyncMock()
+    if failure_phase == "pre_trace":
+        governed.side_effect = SQLAlchemyError("question governance read failed")
+    else:
+        run_semantic.side_effect = SQLAlchemyError("embedding audit write failed")
+
+    session.commit.side_effect = commit
+    monkeypatch.setattr(
+        handler.SemanticQuotaRepo,
+        "reserve",
+        AsyncMock(
+            return_value=SimpleNamespace(
+                allowed=True,
+                replayed=False,
+                attempt_id=3016,
+                limit=2,
+            )
+        ),
+    )
+    monkeypatch.setattr(handler, "hold_evidence_delivery_locks", locked)
+    monkeypatch.setattr(handler, "_question_is_governed", governed)
+    create_trace = AsyncMock(return_value=SimpleNamespace(id=5017))
+    monkeypatch.setattr(
+        handler.QaTraceRepo,
+        "create",
+        create_trace,
+    )
+    monkeypatch.setattr(handler.SemanticQuotaRepo, "attach_trace", AsyncMock())
+    finalize = AsyncMock(side_effect=record_finalize)
+    monkeypatch.setattr(handler.SemanticQuotaRepo, "finalize", finalize)
+    monkeypatch.setattr(handler, "run_semantic_qa", run_semantic)
+    monkeypatch.setattr(handler, "_reply_after_technical_release", fallback)
+
+    await handler._semantic_mention_question(
+        message=message,
+        session=session,
+        sender_id=1001,
+        persisted_chat_message_id=8501,
+        question_bundle=_question_bundle(),
+        query=f"ошибка {failure_phase}",
+        query_redacted=False,
+    )
+
+    assert tuple(events) == expected_events
+    assert finalize.await_args.kwargs == {
+        "attempt_id": 3016,
+        "outcome": "technical_failure",
+        "qa_trace_id": expected_trace_id,
+    }
+    if failure_phase == "pre_trace":
+        create_trace.assert_not_awaited()
+        run_semantic.assert_not_awaited()
+    else:
+        create_trace.assert_awaited_once()
+        run_semantic.assert_awaited_once()
+
+
 async def test_semantic_embedding_failure_releases_slot(monkeypatch) -> None:
     handler = import_module("bot.handlers.qa")
     from bot.services.llm_providers import ProviderTransientError

--- a/tests/handlers/test_qa_mentions.py
+++ b/tests/handlers/test_qa_mentions.py
@@ -7,7 +7,7 @@ from html.parser import HTMLParser
 import re
 from contextlib import asynccontextmanager
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, Mock
+from unittest.mock import ANY, AsyncMock, Mock
 
 import pytest
 
@@ -49,6 +49,9 @@ def _mock_semantic_delivery_intent(monkeypatch, app_env):
     handler = import_module("bot.handlers.qa")
     marker = AsyncMock()
     monkeypatch.setattr(handler.SemanticQuotaRepo, "mark_delivery_started", marker)
+    monkeypatch.setattr(handler.SemanticQuotaRepo, "touch", AsyncMock())
+    monkeypatch.setattr(handler, "_question_is_governed", AsyncMock(return_value=True))
+    monkeypatch.setattr(handler, "persist_semantic_retrieval_trace", AsyncMock())
     return marker
 
 
@@ -106,6 +109,7 @@ def _message(*, user_id: int = 1001, text: str = "@bot память") -> SimpleN
             is_bot=False,
         ),
         message_id=500,
+        date=datetime(2026, 7, 14, 12, 0, tzinfo=timezone.utc),
         text=text,
         caption=None,
         reply=AsyncMock(),
@@ -156,6 +160,31 @@ def _qa_result(
             created_at=now,
         ),
         query_redacted=query_redacted,
+    )
+
+
+def _question_bundle():
+    from bot.services.evidence import EvidenceBundle, EvidenceItem
+
+    now = datetime(2026, 7, 14, 12, 0, tzinfo=timezone.utc)
+    return EvidenceBundle(
+        query="что решили про память?",
+        chat_id=COMMUNITY_CHAT_ID,
+        items=(
+            EvidenceItem(
+                message_version_id=9501,
+                chat_message_id=8501,
+                chat_id=COMMUNITY_CHAT_ID,
+                message_id=500,
+                user_id=1001,
+                snippet="",
+                ts_rank=1.0,
+                captured_at=now,
+                message_date=now,
+            ),
+        ),
+        abstained=False,
+        created_at=now,
     )
 
 
@@ -240,12 +269,59 @@ def test_semantic_trace_binding_flattens_card_provenance() -> None:
     assert qa_service._semantic_evidence_provenance_ids(bundle) == [101, 102, 103, 104]
 
 
+async def test_semantic_retrieval_trace_persists_only_governed_result_ranks(
+    monkeypatch,
+) -> None:
+    qa_service = import_module("bot.services.qa")
+    session = AsyncMock()
+    session.add = Mock()
+    update_retrieval = AsyncMock()
+    monkeypatch.setattr(qa_service.QaTraceRepo, "update_retrieval_fields", update_retrieval)
+    result = SimpleNamespace(
+        bundle=_qa_result().bundle,
+        embedding_model="text-embedding-3-small",
+        retrieval=SimpleNamespace(
+            candidate_ranks={
+                "message:101": {"vector": 1, "fts": 2},
+                "message:999": {"vector": 2},
+            },
+            fts_latency_ms=2,
+            vector_latency_ms=3,
+            fusion_latency_ms=1,
+            total_latency_ms=6,
+        ),
+    )
+
+    trace = await qa_service.persist_semantic_retrieval_trace(
+        session,
+        result=result,
+        query="память",
+        attempt_id=3017,
+        qa_trace_id=5017,
+    )
+
+    assert trace.result_source_ids == ["message:101"]
+    assert trace.candidate_ranks == {"message:101": {"vector": 1, "fts": 2}}
+    update_retrieval.assert_awaited_once_with(
+        session,
+        qa_trace_id=5017,
+        evidence_ids=[101],
+        abstained=False,
+    )
+    session.add.assert_called_once_with(trace)
+    session.flush.assert_awaited_once()
+
+
 def _patch_common(handler, monkeypatch, *, member: bool = True) -> None:
     monkeypatch.setattr(handler.UserRepo, "upsert", AsyncMock())
     monkeypatch.setattr(
         handler,
         "persist_message_with_policy",
-        AsyncMock(return_value=SimpleNamespace(chat_message=SimpleNamespace(id=8501))),
+        AsyncMock(
+            return_value=SimpleNamespace(
+                chat_message=SimpleNamespace(id=8501, current_version_id=9501)
+            )
+        ),
     )
     monkeypatch.setattr(
         handler.QaTraceRepo,
@@ -1125,10 +1201,104 @@ async def test_semantic_feature_routes_before_legacy_retrieval(monkeypatch) -> N
         session=session,
         sender_id=1001,
         persisted_chat_message_id=8501,
+        question_bundle=ANY,
         query="что решили про память?",
         query_redacted=False,
     )
     legacy.assert_not_awaited()
+
+
+async def test_semantic_question_forget_gate_blocks_attempt_before_provider(monkeypatch) -> None:
+    handler = import_module("bot.handlers.qa")
+    message = _message()
+    session = AsyncMock()
+    semantic = AsyncMock()
+    trace_create = AsyncMock()
+    finalize = AsyncMock()
+    monkeypatch.setattr(
+        handler.SemanticQuotaRepo,
+        "reserve",
+        AsyncMock(return_value=SimpleNamespace(allowed=True, replayed=False, attempt_id=3003)),
+    )
+    monkeypatch.setattr(handler, "_question_is_governed", AsyncMock(return_value=False))
+    monkeypatch.setattr(handler.QaTraceRepo, "create", trace_create)
+    monkeypatch.setattr(handler.SemanticQuotaRepo, "finalize", finalize)
+    monkeypatch.setattr(handler, "run_semantic_qa", semantic)
+
+    await handler._semantic_mention_question(
+        message=message,
+        session=session,
+        sender_id=1001,
+        persisted_chat_message_id=8501,
+        question_bundle=_question_bundle(),
+        query="что решили про память?",
+        query_redacted=False,
+    )
+
+    trace_create.assert_not_awaited()
+    semantic.assert_not_awaited()
+    assert finalize.await_args.kwargs["outcome"] == "technical_failure"
+    assert "удалён из памяти" in message.reply.await_args.args[0]
+    assert "лимит не списан" in message.reply.await_args.args[0]
+
+
+async def test_semantic_question_invalidation_after_embedding_blocks_synthesis(monkeypatch) -> None:
+    handler = import_module("bot.handlers.qa")
+    message = _message()
+    session = AsyncMock()
+    semantic_result = _qa_result()
+    synthesize = AsyncMock()
+    finalize = AsyncMock()
+
+    monkeypatch.setattr(
+        handler.SemanticQuotaRepo,
+        "reserve",
+        AsyncMock(return_value=SimpleNamespace(allowed=True, replayed=False, attempt_id=3016)),
+    )
+    monkeypatch.setattr(
+        handler,
+        "_question_is_governed",
+        AsyncMock(side_effect=[True, False]),
+    )
+    monkeypatch.setattr(
+        handler.QaTraceRepo,
+        "create",
+        AsyncMock(return_value=SimpleNamespace(id=5016)),
+    )
+    monkeypatch.setattr(handler.SemanticQuotaRepo, "attach_trace", AsyncMock())
+    monkeypatch.setattr(
+        handler,
+        "run_semantic_qa",
+        AsyncMock(
+            return_value=SimpleNamespace(
+                bundle=semantic_result.bundle,
+                embedding_llm_call_id=4016,
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        handler,
+        "_load_gateway_config",
+        Mock(return_value=SimpleNamespace(provider="deepseek", model="deepseek-v4-flash")),
+    )
+    monkeypatch.setattr(handler, "_resolve_provider", Mock(return_value=object()))
+    monkeypatch.setattr(handler, "synthesize_answer", synthesize)
+    monkeypatch.setattr(handler.SemanticQuotaRepo, "finalize", finalize)
+
+    await handler._semantic_mention_question(
+        message=message,
+        session=session,
+        sender_id=1001,
+        persisted_chat_message_id=8501,
+        question_bundle=_question_bundle(),
+        query="что решили про память?",
+        query_redacted=False,
+    )
+
+    synthesize.assert_not_awaited()
+    assert finalize.await_args.kwargs["outcome"] == "technical_failure"
+    assert finalize.await_args.kwargs["embedding_llm_call_id"] == 4016
+    assert "удалён из памяти" in message.reply.await_args.args[0]
 
 
 async def test_semantic_user_scoped_flag_routes_when_global_is_off(monkeypatch) -> None:
@@ -1230,6 +1400,7 @@ async def test_semantic_third_question_calls_only_ordinary_search(monkeypatch) -
         session=session,
         sender_id=1001,
         persisted_chat_message_id=8501,
+        question_bundle=_question_bundle(),
         query="что решили про память?",
         query_redacted=False,
     )
@@ -1282,6 +1453,7 @@ async def test_semantic_empty_retrieval_consumes_abstention_slot(monkeypatch) ->
         session=session,
         sender_id=1001,
         persisted_chat_message_id=8501,
+        question_bundle=_question_bundle(),
         query="нет ответа",
         query_redacted=False,
     )
@@ -1337,6 +1509,7 @@ async def test_semantic_trace_is_committed_before_embedding_dispatch(monkeypatch
         session=session,
         sender_id=1001,
         persisted_chat_message_id=8501,
+        question_bundle=_question_bundle(),
         query="порядок",
         query_redacted=False,
     )
@@ -1395,6 +1568,7 @@ async def test_semantic_embedding_failure_releases_slot(monkeypatch) -> None:
         session=session,
         sender_id=1001,
         persisted_chat_message_id=8501,
+        question_bundle=_question_bundle(),
         query="техническая ошибка",
         query_redacted=False,
     )
@@ -1412,6 +1586,19 @@ async def test_semantic_answer_has_valid_link_and_consumes_slot(monkeypatch) -> 
     semantic_result = _qa_result()
     finalize = AsyncMock()
     author = SimpleNamespace(first_name="Author", last_name=None, username="author")
+    lock_depth = 0
+    lock_entries = 0
+
+    @asynccontextmanager
+    async def sequential_lock_scope(*_args, **_kwargs):
+        nonlocal lock_depth, lock_entries
+        lock_depth += 1
+        lock_entries += 1
+        assert lock_depth == 1, "semantic governance locks must never be nested"
+        try:
+            yield
+        finally:
+            lock_depth -= 1
 
     monkeypatch.setattr(
         handler.SemanticQuotaRepo,
@@ -1453,6 +1640,7 @@ async def test_semantic_answer_has_valid_link_and_consumes_slot(monkeypatch) -> 
         AsyncMock(return_value=semantic_result.bundle),
     )
     monkeypatch.setattr(handler.SemanticQuotaRepo, "finalize", finalize)
+    monkeypatch.setattr(handler, "hold_evidence_delivery_locks", sequential_lock_scope)
     monkeypatch.setattr(
         handler,
         "_load_gateway_config",
@@ -1484,6 +1672,7 @@ async def test_semantic_answer_has_valid_link_and_consumes_slot(monkeypatch) -> 
         session=session,
         sender_id=1001,
         persisted_chat_message_id=8501,
+        question_bundle=_question_bundle(),
         query="что решили",
         query_redacted=False,
     )
@@ -1492,6 +1681,9 @@ async def test_semantic_answer_has_valid_link_and_consumes_slot(monkeypatch) -> 
     assert handler.synthesize_answer.await_args.kwargs["max_evidence_items"] == 5
     assert handler.synthesize_answer.await_args.kwargs["durable_placeholder"] is True
     assert handler.synthesize_answer.await_args.kwargs["revalidate_after_provider"] is True
+    assert handler.synthesize_answer.await_args.kwargs["cache_enabled"] is False
+    assert lock_entries == 5
+    assert lock_depth == 0
     handler.SemanticQuotaRepo.attach_trace.assert_awaited_once_with(
         session,
         attempt_id=3006,
@@ -1540,6 +1732,7 @@ async def test_semantic_reserved_replay_never_dispatches_providers(monkeypatch) 
         session=session,
         sender_id=1001,
         persisted_chat_message_id=8501,
+        question_bundle=_question_bundle(),
         query="повтор",
         query_redacted=False,
     )
@@ -1590,6 +1783,7 @@ async def test_semantic_answer_replay_never_emits_stored_content(monkeypatch) ->
         session=session,
         sender_id=1001,
         persisted_chat_message_id=8501,
+        question_bundle=_question_bundle(),
         query="повтор",
         query_redacted=False,
     )
@@ -1637,6 +1831,11 @@ async def test_semantic_abstention_classifies_quota_outcome(
     monkeypatch.setattr(handler.SemanticQuotaRepo, "finalize", finalize)
     monkeypatch.setattr(
         handler,
+        "filter_surviving_evidence",
+        AsyncMock(return_value=_qa_result().bundle),
+    )
+    monkeypatch.setattr(
+        handler,
         "run_semantic_qa",
         AsyncMock(
             return_value=SimpleNamespace(
@@ -1673,6 +1872,7 @@ async def test_semantic_abstention_classifies_quota_outcome(
         session=session,
         sender_id=1001,
         persisted_chat_message_id=8501,
+        question_bundle=_question_bundle(),
         query="классификация",
         query_redacted=False,
     )
@@ -1680,7 +1880,9 @@ async def test_semantic_abstention_classifies_quota_outcome(
     assert finalize.await_args.kwargs["outcome"] == expected_outcome
 
 
-async def test_semantic_render_revalidation_change_abstains_without_leak(monkeypatch) -> None:
+async def test_semantic_retrieval_trace_revalidation_change_abstains_without_leak(
+    monkeypatch,
+) -> None:
     handler = import_module("bot.handlers.qa")
     from bot.services.llm_gateway import AnswerWithCitations
 
@@ -1751,11 +1953,14 @@ async def test_semantic_render_revalidation_change_abstains_without_leak(monkeyp
         session=session,
         sender_id=1001,
         persisted_chat_message_id=8501,
+        question_bundle=_question_bundle(),
         query="гонка forget",
         query_redacted=False,
     )
 
     assert finalize.await_args.kwargs["outcome"] == "abstained"
+    handler.persist_semantic_retrieval_trace.assert_not_awaited()
+    handler.synthesize_answer.assert_not_awaited()
     reply = message.reply.await_args.args[0]
     assert "PRIVATE-FORGOTTEN-SNIPPET" not in reply
     assert "Не нашёл достаточно" in reply
@@ -1808,6 +2013,7 @@ async def test_semantic_technical_release_precedes_failing_ordinary_fallback(
         session=session,
         sender_id=1001,
         persisted_chat_message_id=8501,
+        question_bundle=_question_bundle(),
         query="ошибка fallback",
         query_redacted=False,
     )
@@ -2022,6 +2228,32 @@ async def test_final_delivery_gate_blocks_invalidated_evidence(monkeypatch) -> N
     invalidate.assert_awaited()
     clear.assert_awaited_once_with(session, qa_trace_id=44)
     reply.assert_not_awaited()
+
+
+async def test_generic_semantic_delivery_revalidates_required_question(monkeypatch) -> None:
+    handler = import_module("bot.handlers.qa")
+    session = AsyncMock()
+    message = _message()
+    finalize = AsyncMock()
+    monkeypatch.setattr(handler, "_question_is_governed", AsyncMock(return_value=False))
+    monkeypatch.setattr(handler.SemanticQuotaRepo, "finalize", finalize)
+
+    await handler._deliver_and_consume_semantic_attempt(
+        message,
+        session,
+        attempt_id=39,
+        outcome="abstained",
+        qa_trace_id=49,
+        embedding_llm_call_id=59,
+        synthesis_llm_call_id=None,
+        reply_text="must not be delivered",
+        required_governed_bundle=_question_bundle(),
+    )
+
+    handler.SemanticQuotaRepo.mark_delivery_started.assert_not_awaited()
+    assert finalize.await_args.kwargs["outcome"] == "technical_failure"
+    assert "must not be delivered" not in message.reply.await_args.args[0]
+    assert "удалён из памяти" in message.reply.await_args.args[0]
 
 
 async def test_semantic_ambiguous_delivery_failure_consumes_and_preserves_summary(

--- a/tests/scripts/test_backfill_semantic_index_cli.py
+++ b/tests/scripts/test_backfill_semantic_index_cli.py
@@ -1,0 +1,310 @@
+"""Unit tests for the no-content semantic rollout CLI boundary."""
+
+from __future__ import annotations
+
+import json
+import stat
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from scripts import backfill_semantic_index as cli
+
+
+def test_parser_requires_explicit_backfill_scope() -> None:
+    parser = cli.build_parser()
+
+    with pytest.raises(SystemExit):
+        parser.parse_args(["backfill"])
+
+    args = parser.parse_args(["backfill", "--all-chats"])
+    assert args.all_chats is True
+    assert args.chat_id is None
+    assert args.batch_size == 64
+
+
+def test_top_level_help_renders_without_argparse_percent_expansion(capsys) -> None:
+    parser = cli.build_parser()
+
+    parser.print_help()
+
+    assert "backfill" in capsys.readouterr().out
+
+
+def test_load_shadow_cases_accepts_only_bounded_opaque_metadata(tmp_path) -> None:
+    raw_question = "Кто обсуждал распределённые транзакции?"
+    source = tmp_path / "private.jsonl"
+    source.write_text(
+        json.dumps(
+            {
+                "question_id": "semantic-001",
+                "chat_id": -100123,
+                "query": raw_question,
+                "exclude_chat_message_id": 42,
+            },
+            ensure_ascii=False,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    cases = cli._load_shadow_cases(source, max_queries=1)
+
+    assert cases == (
+        cli.ShadowCase(
+            question_id="semantic-001",
+            chat_id=-100123,
+            query=raw_question,
+            exclude_chat_message_id=42,
+        ),
+    )
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"question_id": "raw question with spaces", "chat_id": 1, "query": "x"},
+        {"question_id": "q1", "chat_id": True, "query": "x"},
+        {"question_id": "q1", "chat_id": 1, "query": "   "},
+        {"question_id": "q1", "chat_id": 1, "query": "x", "snippet": "forbidden"},
+    ],
+)
+def test_shadow_case_validation_fails_closed(payload) -> None:
+    with pytest.raises(ValueError):
+        cli._parse_shadow_case(payload, line_number=7)
+
+
+def test_shadow_file_is_validated_before_any_provider_work(tmp_path) -> None:
+    source = tmp_path / "private.jsonl"
+    source.write_text(
+        "\n".join(
+            [
+                json.dumps({"question_id": "q1", "chat_id": 1, "query": "first"}),
+                json.dumps({"question_id": "q2", "chat_id": 1, "query": "second"}),
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="no provider calls were made"):
+        cli._load_shadow_cases(source, max_queries=1)
+
+
+def test_private_report_is_mode_0600_and_exclusive_by_default(tmp_path) -> None:
+    report = tmp_path / "report.json"
+    payload = {"status": "pass", "query_sha256": "a" * 64}
+
+    cli._write_private_report(report, payload, overwrite=False)
+
+    assert stat.S_IMODE(report.stat().st_mode) == 0o600
+    assert json.loads(report.read_text(encoding="utf-8")) == payload
+    with pytest.raises(FileExistsError):
+        cli._write_private_report(report, payload, overwrite=False)
+
+    report.chmod(0o644)
+    cli._write_private_report(report, payload, overwrite=True)
+    assert stat.S_IMODE(report.stat().st_mode) == 0o600
+
+
+def test_emit_does_not_print_success_when_report_write_fails(tmp_path, capsys) -> None:
+    report = tmp_path / "report.json"
+    report.write_text("already exists", encoding="utf-8")
+
+    with pytest.raises(FileExistsError):
+        cli._emit_report(
+            {"status": "pass"},
+            report_path=str(report),
+            overwrite=False,
+        )
+
+    assert capsys.readouterr().out == ""
+
+
+def test_ranked_keys_are_branch_specific_and_bounded() -> None:
+    ranks = {
+        "message:3": {"fts": 2, "vector": 1},
+        "message:1": {"fts": 1},
+        "card:abc": {"vector": 2},
+    }
+
+    assert cli._ranked_keys(ranks, branch="fts", limit=2) == ["message:1", "message:3"]
+    assert cli._ranked_keys(ranks, branch="vector", limit=1) == ["message:3"]
+
+
+def test_shadow_failure_payload_contains_only_bounded_error_class() -> None:
+    secret = "provider response must not leak"
+
+    payload = cli._shadow_failure_payload(processed=3, exc=RuntimeError(secret))
+
+    rendered = json.dumps(payload)
+    assert payload["reason_counts"] == {"failed:RuntimeError": 1}
+    assert secret not in rendered
+    assert payload["contains_raw_text"] is False
+    assert payload["synthesis_called"] is False
+
+
+@pytest.mark.parametrize("chat_id", [None, -1001234567890])
+async def test_coverage_audit_fails_closed_when_scope_has_no_eligible_identities(
+    monkeypatch,
+    chat_id,
+) -> None:
+    monkeypatch.setattr(cli, "_eligible_identities", AsyncMock(return_value={}))
+    session = SimpleNamespace(
+        execute=AsyncMock(
+            return_value=SimpleNamespace(mappings=lambda: SimpleNamespace(all=lambda: []))
+        ),
+    )
+
+    report = await cli._coverage_report(
+        session,
+        chat_id=chat_id,
+        model="text-embedding-3-small",
+        batch_size=64,
+    )
+
+    assert report["status"] == "fail"
+    assert report["eligible"] == 0
+    assert report["coverage_percent"] == 0.0
+    assert report["reason_counts"]["failed:no_eligible_identities"] == 1
+
+
+@pytest.mark.parametrize("actual_sources", [(), (11,), (12, 11)])
+async def test_coverage_audit_rejects_missing_partial_or_reordered_provenance(
+    monkeypatch,
+    actual_sources,
+) -> None:
+    identity = ("card", "card-id", "revision", -100404, "a" * 64, "model")
+    monkeypatch.setattr(
+        cli,
+        "_eligible_identities",
+        AsyncMock(return_value={identity: (11, 12)}),
+    )
+    row = {
+        "source_type": "card",
+        "source_id": "card-id",
+        "source_revision": "revision",
+        "chat_id": -100404,
+        "content_hash": "a" * 64,
+        "embedding_model": "model",
+        "invalidated_at": None,
+        "message_version_ids": actual_sources,
+    }
+    session = SimpleNamespace(
+        execute=AsyncMock(
+            return_value=SimpleNamespace(mappings=lambda: SimpleNamespace(all=lambda: [row]))
+        )
+    )
+
+    report = await cli._coverage_report(
+        session,
+        chat_id=-100404,
+        model="model",
+        batch_size=64,
+    )
+
+    assert report["status"] == "fail"
+    assert report["indexed"] == 0
+    assert report["reason_counts"]["failed:provenance_mismatch"] == 1
+
+
+def test_main_redacts_validation_error_details(capsys, tmp_path) -> None:
+    raw_question = "секретный вопрос нельзя печатать"
+    source = tmp_path / "private.jsonl"
+    source.write_text(
+        json.dumps({"question_id": raw_question, "chat_id": 1, "query": raw_question}),
+        encoding="utf-8",
+    )
+
+    result = cli.main(
+        [
+            "shadow",
+            "--input",
+            str(source),
+            "--output",
+            str(tmp_path / "result.jsonl"),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert result == 2
+    assert raw_question not in captured.out
+    assert raw_question not in captured.err
+    assert json.loads(captured.err)["error_class"] == "ValueError"
+
+
+@pytest.mark.asyncio
+async def test_backfill_cli_emits_service_reason_counts_without_relabeling(
+    monkeypatch,
+    capsys,
+) -> None:
+    monkeypatch.setenv("BOT_TOKEN", "123456:test-token")
+    monkeypatch.setenv("DEV_MODE", "true")
+    import bot.db.engine
+    import bot.services.llm_gateway
+    import bot.services.semantic_index
+
+    session = SimpleNamespace()
+
+    class SessionContext:
+        async def __aenter__(self):
+            return session
+
+        async def __aexit__(self, exc_type, exc, traceback):
+            return False
+
+    reasons = {
+        "indexed:new_embedding": 2,
+        "indexed:reused_embedding": 1,
+        "skipped:unchanged": 3,
+        "skipped:governance_race": 1,
+        "invalidated:ineligible": 2,
+    }
+    monkeypatch.setattr(bot.db.engine, "async_session", SessionContext)
+    monkeypatch.setattr(
+        bot.services.llm_gateway,
+        "load_embedding_gateway_config",
+        lambda: SimpleNamespace(model="text-embedding-3-small", dimensions=1536),
+    )
+    monkeypatch.setattr(
+        bot.services.semantic_index,
+        "backfill_semantic_index",
+        AsyncMock(
+            return_value=SimpleNamespace(
+                run_id=404,
+                eligible=7,
+                indexed=3,
+                skipped=4,
+                failed=0,
+                reason_counts=reasons,
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        cli,
+        "_coverage_report",
+        AsyncMock(
+            return_value={
+                "status": "pass",
+                "eligible": 7,
+                "indexed": 7,
+                "coverage_percent": 100.0,
+                "missing": 0,
+                "unexpected_active": 0,
+                "reason_counts": {"indexed:active_identity": 7},
+            }
+        ),
+    )
+
+    exit_code = await cli._run_backfill(
+        SimpleNamespace(
+            chat_id=-100404,
+            all_chats=False,
+            batch_size=64,
+            report=None,
+            overwrite=False,
+        )
+    )
+
+    assert exit_code == 0
+    assert json.loads(capsys.readouterr().out)["reason_counts"] == reasons

--- a/tests/scripts/test_backfill_semantic_index_cli.py
+++ b/tests/scripts/test_backfill_semantic_index_cli.py
@@ -189,6 +189,7 @@ async def test_coverage_audit_rejects_missing_partial_or_reordered_provenance(
         "chat_id": -100404,
         "content_hash": "a" * 64,
         "embedding_model": "model",
+        "embedding_status": "completed",
         "invalidated_at": None,
         "message_version_ids": actual_sources,
     }
@@ -208,6 +209,97 @@ async def test_coverage_audit_rejects_missing_partial_or_reordered_provenance(
     assert report["status"] == "fail"
     assert report["indexed"] == 0
     assert report["reason_counts"]["failed:provenance_mismatch"] == 1
+
+
+async def test_coverage_audit_fails_on_unresolved_embedding_claim(monkeypatch) -> None:
+    identity = ("message", "11", "revision", 0, 1, -100404, "a" * 64, "model")
+    monkeypatch.setattr(
+        cli,
+        "_eligible_identities",
+        AsyncMock(return_value={identity: (11,)}),
+    )
+    row = {
+        "source_type": "message",
+        "source_id": "11",
+        "source_revision": "revision",
+        "chunk_index": 0,
+        "chunk_count": 1,
+        "chat_id": -100404,
+        "content_hash": "a" * 64,
+        "embedding_model": "model",
+        "embedding_status": "reserved",
+        "invalidated_at": None,
+        "message_version_ids": (11,),
+    }
+    session = SimpleNamespace(
+        execute=AsyncMock(
+            return_value=SimpleNamespace(mappings=lambda: SimpleNamespace(all=lambda: [row]))
+        )
+    )
+
+    report = await cli._coverage_report(
+        session,
+        chat_id=-100404,
+        model="model",
+        batch_size=64,
+    )
+
+    assert report["status"] == "fail"
+    assert report["missing"] == 1
+    assert report["unresolved_claims"] == 1
+    assert report["unresolved_statuses"] == {"reserved": 1}
+
+
+async def test_coverage_ignores_superseded_invalidated_failed_claim(monkeypatch) -> None:
+    current = ("message", "12", "current", 0, 1, -100404, "b" * 64, "model")
+    monkeypatch.setattr(
+        cli,
+        "_eligible_identities",
+        AsyncMock(return_value={current: (12,)}),
+    )
+    rows = [
+        {
+            "source_type": "message",
+            "source_id": "12",
+            "source_revision": "current",
+            "chunk_index": 0,
+            "chunk_count": 1,
+            "chat_id": -100404,
+            "content_hash": "b" * 64,
+            "embedding_model": "model",
+            "embedding_status": "completed",
+            "invalidated_at": None,
+            "message_version_ids": (12,),
+        },
+        {
+            "source_type": "message",
+            "source_id": "11",
+            "source_revision": "old",
+            "chunk_index": 0,
+            "chunk_count": 1,
+            "chat_id": -100404,
+            "content_hash": "a" * 64,
+            "embedding_model": "model",
+            "embedding_status": "failed",
+            "invalidated_at": object(),
+            "message_version_ids": (11,),
+        },
+    ]
+    session = SimpleNamespace(
+        execute=AsyncMock(
+            return_value=SimpleNamespace(mappings=lambda: SimpleNamespace(all=lambda: rows))
+        )
+    )
+
+    report = await cli._coverage_report(
+        session,
+        chat_id=-100404,
+        model="model",
+        batch_size=64,
+    )
+
+    assert report["status"] == "pass"
+    assert report["unresolved_claims"] == 0
 
 
 def test_main_redacts_validation_error_details(capsys, tmp_path) -> None:

--- a/tests/scripts/test_backfill_semantic_index_cli.py
+++ b/tests/scripts/test_backfill_semantic_index_cli.py
@@ -174,7 +174,7 @@ async def test_coverage_audit_rejects_missing_partial_or_reordered_provenance(
     monkeypatch,
     actual_sources,
 ) -> None:
-    identity = ("card", "card-id", "revision", -100404, "a" * 64, "model")
+    identity = ("card", "card-id", "revision", 0, 1, -100404, "a" * 64, "model")
     monkeypatch.setattr(
         cli,
         "_eligible_identities",
@@ -184,6 +184,8 @@ async def test_coverage_audit_rejects_missing_partial_or_reordered_provenance(
         "source_type": "card",
         "source_id": "card-id",
         "source_revision": "revision",
+        "chunk_index": 0,
+        "chunk_count": 1,
         "chat_id": -100404,
         "content_hash": "a" * 64,
         "embedding_model": "model",

--- a/tests/scripts/test_backfill_semantic_index_cli.py
+++ b/tests/scripts/test_backfill_semantic_index_cli.py
@@ -65,8 +65,18 @@ def test_load_shadow_cases_accepts_only_bounded_opaque_metadata(tmp_path) -> Non
     "payload",
     [
         {"question_id": "raw question with spaces", "chat_id": 1, "query": "x"},
+        {
+            "question_id": "sk-A1b2C3d4E5f6G7h8I9j0",
+            "chat_id": 1,
+            "query": "x",
+        },
         {"question_id": "q1", "chat_id": True, "query": "x"},
         {"question_id": "q1", "chat_id": 1, "query": "   "},
+        {
+            "question_id": "q1",
+            "chat_id": 1,
+            "query": "token=Abcd1234EfgH5678!",
+        },
         {"question_id": "q1", "chat_id": 1, "query": "x", "snippet": "forbidden"},
     ],
 )

--- a/tests/scripts/test_evaluate_semantic_qa.py
+++ b/tests/scripts/test_evaluate_semantic_qa.py
@@ -105,6 +105,15 @@ def _passing_rows(count: int = 50) -> tuple[list[dict[str, object]], list[dict[s
         + ["no_answer"] * 10
         + ["privacy_governance"] * 5
     )
+    privacy_class_groups = iter(
+        (
+            ["cross_chat", "stale_version"],
+            ["bot_authored"],
+            ["forgotten"],
+            ["redacted"],
+            ["non_normal"],
+        )
+    )
     cases: list[dict[str, object]] = []
     results: list[dict[str, object]] = []
     for index, category in enumerate(categories[:count], start=1):
@@ -117,6 +126,9 @@ def _passing_rows(count: int = 50) -> tuple[list[dict[str, object]], list[dict[s
                 "category": category,
                 "expected_source_ids": expected,
                 "forbidden_source_ids": forbidden,
+                "privacy_classes": next(privacy_class_groups)
+                if category == "privacy_governance"
+                else [],
                 "expected_abstain": abstain,
             }
         )
@@ -199,6 +211,14 @@ def test_private_fifty_case_report_is_hashed_release_bound_and_mode_0600(
     assert payload["results_sha256"] == hashlib.sha256(results_path.read_bytes()).hexdigest()
     assert payload["report"]["case_count"] == 50
     assert payload["report"]["privacy_governance_case_count"] == 5
+    assert payload["report"]["privacy_classes"] == [
+        "bot_authored",
+        "cross_chat",
+        "forgotten",
+        "non_normal",
+        "redacted",
+        "stale_version",
+    ]
     assert payload["contains_raw_text"] is False
     assert stat.S_IMODE(report_path.stat().st_mode) == 0o600
     assert "private query case-001" not in capsys.readouterr().out
@@ -229,6 +249,15 @@ def test_validator_rejects_fractional_unexpected_abstention_count(tmp_path: Path
     payload["report"]["unexpected_answerable_abstention_count"] = 0.5
 
     with pytest.raises(ValueError, match="non-negative integer"):
+        validate_report_payload(payload, expected_release_sha=RELEASE_SHA)
+
+
+def test_validator_rejects_incomplete_privacy_class_evidence(tmp_path: Path) -> None:
+    _, _, _, _, report_path = _evaluate(tmp_path)
+    payload = json.loads(report_path.read_text(encoding="utf-8"))
+    payload["report"]["privacy_classes"].remove("stale_version")
+
+    with pytest.raises(ValueError, match="blocking metric violation"):
         validate_report_payload(payload, expected_release_sha=RELEASE_SHA)
 
 
@@ -312,6 +341,38 @@ def test_gate_rejects_fewer_than_fifty_cases_without_report(tmp_path: Path) -> N
                 str(observations_path),
                 "--results",
                 str(results_path),
+                "--release-sha",
+                RELEASE_SHA,
+                "--report",
+                str(report_path),
+            ]
+        )
+        == 2
+    )
+    assert not report_path.exists()
+
+
+def test_gate_rejects_missing_privacy_class_before_loading_results(tmp_path: Path) -> None:
+    cases, _ = _passing_rows()
+    cases[-5]["privacy_classes"] = ["cross_chat"]
+    dataset_path = tmp_path / "dataset.jsonl"
+    cases_path = tmp_path / "cases.jsonl"
+    report_path = tmp_path / "report.json"
+    _write_jsonl(dataset_path, _dataset_rows(cases))
+    _write_jsonl(cases_path, cases)
+
+    assert (
+        main(
+            [
+                "evaluate",
+                "--dataset",
+                str(dataset_path),
+                "--cases",
+                str(cases_path),
+                "--observations",
+                str(tmp_path / "missing-observations.jsonl"),
+                "--results",
+                str(tmp_path / "missing-results.jsonl"),
                 "--release-sha",
                 RELEASE_SHA,
                 "--report",

--- a/tests/scripts/test_evaluate_semantic_qa.py
+++ b/tests/scripts/test_evaluate_semantic_qa.py
@@ -1,0 +1,441 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import stat
+from pathlib import Path
+
+import pytest
+import yaml
+
+from scripts.evaluate_semantic_qa import (
+    OBSERVATIONS_SCHEMA_VERSION,
+    REVIEWED_RESULTS_SCHEMA_VERSION,
+    main,
+    validate_report_payload,
+)
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+EVAL_WORKFLOW = PROJECT_ROOT / ".github/workflows/evals.yml"
+RELEASE_SHA = "a" * 40
+
+
+def _write_jsonl(path: Path, rows: list[dict[str, object]]) -> None:
+    path.write_text(
+        "".join(json.dumps(row, sort_keys=True) + "\n" for row in rows),
+        encoding="utf-8",
+    )
+
+
+def _write_observations(
+    path: Path,
+    dataset_path: Path,
+    rows: list[dict[str, object]],
+    *,
+    release_sha: str = RELEASE_SHA,
+) -> None:
+    _write_jsonl(
+        path,
+        [
+            {
+                "record_type": "header",
+                "schema_version": OBSERVATIONS_SCHEMA_VERSION,
+                "contains_raw_text": False,
+                "release_sha": release_sha,
+                "dataset_sha256": hashlib.sha256(dataset_path.read_bytes()).hexdigest(),
+                "case_count": len(rows),
+            },
+            *[
+                {
+                    "record_type": "case_observation",
+                    "case_id": row["case_id"],
+                    "fts_source_ids": row["fts_source_ids"],
+                    "hybrid_source_ids": row["hybrid_source_ids"],
+                    "abstained": row["abstained"],
+                    "leakage_count": row["leakage_count"],
+                    "retrieval_latency_seconds": row["retrieval_latency_seconds"],
+                    "full_latency_seconds": row["full_latency_seconds"],
+                }
+                for row in rows
+            ],
+        ],
+    )
+
+
+def _write_results(
+    path: Path,
+    dataset_path: Path,
+    observations_path: Path,
+    rows: list[dict[str, object]],
+    *,
+    release_sha: str = RELEASE_SHA,
+) -> None:
+    _write_jsonl(
+        path,
+        [
+            {
+                "record_type": "header",
+                "schema_version": REVIEWED_RESULTS_SCHEMA_VERSION,
+                "contains_raw_text": False,
+                "release_sha": release_sha,
+                "dataset_sha256": hashlib.sha256(dataset_path.read_bytes()).hexdigest(),
+                "observations_sha256": hashlib.sha256(observations_path.read_bytes()).hexdigest(),
+                "case_count": len(rows),
+            },
+            *[
+                {
+                    "case_id": row["case_id"],
+                    "valid_source_links": row["valid_source_links"],
+                    "invalid_source_links": row["invalid_source_links"],
+                    "unsupported_claims": row["unsupported_claims"],
+                    "total_claims": row["total_claims"],
+                }
+                for row in rows
+            ],
+        ],
+    )
+
+
+def _passing_rows(count: int = 50) -> tuple[list[dict[str, object]], list[dict[str, object]]]:
+    categories = (
+        ["semantic"] * 15
+        + ["exact"] * 10
+        + ["multi_source"] * 10
+        + ["no_answer"] * 10
+        + ["privacy_governance"] * 5
+    )
+    cases: list[dict[str, object]] = []
+    results: list[dict[str, object]] = []
+    for index, category in enumerate(categories[:count], start=1):
+        abstain = category == "no_answer"
+        expected = [] if abstain else [f"message:{index}"]
+        forbidden = [f"message:{1000 + index}"] if category == "privacy_governance" else []
+        cases.append(
+            {
+                "case_id": f"case-{index:03d}",
+                "category": category,
+                "expected_source_ids": expected,
+                "forbidden_source_ids": forbidden,
+                "expected_abstain": abstain,
+            }
+        )
+        results.append(
+            {
+                "case_id": f"case-{index:03d}",
+                "fts_source_ids": [] if category == "semantic" else expected,
+                "hybrid_source_ids": expected,
+                "abstained": abstain,
+                "leakage_count": 0,
+                "valid_source_links": 0 if abstain else 1,
+                "invalid_source_links": 0,
+                "unsupported_claims": 0,
+                "total_claims": 0 if abstain else 1,
+                "retrieval_latency_seconds": 1.0,
+                "full_latency_seconds": 5.0,
+            }
+        )
+    return cases, results
+
+
+def _dataset_rows(cases: list[dict[str, object]]) -> list[dict[str, object]]:
+    return [
+        {
+            **case,
+            "chat_id": -1001234567890,
+            "query": f"private query {case['case_id']}",
+            "exclude_chat_message_id": None,
+        }
+        for case in cases
+    ]
+
+
+def _evaluate(tmp_path: Path) -> tuple[Path, Path, Path, Path, Path]:
+    cases, results = _passing_rows()
+    dataset_path = tmp_path / "private-dataset.jsonl"
+    cases_path = tmp_path / "cases.jsonl"
+    observations_path = tmp_path / "observations.jsonl"
+    results_path = tmp_path / "results.jsonl"
+    report_path = tmp_path / "report.json"
+    _write_jsonl(dataset_path, _dataset_rows(cases))
+    _write_jsonl(cases_path, cases)
+    _write_observations(observations_path, dataset_path, results)
+    _write_results(results_path, dataset_path, observations_path, results)
+    assert (
+        main(
+            [
+                "evaluate",
+                "--dataset",
+                str(dataset_path),
+                "--cases",
+                str(cases_path),
+                "--observations",
+                str(observations_path),
+                "--results",
+                str(results_path),
+                "--release-sha",
+                RELEASE_SHA,
+                "--report",
+                str(report_path),
+            ]
+        )
+        == 0
+    )
+    return dataset_path, cases_path, observations_path, results_path, report_path
+
+
+def test_private_fifty_case_report_is_hashed_release_bound_and_mode_0600(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    dataset_path, _, observations_path, results_path, report_path = _evaluate(tmp_path)
+
+    payload = json.loads(report_path.read_text(encoding="utf-8"))
+    assert payload["status"] == "pass"
+    assert payload["release_sha"] == RELEASE_SHA
+    assert payload["dataset_sha256"] == hashlib.sha256(dataset_path.read_bytes()).hexdigest()
+    assert (
+        payload["observations_sha256"] == hashlib.sha256(observations_path.read_bytes()).hexdigest()
+    )
+    assert payload["results_sha256"] == hashlib.sha256(results_path.read_bytes()).hexdigest()
+    assert payload["report"]["case_count"] == 50
+    assert payload["report"]["privacy_governance_case_count"] == 5
+    assert payload["contains_raw_text"] is False
+    assert stat.S_IMODE(report_path.stat().st_mode) == 0o600
+    assert "private query case-001" not in capsys.readouterr().out
+
+
+def test_validator_binds_exact_release_sha_and_workflow_calls_it(tmp_path: Path) -> None:
+    _, _, _, _, report_path = _evaluate(tmp_path)
+    payload = json.loads(report_path.read_text(encoding="utf-8"))
+
+    artifact = validate_report_payload(payload, expected_release_sha=RELEASE_SHA)
+
+    assert artifact["commit_sha"] == RELEASE_SHA
+    assert artifact["suite"] == "private-frozen-semantic-eval"
+    with pytest.raises(ValueError, match="release-bound"):
+        validate_report_payload(payload, expected_release_sha="b" * 40)
+
+    workflow_text = EVAL_WORKFLOW.read_text(encoding="utf-8")
+    workflow = yaml.safe_load(workflow_text)
+    assert set(workflow[True]) == {"workflow_dispatch"}
+    assert "evals-gate" not in workflow["jobs"]
+    assert "python -m scripts.evaluate_semantic_qa validate-report" in workflow_text
+    assert "MIN_MACRO_RECALL_AT_5" not in workflow_text
+
+
+def test_validator_rejects_fractional_unexpected_abstention_count(tmp_path: Path) -> None:
+    _, _, _, _, report_path = _evaluate(tmp_path)
+    payload = json.loads(report_path.read_text(encoding="utf-8"))
+    payload["report"]["unexpected_answerable_abstention_count"] = 0.5
+
+    with pytest.raises(ValueError, match="non-negative integer"):
+        validate_report_payload(payload, expected_release_sha=RELEASE_SHA)
+
+
+def test_validate_report_command_fails_closed_without_or_with_wrong_secret(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    artifact_path = tmp_path / "artifact.jsonl"
+    monkeypatch.delenv("SEMANTIC_EVAL_REPORT_JSON", raising=False)
+    assert (
+        main(
+            [
+                "validate-report",
+                "--expected-release-sha",
+                RELEASE_SHA,
+                "--artifact",
+                str(artifact_path),
+            ]
+        )
+        == 2
+    )
+    monkeypatch.setenv("SEMANTIC_EVAL_REPORT_JSON", "{}")
+    assert (
+        main(
+            [
+                "validate-report",
+                "--expected-release-sha",
+                RELEASE_SHA,
+                "--artifact",
+                str(artifact_path),
+            ]
+        )
+        == 2
+    )
+    assert not artifact_path.exists()
+
+
+def test_validate_report_command_appends_only_sanitized_artifact(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _, _, _, _, report_path = _evaluate(tmp_path)
+    monkeypatch.setenv("SEMANTIC_EVAL_REPORT_JSON", report_path.read_text(encoding="utf-8"))
+    artifact_path = tmp_path / "artifact.jsonl"
+
+    exit_code = main(
+        [
+            "validate-report",
+            "--expected-release-sha",
+            RELEASE_SHA,
+            "--artifact",
+            str(artifact_path),
+        ]
+    )
+
+    assert exit_code == 0
+    artifact = json.loads(artifact_path.read_text(encoding="utf-8"))
+    assert artifact["commit_sha"] == RELEASE_SHA
+    assert artifact["contains_raw_text"] is False
+
+
+def test_gate_rejects_fewer_than_fifty_cases_without_report(tmp_path: Path) -> None:
+    cases, results = _passing_rows(count=49)
+    dataset_path = tmp_path / "dataset.jsonl"
+    cases_path = tmp_path / "cases.jsonl"
+    observations_path = tmp_path / "observations.jsonl"
+    results_path = tmp_path / "results.jsonl"
+    report_path = tmp_path / "report.json"
+    _write_jsonl(dataset_path, _dataset_rows(cases))
+    _write_jsonl(cases_path, cases)
+    _write_observations(observations_path, dataset_path, results)
+    _write_results(results_path, dataset_path, observations_path, results)
+
+    assert (
+        main(
+            [
+                "evaluate",
+                "--dataset",
+                str(dataset_path),
+                "--cases",
+                str(cases_path),
+                "--observations",
+                str(observations_path),
+                "--results",
+                str(results_path),
+                "--release-sha",
+                RELEASE_SHA,
+                "--report",
+                str(report_path),
+            ]
+        )
+        == 2
+    )
+    assert not report_path.exists()
+
+
+def test_objective_privacy_leakage_cannot_be_overridden_by_reviewer(tmp_path: Path) -> None:
+    cases, results = _passing_rows()
+    dataset_path = tmp_path / "dataset.jsonl"
+    cases_path = tmp_path / "cases.jsonl"
+    observations_path = tmp_path / "observations.jsonl"
+    results_path = tmp_path / "results.jsonl"
+    report_path = tmp_path / "report.json"
+    _write_jsonl(dataset_path, _dataset_rows(cases))
+    _write_jsonl(cases_path, cases)
+    _write_observations(observations_path, dataset_path, results)
+    _write_results(results_path, dataset_path, observations_path, results)
+    result_rows = [json.loads(line) for line in results_path.read_text().splitlines()]
+    result_rows[-1]["hybrid_source_ids"] = cases[-1]["forbidden_source_ids"]
+    result_rows[-1]["leakage_count"] = 0
+    _write_jsonl(results_path, result_rows)
+
+    assert (
+        main(
+            [
+                "evaluate",
+                "--dataset",
+                str(dataset_path),
+                "--cases",
+                str(cases_path),
+                "--observations",
+                str(observations_path),
+                "--results",
+                str(results_path),
+                "--release-sha",
+                RELEASE_SHA,
+                "--report",
+                str(report_path),
+            ]
+        )
+        == 2
+    )
+    assert not report_path.exists()
+
+
+def test_gate_rejects_results_from_another_release(tmp_path: Path) -> None:
+    cases, results = _passing_rows()
+    dataset_path = tmp_path / "dataset.jsonl"
+    cases_path = tmp_path / "cases.jsonl"
+    observations_path = tmp_path / "observations.jsonl"
+    results_path = tmp_path / "results.jsonl"
+    report_path = tmp_path / "report.json"
+    _write_jsonl(dataset_path, _dataset_rows(cases))
+    _write_jsonl(cases_path, cases)
+    _write_observations(observations_path, dataset_path, results)
+    _write_results(
+        results_path,
+        dataset_path,
+        observations_path,
+        results,
+        release_sha="b" * 40,
+    )
+
+    assert (
+        main(
+            [
+                "evaluate",
+                "--dataset",
+                str(dataset_path),
+                "--cases",
+                str(cases_path),
+                "--observations",
+                str(observations_path),
+                "--results",
+                str(results_path),
+                "--release-sha",
+                RELEASE_SHA,
+                "--report",
+                str(report_path),
+            ]
+        )
+        == 2
+    )
+    assert not report_path.exists()
+
+
+def test_gate_rejects_results_from_changed_dataset(tmp_path: Path) -> None:
+    cases, results = _passing_rows()
+    dataset_path = tmp_path / "dataset.jsonl"
+    cases_path = tmp_path / "cases.jsonl"
+    observations_path = tmp_path / "observations.jsonl"
+    results_path = tmp_path / "results.jsonl"
+    report_path = tmp_path / "report.json"
+    dataset_rows = _dataset_rows(cases)
+    _write_jsonl(dataset_path, dataset_rows)
+    _write_jsonl(cases_path, cases)
+    _write_observations(observations_path, dataset_path, results)
+    _write_results(results_path, dataset_path, observations_path, results)
+    dataset_rows[0]["query"] = "changed after runner execution"
+    _write_jsonl(dataset_path, dataset_rows)
+
+    assert (
+        main(
+            [
+                "evaluate",
+                "--dataset",
+                str(dataset_path),
+                "--cases",
+                str(cases_path),
+                "--observations",
+                str(observations_path),
+                "--results",
+                str(results_path),
+                "--release-sha",
+                RELEASE_SHA,
+                "--report",
+                str(report_path),
+            ]
+        )
+        == 2
+    )
+    assert not report_path.exists()

--- a/tests/scripts/test_postgres_image_contract.py
+++ b/tests/scripts/test_postgres_image_contract.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_postgres_image_is_exact_pg15_alpine_parent_with_verified_pgvector() -> None:
+    dockerfile = (PROJECT_ROOT / "Dockerfile.postgres").read_text(encoding="utf-8")
+
+    assert (
+        "FROM postgres@sha256:1c52f5ad23db5d7648a63634444af76de48e63b860fccbe3e3a5458b2812eaed"
+    ) in dockerfile
+    assert "PGVECTOR_VERSION=0.8.2" in dockerfile
+    assert (
+        "PGVECTOR_TARBALL_SHA256=69f4019389af05dc1c9548deb8628e62878e6e207c03907f2b8af2016472cdaa"
+    ) in dockerfile
+    assert "sha256sum -c -" in dockerfile
+    assert "apk del .pgvector-build" in dockerfile
+
+
+def test_ci_smokes_image_and_release_publishes_commit_bound_db_image() -> None:
+    ci_text = (PROJECT_ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
+    ci = yaml.safe_load(ci_text)
+    release_text = (PROJECT_ROOT / ".github/workflows/release.yml").read_text(encoding="utf-8")
+    release = yaml.safe_load(release_text)
+
+    assert "postgres-image-smoke" in ci["jobs"]
+    assert "docker build --file Dockerfile.postgres" in ci_text
+    assert "CREATE EXTENSION vector" in ci_text
+    assert "server_version_num" in ci_text
+    assert "::vector <=>" in ci_text
+    assert "alembic upgrade 089" in ci_text
+    assert "alembic downgrade 088" in ci_text
+    assert "alembic upgrade head" in ci_text
+    assert "ck_semantic_attempts_state" in ci_text
+    assert release["env"]["IMAGE_DB"] == "ghcr.io/jekudy/vibe-gatekeeper-postgres"
+    assert "file: ./Dockerfile.postgres" in release_text
+    assert "sha-${{ github.event.workflow_run.head_sha }}" in release_text

--- a/tests/scripts/test_run_semantic_qa_eval.py
+++ b/tests/scripts/test_run_semantic_qa_eval.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+from concurrent.futures import ThreadPoolExecutor
 from unittest.mock import AsyncMock
+import hashlib
 import json
 import stat
+import threading
 from pathlib import Path
 
 import pytest
@@ -115,6 +118,242 @@ async def test_missing_privacy_coverage_stops_before_provider_dispatch(
     with pytest.raises(ValueError, match="missing=.*stale_version"):
         await runner.run_private_evaluation(args)
     run_case.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    "overlap",
+    ["input-output", "output-output", "input-hardlink", "output-hardlink", "symlink"],
+)
+@pytest.mark.asyncio
+async def test_overlapping_eval_paths_fail_before_truncate_or_provider(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    overlap: str,
+) -> None:
+    input_path = tmp_path / "input.jsonl"
+    cases_path = tmp_path / "cases.jsonl"
+    observations_path = tmp_path / "observations.jsonl"
+    review_path = tmp_path / "review.jsonl"
+    _write(input_path, _rows())
+    original_input = input_path.read_bytes()
+    original_output: bytes | None = None
+    if overlap == "input-output":
+        cases_path = input_path
+    elif overlap == "output-output":
+        observations_path = cases_path
+    elif overlap == "input-hardlink":
+        cases_path.hardlink_to(input_path)
+    elif overlap == "output-hardlink":
+        cases_path.write_bytes(b"existing private artifact\n")
+        observations_path.hardlink_to(cases_path)
+        original_output = cases_path.read_bytes()
+    else:
+        cases_path.symlink_to(input_path)
+    run_case = AsyncMock()
+    monkeypatch.setattr(runner, "_run_case", run_case)
+    args = runner.build_parser().parse_args(
+        [
+            "--input",
+            str(input_path),
+            "--cases-output",
+            str(cases_path),
+            "--observations-output",
+            str(observations_path),
+            "--review-output",
+            str(review_path),
+            "--release-sha",
+            RELEASE_SHA,
+            "--overwrite",
+        ]
+    )
+
+    expected_error = "symbolic links" if overlap == "symlink" else "paths must be distinct"
+    with pytest.raises(ValueError, match=expected_error):
+        await runner.run_private_evaluation(args)
+
+    assert input_path.read_bytes() == original_input
+    if original_output is not None:
+        assert cases_path.read_bytes() == original_output
+    run_case.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_concurrent_hardlink_substitution_is_detected_by_open_fds(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    input_path = tmp_path / "input.jsonl"
+    cases_path = tmp_path / "cases.jsonl"
+    observations_path = tmp_path / "observations.jsonl"
+    review_path = tmp_path / "review.jsonl"
+    _write(input_path, _rows())
+    original_input = input_path.read_bytes()
+    original_mode = stat.S_IMODE(input_path.stat().st_mode)
+    open_window = threading.Event()
+    substitution_done = threading.Event()
+    original_open = runner._open_private_text
+
+    def synchronized_open(path: Path, *, overwrite: bool):  # type: ignore[no-untyped-def]
+        if path == cases_path:
+            open_window.set()
+            assert substitution_done.wait(timeout=5)
+        return original_open(path, overwrite=overwrite)
+
+    def substitute_output_with_input_hardlink() -> None:
+        assert open_window.wait(timeout=5)
+        cases_path.hardlink_to(input_path)
+        substitution_done.set()
+
+    monkeypatch.setattr(runner, "_open_private_text", synchronized_open)
+    run_case = AsyncMock()
+    monkeypatch.setattr(runner, "_run_case", run_case)
+    args = runner.build_parser().parse_args(
+        [
+            "--input",
+            str(input_path),
+            "--cases-output",
+            str(cases_path),
+            "--observations-output",
+            str(observations_path),
+            "--review-output",
+            str(review_path),
+            "--release-sha",
+            RELEASE_SHA,
+            "--overwrite",
+        ]
+    )
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        attacker = executor.submit(substitute_output_with_input_hardlink)
+        with pytest.raises(ValueError, match="paths must be distinct"):
+            await runner.run_private_evaluation(args)
+        attacker.result(timeout=5)
+
+    assert input_path.read_bytes() == original_input
+    assert stat.S_IMODE(input_path.stat().st_mode) == original_mode
+    run_case.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_input_path_substitution_after_open_cannot_change_cases_or_hash(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    input_path = tmp_path / "input.jsonl"
+    detached_path = tmp_path / "detached-input.jsonl"
+    cases_path = tmp_path / "cases.jsonl"
+    observations_path = tmp_path / "observations.jsonl"
+    review_path = tmp_path / "review.jsonl"
+    original_row = _rows()[0]
+    replacement_row = dict(original_row)
+    replacement_row["query"] = "replacement query"
+    _write(input_path, [original_row])
+    original_bytes = input_path.read_bytes()
+    original_load = runner._load_jsonl
+
+    def substitute_after_fd_open(source):  # type: ignore[no-untyped-def]
+        input_path.rename(detached_path)
+        _write(input_path, [replacement_row])
+        return original_load(source)
+
+    async def fake_run_case(case: runner.PrivateEvalCase) -> dict[str, object]:
+        assert case.query == original_row["query"]
+        return {
+            "record_type": "case_review",
+            "case_id": case.label.case_id,
+            "query": case.query,
+            "answer": None,
+            "fts_source_ids": [],
+            "hybrid_source_ids": [],
+            "objective_leakage_count": 0,
+            "reviewed_result": {
+                "abstained": True,
+                "retrieval_latency_seconds": 0.1,
+                "full_latency_seconds": 0.2,
+            },
+        }
+
+    monkeypatch.setattr(runner, "_load_jsonl", substitute_after_fd_open)
+    run_case = AsyncMock(side_effect=fake_run_case)
+    monkeypatch.setattr(runner, "_run_case", run_case)
+    args = runner.build_parser().parse_args(
+        [
+            "--input",
+            str(input_path),
+            "--cases-output",
+            str(cases_path),
+            "--observations-output",
+            str(observations_path),
+            "--review-output",
+            str(review_path),
+            "--release-sha",
+            RELEASE_SHA,
+            "--smoke",
+        ]
+    )
+
+    assert await runner.run_private_evaluation(args) == 0
+
+    header = json.loads(observations_path.read_text(encoding="utf-8").splitlines()[0])
+    assert header["dataset_sha256"] == hashlib.sha256(original_bytes).hexdigest()
+    run_case.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_observations_hash_stays_bound_to_open_output_fd(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    input_path = tmp_path / "input.jsonl"
+    cases_path = tmp_path / "cases.jsonl"
+    observations_path = tmp_path / "observations.jsonl"
+    detached_observations_path = tmp_path / "detached-observations.jsonl"
+    review_path = tmp_path / "review.jsonl"
+    _write(input_path, [_rows()[0]])
+
+    async def fake_run_case(case: runner.PrivateEvalCase) -> dict[str, object]:
+        observations_path.rename(detached_observations_path)
+        observations_path.write_text("substituted pathname\n", encoding="utf-8")
+        return {
+            "record_type": "case_review",
+            "case_id": case.label.case_id,
+            "query": case.query,
+            "answer": None,
+            "fts_source_ids": [],
+            "hybrid_source_ids": [],
+            "objective_leakage_count": 0,
+            "reviewed_result": {
+                "abstained": True,
+                "retrieval_latency_seconds": 0.1,
+                "full_latency_seconds": 0.2,
+            },
+        }
+
+    monkeypatch.setattr(runner, "_run_case", fake_run_case)
+    args = runner.build_parser().parse_args(
+        [
+            "--input",
+            str(input_path),
+            "--cases-output",
+            str(cases_path),
+            "--observations-output",
+            str(observations_path),
+            "--review-output",
+            str(review_path),
+            "--release-sha",
+            RELEASE_SHA,
+            "--smoke",
+        ]
+    )
+
+    assert await runner.run_private_evaluation(args) == 0
+
+    report = json.loads(capsys.readouterr().out)
+    detached_bytes = detached_observations_path.read_bytes()
+    assert report["observations_sha256"] == hashlib.sha256(detached_bytes).hexdigest()
+    assert (
+        report["observations_sha256"] != hashlib.sha256(observations_path.read_bytes()).hexdigest()
+    )
 
 
 def test_smoke_mode_is_explicit_and_requires_exactly_one_case(tmp_path: Path) -> None:

--- a/tests/scripts/test_run_semantic_qa_eval.py
+++ b/tests/scripts/test_run_semantic_qa_eval.py
@@ -27,6 +27,15 @@ def _rows(count: int = 50) -> list[dict[str, object]]:
         + ["no_answer"] * 10
         + ["privacy_governance"] * 5
     )
+    privacy_class_groups = iter(
+        (
+            ["cross_chat", "stale_version"],
+            ["bot_authored"],
+            ["forgotten"],
+            ["redacted"],
+            ["non_normal"],
+        )
+    )
     rows: list[dict[str, object]] = []
     for index, category in enumerate(categories[:count], start=1):
         abstain = category == "no_answer"
@@ -38,6 +47,9 @@ def _rows(count: int = 50) -> list[dict[str, object]]:
                 "query": f"private query {index}",
                 "expected_source_ids": [] if abstain else [f"message:{index}"],
                 "forbidden_source_ids": [f"message:{1000 + index}"]
+                if category == "privacy_governance"
+                else [],
+                "privacy_classes": next(privacy_class_groups)
                 if category == "privacy_governance"
                 else [],
                 "expected_abstain": abstain,
@@ -66,6 +78,43 @@ def test_input_is_fully_validated_before_provider_work(tmp_path: Path) -> None:
     _write(path, _rows(count=49))
     with pytest.raises(ValueError, match="at least 50"):
         runner.load_private_cases(path, smoke=False)
+
+    rows = _rows()
+    rows[-5]["privacy_classes"] = ["cross_chat"]
+    _write(path, rows)
+    with pytest.raises(ValueError, match="missing=.*stale_version"):
+        runner.load_private_cases(path, smoke=False)
+
+
+@pytest.mark.asyncio
+async def test_missing_privacy_coverage_stops_before_provider_dispatch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    input_path = tmp_path / "input.jsonl"
+    rows = _rows()
+    rows[-5]["privacy_classes"] = ["cross_chat"]
+    _write(input_path, rows)
+    run_case = AsyncMock()
+    monkeypatch.setattr(runner, "_run_case", run_case)
+    args = runner.build_parser().parse_args(
+        [
+            "--input",
+            str(input_path),
+            "--cases-output",
+            str(tmp_path / "cases.jsonl"),
+            "--observations-output",
+            str(tmp_path / "observations.jsonl"),
+            "--review-output",
+            str(tmp_path / "review.jsonl"),
+            "--release-sha",
+            RELEASE_SHA,
+        ]
+    )
+
+    with pytest.raises(ValueError, match="missing=.*stale_version"):
+        await runner.run_private_evaluation(args)
+    run_case.assert_not_awaited()
 
 
 def test_smoke_mode_is_explicit_and_requires_exactly_one_case(tmp_path: Path) -> None:
@@ -115,6 +164,7 @@ async def test_run_case_rechecks_query_before_embedding(
             category="privacy_governance",
             expected_source_ids=(),
             forbidden_source_ids=("message:1",),
+            privacy_classes=("redacted",),
             expected_abstain=True,
         ),
         chat_id=-1001234567890,

--- a/tests/scripts/test_run_semantic_qa_eval.py
+++ b/tests/scripts/test_run_semantic_qa_eval.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import json
+import stat
+from pathlib import Path
+
+import pytest
+
+from scripts import run_semantic_qa_eval as runner
+
+
+RELEASE_SHA = "a" * 40
+
+
+def _rows(count: int = 50) -> list[dict[str, object]]:
+    categories = (
+        ["semantic"] * 15
+        + ["exact"] * 10
+        + ["multi_source"] * 10
+        + ["no_answer"] * 10
+        + ["privacy_governance"] * 5
+    )
+    rows: list[dict[str, object]] = []
+    for index, category in enumerate(categories[:count], start=1):
+        abstain = category == "no_answer"
+        rows.append(
+            {
+                "case_id": f"case-{index:03d}",
+                "category": category,
+                "chat_id": -1001234567890,
+                "query": f"private query {index}",
+                "expected_source_ids": [] if abstain else [f"message:{index}"],
+                "forbidden_source_ids": [f"message:{1000 + index}"]
+                if category == "privacy_governance"
+                else [],
+                "expected_abstain": abstain,
+                "exclude_chat_message_id": None,
+            }
+        )
+    return rows
+
+
+def _write(path: Path, rows: list[dict[str, object]]) -> None:
+    path.write_text(
+        "".join(json.dumps(row, sort_keys=True) + "\n" for row in rows),
+        encoding="utf-8",
+    )
+
+
+def test_input_is_fully_validated_before_provider_work(tmp_path: Path) -> None:
+    path = tmp_path / "input.jsonl"
+    rows = _rows()
+    rows[-1]["forbidden_source_ids"] = []
+    _write(path, rows)
+
+    with pytest.raises(ValueError, match="forbidden"):
+        runner.load_private_cases(path, smoke=False)
+
+    _write(path, _rows(count=49))
+    with pytest.raises(ValueError, match="at least 50"):
+        runner.load_private_cases(path, smoke=False)
+
+
+def test_smoke_mode_is_explicit_and_requires_exactly_one_case(tmp_path: Path) -> None:
+    path = tmp_path / "smoke.jsonl"
+    row = _rows()[0]
+    _write(path, [row])
+
+    cases = runner.load_private_cases(path, smoke=True)
+
+    assert len(cases) == 1
+    with pytest.raises(ValueError, match="at least 50"):
+        runner.load_private_cases(path, smoke=False)
+
+
+@pytest.mark.asyncio
+async def test_runner_outputs_private_0600_files_and_never_logs_raw_text(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    input_path = tmp_path / "input.jsonl"
+    cases_path = tmp_path / "cases.jsonl"
+    observations_path = tmp_path / "observations.jsonl"
+    review_path = tmp_path / "review.jsonl"
+    rows = _rows()
+    rows[0]["query"] = "PRIVATE-QUERY-SENTINEL"
+    _write(input_path, rows)
+
+    async def fake_run_case(case: runner.PrivateEvalCase) -> dict[str, object]:
+        return {
+            "record_type": "case_review",
+            "case_id": case.label.case_id,
+            "query": case.query,
+            "answer": "PRIVATE-ANSWER-SENTINEL",
+            "fts_source_ids": [],
+            "hybrid_source_ids": list(case.label.expected_source_ids),
+            "objective_leakage_count": 0,
+            "reviewed_result": {
+                "abstained": False,
+                "retrieval_latency_seconds": 1.0,
+                "full_latency_seconds": 2.0,
+            },
+        }
+
+    monkeypatch.setattr(runner, "_run_case", fake_run_case)
+    args = runner.build_parser().parse_args(
+        [
+            "--input",
+            str(input_path),
+            "--cases-output",
+            str(cases_path),
+            "--observations-output",
+            str(observations_path),
+            "--review-output",
+            str(review_path),
+            "--release-sha",
+            RELEASE_SHA,
+        ]
+    )
+
+    assert await runner.run_private_evaluation(args) == 0
+    captured = capsys.readouterr()
+    assert "PRIVATE-QUERY-SENTINEL" not in captured.out + captured.err
+    assert "PRIVATE-ANSWER-SENTINEL" not in captured.out + captured.err
+    assert stat.S_IMODE(cases_path.stat().st_mode) == 0o600
+    assert stat.S_IMODE(observations_path.stat().st_mode) == 0o600
+    assert stat.S_IMODE(review_path.stat().st_mode) == 0o600
+    assert "PRIVATE-QUERY-SENTINEL" not in cases_path.read_text(encoding="utf-8")
+    observations_text = observations_path.read_text(encoding="utf-8")
+    assert "PRIVATE-QUERY-SENTINEL" not in observations_text
+    observations_header = json.loads(observations_text.splitlines()[0])
+    assert observations_header["contains_raw_text"] is False
+    assert observations_header["release_sha"] == RELEASE_SHA
+    review_text = review_path.read_text(encoding="utf-8")
+    assert "PRIVATE-QUERY-SENTINEL" in review_text
+    assert "PRIVATE-ANSWER-SENTINEL" in review_text
+    header = json.loads(review_text.splitlines()[0])
+    assert header["contains_raw_text"] is True
+    assert header["release_sha"] == RELEASE_SHA
+
+
+def test_source_key_and_branch_ranking_are_canonical() -> None:
+    ranks = {
+        "message:2": {"fts": 2, "vector": 1},
+        "message:1": {"fts": 1},
+        "card:123e4567-e89b-42d3-a456-426614174000": {"vector": 2},
+    }
+
+    assert runner._ranked_branch_keys(ranks, "fts") == ["message:1", "message:2"]
+    assert runner._ranked_branch_keys(ranks, "vector") == [
+        "message:2",
+        "card:123e4567-e89b-42d3-a456-426614174000",
+    ]

--- a/tests/scripts/test_run_semantic_qa_eval.py
+++ b/tests/scripts/test_run_semantic_qa_eval.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from unittest.mock import AsyncMock
 import json
 import stat
 from pathlib import Path
@@ -10,6 +11,12 @@ from scripts import run_semantic_qa_eval as runner
 
 
 RELEASE_SHA = "a" * 40
+
+
+def _secret_query() -> str:
+    """Build a detector fixture without storing a credential-shaped literal."""
+
+    return "".join(("OPENAI_API_KEY=", "sk-", "proj-", "abcdefghijklmnop", "qrstuvwxyz012345"))
 
 
 def _rows(count: int = 50) -> list[dict[str, object]]:
@@ -71,6 +78,53 @@ def test_smoke_mode_is_explicit_and_requires_exactly_one_case(tmp_path: Path) ->
     assert len(cases) == 1
     with pytest.raises(ValueError, match="at least 50"):
         runner.load_private_cases(path, smoke=False)
+
+
+@pytest.mark.parametrize(
+    "unsafe_query",
+    [
+        "x" * 146,
+        pytest.param(_secret_query(), id="secret-like"),
+    ],
+)
+def test_private_input_rejects_queries_outside_production_guard_before_run(
+    tmp_path: Path,
+    unsafe_query: str,
+) -> None:
+    path = tmp_path / "unsafe.jsonl"
+    row = _rows()[0]
+    row["query"] = unsafe_query
+    _write(path, [row])
+
+    with pytest.raises(ValueError):
+        runner.load_private_cases(path, smoke=True)
+
+
+@pytest.mark.asyncio
+async def test_run_case_rechecks_query_before_embedding(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from bot.services import llm_gateway
+    from bot.services.semantic_eval import SemanticEvalCase
+
+    embed = AsyncMock()
+    monkeypatch.setattr(llm_gateway, "embed_texts", embed)
+    case = runner.PrivateEvalCase(
+        label=SemanticEvalCase(
+            case_id="unsafe-direct-case",
+            category="privacy_governance",
+            expected_source_ids=(),
+            forbidden_source_ids=("message:1",),
+            expected_abstain=True,
+        ),
+        chat_id=-1001234567890,
+        query=_secret_query(),
+        exclude_chat_message_id=None,
+    )
+
+    with pytest.raises(ValueError):
+        await runner._run_case(case)
+    embed.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/services/test_deepseek_provider.py
+++ b/tests/services/test_deepseek_provider.py
@@ -130,6 +130,36 @@ async def test_deepseek_provider_requires_api_key_before_network() -> None:
     assert exc_info.value.subtype == "auth"
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "usage",
+    [
+        None,
+        {},
+        {"prompt_tokens": -1, "completion_tokens": 1},
+        {"prompt_tokens": "1", "completion_tokens": 1},
+        {"prompt_tokens": True, "completion_tokens": 1},
+    ],
+)
+async def test_deepseek_provider_rejects_missing_or_invalid_usage(usage: object) -> None:
+    from bot.services.llm_providers import ProviderStructuralError
+    from bot.services.llm_providers.deepseek import DeepSeekProvider
+
+    payload = {
+        "id": "ds-invalid-usage",
+        "choices": [{"message": {"content": "answer"}}],
+    }
+    if usage is not None:
+        payload["usage"] = usage
+    transport = httpx.MockTransport(lambda _request: httpx.Response(200, json=payload))
+    async with _client(transport) as client:
+        provider = DeepSeekProvider(api_key="test-key", client=client)
+        with pytest.raises(ProviderStructuralError) as exc_info:
+            await provider.call(prompt="question", model="deepseek-v4-flash")
+
+    assert exc_info.value.subtype == "contract_violation"
+
+
 def test_deepseek_pricing_is_pinned_to_official_v4_flash_rates() -> None:
     from bot.services.llm_pricing import MODEL_PRICING, estimate_cost
 

--- a/tests/services/test_forget_cascade_semantic.py
+++ b/tests/services/test_forget_cascade_semantic.py
@@ -436,6 +436,69 @@ async def test_forgetting_question_message_redacts_query_embedding_audit(
         assert row.cost_usd == Decimal("0.001234")
 
 
+async def test_forgetting_quota_denied_question_redacts_unlinked_query_trace(
+    db_session,
+) -> None:
+    from bot.db.models import QaTrace, SemanticQaAttempt
+    from bot.services.forget_cascade import run_cascade_worker_once
+
+    owner_id = await _make_user(db_session)
+    message, _ = await _make_message(
+        db_session,
+        user_id=owner_id,
+        texts=("quota denied private question",),
+    )
+    denied_attempt = SemanticQaAttempt(
+        idempotency_key=f"semantic-quota-denied-{_next()}",
+        user_tg_id=owner_id,
+        chat_id=message.chat_id,
+        source_chat_message_id=message.id,
+        local_day=date.today(),
+        slot_number=None,
+        status="denied",
+        outcome="quota_denied",
+        qa_trace_id=None,
+        finalized_at=datetime.now(timezone.utc),
+    )
+    denied_trace = QaTrace(
+        source_chat_message_id=message.id,
+        user_tg_id=owner_id,
+        chat_id=message.chat_id,
+        query_text="quota denied private question",
+        query_redacted=False,
+        evidence_ids=[],
+        abstained=True,
+        llm_response_summary="ordinary search result",
+        llm_response_redacted=False,
+    )
+    db_session.add_all([denied_attempt, denied_trace])
+    await db_session.flush()
+    assert denied_attempt.qa_trace_id is None
+
+    await _make_forget_event(
+        db_session,
+        target_type="message",
+        target_id=str(message.id),
+        tombstone_key=f"message:{message.chat_id}:{message.message_id}",
+    )
+
+    stats = await run_cascade_worker_once(db_session)
+
+    assert stats == {"claimed": 1, "processed": 1, "failed": 0}
+    surviving_attempt = await db_session.get(
+        SemanticQaAttempt,
+        denied_attempt.id,
+        populate_existing=True,
+    )
+    assert surviving_attempt is not None
+    assert surviving_attempt.qa_trace_id is None
+    redacted_trace = await db_session.get(QaTrace, denied_trace.id, populate_existing=True)
+    assert redacted_trace.query_text is None
+    assert redacted_trace.query_redacted is True
+    assert redacted_trace.llm_response_summary is None
+    assert redacted_trace.llm_response_redacted is True
+
+
 async def test_forget_redacts_inflight_trace_ledgers_without_hash_resurrection(
     db_session,
 ) -> None:

--- a/tests/services/test_forget_cascade_semantic.py
+++ b/tests/services/test_forget_cascade_semantic.py
@@ -141,8 +141,11 @@ async def _make_unit(
         embedding_model="text-embedding-3-small",
         embedding_model_version="text-embedding-3-small",
         embedding_dimensions=1536,
+        embedding_status="completed",
+        chunk_text=f"semantic chunk {ordinal}",
         embedding=[0.0] * 1536,
         llm_usage_ledger_id=ledger_id,
+        indexed_at=datetime.now(timezone.utc),
     )
     db_session.add(unit)
     await db_session.flush()
@@ -227,6 +230,137 @@ async def _make_forget_event(
         authorized_by="admin",
         tombstone_key=tombstone_key,
     )
+
+
+@pytest.mark.asyncio
+async def test_failed_embedding_claim_is_forgettable_with_its_ledger(db_session) -> None:
+    from bot.db.models import LlmUsageLedger, SemanticRetrievalUnit
+    from bot.services.forget_cascade import _cascade_semantic_retrieval
+    from bot.services.llm_gateway import EmbeddingGatewayConfig
+    from bot.services.llm_providers import ProviderTransientError
+    from bot.services.semantic_index import (
+        _index_batch,
+        list_eligible_message_documents,
+        vector_search,
+    )
+
+    class FailingProvider:
+        async def embed(self, *, inputs, model, dimensions):
+            raise ProviderTransientError("timeout", message="redacted")
+
+    user_id = await _make_user(db_session)
+    message, versions = await _make_message(db_session, user_id=user_id)
+    documents = await list_eligible_message_documents(
+        db_session,
+        chat_id=message.chat_id,
+    )
+    config = EmbeddingGatewayConfig(
+        model="text-embedding-3-small",
+        dimensions=1536,
+        daily_ceiling_usd=Decimal("100"),
+        monthly_ceiling_usd=Decimal("1000"),
+    )
+
+    with pytest.raises(ProviderTransientError):
+        await _index_batch(
+            db_session,
+            documents=documents,
+            config=config,
+            provider=FailingProvider(),
+        )
+
+    unit = (await db_session.execute(select(SemanticRetrievalUnit))).scalars().one()
+    assert unit.embedding_status == "failed"
+    assert unit.embedding is None
+    ledger_id = unit.llm_usage_ledger_id
+    ledger = await db_session.get(LlmUsageLedger, ledger_id)
+    assert ledger is not None and ledger.prompt_hash is not None
+    assert (
+        await vector_search(
+            db_session,
+            query_embedding=(1.0,) + (0.0,) * 1535,
+            chat_id=message.chat_id,
+            embedding_model=config.model,
+        )
+        == []
+    )
+
+    event = await _make_forget_event(
+        db_session,
+        target_type="message",
+        target_id=str(message.id),
+        tombstone_key=f"failed-claim-forget-{versions[-1].id}",
+    )
+    await _cascade_semantic_retrieval(db_session, event)
+
+    assert await db_session.get(SemanticRetrievalUnit, unit.id) is None
+    redacted_ledger = await db_session.get(LlmUsageLedger, ledger_id)
+    assert redacted_ledger is not None
+    assert redacted_ledger.prompt_hash is None
+    assert redacted_ledger.response_hash is None
+
+
+@pytest.mark.asyncio
+async def test_budget_denied_embedding_claim_is_forgettable_without_provider_call(
+    db_session,
+) -> None:
+    from bot.db.models import LlmUsageLedger, SemanticRetrievalUnit
+    from bot.services.forget_cascade import _cascade_semantic_retrieval
+    from bot.services.llm_gateway import EmbeddingBudgetExceeded, EmbeddingGatewayConfig
+    from bot.services.semantic_index import _index_batch, list_eligible_message_documents
+
+    class ForbiddenProvider:
+        calls = 0
+
+        async def embed(self, *, inputs, model, dimensions):
+            self.calls += 1
+            raise AssertionError("budget denial must precede provider dispatch")
+
+    user_id = await _make_user(db_session)
+    message, versions = await _make_message(
+        db_session,
+        user_id=user_id,
+        texts=("x" * 800,),
+    )
+    documents = await list_eligible_message_documents(
+        db_session,
+        chat_id=message.chat_id,
+    )
+    provider = ForbiddenProvider()
+    config = EmbeddingGatewayConfig(
+        model="text-embedding-3-small",
+        dimensions=1536,
+        daily_ceiling_usd=Decimal("0.000001"),
+        monthly_ceiling_usd=Decimal("0.000001"),
+    )
+
+    with pytest.raises(EmbeddingBudgetExceeded):
+        await _index_batch(
+            db_session,
+            documents=documents,
+            config=config,
+            provider=provider,
+        )
+
+    assert provider.calls == 0
+    unit = (await db_session.execute(select(SemanticRetrievalUnit))).scalars().one()
+    assert unit.embedding_status == "failed"
+    ledger_id = unit.llm_usage_ledger_id
+    ledger = await db_session.get(LlmUsageLedger, ledger_id)
+    assert ledger is not None and ledger.error == "budget_exceeded"
+
+    event = await _make_forget_event(
+        db_session,
+        target_type="message",
+        target_id=str(message.id),
+        tombstone_key=f"budget-claim-forget-{versions[-1].id}",
+    )
+    await _cascade_semantic_retrieval(db_session, event)
+
+    assert await db_session.get(SemanticRetrievalUnit, unit.id) is None
+    redacted_ledger = await db_session.get(LlmUsageLedger, ledger_id)
+    assert redacted_ledger is not None
+    assert redacted_ledger.prompt_hash is None
 
 
 def test_semantic_layer_runs_before_message_versions_and_is_registered() -> None:

--- a/tests/services/test_forget_cascade_semantic.py
+++ b/tests/services/test_forget_cascade_semantic.py
@@ -301,20 +301,30 @@ async def test_failed_embedding_claim_is_forgettable_with_its_ledger(db_session)
 
 
 @pytest.mark.asyncio
-async def test_budget_denied_embedding_claim_is_forgettable_without_provider_call(
+async def test_budget_denial_is_retryable_with_content_free_audit(
     db_session,
 ) -> None:
     from bot.db.models import LlmUsageLedger, SemanticRetrievalUnit
     from bot.services.forget_cascade import _cascade_semantic_retrieval
     from bot.services.llm_gateway import EmbeddingBudgetExceeded, EmbeddingGatewayConfig
+    from bot.services.llm_providers.openai_embeddings import EmbeddingResult
     from bot.services.semantic_index import _index_batch, list_eligible_message_documents
 
-    class ForbiddenProvider:
-        calls = 0
+    class Provider:
+        def __init__(self) -> None:
+            self.calls = 0
+            self.allowed = False
 
         async def embed(self, *, inputs, model, dimensions):
             self.calls += 1
-            raise AssertionError("budget denial must precede provider dispatch")
+            if not self.allowed:
+                raise AssertionError("budget denial must precede provider dispatch")
+            return EmbeddingResult(
+                vectors=((1.0,) + (0.0,) * 1535,),
+                tokens_in=8,
+                request_id="retry-after-budget",
+                raw_latency_ms=1,
+            )
 
     user_id = await _make_user(db_session)
     message, versions = await _make_message(
@@ -326,7 +336,7 @@ async def test_budget_denied_embedding_claim_is_forgettable_without_provider_cal
         db_session,
         chat_id=message.chat_id,
     )
-    provider = ForbiddenProvider()
+    provider = Provider()
     config = EmbeddingGatewayConfig(
         model="text-embedding-3-small",
         dimensions=1536,
@@ -343,11 +353,38 @@ async def test_budget_denied_embedding_claim_is_forgettable_without_provider_cal
         )
 
     assert provider.calls == 0
+    assert (await db_session.execute(select(SemanticRetrievalUnit))).scalars().all() == []
+    budget_ledger = (
+        (
+            await db_session.execute(
+                select(LlmUsageLedger).where(LlmUsageLedger.error == "budget_exceeded")
+            )
+        )
+        .scalars()
+        .one()
+    )
+    safe_budget_hash = hashlib.sha256(
+        b"embedding_budget_exceeded_without_provider_dispatch"
+    ).hexdigest()
+    assert budget_ledger.prompt_hash == safe_budget_hash
+
+    provider.allowed = True
+    retry = await _index_batch(
+        db_session,
+        documents=documents,
+        config=EmbeddingGatewayConfig(
+            model="text-embedding-3-small",
+            dimensions=1536,
+            daily_ceiling_usd=Decimal("100"),
+            monthly_ceiling_usd=Decimal("1000"),
+        ),
+        provider=provider,
+    )
+    assert retry.indexed == 1
+    assert provider.calls == 1
     unit = (await db_session.execute(select(SemanticRetrievalUnit))).scalars().one()
-    assert unit.embedding_status == "failed"
-    ledger_id = unit.llm_usage_ledger_id
-    ledger = await db_session.get(LlmUsageLedger, ledger_id)
-    assert ledger is not None and ledger.error == "budget_exceeded"
+    assert unit.embedding_status == "completed"
+    successful_ledger_id = unit.llm_usage_ledger_id
 
     event = await _make_forget_event(
         db_session,
@@ -358,9 +395,15 @@ async def test_budget_denied_embedding_claim_is_forgettable_without_provider_cal
     await _cascade_semantic_retrieval(db_session, event)
 
     assert await db_session.get(SemanticRetrievalUnit, unit.id) is None
-    redacted_ledger = await db_session.get(LlmUsageLedger, ledger_id)
+    redacted_ledger = await db_session.get(LlmUsageLedger, successful_ledger_id)
     assert redacted_ledger is not None
     assert redacted_ledger.prompt_hash is None
+    unchanged_budget_ledger = await db_session.get(
+        LlmUsageLedger,
+        budget_ledger.id,
+        populate_existing=True,
+    )
+    assert unchanged_budget_ledger.prompt_hash == safe_budget_hash
 
 
 def test_semantic_layer_runs_before_message_versions_and_is_registered() -> None:

--- a/tests/services/test_forget_cascade_semantic.py
+++ b/tests/services/test_forget_cascade_semantic.py
@@ -1,0 +1,731 @@
+"""Issue #404 privacy cascade coverage for pgvector semantic Q&A data."""
+
+from __future__ import annotations
+
+import hashlib
+import itertools
+from datetime import date, datetime, timezone
+from decimal import Decimal
+
+import pytest
+from sqlalchemy import func, select, update
+
+
+pytestmark = pytest.mark.usefixtures("app_env")
+
+_counter = itertools.count(1)
+
+
+def _next() -> int:
+    return next(_counter)
+
+
+async def _make_user(db_session) -> int:
+    from bot.db.repos.user import UserRepo
+
+    user_id = 9_700_000_000 + _next()
+    await UserRepo.upsert(
+        db_session,
+        telegram_id=user_id,
+        username=f"semantic_forget_{user_id}",
+        first_name="Semantic",
+        last_name=None,
+        is_bot=False,
+    )
+    return user_id
+
+
+async def _make_message(
+    db_session,
+    *,
+    user_id: int,
+    texts: tuple[str, ...] = ("semantic secret",),
+    content_hashes: tuple[str, ...] | None = None,
+):
+    from bot.db.models import ChatMessage, MessageVersion
+
+    ordinal = _next()
+    message = ChatMessage(
+        message_id=1_900_000 + ordinal,
+        chat_id=-100_900_000_000 - ordinal,
+        user_id=user_id,
+        text=texts[-1],
+        date=datetime.now(timezone.utc),
+        raw_json={"text": texts[-1]},
+        memory_policy="normal",
+        visibility="member",
+        is_redacted=False,
+    )
+    db_session.add(message)
+    await db_session.flush()
+
+    versions = []
+    for sequence, body in enumerate(texts, start=1):
+        content_hash = (
+            content_hashes[sequence - 1]
+            if content_hashes is not None
+            else hashlib.sha256(f"{message.id}:{sequence}:{body}".encode()).hexdigest()
+        )
+        version = MessageVersion(
+            chat_message_id=message.id,
+            version_seq=sequence,
+            text=body,
+            normalized_text=body,
+            entities_json={"entities": []},
+            content_hash=content_hash,
+            is_redacted=False,
+        )
+        db_session.add(version)
+        await db_session.flush()
+        versions.append(version)
+
+    await db_session.execute(
+        update(ChatMessage)
+        .where(ChatMessage.id == message.id)
+        .values(
+            current_version_id=versions[-1].id,
+            content_hash=versions[-1].content_hash,
+        )
+    )
+    await db_session.flush()
+    return message, versions
+
+
+async def _make_ledger(
+    db_session,
+    *,
+    call_type: str = "semantic_embedding",
+    provider: str = "openai",
+):
+    from bot.db.models import LlmUsageLedger
+
+    row = LlmUsageLedger(
+        qa_trace_id=None,
+        provider=provider,
+        model=("text-embedding-3-small" if provider == "openai" else "deepseek-v4-flash"),
+        prompt_hash="a" * 64,
+        response_hash="b" * 64,
+        tokens_in=123,
+        tokens_out=17 if call_type == "qa_synthesis" else 0,
+        cost_usd=Decimal("0.001234"),
+        latency_ms=321,
+        request_id=f"req-{_next()}",
+        cache_hit=False,
+        error=None,
+        call_type=call_type,
+    )
+    db_session.add(row)
+    await db_session.flush()
+    return row
+
+
+async def _make_unit(
+    db_session,
+    *,
+    source_type: str,
+    source_id: str,
+    chat_id: int,
+    message_version_ids: list[int],
+    ledger_id: int,
+):
+    from bot.db.models import SemanticRetrievalUnit, SemanticRetrievalUnitSource
+
+    ordinal = _next()
+    unit = SemanticRetrievalUnit(
+        source_type=source_type,
+        source_id=source_id,
+        source_revision=f"test-r{ordinal}",
+        chat_id=chat_id,
+        content_hash=hashlib.sha256(f"unit:{ordinal}".encode()).hexdigest(),
+        embedding_provider="openai",
+        embedding_model="text-embedding-3-small",
+        embedding_model_version="text-embedding-3-small",
+        embedding_dimensions=1536,
+        embedding=[0.0] * 1536,
+        llm_usage_ledger_id=ledger_id,
+    )
+    db_session.add(unit)
+    await db_session.flush()
+    for position, message_version_id in enumerate(message_version_ids):
+        db_session.add(
+            SemanticRetrievalUnitSource(
+                unit_id=unit.id,
+                message_version_id=message_version_id,
+                position=position,
+            )
+        )
+    await db_session.flush()
+    return unit
+
+
+async def _make_attempt_with_trace(
+    db_session,
+    *,
+    user_id: int,
+    chat_id: int,
+    source_keys: list[str],
+    slot_number: int = 1,
+    source_chat_message_id: int | None = None,
+):
+    from bot.db.models import SemanticQaAttempt, SemanticRetrievalTrace
+
+    embedding_ledger = await _make_ledger(db_session)
+    synthesis_ledger = await _make_ledger(
+        db_session,
+        call_type="qa_synthesis",
+        provider="deepseek",
+    )
+    attempt = SemanticQaAttempt(
+        idempotency_key=f"semantic-forget-attempt-{_next()}",
+        user_tg_id=user_id,
+        chat_id=chat_id,
+        source_chat_message_id=source_chat_message_id,
+        local_day=date.today(),
+        slot_number=slot_number,
+        status="consumed",
+        outcome="answered",
+        qa_trace_id=None,
+        embedding_llm_call_id=embedding_ledger.id,
+        synthesis_llm_call_id=synthesis_ledger.id,
+        delivery_started_at=datetime.now(timezone.utc),
+        finalized_at=datetime.now(timezone.utc),
+    )
+    db_session.add(attempt)
+    await db_session.flush()
+    trace = SemanticRetrievalTrace(
+        attempt_id=attempt.id,
+        qa_trace_id=None,
+        query_hash="c" * 64,
+        embedding_model="text-embedding-3-small",
+        retrieval_mode="hybrid",
+        candidate_ranks={key: {"vector": index + 1} for index, key in enumerate(source_keys)},
+        result_source_ids=list(source_keys),
+        fts_latency_ms=1,
+        vector_latency_ms=2,
+        fusion_latency_ms=1,
+        total_latency_ms=4,
+    )
+    db_session.add(trace)
+    await db_session.flush()
+    return attempt, trace, embedding_ledger, synthesis_ledger
+
+
+async def _make_forget_event(
+    db_session,
+    *,
+    target_type: str,
+    target_id: str,
+    tombstone_key: str,
+):
+    from bot.db.repos.forget_event import ForgetEventRepo
+
+    return await ForgetEventRepo.create(
+        db_session,
+        target_type=target_type,
+        target_id=target_id,
+        actor_user_id=None,
+        authorized_by="admin",
+        tombstone_key=tombstone_key,
+    )
+
+
+def test_semantic_layer_runs_before_message_versions_and_is_registered() -> None:
+    from bot.services.forget_cascade import CASCADE_LAYER_ORDER, _LAYER_FUNCS
+
+    assert CASCADE_LAYER_ORDER.index("semantic_retrieval") < CASCADE_LAYER_ORDER.index(
+        "message_versions"
+    )
+    assert "semantic_retrieval" in _LAYER_FUNCS
+
+
+async def test_forgetting_question_message_redacts_query_embedding_audit(
+    db_session,
+) -> None:
+    from bot.db.models import (
+        LlmUsageLedger,
+        QaTrace,
+        SemanticQaAttempt,
+        SemanticRetrievalTrace,
+    )
+    from bot.services.forget_cascade import run_cascade_worker_once
+
+    owner_id = await _make_user(db_session)
+    message, _ = await _make_message(
+        db_session,
+        user_id=owner_id,
+        texts=("forgotten semantic question",),
+    )
+    attempt, trace, embedding_ledger, synthesis_ledger = await _make_attempt_with_trace(
+        db_session,
+        user_id=owner_id,
+        chat_id=message.chat_id,
+        source_keys=[],
+        source_chat_message_id=message.id,
+    )
+    qa_trace = QaTrace(
+        source_chat_message_id=message.id,
+        user_tg_id=owner_id,
+        chat_id=message.chat_id,
+        query_text="forgotten semantic question",
+        query_redacted=False,
+        evidence_ids=[],
+        abstained=True,
+        llm_response_summary="derived answer",
+        llm_response_redacted=False,
+    )
+    db_session.add(qa_trace)
+    await db_session.flush()
+    attempt.qa_trace_id = qa_trace.id
+    trace.qa_trace_id = qa_trace.id
+    await db_session.flush()
+    await _make_forget_event(
+        db_session,
+        target_type="message",
+        target_id=str(message.id),
+        tombstone_key=f"message:{message.chat_id}:{message.message_id}",
+    )
+
+    stats = await run_cascade_worker_once(db_session)
+
+    assert stats == {"claimed": 1, "processed": 1, "failed": 0}
+    assert await db_session.get(SemanticQaAttempt, attempt.id) is not None
+    assert await db_session.get(SemanticRetrievalTrace, trace.id) is None
+    redacted_qa = await db_session.get(QaTrace, qa_trace.id, populate_existing=True)
+    assert redacted_qa.query_text is None
+    assert redacted_qa.query_redacted is True
+    assert redacted_qa.llm_response_summary is None
+    assert redacted_qa.llm_response_redacted is True
+    for ledger in (embedding_ledger, synthesis_ledger):
+        row = await db_session.get(LlmUsageLedger, ledger.id, populate_existing=True)
+        assert row.prompt_hash is None
+        assert row.response_hash is None
+        assert row.cost_usd == Decimal("0.001234")
+
+
+async def test_forget_redacts_inflight_trace_ledgers_without_hash_resurrection(
+    db_session,
+) -> None:
+    from bot.db.models import LlmUsageLedger, QaTrace
+    from bot.db.repos.llm_usage_ledger import LedgerRepo
+    from bot.services.forget_cascade import run_cascade_worker_once
+
+    owner_id = await _make_user(db_session)
+    message, _ = await _make_message(
+        db_session,
+        user_id=owner_id,
+        texts=("question forgotten during provider call",),
+    )
+    attempt, trace, embedding_ledger, synthesis_ledger = await _make_attempt_with_trace(
+        db_session,
+        user_id=owner_id,
+        chat_id=message.chat_id,
+        source_keys=[],
+        source_chat_message_id=message.id,
+    )
+    qa_trace = QaTrace(
+        source_chat_message_id=message.id,
+        user_tg_id=owner_id,
+        chat_id=message.chat_id,
+        query_text="question forgotten during provider call",
+        query_redacted=False,
+        evidence_ids=[],
+        abstained=True,
+        llm_response_summary=None,
+        llm_response_redacted=False,
+    )
+    db_session.add(qa_trace)
+    await db_session.flush()
+    attempt.qa_trace_id = qa_trace.id
+    trace.qa_trace_id = qa_trace.id
+    # Provider placeholders exist before the result FKs can be attached to the
+    # attempt.  The forget cascade must discover them through qa_trace_id.
+    attempt.embedding_llm_call_id = None
+    attempt.synthesis_llm_call_id = None
+    embedding_ledger.qa_trace_id = qa_trace.id
+    synthesis_ledger.qa_trace_id = qa_trace.id
+    await db_session.flush()
+    await _make_forget_event(
+        db_session,
+        target_type="message",
+        target_id=str(message.id),
+        tombstone_key=f"message:{message.chat_id}:{message.message_id}",
+    )
+
+    stats = await run_cascade_worker_once(db_session)
+
+    assert stats == {"claimed": 1, "processed": 1, "failed": 0}
+    for ledger in (embedding_ledger, synthesis_ledger):
+        row = await db_session.get(LlmUsageLedger, ledger.id, populate_existing=True)
+        assert row.prompt_hash is None
+        assert row.response_hash is None
+
+    # Simulate the provider result resuming after the forget transaction.  Cost
+    # and telemetry remain auditable, while redacted hashes are irreversible.
+    await LedgerRepo.update_placeholder(
+        db_session,
+        llm_call_id=synthesis_ledger.id,
+        tokens_in=321,
+        tokens_out=42,
+        cost_usd=Decimal("0.004200"),
+        latency_ms=654,
+        request_id="provider-resumed-after-forget",
+        response_hash="f" * 64,
+        error=None,
+    )
+    resumed = await db_session.get(
+        LlmUsageLedger,
+        synthesis_ledger.id,
+        populate_existing=True,
+    )
+    assert resumed.prompt_hash is None
+    assert resumed.response_hash is None
+    assert resumed.tokens_in == 321
+    assert resumed.tokens_out == 42
+    assert resumed.cost_usd == Decimal("0.004200")
+
+
+async def test_message_forget_purges_all_revision_and_card_units_and_related_audit(
+    db_session,
+) -> None:
+    from bot.db.models import (
+        CardSource,
+        ForgetEvent,
+        KnowledgeCard,
+        LlmUsageLedger,
+        MessageVersion,
+        SemanticQaAttempt,
+        SemanticRetrievalTrace,
+        SemanticRetrievalUnit,
+        SemanticRetrievalUnitSource,
+    )
+    from bot.services.forget_cascade import run_cascade_worker_once
+
+    owner_id = await _make_user(db_session)
+    message, versions = await _make_message(
+        db_session,
+        user_id=owner_id,
+        texts=("old forgotten revision", "current forgotten revision"),
+    )
+    target_ledgers = [await _make_ledger(db_session) for _ in range(3)]
+    old_unit = await _make_unit(
+        db_session,
+        source_type="message",
+        source_id=str(versions[0].id),
+        chat_id=message.chat_id,
+        message_version_ids=[versions[0].id],
+        ledger_id=target_ledgers[0].id,
+    )
+    current_unit = await _make_unit(
+        db_session,
+        source_type="message",
+        source_id=str(versions[1].id),
+        chat_id=message.chat_id,
+        message_version_ids=[versions[1].id],
+        ledger_id=target_ledgers[1].id,
+    )
+
+    support_owner_id = await _make_user(db_session)
+    _support_message, support_versions = await _make_message(
+        db_session,
+        user_id=support_owner_id,
+        texts=("card anchor must remain",),
+    )
+
+    card = KnowledgeCard(
+        title="Forgotten card",
+        body_markdown="Derived from the forgotten source",
+        card_status="approved",
+        approved_by_user_id=owner_id,
+        approved_at=datetime.now(timezone.utc),
+    )
+    db_session.add(card)
+    await db_session.flush()
+    db_session.add_all(
+        [
+            CardSource(
+                card_id=card.id,
+                message_version_id=support_versions[0].id,
+                position=0,
+            ),
+            CardSource(
+                card_id=card.id,
+                message_version_id=versions[1].id,
+                position=1,
+            ),
+        ]
+    )
+    await db_session.flush()
+    card_unit = await _make_unit(
+        db_session,
+        source_type="card",
+        source_id=str(card.id),
+        chat_id=message.chat_id,
+        message_version_ids=[support_versions[0].id, versions[1].id],
+        ledger_id=target_ledgers[2].id,
+    )
+
+    other_owner_id = await _make_user(db_session)
+    other_message, other_versions = await _make_message(
+        db_session,
+        user_id=other_owner_id,
+        texts=("must remain",),
+    )
+    other_unit_ledger = await _make_ledger(db_session)
+    other_unit = await _make_unit(
+        db_session,
+        source_type="message",
+        source_id=str(other_versions[0].id),
+        chat_id=other_message.chat_id,
+        message_version_ids=[other_versions[0].id],
+        ledger_id=other_unit_ledger.id,
+    )
+
+    querying_user_id = await _make_user(db_session)
+    (
+        affected_attempt,
+        affected_trace,
+        query_ledger,
+        synthesis_ledger,
+    ) = await _make_attempt_with_trace(
+        db_session,
+        user_id=querying_user_id,
+        chat_id=message.chat_id,
+        source_keys=[f"message:{versions[0].id}", f"card:{card.id}"],
+        slot_number=1,
+    )
+    from bot.db.models import LlmSynthesisCache, QaTrace
+
+    affected_qa_trace = QaTrace(
+        user_tg_id=querying_user_id,
+        chat_id=message.chat_id,
+        query_text="answer from card",
+        query_redacted=False,
+        evidence_ids=[support_versions[0].id, versions[1].id],
+        abstained=False,
+        llm_response_summary="derived from forgotten non-anchor source",
+        llm_response_redacted=False,
+    )
+    db_session.add(affected_qa_trace)
+    affected_cache = LlmSynthesisCache(
+        input_hash=hashlib.sha256(f"cache:{_next()}".encode()).hexdigest(),
+        answer_text="cached from forgotten non-anchor source",
+        citation_ids=[support_versions[0].id, versions[1].id],
+        model="deepseek-v4-flash",
+    )
+    db_session.add(affected_cache)
+    await db_session.flush()
+    affected_attempt.qa_trace_id = affected_qa_trace.id
+    affected_trace.qa_trace_id = affected_qa_trace.id
+    await db_session.flush()
+    (
+        other_attempt,
+        other_trace,
+        other_query_ledger,
+        other_synthesis_ledger,
+    ) = await _make_attempt_with_trace(
+        db_session,
+        user_id=querying_user_id,
+        chat_id=other_message.chat_id,
+        source_keys=[f"message:{other_versions[0].id}"],
+        slot_number=2,
+    )
+
+    event = await _make_forget_event(
+        db_session,
+        target_type="message",
+        target_id=str(message.id),
+        tombstone_key=f"message:{message.chat_id}:{message.message_id}",
+    )
+    stats = await run_cascade_worker_once(db_session)
+
+    assert stats == {"claimed": 1, "processed": 1, "failed": 0}
+    for unit in (old_unit, current_unit, card_unit):
+        assert await db_session.get(SemanticRetrievalUnit, unit.id) is None
+    assert (
+        await db_session.scalar(
+            select(func.count())
+            .select_from(SemanticRetrievalUnitSource)
+            .where(
+                SemanticRetrievalUnitSource.unit_id.in_(
+                    [old_unit.id, current_unit.id, card_unit.id]
+                )
+            )
+        )
+        == 0
+    )
+    assert await db_session.get(SemanticRetrievalUnit, other_unit.id) is not None
+    assert (
+        await db_session.scalar(
+            select(SemanticRetrievalTrace.id).where(SemanticRetrievalTrace.id == affected_trace.id)
+        )
+        is None
+    )
+    assert (
+        await db_session.scalar(
+            select(SemanticRetrievalTrace.id).where(SemanticRetrievalTrace.id == other_trace.id)
+        )
+        == other_trace.id
+    )
+    assert await db_session.get(SemanticQaAttempt, affected_attempt.id) is not None
+    assert await db_session.get(SemanticQaAttempt, other_attempt.id) is not None
+    assert (
+        await db_session.scalar(
+            select(func.count())
+            .select_from(LlmSynthesisCache)
+            .where(LlmSynthesisCache.id == affected_cache.id)
+        )
+        == 0
+    )
+    redacted_trace = await db_session.get(
+        QaTrace,
+        affected_qa_trace.id,
+        populate_existing=True,
+    )
+    assert redacted_trace.llm_response_summary is None
+    assert redacted_trace.llm_response_redacted is True
+
+    for ledger in (*target_ledgers, synthesis_ledger):
+        row = await db_session.get(LlmUsageLedger, ledger.id, populate_existing=True)
+        assert row.prompt_hash is None
+        assert row.response_hash is None
+        assert row.cost_usd == Decimal("0.001234")
+        assert row.tokens_in == 123
+        assert row.latency_ms == 321
+    for ledger in (query_ledger, other_unit_ledger, other_query_ledger, other_synthesis_ledger):
+        row = await db_session.get(LlmUsageLedger, ledger.id, populate_existing=True)
+        assert row.prompt_hash == "a" * 64
+        assert row.response_hash == "b" * 64
+
+    for version in versions:
+        row = await db_session.get(MessageVersion, version.id, populate_existing=True)
+        assert row.is_redacted is True
+        assert row.text is None
+    event_row = await db_session.get(ForgetEvent, event.id, populate_existing=True)
+    assert event_row.cascade_status["semantic_retrieval"]["status"] == "completed"
+    assert event_row.cascade_status["semantic_retrieval"]["rows"] >= 8
+
+
+async def test_user_forget_deletes_query_trace_but_preserves_quota_and_cost_audit(
+    db_session,
+) -> None:
+    from bot.db.models import (
+        LlmUsageLedger,
+        SemanticQaAttempt,
+        SemanticRetrievalTrace,
+        SemanticRetrievalUnit,
+    )
+    from bot.services.forget_cascade import run_cascade_worker_once
+
+    forgotten_user_id = await _make_user(db_session)
+    message, versions = await _make_message(db_session, user_id=forgotten_user_id)
+    unit_ledger = await _make_ledger(db_session)
+    unit = await _make_unit(
+        db_session,
+        source_type="message",
+        source_id=str(versions[0].id),
+        chat_id=message.chat_id,
+        message_version_ids=[versions[0].id],
+        ledger_id=unit_ledger.id,
+    )
+    attempt, trace, query_ledger, synthesis_ledger = await _make_attempt_with_trace(
+        db_session,
+        user_id=forgotten_user_id,
+        chat_id=message.chat_id,
+        source_keys=[],
+    )
+
+    other_user_id = await _make_user(db_session)
+    other_message, other_versions = await _make_message(db_session, user_id=other_user_id)
+    other_unit_ledger = await _make_ledger(db_session)
+    other_unit = await _make_unit(
+        db_session,
+        source_type="message",
+        source_id=str(other_versions[0].id),
+        chat_id=other_message.chat_id,
+        message_version_ids=[other_versions[0].id],
+        ledger_id=other_unit_ledger.id,
+    )
+    (
+        other_attempt,
+        other_trace,
+        other_query_ledger,
+        other_synthesis_ledger,
+    ) = await _make_attempt_with_trace(
+        db_session,
+        user_id=other_user_id,
+        chat_id=other_message.chat_id,
+        source_keys=[f"message:{other_versions[0].id}"],
+    )
+
+    await _make_forget_event(
+        db_session,
+        target_type="user",
+        target_id=str(forgotten_user_id),
+        tombstone_key=f"user:{forgotten_user_id}",
+    )
+    stats = await run_cascade_worker_once(db_session)
+
+    assert stats == {"claimed": 1, "processed": 1, "failed": 0}
+    assert await db_session.get(SemanticRetrievalUnit, unit.id) is None
+    assert await db_session.get(SemanticRetrievalTrace, trace.id) is None
+    surviving_attempt = await db_session.get(SemanticQaAttempt, attempt.id)
+    assert surviving_attempt is not None
+    assert surviving_attempt.status == "consumed"
+    assert surviving_attempt.outcome == "answered"
+    for ledger in (unit_ledger, query_ledger, synthesis_ledger):
+        row = await db_session.get(LlmUsageLedger, ledger.id, populate_existing=True)
+        assert row.prompt_hash is None
+        assert row.response_hash is None
+        assert row.cost_usd == Decimal("0.001234")
+
+    assert await db_session.get(SemanticRetrievalUnit, other_unit.id) is not None
+    assert await db_session.get(SemanticRetrievalTrace, other_trace.id) is not None
+    assert await db_session.get(SemanticQaAttempt, other_attempt.id) is not None
+    for ledger in (other_unit_ledger, other_query_ledger, other_synthesis_ledger):
+        row = await db_session.get(LlmUsageLedger, ledger.id, populate_existing=True)
+        assert row.prompt_hash == "a" * 64
+        assert row.response_hash == "b" * 64
+
+
+async def test_message_hash_forget_purges_matching_units_across_messages(db_session) -> None:
+    from bot.db.models import LlmUsageLedger, SemanticRetrievalUnit
+    from bot.services.forget_cascade import run_cascade_worker_once
+
+    shared_hash = "d" * 64
+    target_units = []
+    target_ledgers = []
+    for _ in range(2):
+        owner_id = await _make_user(db_session)
+        message, versions = await _make_message(
+            db_session,
+            user_id=owner_id,
+            content_hashes=(shared_hash,),
+        )
+        ledger = await _make_ledger(db_session)
+        target_ledgers.append(ledger)
+        target_units.append(
+            await _make_unit(
+                db_session,
+                source_type="message",
+                source_id=str(versions[0].id),
+                chat_id=message.chat_id,
+                message_version_ids=[versions[0].id],
+                ledger_id=ledger.id,
+            )
+        )
+
+    await _make_forget_event(
+        db_session,
+        target_type="message_hash",
+        target_id=shared_hash,
+        tombstone_key=f"message_hash:{shared_hash}:semantic-test",
+    )
+    stats = await run_cascade_worker_once(db_session)
+
+    assert stats == {"claimed": 1, "processed": 1, "failed": 0}
+    for unit in target_units:
+        assert await db_session.get(SemanticRetrievalUnit, unit.id) is None
+    for ledger in target_ledgers:
+        row = await db_session.get(LlmUsageLedger, ledger.id, populate_existing=True)
+        assert row.prompt_hash is None
+        assert row.response_hash is None

--- a/tests/services/test_llm_gateway.py
+++ b/tests/services/test_llm_gateway.py
@@ -1542,6 +1542,44 @@ async def test_cache_miss_calls_provider_and_stores() -> None:
     assert ledger.rows[-1].cache_hit is False
 
 
+@pytest.mark.asyncio
+async def test_cache_disabled_ignores_existing_row_and_does_not_store() -> None:
+    bundle = _make_bundle((100,))
+    ledger = FakeLedgerRepo()
+    cache = FakeCacheRepo()
+    provider = FakeProvider(answer_text="fresh", citation_ids=(100,))
+    session = FakeSession(
+        query_results=[
+            [{"message_version_id": 100}],
+            [],
+        ]
+    )
+    await cache.store(
+        session,
+        input_hash="unrelated-seed",
+        answer_text="cached",
+        citation_ids=[100],
+        model=_config().model,
+    )
+
+    result = await synthesize_answer(
+        session,  # type: ignore[arg-type]
+        bundle=bundle,
+        query="q",
+        config=_config(),
+        qa_trace_id=11,
+        ledger_repo=ledger,
+        cache_repo=cache,
+        provider=provider,
+        cache_enabled=False,
+    )
+
+    assert isinstance(result, AnswerWithCitations)
+    assert result.answer_text == "fresh"
+    assert len(provider.calls) == 1
+    assert list(cache.rows) == ["unrelated-seed"]
+
+
 # ─── Tests: invariant 5 — budget guard ──────────────────────────────────────
 
 

--- a/tests/services/test_llm_gateway.py
+++ b/tests/services/test_llm_gateway.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import hashlib
+import uuid
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from decimal import Decimal
@@ -30,13 +31,14 @@ from typing import Any, Protocol
 import pytest
 from sqlalchemy.exc import IntegrityError
 
-from bot.services.evidence import EvidenceBundle
+from bot.services.evidence import EvidenceBundle, EvidenceItem
 from bot.services.llm_gateway import (
     LLM_BUDGET_LOCK_ID,
     Abstention,
     AnswerWithCitations,
     LLMGatewayConfig,
     SynthesisResult,
+    _SOURCE_FILTER_SQL,
     _build_prompt,
     _cache_input_hash,
     _estimate_cost,
@@ -407,6 +409,7 @@ class FakeSession:
     query_results: list[list[dict[str, Any]]] = field(default_factory=list)
     nested_depth: int = 0
     nested_entries: int = 0
+    commits: int = 0
 
     def begin_nested(self) -> _FakeNestedTransaction:
         self.nested_entries += 1
@@ -421,6 +424,9 @@ class FakeSession:
         else:
             rows = []
         return _SessionExecutor(rows)
+
+    async def commit(self) -> None:
+        self.commits += 1
 
 
 # ─── Helper: build a non-empty bundle ────────────────────────────────────────
@@ -555,6 +561,21 @@ def test_llm_budget_lock_id_is_deterministic_int64() -> None:
     assert LLM_BUDGET_LOCK_ID == expected
 
 
+def test_source_filter_sql_revalidates_complete_semantic_governance() -> None:
+    sql = str(_SOURCE_FILTER_SQL)
+    for required in (
+        "cm.chat_id = :chat_id",
+        "cm.current_version_id = mv.id",
+        "author.is_bot = FALSE",
+        "cm.memory_policy = 'normal'",
+        "NOT IN ('voice', 'audio')",
+        "cm.is_redacted = FALSE",
+        "mv.is_redacted = FALSE",
+        "fe.status IN ('pending', 'processing', 'completed')",
+    ):
+        assert required in sql
+
+
 # ─── Tests: invariant 1 — empty bundle short-circuit ────────────────────────
 
 
@@ -653,6 +674,272 @@ async def test_source_filter_partial_keeps_subset() -> None:
     assert isinstance(res, AnswerWithCitations)
     assert res.citation_ids == (100,)
     assert len(provider.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_semantic_mode_sends_five_governed_evidence_items() -> None:
+    bundle = _make_bundle((100, 101, 102, 103, 104))
+    ledger = FakeLedgerRepo()
+    cache = FakeCacheRepo()
+    provider = FakeProvider(citation_ids=(100,))
+    session = FakeSession(
+        query_results=[
+            [{"message_version_id": value} for value in bundle.evidence_ids],
+            [],
+        ]
+    )
+
+    result = await synthesize_answer(
+        session,  # type: ignore[arg-type]
+        bundle=bundle,
+        query="q",
+        config=_config(),
+        qa_trace_id=11,
+        ledger_repo=ledger,
+        cache_repo=cache,
+        provider=provider,
+        max_evidence_items=5,
+    )
+
+    assert isinstance(result, AnswerWithCitations)
+    assert result.surviving_evidence_ids == (100, 101, 102, 103, 104)
+    prompt = provider.calls[0]["prompt"]
+    assert all(f'"message_version_id": {value}' in prompt for value in bundle.evidence_ids)
+
+
+@pytest.mark.asyncio
+async def test_card_is_dropped_when_non_anchor_provenance_is_not_governed() -> None:
+    now = datetime(2026, 7, 14, 12, tzinfo=timezone.utc)
+    card = EvidenceItem(
+        message_version_id=100,
+        chat_message_id=200,
+        chat_id=-1001,
+        message_id=300,
+        user_id=None,
+        snippet="approved card",
+        ts_rank=0.8,
+        captured_at=now,
+        message_date=now,
+        source_type="card",
+        card_id=uuid.uuid4(),
+        card_source_message_version_ids=(100, 101),
+    )
+    bundle = EvidenceBundle("q", -1001, (card,), False, now)
+    provider = FakeProvider(citation_ids=(100,))
+
+    result = await synthesize_answer(
+        FakeSession(
+            query_results=[
+                [{"card_id": str(card.card_id), "source_ids": [100, 101]}],
+                [{"message_version_id": 100}],
+                [],
+            ]
+        ),  # type: ignore[arg-type]
+        bundle=bundle,
+        query="q",
+        config=_config(),
+        qa_trace_id=11,
+        ledger_repo=FakeLedgerRepo(),
+        cache_repo=FakeCacheRepo(),
+        provider=provider,
+        max_evidence_items=5,
+    )
+
+    assert isinstance(result, Abstention)
+    assert result.reason == "all_filtered"
+    assert provider.calls == []
+
+
+@pytest.mark.asyncio
+async def test_approved_card_cache_binds_complete_current_provenance() -> None:
+    now = datetime(2026, 7, 14, 12, tzinfo=timezone.utc)
+    card = EvidenceItem(
+        message_version_id=100,
+        chat_message_id=200,
+        chat_id=-1001,
+        message_id=300,
+        user_id=None,
+        snippet="approved card",
+        ts_rank=0.8,
+        captured_at=now,
+        message_date=now,
+        source_type="card",
+        card_id=uuid.uuid4(),
+        card_source_message_version_ids=(100, 101),
+    )
+    bundle = EvidenceBundle("q", -1001, (card,), False, now)
+    cache = FakeCacheRepo()
+
+    result = await synthesize_answer(
+        FakeSession(
+            query_results=[
+                [{"card_id": str(card.card_id), "source_ids": [100, 101]}],
+                [{"message_version_id": 100}, {"message_version_id": 101}],
+                [],
+            ]
+        ),  # type: ignore[arg-type]
+        bundle=bundle,
+        query="q",
+        config=_config(),
+        qa_trace_id=11,
+        ledger_repo=FakeLedgerRepo(),
+        cache_repo=cache,
+        provider=FakeProvider(citation_ids=(100,)),
+        max_evidence_items=5,
+    )
+
+    assert isinstance(result, AnswerWithCitations)
+    assert result.citation_ids == (100,)
+    assert next(iter(cache.rows.values())).citation_ids == [100, 101]
+
+
+@pytest.mark.asyncio
+async def test_card_is_dropped_when_not_currently_approved() -> None:
+    now = datetime(2026, 7, 14, 12, tzinfo=timezone.utc)
+    card = EvidenceItem(
+        message_version_id=100,
+        chat_message_id=200,
+        chat_id=-1001,
+        message_id=300,
+        user_id=None,
+        snippet="stale approved search hit",
+        ts_rank=0.8,
+        captured_at=now,
+        message_date=now,
+        source_type="card",
+        card_id=uuid.uuid4(),
+        card_source_message_version_ids=(100,),
+    )
+    provider = FakeProvider(citation_ids=(100,))
+
+    result = await synthesize_answer(
+        FakeSession(query_results=[[]]),  # type: ignore[arg-type]
+        bundle=EvidenceBundle("q", -1001, (card,), False, now),
+        query="q",
+        config=_config(),
+        qa_trace_id=11,
+        ledger_repo=FakeLedgerRepo(),
+        cache_repo=FakeCacheRepo(),
+        provider=provider,
+    )
+
+    assert isinstance(result, Abstention)
+    assert result.reason == "all_filtered"
+    assert provider.calls == []
+
+
+@pytest.mark.asyncio
+async def test_duplicate_message_and_card_anchor_is_prompted_once() -> None:
+    message_bundle = _make_bundle((100,))
+    item = message_bundle.items[0]
+    card = EvidenceItem(
+        message_version_id=100,
+        chat_message_id=201,
+        chat_id=-1001,
+        message_id=301,
+        user_id=None,
+        snippet="same anchor card",
+        ts_rank=0.7,
+        captured_at=item.captured_at,
+        message_date=item.message_date,
+        source_type="card",
+        card_id=uuid.uuid4(),
+        card_source_message_version_ids=(100, 101),
+    )
+    bundle = EvidenceBundle(
+        "q",
+        -1001,
+        (item, card),
+        False,
+        message_bundle.created_at,
+    )
+    provider = FakeProvider(citation_ids=(100,))
+
+    result = await synthesize_answer(
+        FakeSession(
+            query_results=[
+                [{"card_id": str(card.card_id), "source_ids": [100, 101]}],
+                [{"message_version_id": 100}, {"message_version_id": 101}],
+                [],
+            ]
+        ),  # type: ignore[arg-type]
+        bundle=bundle,
+        query="q",
+        config=_config(),
+        qa_trace_id=11,
+        ledger_repo=FakeLedgerRepo(),
+        cache_repo=FakeCacheRepo(),
+        provider=provider,
+        max_evidence_items=5,
+    )
+
+    assert isinstance(result, AnswerWithCitations)
+    assert result.surviving_evidence_ids == (100,)
+    assert provider.calls[0]["prompt"].count('"message_version_id": 100') == 1
+
+
+@pytest.mark.asyncio
+async def test_post_provider_governance_change_abstains_before_cache() -> None:
+    bundle = _make_bundle((100,))
+    provider = FakeProvider(citation_ids=(100,))
+    cache = FakeCacheRepo()
+    result = await synthesize_answer(
+        FakeSession(
+            query_results=[
+                [{"message_version_id": 100}],
+                [],
+                [],
+                [],
+            ]
+        ),  # type: ignore[arg-type]
+        bundle=bundle,
+        query="q",
+        config=_config(),
+        qa_trace_id=11,
+        ledger_repo=FakeLedgerRepo(),
+        cache_repo=cache,
+        provider=provider,
+        revalidate_after_provider=True,
+    )
+
+    assert isinstance(result, Abstention)
+    assert result.reason == "all_filtered"
+    assert len(provider.calls) == 1
+    assert cache.rows == {}
+
+
+@pytest.mark.asyncio
+async def test_semantic_placeholder_is_committed_with_cost_before_provider() -> None:
+    bundle = _make_bundle((100,))
+    session = FakeSession(
+        query_results=[
+            [{"message_version_id": 100}],
+            [],
+        ]
+    )
+
+    class CommitCheckingProvider(FakeProvider):
+        async def call(self, *, prompt: str, model: str) -> ProviderResult:
+            assert session.commits == 1
+            assert ledger.rows[0].error == "reserved_in_flight"
+            return await super().call(prompt=prompt, model=model)
+
+    ledger = FakeLedgerRepo()
+    result = await synthesize_answer(
+        session,  # type: ignore[arg-type]
+        bundle=bundle,
+        query="q",
+        config=_config(),
+        qa_trace_id=11,
+        ledger_repo=ledger,
+        cache_repo=FakeCacheRepo(),
+        provider=CommitCheckingProvider(citation_ids=(100,)),
+        durable_placeholder=True,
+    )
+
+    assert isinstance(result, AnswerWithCitations)
+    assert session.commits == 1
+    assert ledger.rows[0].cost_usd > 0
 
 
 @pytest.mark.parametrize("secret", FAKE_SECRET_FAMILIES)
@@ -1372,6 +1659,41 @@ async def test_budget_atomic_advisory_lock_invoked() -> None:
     assert len(provider.calls) == 1
 
 
+@pytest.mark.asyncio
+async def test_durable_synthesis_uses_transaction_lock_and_commits_release() -> None:
+    captured: list[str] = []
+
+    class _CapturingSession(FakeSession):
+        async def execute(self, *args: Any, **kwargs: Any) -> _SessionExecutor:
+            statement = args[0] if args else kwargs.get("statement")
+            if statement is not None:
+                captured.append(str(statement))
+            return await super().execute(*args, **kwargs)
+
+    session = _CapturingSession(
+        query_results=[
+            [{"message_version_id": 100}],
+            [],
+        ]
+    )
+    result = await synthesize_answer(
+        session,  # type: ignore[arg-type]
+        bundle=_make_bundle((100,)),
+        query="q",
+        config=_config(),
+        qa_trace_id=11,
+        ledger_repo=FakeLedgerRepo(),
+        cache_repo=FakeCacheRepo(),
+        provider=FakeProvider(citation_ids=(100,)),
+        durable_placeholder=True,
+    )
+
+    assert isinstance(result, AnswerWithCitations)
+    assert any("pg_advisory_xact_lock" in sql for sql in captured)
+    assert not any("pg_advisory_unlock" in sql for sql in captured)
+    assert session.commits == 1
+
+
 # ─── Tests: invariant 6 — provider error categorisation ─────────────────────
 
 
@@ -1403,6 +1725,33 @@ async def test_provider_transient_error_abstains(subtype: str) -> None:
     assert isinstance(res, Abstention)
     assert res.reason == "provider_error"
     assert ledger.rows[-1].error == f"provider_transient:{subtype}"
+
+
+@pytest.mark.asyncio
+async def test_durable_timeout_keeps_conservative_cost_reservation() -> None:
+    ledger = FakeLedgerRepo()
+    result = await synthesize_answer(
+        FakeSession(
+            query_results=[
+                [{"message_version_id": 100}],
+                [],
+            ]
+        ),  # type: ignore[arg-type]
+        bundle=_make_bundle((100,)),
+        query="q",
+        config=_config(),
+        qa_trace_id=11,
+        ledger_repo=ledger,
+        cache_repo=FakeCacheRepo(),
+        provider=FakeProvider(
+            raise_exc=ProviderTransientError("timeout", message="ambiguous timeout")
+        ),
+        durable_placeholder=True,
+    )
+
+    assert isinstance(result, Abstention)
+    assert result.cost_usd > 0
+    assert ledger.rows[-1].cost_usd == result.cost_usd
 
 
 @pytest.mark.asyncio
@@ -1659,6 +2008,8 @@ async def test_citation_hallucination_rejected() -> None:
     assert isinstance(res, Abstention)
     assert res.reason == "provider_error"
     assert ledger.rows[-1].error == "citation_hallucination"
+    assert res.cost_usd > 0
+    assert ledger.rows[-1].cost_usd == res.cost_usd
 
 
 @pytest.mark.asyncio
@@ -2151,6 +2502,8 @@ async def test_provider_empty_citations_aborts_synthesis() -> None:
     assert res.reason == "provider_error"
     # Ledger has the placeholder UPDATEd with the no-citations sentinel.
     assert ledger.rows[-1].error == "provider_returned_no_citations"
+    assert res.cost_usd > 0
+    assert ledger.rows[-1].cost_usd == res.cost_usd
     # No cache row was written — defends against forget invalidation
     # being unable to join on the empty array.
     assert len(cache.rows) == 0

--- a/tests/services/test_llm_gateway_embeddings.py
+++ b/tests/services/test_llm_gateway_embeddings.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 from dataclasses import dataclass
 from decimal import Decimal
 from types import SimpleNamespace
@@ -162,6 +163,10 @@ async def test_embedding_budget_denial_is_audited_and_skips_provider() -> None:
 
     assert raised.value.llm_usage_ledger_id == 1
     assert ledger.records[0]["error"] == "budget_exceeded"
+    assert (
+        ledger.records[0]["prompt_hash"]
+        == hashlib.sha256(b"embedding_budget_exceeded_without_provider_dispatch").hexdigest()
+    )
     session.commit.assert_awaited_once()
     provider.embed.assert_not_awaited()
 

--- a/tests/services/test_llm_gateway_embeddings.py
+++ b/tests/services/test_llm_gateway_embeddings.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from bot.services.llm_gateway import (
+    EmbeddingBudgetExceeded,
+    EmbeddingGatewayConfig,
+    embed_texts,
+    load_embedding_gateway_config,
+)
+from bot.services.llm_providers.openai_embeddings import EmbeddingResult
+
+
+@dataclass
+class _Ledger:
+    daily: Decimal = Decimal("0")
+    monthly: Decimal = Decimal("0")
+
+    def __post_init__(self) -> None:
+        self.records: list[dict[str, object]] = []
+        self.updates: list[dict[str, object]] = []
+
+    async def daily_cost_usd(self, session, *, day, call_type=None):
+        assert call_type == "semantic_embedding"
+        return self.daily
+
+    async def monthly_cost_usd(self, session, *, year, month, call_type=None):
+        assert call_type == "semantic_embedding"
+        return self.monthly
+
+    async def record(self, session, **kwargs):
+        self.records.append(kwargs)
+        return SimpleNamespace(id=len(self.records))
+
+    async def update_placeholder(self, session, **kwargs):
+        self.updates.append(kwargs)
+        return 1
+
+
+def _config(
+    *,
+    daily: Decimal = Decimal("1"),
+    monthly: Decimal = Decimal("10"),
+) -> EmbeddingGatewayConfig:
+    return EmbeddingGatewayConfig(
+        model="text-embedding-3-small",
+        dimensions=1536,
+        daily_ceiling_usd=daily,
+        monthly_ceiling_usd=monthly,
+    )
+
+
+async def test_embedding_gateway_commits_reservation_before_provider() -> None:
+    session = AsyncMock()
+    ledger = _Ledger()
+    events: list[str] = []
+
+    async def commit() -> None:
+        events.append("commit_reservation")
+
+    session.commit.side_effect = commit
+
+    class Provider:
+        async def embed(self, **kwargs):
+            events.append("provider")
+            assert ledger.records[0]["error"] == "reserved_in_flight"
+            assert kwargs == {
+                "inputs": ("semantic query",),
+                "model": "text-embedding-3-small",
+                "dimensions": 1536,
+            }
+            return EmbeddingResult(
+                vectors=((0.0,) * 1536,),
+                tokens_in=12,
+                request_id="emb-request-1",
+                raw_latency_ms=7,
+            )
+
+    result = await embed_texts(
+        session,
+        inputs=["semantic query"],
+        config=_config(),
+        ledger_repo=ledger,
+        provider=Provider(),
+    )
+
+    assert events == ["commit_reservation", "provider", "commit_reservation"]
+    assert result.llm_usage_ledger_id == 1
+    assert result.vectors == ((0.0,) * 1536,)
+    assert ledger.records[0]["call_type"] == "semantic_embedding"
+    assert ledger.records[0]["prompt_hash"] != "semantic query"
+    assert ledger.updates[0]["request_id"] == "emb-request-1"
+    assert ledger.updates[0]["response_hash"] is not None
+    lock_sql = str(session.execute.await_args_list[0].args[0])
+    assert "pg_advisory_xact_lock" in lock_sql
+
+
+async def test_embedding_budget_denial_is_audited_and_skips_provider() -> None:
+    session = AsyncMock()
+    ledger = _Ledger()
+    provider = AsyncMock()
+
+    with pytest.raises(EmbeddingBudgetExceeded) as raised:
+        await embed_texts(
+            session,
+            inputs=["x" * 8_000],
+            config=_config(daily=Decimal("0.000100")),
+            ledger_repo=ledger,
+            provider=provider,
+        )
+
+    assert raised.value.llm_usage_ledger_id == 1
+    assert ledger.records[0]["error"] == "budget_exceeded"
+    session.commit.assert_awaited_once()
+    provider.embed.assert_not_awaited()
+
+
+async def test_embedding_provider_failure_keeps_safe_taxonomy() -> None:
+    from bot.services.llm_providers import ProviderTransientError
+
+    session = AsyncMock()
+    ledger = _Ledger()
+
+    class Provider:
+        async def embed(self, **kwargs):
+            raise ProviderTransientError("timeout", message="secret provider payload")
+
+    with pytest.raises(ProviderTransientError) as raised:
+        await embed_texts(
+            session,
+            inputs=["query"],
+            config=_config(),
+            ledger_repo=ledger,
+            provider=Provider(),
+        )
+
+    assert raised.value.llm_usage_ledger_id == 1
+    assert ledger.updates[0]["error"] == "provider_ProviderTransientError:timeout"
+    assert "secret provider payload" not in str(ledger.updates[0])
+    assert session.commit.await_count == 2
+
+
+@pytest.mark.parametrize(
+    ("subtype", "expected_zero_cost"),
+    [("auth", True), ("rate_limit", True), ("timeout", False), ("5xx", False)],
+)
+async def test_embedding_failure_cost_and_latency_match_provider_taxonomy(
+    monkeypatch,
+    subtype: str,
+    expected_zero_cost: bool,
+) -> None:
+    from bot.services.llm_providers import (
+        ProviderStructuralError,
+        ProviderTransientError,
+    )
+
+    session = AsyncMock()
+    ledger = _Ledger()
+    error_type = ProviderStructuralError if subtype == "auth" else ProviderTransientError
+
+    class Provider:
+        async def embed(self, **kwargs):
+            raise error_type(subtype, message="redacted")
+
+    clock = iter((10.0, 10.125))
+    monkeypatch.setitem(embed_texts.__globals__, "_monotonic", lambda: next(clock))
+    with pytest.raises(error_type):
+        await embed_texts(
+            session,
+            inputs=["query"],
+            config=_config(),
+            ledger_repo=ledger,
+            provider=Provider(),
+        )
+
+    assert ledger.updates[0]["latency_ms"] == 125
+    if expected_zero_cost:
+        assert ledger.updates[0]["cost_usd"] == Decimal("0")
+    else:
+        assert ledger.updates[0]["cost_usd"] == ledger.records[0]["cost_usd"]
+
+
+def test_embedding_config_is_fixed_and_fails_fast(monkeypatch) -> None:
+    monkeypatch.setenv("EMBEDDING_MODEL", "different-model")
+    with pytest.raises(ValueError, match="text-embedding-3-small"):
+        load_embedding_gateway_config()
+
+    monkeypatch.setenv("EMBEDDING_MODEL", "text-embedding-3-small")
+    monkeypatch.setenv("EMBEDDING_DIMENSIONS", "3072")
+    with pytest.raises(ValueError, match="1536"):
+        load_embedding_gateway_config()
+
+
+def test_embedding_config_rejects_non_positive_cost_ceiling(monkeypatch) -> None:
+    monkeypatch.setenv("EMBEDDING_DAILY_USD_CEILING", "0")
+    with pytest.raises(ValueError, match="positive"):
+        load_embedding_gateway_config()

--- a/tests/services/test_llm_gateway_embeddings.py
+++ b/tests/services/test_llm_gateway_embeddings.py
@@ -100,6 +100,52 @@ async def test_embedding_gateway_commits_reservation_before_provider() -> None:
     assert "pg_advisory_xact_lock" in lock_sql
 
 
+async def test_embedding_recorder_shares_reservation_and_terminal_commits() -> None:
+    session = AsyncMock()
+    ledger = _Ledger()
+    events: list[str] = []
+
+    async def commit() -> None:
+        events.append("commit")
+
+    session.commit.side_effect = commit
+
+    class Recorder:
+        async def reserve(self, session, *, llm_usage_ledger_id, budget_denied):
+            assert llm_usage_ledger_id == 1
+            assert budget_denied is False
+            events.append("reserve")
+
+        async def fail(self, session, *, llm_usage_ledger_id):
+            raise AssertionError("successful embedding must not fail its recorder")
+
+        async def complete(self, session, *, llm_usage_ledger_id, vectors):
+            assert llm_usage_ledger_id == 1
+            assert len(vectors) == 1
+            events.append("complete")
+
+    class Provider:
+        async def embed(self, **kwargs):
+            events.append("provider")
+            return EmbeddingResult(
+                vectors=((0.0,) * 1536,),
+                tokens_in=1,
+                request_id="recorder-order",
+                raw_latency_ms=1,
+            )
+
+    await embed_texts(
+        session,
+        inputs=["semantic recorder"],
+        config=_config(),
+        ledger_repo=ledger,
+        provider=Provider(),
+        outcome_recorder=Recorder(),
+    )
+
+    assert events == ["reserve", "commit", "provider", "complete", "commit"]
+
+
 async def test_embedding_budget_denial_is_audited_and_skips_provider() -> None:
     session = AsyncMock()
     ledger = _Ledger()

--- a/tests/services/test_openai_embeddings_provider.py
+++ b/tests/services/test_openai_embeddings_provider.py
@@ -1,0 +1,390 @@
+from __future__ import annotations
+
+import json
+from dataclasses import FrozenInstanceError
+from typing import Any, Callable
+
+import httpx
+import pytest
+
+from bot.services.llm_providers import ProviderStructuralError, ProviderTransientError
+from bot.services.llm_providers.openai_embeddings import (
+    DEFAULT_OPENAI_EMBEDDING_MODEL,
+    MAX_EMBEDDING_BATCH_CHARS,
+    MAX_EMBEDDING_BATCH_SIZE,
+    MAX_EMBEDDING_INPUT_CHARS,
+    OPENAI_EMBEDDING_DIMENSIONS,
+    OpenAIEmbeddingsProvider,
+)
+
+
+def _vector(value: int | float = 0.125) -> list[int | float]:
+    return [value] * OPENAI_EMBEDDING_DIMENSIONS
+
+
+def _response_payload(count: int = 1) -> dict[str, Any]:
+    return {
+        "object": "list",
+        "model": DEFAULT_OPENAI_EMBEDDING_MODEL,
+        "data": [
+            {
+                "object": "embedding",
+                "index": index,
+                "embedding": _vector(index + 0.25),
+            }
+            for index in range(count)
+        ],
+        "usage": {"prompt_tokens": 17, "total_tokens": 17},
+    }
+
+
+@pytest.mark.asyncio
+async def test_embed_sends_bounded_ordered_request_and_returns_frozen_result() -> None:
+    captured: dict[str, object] = {}
+
+    def handle(request: httpx.Request) -> httpx.Response:
+        captured["path"] = request.url.path
+        captured["auth"] = request.headers.get("authorization")
+        captured["payload"] = json.loads(request.content)
+        return httpx.Response(
+            200,
+            headers={"x-request-id": "emb-req-1"},
+            json=_response_payload(count=2),
+        )
+
+    transport = httpx.MockTransport(handle)
+    async with httpx.AsyncClient(
+        transport=transport,
+        base_url="https://api.openai.com/v1/",
+    ) as client:
+        provider = OpenAIEmbeddingsProvider(api_key="test-key", client=client)
+        result = await provider.embed(inputs=("first", "second"))
+        assert not client.is_closed
+
+    assert captured == {
+        "path": "/v1/embeddings",
+        "auth": "Bearer test-key",
+        "payload": {
+            "model": DEFAULT_OPENAI_EMBEDDING_MODEL,
+            "input": ["first", "second"],
+            "dimensions": OPENAI_EMBEDDING_DIMENSIONS,
+            "encoding_format": "float",
+        },
+    }
+    assert len(result.vectors) == 2
+    assert all(len(vector) == OPENAI_EMBEDDING_DIMENSIONS for vector in result.vectors)
+    assert result.vectors[0][0] == 0.25
+    assert result.vectors[1][0] == 1.25
+    assert isinstance(result.vectors, tuple)
+    assert isinstance(result.vectors[0], tuple)
+    assert result.tokens_in == 17
+    assert result.request_id == "emb-req-1"
+    assert result.raw_latency_ms >= 0
+    with pytest.raises(FrozenInstanceError):
+        result.tokens_in = 18  # type: ignore[misc]
+
+
+@pytest.mark.asyncio
+async def test_embed_reads_existing_openai_api_key_from_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_auth: list[str | None] = []
+
+    def handle(request: httpx.Request) -> httpx.Response:
+        captured_auth.append(request.headers.get("authorization"))
+        return httpx.Response(200, json=_response_payload())
+
+    monkeypatch.setenv("OPENAI_API_KEY", "environment-key")
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handle),
+        base_url="https://api.openai.com/v1/",
+    ) as client:
+        result = await OpenAIEmbeddingsProvider(client=client).embed(inputs=["text"])
+
+    assert captured_auth == ["Bearer environment-key"]
+    assert result.request_id == ""
+
+
+@pytest.mark.asyncio
+async def test_embed_missing_api_key_is_structural_auth_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    with pytest.raises(ProviderStructuralError) as caught:
+        await OpenAIEmbeddingsProvider().embed(inputs=["text"])
+
+    assert caught.value.subtype == "auth"
+
+
+@pytest.mark.parametrize(
+    ("inputs", "model", "dimensions", "message"),
+    [
+        ("raw string", DEFAULT_OPENAI_EMBEDDING_MODEL, 1536, "sequence of strings"),
+        (b"bytes", DEFAULT_OPENAI_EMBEDDING_MODEL, 1536, "sequence of strings"),
+        ([], DEFAULT_OPENAI_EMBEDDING_MODEL, 1536, "must not be empty"),
+        (["  \n"], DEFAULT_OPENAI_EMBEDDING_MODEL, 1536, "must not be blank"),
+        ([1], DEFAULT_OPENAI_EMBEDDING_MODEL, 1536, "must be a string"),
+        (
+            ["x"] * (MAX_EMBEDDING_BATCH_SIZE + 1),
+            DEFAULT_OPENAI_EMBEDDING_MODEL,
+            1536,
+            "batch exceeds",
+        ),
+        (
+            ["x" * (MAX_EMBEDDING_INPUT_CHARS + 1)],
+            DEFAULT_OPENAI_EMBEDDING_MODEL,
+            1536,
+            "input at index 0 exceeds",
+        ),
+        (
+            ["x" * MAX_EMBEDDING_INPUT_CHARS]
+            * (MAX_EMBEDDING_BATCH_CHARS // MAX_EMBEDDING_INPUT_CHARS + 1),
+            DEFAULT_OPENAI_EMBEDDING_MODEL,
+            1536,
+            "batch exceeds",
+        ),
+        (["text"], "text-embedding-ada-002", 1536, "unsupported"),
+        (["text"], DEFAULT_OPENAI_EMBEDDING_MODEL, 512, "must equal"),
+        (["text"], DEFAULT_OPENAI_EMBEDDING_MODEL, True, "must equal"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_invalid_request_is_rejected_before_network_without_content_leakage(
+    inputs: Any,
+    model: str,
+    dimensions: Any,
+    message: str,
+) -> None:
+    calls = 0
+
+    def handle(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        return httpx.Response(500)
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handle),
+        base_url="https://api.openai.com/v1/",
+    ) as client:
+        provider = OpenAIEmbeddingsProvider(api_key="test-key", client=client)
+        with pytest.raises(ProviderStructuralError, match=message) as caught:
+            await provider.embed(inputs=inputs, model=model, dimensions=dimensions)
+
+    assert caught.value.subtype in {"bad_request", "model_not_found"}
+    assert "raw string" not in str(caught.value)
+    assert calls == 0
+
+
+@pytest.mark.parametrize(
+    ("status", "error_type", "subtype"),
+    [
+        (302, ProviderStructuralError, "bad_request"),
+        (400, ProviderStructuralError, "bad_request"),
+        (401, ProviderStructuralError, "auth"),
+        (403, ProviderStructuralError, "auth"),
+        (404, ProviderStructuralError, "model_not_found"),
+        (422, ProviderStructuralError, "bad_request"),
+        (429, ProviderTransientError, "rate_limit"),
+        (500, ProviderTransientError, "5xx"),
+        (503, ProviderTransientError, "5xx"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_http_errors_are_classified_without_retry(
+    status: int,
+    error_type: type[ProviderStructuralError] | type[ProviderTransientError],
+    subtype: str,
+) -> None:
+    calls = 0
+
+    def handle(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        return httpx.Response(status, json={"error": {"message": "must not leak"}})
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handle),
+        base_url="https://api.openai.com/v1/",
+    ) as client:
+        provider = OpenAIEmbeddingsProvider(api_key="test-key", client=client)
+        with pytest.raises(error_type) as caught:
+            await provider.embed(inputs=["private input"])
+
+    assert caught.value.subtype == subtype
+    assert "private input" not in str(caught.value)
+    assert "must not leak" not in str(caught.value)
+    assert calls == 1
+
+
+@pytest.mark.parametrize(
+    ("transport_error_factory", "subtype"),
+    [
+        (lambda request: httpx.ReadTimeout("transport failed", request=request), "timeout"),
+        (
+            lambda request: httpx.ConnectError("transport failed", request=request),
+            "connection_reset",
+        ),
+        (
+            lambda request: httpx.RemoteProtocolError("transport failed", request=request),
+            "connection_reset",
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_transport_errors_are_transient_without_retry(
+    transport_error_factory: Callable[[httpx.Request], httpx.TransportError],
+    subtype: str,
+) -> None:
+    calls = 0
+
+    def handle(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        raise transport_error_factory(request)
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handle),
+        base_url="https://api.openai.com/v1/",
+    ) as client:
+        provider = OpenAIEmbeddingsProvider(api_key="test-key", client=client)
+        with pytest.raises(ProviderTransientError) as caught:
+            await provider.embed(inputs=["private input"])
+
+    assert caught.value.subtype == subtype
+    assert "private input" not in str(caught.value)
+    assert calls == 1
+
+
+ResponseMutation = Callable[[dict[str, Any]], None]
+
+
+def _set_object(payload: dict[str, Any]) -> None:
+    payload["object"] = "embedding"
+
+
+def _set_model(payload: dict[str, Any]) -> None:
+    payload["model"] = "unexpected-model"
+
+
+def _remove_embedding(payload: dict[str, Any]) -> None:
+    payload["data"] = []
+
+
+def _reverse_order(payload: dict[str, Any]) -> None:
+    payload["data"][0]["index"] = 1
+
+
+def _set_item_object(payload: dict[str, Any]) -> None:
+    payload["data"][0]["object"] = "other"
+
+
+def _set_bool_index(payload: dict[str, Any]) -> None:
+    payload["data"][0]["index"] = False
+
+
+def _set_short_vector(payload: dict[str, Any]) -> None:
+    payload["data"][0]["embedding"] = _vector()[:-1]
+
+
+def _set_long_vector(payload: dict[str, Any]) -> None:
+    payload["data"][0]["embedding"] = _vector() + [0.0]
+
+
+def _set_vector_value(value: object) -> ResponseMutation:
+    def mutate(payload: dict[str, Any]) -> None:
+        payload["data"][0]["embedding"][0] = value
+
+    return mutate
+
+
+def _remove_usage(payload: dict[str, Any]) -> None:
+    payload.pop("usage")
+
+
+def _set_prompt_tokens(value: object) -> ResponseMutation:
+    def mutate(payload: dict[str, Any]) -> None:
+        payload["usage"]["prompt_tokens"] = value
+
+    return mutate
+
+
+def _set_total_tokens(value: object) -> ResponseMutation:
+    def mutate(payload: dict[str, Any]) -> None:
+        payload["usage"]["total_tokens"] = value
+
+    return mutate
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        _set_object,
+        _set_model,
+        _remove_embedding,
+        _reverse_order,
+        _set_item_object,
+        _set_bool_index,
+        _set_short_vector,
+        _set_long_vector,
+        _set_vector_value("0.125"),
+        _set_vector_value(True),
+        _set_vector_value(float("nan")),
+        _set_vector_value(float("inf")),
+        _set_vector_value(float("-inf")),
+        _set_vector_value(10**1000),
+        _remove_usage,
+        _set_prompt_tokens(True),
+        _set_prompt_tokens(-1),
+        _set_total_tokens(False),
+        _set_total_tokens(16),
+    ],
+)
+@pytest.mark.asyncio
+async def test_response_contract_violations_are_structural(
+    mutate: ResponseMutation,
+) -> None:
+    payload = _response_payload()
+    mutate(payload)
+
+    def handle(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            headers={"content-type": "application/json"},
+            content=json.dumps(payload, allow_nan=True).encode(),
+        )
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handle),
+        base_url="https://api.openai.com/v1/",
+    ) as client:
+        provider = OpenAIEmbeddingsProvider(api_key="test-key", client=client)
+        with pytest.raises(ProviderStructuralError) as caught:
+            await provider.embed(inputs=["private input"])
+
+    assert caught.value.subtype == "contract_violation"
+    assert "private input" not in str(caught.value)
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        b"not-json",
+        b"[]",
+        b"null",
+    ],
+)
+@pytest.mark.asyncio
+async def test_malformed_response_body_is_contract_violation(body: bytes) -> None:
+    def handle(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=body)
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handle),
+        base_url="https://api.openai.com/v1/",
+    ) as client:
+        provider = OpenAIEmbeddingsProvider(api_key="test-key", client=client)
+        with pytest.raises(ProviderStructuralError) as caught:
+            await provider.embed(inputs=["text"])
+
+    assert caught.value.subtype == "contract_violation"

--- a/tests/services/test_semantic_eval.py
+++ b/tests/services/test_semantic_eval.py
@@ -8,6 +8,7 @@ from typing import Any
 import pytest
 
 from bot.services.semantic_eval import (
+    REQUIRED_PRIVACY_CLASSES,
     SemanticEvalCase,
     SemanticEvalResult,
     evaluate_semantic_run,
@@ -25,6 +26,7 @@ def _case(
     expected: tuple[str, ...],
     *,
     forbidden: tuple[str, ...] = (),
+    privacy_classes: tuple[str, ...] = (),
     abstain: bool = False,
 ) -> SemanticEvalCase:
     return SemanticEvalCase(
@@ -32,6 +34,7 @@ def _case(
         category=category,  # type: ignore[arg-type]
         expected_source_ids=expected,
         forbidden_source_ids=forbidden,
+        privacy_classes=privacy_classes,  # type: ignore[arg-type]
         expected_abstain=abstain,
     )
 
@@ -79,6 +82,7 @@ def _passing_run() -> tuple[list[SemanticEvalCase], list[SemanticEvalResult]]:
             "privacy_governance",
             (_message(30),),
             forbidden=(_message(999),),
+            privacy_classes=tuple(sorted(REQUIRED_PRIVACY_CLASSES)),
         ),
     ]
     results = [
@@ -99,6 +103,7 @@ def test_passing_report_has_every_category_and_separate_privacy_abstentions() ->
             "privacy_governance",
             (),
             forbidden=(_message(998),),
+            privacy_classes=("redacted",),
             abstain=True,
         )
     )
@@ -138,7 +143,14 @@ def test_privacy_leakage_is_computed_and_review_count_must_match() -> None:
 
 def test_privacy_expected_abstention_failure_is_blocking_but_not_no_answer_metric() -> None:
     cases, results = _passing_run()
-    cases[-1] = _case("privacy", "privacy_governance", (), forbidden=(_message(999),), abstain=True)
+    cases[-1] = _case(
+        "privacy",
+        "privacy_governance",
+        (),
+        forbidden=(_message(999),),
+        privacy_classes=tuple(sorted(REQUIRED_PRIVACY_CLASSES)),
+        abstain=True,
+    )
     results[-1] = _result("privacy", hybrid=(_message(30),))
 
     report, violations = evaluate_semantic_run(cases, results)
@@ -185,6 +197,7 @@ def test_source_ids_are_canonical_strings(source_id: str, valid: bool) -> None:
         "category": "semantic",
         "expected_source_ids": (source_id,),
         "forbidden_source_ids": (),
+        "privacy_classes": (),
         "expected_abstain": False,
     }
     if valid:
@@ -203,6 +216,7 @@ def test_source_ids_are_canonical_strings(source_id: str, valid: bool) -> None:
                 "category": "privacy_governance",
                 "expected_source_ids": (),
                 "forbidden_source_ids": (),
+                "privacy_classes": ("cross_chat",),
                 "expected_abstain": True,
             },
             "forbidden",
@@ -213,6 +227,7 @@ def test_source_ids_are_canonical_strings(source_id: str, valid: bool) -> None:
                 "category": "exact",
                 "expected_source_ids": (_message(1),),
                 "forbidden_source_ids": (_message(2),),
+                "privacy_classes": (),
                 "expected_abstain": False,
             },
             "only privacy",
@@ -223,6 +238,7 @@ def test_source_ids_are_canonical_strings(source_id: str, valid: bool) -> None:
                 "category": "privacy_governance",
                 "expected_source_ids": (_message(1),),
                 "forbidden_source_ids": (_message(1),),
+                "privacy_classes": ("cross_chat",),
                 "expected_abstain": False,
             },
             "disjoint",
@@ -246,6 +262,36 @@ def test_result_and_run_validation_fail_closed() -> None:
         _result("x", retrieval=float("nan"))
 
 
+def test_privacy_class_schema_and_frozen_coverage_fail_closed() -> None:
+    with pytest.raises(ValueError, match="privacy_classes"):
+        _case(
+            "privacy",
+            "privacy_governance",
+            (_message(1),),
+            forbidden=(_message(2),),
+        )
+    with pytest.raises(ValueError, match="only privacy"):
+        _case(
+            "semantic",
+            "semantic",
+            (_message(1),),
+            privacy_classes=("cross_chat",),
+        )
+    with pytest.raises(ValueError, match="unsupported governance"):
+        _case(
+            "privacy",
+            "privacy_governance",
+            (_message(1),),
+            forbidden=(_message(2),),
+            privacy_classes=("unknown",),
+        )
+
+    cases, results = _passing_run()
+    cases[-1] = replace(cases[-1], privacy_classes=("cross_chat",))
+    with pytest.raises(ValueError, match="missing=.*bot_authored"):
+        evaluate_semantic_run(cases, results)
+
+
 def test_sanitized_report_validator_rejects_impossible_metrics() -> None:
     cases, results = _passing_run()
     report, _ = evaluate_semantic_run(cases, results)
@@ -255,6 +301,12 @@ def test_sanitized_report_validator_rejects_impossible_metrics() -> None:
 
     assert any("outside [0,1]" in value for value in violations)
     assert "unsupported_claims > total_claims" in violations
+
+    incomplete_privacy = replace(report, privacy_classes=("cross_chat",))
+    assert (
+        "privacy_classes do not cover every required governance class"
+        in validate_semantic_report(incomplete_privacy)
+    )
 
 
 def test_sanitized_report_validator_rejects_unexpected_abstention_overflow() -> None:

--- a/tests/services/test_semantic_eval.py
+++ b/tests/services/test_semantic_eval.py
@@ -1,0 +1,271 @@
+"""Deterministic acceptance-gate tests for semantic Q&A evaluation."""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError, replace
+from typing import Any
+
+import pytest
+
+from bot.services.semantic_eval import (
+    SemanticEvalCase,
+    SemanticEvalResult,
+    evaluate_semantic_run,
+    validate_semantic_report,
+)
+
+
+def _message(value: int) -> str:
+    return f"message:{value}"
+
+
+def _case(
+    case_id: str,
+    category: str,
+    expected: tuple[str, ...],
+    *,
+    forbidden: tuple[str, ...] = (),
+    abstain: bool = False,
+) -> SemanticEvalCase:
+    return SemanticEvalCase(
+        case_id=case_id,
+        category=category,  # type: ignore[arg-type]
+        expected_source_ids=expected,
+        forbidden_source_ids=forbidden,
+        expected_abstain=abstain,
+    )
+
+
+def _result(
+    case_id: str,
+    *,
+    fts: tuple[str, ...] = (),
+    hybrid: tuple[str, ...] = (),
+    abstained: bool = False,
+    leakage_count: int = 0,
+    valid_source_links: int | None = None,
+    invalid_source_links: int = 0,
+    unsupported_claims: int = 0,
+    total_claims: int | None = None,
+    retrieval: float = 1.0,
+    full: float = 5.0,
+) -> SemanticEvalResult:
+    return SemanticEvalResult(
+        case_id=case_id,
+        fts_source_ids=fts,
+        hybrid_source_ids=hybrid,
+        abstained=abstained,
+        leakage_count=leakage_count,
+        valid_source_links=(0 if abstained else 1)
+        if valid_source_links is None
+        else valid_source_links,
+        invalid_source_links=invalid_source_links,
+        unsupported_claims=unsupported_claims,
+        total_claims=(0 if abstained else 1) if total_claims is None else total_claims,
+        retrieval_latency_seconds=retrieval,
+        full_latency_seconds=full,
+    )
+
+
+def _passing_run() -> tuple[list[SemanticEvalCase], list[SemanticEvalResult]]:
+    semantic_ids = tuple(_message(value) for value in range(1, 6))
+    cases = [
+        _case("semantic", "semantic", semantic_ids),
+        _case("exact", "exact", (_message(10),)),
+        _case("multi", "multi_source", (_message(20),)),
+        _case("no-answer", "no_answer", (), abstain=True),
+        _case(
+            "privacy",
+            "privacy_governance",
+            (_message(30),),
+            forbidden=(_message(999),),
+        ),
+    ]
+    results = [
+        _result("semantic", fts=semantic_ids[:4], hybrid=semantic_ids),
+        _result("exact", fts=(_message(10),), hybrid=(_message(10),)),
+        _result("multi", fts=(_message(20),), hybrid=(_message(20),)),
+        _result("no-answer", abstained=True),
+        _result("privacy", fts=(_message(30),), hybrid=(_message(30),)),
+    ]
+    return cases, results
+
+
+def test_passing_report_has_every_category_and_separate_privacy_abstentions() -> None:
+    cases, results = _passing_run()
+    cases.append(
+        _case(
+            "privacy-abstain",
+            "privacy_governance",
+            (),
+            forbidden=(_message(998),),
+            abstain=True,
+        )
+    )
+    results.append(_result("privacy-abstain", abstained=True))
+
+    report, violations = evaluate_semantic_run(cases, results)
+
+    assert report.case_count == 6
+    assert report.answerable_case_count == 4
+    assert report.no_answer_case_count == 1
+    assert report.privacy_expected_abstention_case_count == 1
+    assert report.privacy_expected_abstention_failures == 0
+    assert report.unexpected_answerable_abstention_count == 0
+    assert report.no_answer_abstention_rate == 1.0
+    assert report.macro_recall_at_5 == 1.0
+    assert report.semantic_hybrid_minus_fts_at_5 == 0.2
+    assert violations == ()
+    with pytest.raises(FrozenInstanceError):
+        report.case_count = 7  # type: ignore[misc]
+
+
+def test_privacy_leakage_is_computed_and_review_count_must_match() -> None:
+    cases, results = _passing_run()
+    leaked = replace(
+        results[-1],
+        hybrid_source_ids=(_message(30), _message(999)),
+        leakage_count=1,
+    )
+
+    report, violations = evaluate_semantic_run(cases, [*results[:-1], leaked])
+
+    assert report.leakage_count == 1
+    assert "leakage_count=1 > 0" in violations
+    with pytest.raises(ValueError, match="forbidden-source intersection"):
+        evaluate_semantic_run(cases, [*results[:-1], replace(leaked, leakage_count=0)])
+
+
+def test_privacy_expected_abstention_failure_is_blocking_but_not_no_answer_metric() -> None:
+    cases, results = _passing_run()
+    cases[-1] = _case("privacy", "privacy_governance", (), forbidden=(_message(999),), abstain=True)
+    results[-1] = _result("privacy", hybrid=(_message(30),))
+
+    report, violations = evaluate_semantic_run(cases, results)
+
+    assert report.no_answer_abstention_rate == 1.0
+    assert report.privacy_expected_abstention_failures == 1
+    assert any(value.startswith("privacy_expected_abstention_failures=") for value in violations)
+
+
+@pytest.mark.parametrize("case_id", ["semantic", "exact"])
+def test_unexpected_answerable_abstention_is_blocking_even_with_perfect_retrieval(
+    case_id: str,
+) -> None:
+    cases, results = _passing_run()
+    result_index = next(index for index, result in enumerate(results) if result.case_id == case_id)
+    results[result_index] = replace(
+        results[result_index],
+        abstained=True,
+        valid_source_links=0,
+        total_claims=0,
+    )
+
+    report, violations = evaluate_semantic_run(cases, results)
+
+    assert report.macro_recall_at_5 == 1.0
+    assert report.unexpected_answerable_abstention_count == 1
+    assert "unexpected_answerable_abstention_count=1 > 0" in violations
+
+
+@pytest.mark.parametrize(
+    ("source_id", "valid"),
+    [
+        ("message:1", True),
+        ("message:0", False),
+        ("message:-1", False),
+        ("card:123e4567-e89b-42d3-a456-426614174000", True),
+        ("card:123E4567-E89B-42D3-A456-426614174000", False),
+        ("123", False),
+    ],
+)
+def test_source_ids_are_canonical_strings(source_id: str, valid: bool) -> None:
+    kwargs = {
+        "case_id": "case",
+        "category": "semantic",
+        "expected_source_ids": (source_id,),
+        "forbidden_source_ids": (),
+        "expected_abstain": False,
+    }
+    if valid:
+        assert SemanticEvalCase(**kwargs).expected_source_ids == (source_id,)  # type: ignore[arg-type]
+    else:
+        with pytest.raises(ValueError, match="canonical"):
+            SemanticEvalCase(**kwargs)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        (
+            {
+                "case_id": "x",
+                "category": "privacy_governance",
+                "expected_source_ids": (),
+                "forbidden_source_ids": (),
+                "expected_abstain": True,
+            },
+            "forbidden",
+        ),
+        (
+            {
+                "case_id": "x",
+                "category": "exact",
+                "expected_source_ids": (_message(1),),
+                "forbidden_source_ids": (_message(2),),
+                "expected_abstain": False,
+            },
+            "only privacy",
+        ),
+        (
+            {
+                "case_id": "x",
+                "category": "privacy_governance",
+                "expected_source_ids": (_message(1),),
+                "forbidden_source_ids": (_message(1),),
+                "expected_abstain": False,
+            },
+            "disjoint",
+        ),
+    ],
+)
+def test_case_privacy_schema_fails_closed(kwargs: dict[str, Any], message: str) -> None:
+    with pytest.raises(ValueError, match=message):
+        SemanticEvalCase(**kwargs)  # type: ignore[arg-type]
+
+
+def test_result_and_run_validation_fail_closed() -> None:
+    cases, results = _passing_run()
+    with pytest.raises(ValueError, match="category"):
+        evaluate_semantic_run(cases[:-1], results[:-1])
+    with pytest.raises(ValueError, match="match cases exactly"):
+        evaluate_semantic_run(cases, results[:-1])
+    with pytest.raises(ValueError, match="claim annotations"):
+        _result("x", total_claims=0)
+    with pytest.raises(ValueError, match="finite"):
+        _result("x", retrieval=float("nan"))
+
+
+def test_sanitized_report_validator_rejects_impossible_metrics() -> None:
+    cases, results = _passing_run()
+    report, _ = evaluate_semantic_run(cases, results)
+    impossible = replace(report, macro_recall_at_5=1.1, unsupported_claims=2, total_claims=1)
+
+    violations = validate_semantic_report(impossible)
+
+    assert any("outside [0,1]" in value for value in violations)
+    assert "unsupported_claims > total_claims" in violations
+
+
+def test_sanitized_report_validator_rejects_unexpected_abstention_overflow() -> None:
+    cases, results = _passing_run()
+    report, _ = evaluate_semantic_run(cases, results)
+    impossible = replace(
+        report,
+        unexpected_answerable_abstention_count=report.answerable_case_count + 1,
+    )
+
+    violations = validate_semantic_report(impossible)
+
+    assert "unexpected_answerable_abstention_count=5 > 0" in violations
+    assert "unexpected_answerable_abstention_count > answerable_case_count" in violations

--- a/tests/services/test_semantic_index_postgres.py
+++ b/tests/services/test_semantic_index_postgres.py
@@ -10,7 +10,7 @@ from decimal import Decimal
 from typing import Literal
 
 import pytest
-from sqlalchemy import delete, select
+from sqlalchemy import delete, select, text
 
 from bot.db.models import (
     CardSource,
@@ -1004,7 +1004,9 @@ async def test_embedding_dispatch_splits_batch_at_provider_character_cap(db_sess
 
 
 @pytest.mark.asyncio
-async def test_oversize_document_is_accounted_without_provider_dispatch(db_session) -> None:
+async def test_oversize_document_is_chunked_with_full_coverage(db_session) -> None:
+    from scripts.backfill_semantic_index import _coverage_report
+
     human = await _user(db_session, user_id=8_044_042_250, is_bot=False)
     await _message(
         db_session,
@@ -1022,10 +1024,113 @@ async def test_oversize_document_is_accounted_without_provider_dispatch(db_sessi
         provider=provider,
     )
 
-    assert (result.indexed, result.skipped) == (0, 1)
-    assert result.reason_counts == {"skipped:oversize": 1}
-    assert provider.calls == []
-    assert (await db_session.execute(select(SemanticRetrievalUnit.id))).scalar_one_or_none() is None
+    assert (result.indexed, result.skipped) == (2, 0)
+    assert result.reason_counts == {"indexed:new_embedding": 2}
+    assert [tuple(len(value) for value in call) for call in provider.calls] == [(8_000, 1)]
+    units = (
+        (
+            await db_session.execute(
+                select(SemanticRetrievalUnit).order_by(SemanticRetrievalUnit.chunk_index)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert [(unit.chunk_index, unit.chunk_count) for unit in units] == [(0, 2), (1, 2)]
+    assert len({unit.llm_usage_ledger_id for unit in units}) == 1
+    coverage = await _coverage_report(
+        db_session,
+        chat_id=CHAT_ID,
+        model=CONFIG.model,
+        batch_size=100,
+    )
+    assert coverage["status"] == "pass"
+    assert coverage["eligible"] == 2
+    assert coverage["coverage_percent"] == 100.0
+    hits = await vector_search(
+        db_session,
+        query_embedding=VECTOR_X,
+        chat_id=CHAT_ID,
+        embedding_model=CONFIG.model,
+        limit=5,
+    )
+    assert len(hits) == 1
+    assert hits[0].message_version_id == documents[0].message_version_ids[0]
+
+
+@pytest.mark.asyncio
+async def test_partial_provider_batch_is_durable_and_retry_does_not_repay(db_session) -> None:
+    from bot.services.llm_providers import ProviderTransientError
+
+    human = await _user(db_session, user_id=8_044_042_260, is_bot=False)
+    for offset in range(17):
+        await _message(
+            db_session,
+            user_id=human.id,
+            message_id=4042260 + offset,
+            text=(chr(ord("a") + offset) * 3996) + f"{offset:04d}",
+        )
+    documents = await list_eligible_message_documents(db_session, chat_id=CHAT_ID, limit=100)
+
+    class FailSecondProvider(CountingEmbeddingProvider):
+        async def embed(self, *, inputs, model: str, dimensions: int) -> EmbeddingResult:
+            values = tuple(inputs)
+            self.calls.append(values)
+            if len(self.calls) == 2:
+                raise ProviderTransientError("timeout", message="second partition failed")
+            return EmbeddingResult(
+                vectors=tuple(VECTOR_X for _ in values),
+                tokens_in=sum(len(value) for value in values),
+                request_id="partial-first",
+                raw_latency_ms=1,
+            )
+
+    first_provider = FailSecondProvider()
+    with pytest.raises(ProviderTransientError) as raised:
+        await backfill_semantic_index(
+            db_session,
+            config=CONFIG,
+            provider=first_provider,
+            batch_size=100,
+            chat_id=CHAT_ID,
+        )
+    partial = raised.value.semantic_batch_result
+    assert (partial.indexed, partial.skipped) == (16, 0)
+    assert partial.reason_counts == {"indexed:new_embedding": 16}
+    assert [len(call) for call in first_provider.calls] == [16, 1]
+    failed_run = (
+        (
+            await db_session.execute(
+                select(SemanticIndexRun).order_by(SemanticIndexRun.id.desc()).limit(1)
+            )
+        )
+        .scalars()
+        .one()
+    )
+    assert failed_run.status == "failed"
+    assert (failed_run.eligible_count, failed_run.indexed_count, failed_run.failed_count) == (
+        17,
+        16,
+        1,
+    )
+    first_units = (await db_session.execute(select(SemanticRetrievalUnit))).scalars().all()
+    assert len(first_units) == 16
+    assert len({unit.llm_usage_ledger_id for unit in first_units}) == 1
+
+    retry_provider = CountingEmbeddingProvider()
+    retry = await _index_batch(
+        db_session,
+        documents=documents,
+        config=CONFIG,
+        provider=retry_provider,
+    )
+
+    assert (retry.indexed, retry.skipped) == (1, 16)
+    assert [len(call) for call in retry_provider.calls] == [1]
+    assert retry_provider.calls[0] == (documents[-1].canonical_text,)
+    final_units = (await db_session.execute(select(SemanticRetrievalUnit))).scalars().all()
+    assert len(final_units) == 17
+    assert len({unit.llm_usage_ledger_id for unit in final_units}) == 2
 
 
 @pytest.mark.asyncio
@@ -1270,6 +1375,37 @@ async def test_cancelled_delivery_scope_releases_dedicated_xact_lock(postgres_en
                 return
 
     await asyncio.wait_for(reacquire(), timeout=2)
+
+
+@pytest.mark.asyncio
+async def test_advisory_lock_scope_does_not_consume_application_pool_slot(
+    postgres_engine,
+) -> None:
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+    from bot.services.advisory_locks import hold_session_advisory_locks
+
+    single_slot_engine = create_async_engine(
+        postgres_engine.url,
+        pool_size=1,
+        max_overflow=0,
+        pool_timeout=0.2,
+    )
+    factory = async_sessionmaker(
+        single_slot_engine,
+        class_=AsyncSession,
+        expire_on_commit=False,
+    )
+    lock_id = 8_044_046_500 + (uuid.uuid4().int % 1_000_000)
+    try:
+        async with factory() as session:
+            # Pin the only application-pool connection before entering the lock
+            # scope. The lock connection must come from independent capacity.
+            await session.execute(text("SELECT 1"))
+            async with hold_session_advisory_locks(session, (lock_id,)):
+                assert (await session.execute(text("SELECT 1"))).scalar_one() == 1
+    finally:
+        await single_slot_engine.dispose()
 
 
 @pytest.mark.asyncio

--- a/tests/services/test_semantic_index_postgres.py
+++ b/tests/services/test_semantic_index_postgres.py
@@ -745,8 +745,7 @@ async def test_forget_that_wins_source_lock_blocks_stale_text_before_provider(
 ) -> None:
     from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
-    from bot.services.advisory_locks import hold_session_advisory_locks
-    from bot.services.forget_cascade import _p6_mvid_advisory_lock_id
+    from bot.db.repos.forget_event import ForgetEventRepo
 
     factory = async_sessionmaker(postgres_engine, class_=AsyncSession, expire_on_commit=False)
     suffix = uuid.uuid4().int % 1_000_000
@@ -771,32 +770,28 @@ async def test_forget_that_wins_source_lock_blocks_stale_text_before_provider(
                 chat_id=chat_id,
             )
             assert len(stale_documents) == 1
-            lock_id = _p6_mvid_advisory_lock_id(source.version.id)
 
             async with factory() as forget_session:
-                async with hold_session_advisory_locks(forget_session, (lock_id,)):
-                    forget_session.add(
-                        ForgetEvent(
-                            target_type="message",
-                            target_id=str(source.message.id),
-                            actor_user_id=human.id,
-                            authorized_by="self",
-                            tombstone_key=f"message:{chat_id}:{source.message.message_id}",
-                            status="pending",
-                        )
+                await ForgetEventRepo.create(
+                    forget_session,
+                    target_type="message",
+                    target_id=str(source.message.id),
+                    actor_user_id=human.id,
+                    authorized_by="self",
+                    tombstone_key=f"message:{chat_id}:{source.message.message_id}",
+                )
+                index_task = asyncio.create_task(
+                    _index_batch(
+                        index_session,
+                        documents=stale_documents,
+                        config=CONFIG,
+                        provider=provider,
                     )
-                    await forget_session.commit()
-                    index_task = asyncio.create_task(
-                        _index_batch(
-                            index_session,
-                            documents=stale_documents,
-                            config=CONFIG,
-                            provider=provider,
-                        )
-                    )
-                    await asyncio.sleep(0.1)
-                    assert index_task.done() is False
-                    assert provider.calls == []
+                )
+                await asyncio.sleep(0.1)
+                assert index_task.done() is False
+                assert provider.calls == []
+                await forget_session.commit()
 
             result = await asyncio.wait_for(index_task, timeout=2)
 
@@ -815,6 +810,116 @@ async def test_forget_that_wins_source_lock_blocks_stale_text_before_provider(
                 delete(ForgetEvent).where(ForgetEvent.target_id == str(source.message.id))
             )
             await cleanup.execute(delete(ChatMessage).where(ChatMessage.chat_id == chat_id))
+            await cleanup.execute(delete(User).where(User.id == user_id))
+            await cleanup.commit()
+
+
+@pytest.mark.asyncio
+async def test_provider_dispatch_holds_same_lock_as_pending_forget_creation(
+    postgres_engine,
+) -> None:
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+    from bot.db.repos.forget_event import ForgetEventRepo
+
+    factory = async_sessionmaker(postgres_engine, class_=AsyncSession, expire_on_commit=False)
+    suffix = uuid.uuid4().int % 1_000_000
+    user_id = 8_044_042_215 + suffix
+    chat_id = -9_044_042_215 - suffix
+    provider_entered = asyncio.Event()
+    release_provider = asyncio.Event()
+    ledger_ids: set[int] = set()
+
+    class BarrierProvider(CountingEmbeddingProvider):
+        async def embed(self, *, inputs, model: str, dimensions: int) -> EmbeddingResult:
+            self.calls.append(tuple(inputs))
+            provider_entered.set()
+            await release_provider.wait()
+            return EmbeddingResult(
+                vectors=(VECTOR_X,),
+                tokens_in=sum(len(value) for value in inputs),
+                request_id="forget-lock-provider-dispatch",
+                raw_latency_ms=1,
+            )
+
+    provider = BarrierProvider()
+    try:
+        async with factory() as setup:
+            human = await _user(setup, user_id=user_id, is_bot=False)
+            source = await _message(
+                setup,
+                user_id=human.id,
+                message_id=4042215 + suffix,
+                text="provider dispatch owns the forget target lock",
+                chat_id=chat_id,
+            )
+            await setup.commit()
+
+        async with factory() as index_session:
+            documents = await list_eligible_message_documents(index_session, chat_id=chat_id)
+            index_task = asyncio.create_task(
+                _index_batch(
+                    index_session,
+                    documents=documents,
+                    config=CONFIG,
+                    provider=provider,
+                )
+            )
+            await asyncio.wait_for(provider_entered.wait(), timeout=2)
+
+            async def create_forget() -> None:
+                async with factory() as forget_session:
+                    await ForgetEventRepo.create(
+                        forget_session,
+                        target_type="message",
+                        target_id=str(source.message.id),
+                        actor_user_id=human.id,
+                        authorized_by="self",
+                        tombstone_key=f"message:{chat_id}:{source.message.message_id}",
+                    )
+                    await forget_session.commit()
+
+            forget_task = asyncio.create_task(create_forget())
+            await asyncio.sleep(0.1)
+            assert forget_task.done() is False
+            assert len(provider.calls) == 1
+            release_provider.set()
+            result, _ = await asyncio.gather(index_task, forget_task)
+
+        assert (result.indexed, result.skipped) == (1, 0)
+        async with factory() as verification:
+            units = (
+                (
+                    await verification.execute(
+                        select(SemanticRetrievalUnit).where(
+                            SemanticRetrievalUnit.chat_id == chat_id
+                        )
+                    )
+                )
+                .scalars()
+                .all()
+            )
+            assert len(units) == 1
+            ledger_ids = {unit.llm_usage_ledger_id for unit in units}
+            assert (
+                await verification.execute(
+                    select(ForgetEvent.id).where(ForgetEvent.target_id == str(source.message.id))
+                )
+            ).scalar_one() > 0
+    finally:
+        release_provider.set()
+        async with factory() as cleanup:
+            await cleanup.execute(
+                delete(SemanticRetrievalUnit).where(SemanticRetrievalUnit.chat_id == chat_id)
+            )
+            await cleanup.execute(
+                delete(ForgetEvent).where(ForgetEvent.target_id == str(source.message.id))
+            )
+            await cleanup.execute(delete(ChatMessage).where(ChatMessage.chat_id == chat_id))
+            if ledger_ids:
+                await cleanup.execute(
+                    delete(LlmUsageLedger).where(LlmUsageLedger.id.in_(ledger_ids))
+                )
             await cleanup.execute(delete(User).where(User.id == user_id))
             await cleanup.commit()
 
@@ -870,6 +975,57 @@ async def test_concurrent_winner_is_reported_as_conflict_not_unchanged(db_sessio
     assert result.reason_counts == {"skipped:conflict": 1}
     assert len(provider.calls) == 1
     assert len((await db_session.execute(select(SemanticRetrievalUnit.id))).scalars().all()) == 1
+
+
+@pytest.mark.asyncio
+async def test_embedding_dispatch_splits_batch_at_provider_character_cap(db_session) -> None:
+    human = await _user(db_session, user_id=8_044_042_230, is_bot=False)
+    for offset in range(17):
+        await _message(
+            db_session,
+            user_id=human.id,
+            message_id=4042230 + offset,
+            text=(chr(ord("a") + offset) * 3996) + f"{offset:04d}",
+        )
+    documents = await list_eligible_message_documents(db_session, chat_id=CHAT_ID, limit=100)
+    provider = CountingEmbeddingProvider()
+
+    result = await _index_batch(
+        db_session,
+        documents=documents,
+        config=CONFIG,
+        provider=provider,
+    )
+
+    assert (result.indexed, result.skipped) == (17, 0)
+    assert [len(call) for call in provider.calls] == [16, 1]
+    assert all(sum(len(value) for value in call) <= 64_000 for call in provider.calls)
+    assert len((await db_session.execute(select(SemanticRetrievalUnit.id))).scalars().all()) == 17
+
+
+@pytest.mark.asyncio
+async def test_oversize_document_is_accounted_without_provider_dispatch(db_session) -> None:
+    human = await _user(db_session, user_id=8_044_042_250, is_bot=False)
+    await _message(
+        db_session,
+        user_id=human.id,
+        message_id=4042250,
+        text="x" * 8_001,
+    )
+    documents = await list_eligible_message_documents(db_session, chat_id=CHAT_ID)
+    provider = CountingEmbeddingProvider()
+
+    result = await _index_batch(
+        db_session,
+        documents=documents,
+        config=CONFIG,
+        provider=provider,
+    )
+
+    assert (result.indexed, result.skipped) == (0, 1)
+    assert result.reason_counts == {"skipped:oversize": 1}
+    assert provider.calls == []
+    assert (await db_session.execute(select(SemanticRetrievalUnit.id))).scalar_one_or_none() is None
 
 
 @pytest.mark.asyncio

--- a/tests/services/test_semantic_index_postgres.py
+++ b/tests/services/test_semantic_index_postgres.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import uuid
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
@@ -229,18 +230,22 @@ async def _unit(
     vector: tuple[float, ...],
     ledger_id: int,
 ) -> SemanticRetrievalUnit:
+    chunk_text = source.version.normalized_text or source.version.text or ""
     unit = SemanticRetrievalUnit(
         source_type="message",
         source_id=str(source.version.id),
         source_revision="v1:media:none",
         chat_id=source.message.chat_id,
-        content_hash=source.version.content_hash,
+        content_hash=hashlib.sha256(chunk_text.encode()).hexdigest(),
         embedding_provider="openai",
         embedding_model="text-embedding-3-small",
         embedding_model_version="text-embedding-3-small",
         embedding_dimensions=1536,
+        embedding_status="completed",
+        chunk_text=chunk_text,
         embedding=list(vector),
         llm_usage_ledger_id=ledger_id,
+        indexed_at=datetime.now(timezone.utc),
     )
     session.add(unit)
     await session.flush()
@@ -736,7 +741,11 @@ async def test_pending_forget_created_during_embedding_prevents_unit_store(db_se
     assert (result.indexed, result.skipped) == (0, 1)
     assert result.reason_counts == {"skipped:governance_race": 1}
     assert len(provider.calls) == 1
-    assert (await db_session.execute(select(SemanticRetrievalUnit.id))).scalar_one_or_none() is None
+    claim = (await db_session.execute(select(SemanticRetrievalUnit))).scalars().one()
+    assert claim.embedding_status == "failed"
+    assert claim.embedding is None
+    assert claim.chunk_text is None
+    assert claim.invalidation_reason == "governance_race"
 
 
 @pytest.mark.asyncio
@@ -925,7 +934,9 @@ async def test_provider_dispatch_holds_same_lock_as_pending_forget_creation(
 
 
 @pytest.mark.asyncio
-async def test_concurrent_winner_is_reported_as_conflict_not_unchanged(db_session) -> None:
+async def test_unresolved_exact_claim_blocks_provider_retry(db_session) -> None:
+    EmbeddingClaimUnresolved = _index_batch.__globals__["EmbeddingClaimUnresolved"]
+
     human = await _user(db_session, user_id=8_044_042_221, is_bot=False)
     source = await _message(
         db_session,
@@ -936,56 +947,55 @@ async def test_concurrent_winner_is_reported_as_conflict_not_unchanged(db_sessio
     document = (await list_eligible_message_documents(db_session, chat_id=CHAT_ID))[0]
     winner_ledger = await _ledger(db_session, suffix="winner")
 
-    class ConcurrentWinnerProvider(CountingEmbeddingProvider):
-        async def embed(self, *, inputs, model: str, dimensions: int) -> EmbeddingResult:
-            winner = SemanticRetrievalUnit(
-                source_type=document.source_type,
-                source_id=document.source_id,
-                source_revision=document.source_revision,
-                chat_id=document.chat_id,
-                content_hash=document.content_hash,
-                embedding_provider="openai",
-                embedding_model=model,
-                embedding_model_version="text-embedding-3-small",
-                embedding_dimensions=dimensions,
-                embedding=list(VECTOR_X),
-                llm_usage_ledger_id=winner_ledger.id,
-            )
-            db_session.add(winner)
-            await db_session.flush()
-            db_session.add(
-                SemanticRetrievalUnitSource(
-                    unit_id=winner.id,
-                    message_version_id=source.version.id,
-                    position=0,
-                )
-            )
-            await db_session.flush()
-            return await super().embed(inputs=inputs, model=model, dimensions=dimensions)
-
-    provider = ConcurrentWinnerProvider()
-    result = await _index_batch(
-        db_session,
-        documents=[document],
-        config=CONFIG,
-        provider=provider,
+    unresolved = SemanticRetrievalUnit(
+        source_type=document.source_type,
+        source_id=document.source_id,
+        source_revision=document.source_revision,
+        chat_id=document.chat_id,
+        content_hash=document.content_hash,
+        embedding_provider="openai",
+        embedding_model=CONFIG.model,
+        embedding_model_version="text-embedding-3-small",
+        embedding_dimensions=CONFIG.dimensions,
+        embedding_status="failed",
+        chunk_text=None,
+        embedding=None,
+        llm_usage_ledger_id=winner_ledger.id,
+        indexed_at=None,
     )
+    db_session.add(unresolved)
+    await db_session.flush()
+    db_session.add(
+        SemanticRetrievalUnitSource(
+            unit_id=unresolved.id,
+            message_version_id=source.version.id,
+            position=0,
+        )
+    )
+    await db_session.flush()
 
-    assert (result.indexed, result.skipped) == (0, 1)
-    assert result.reason_counts == {"skipped:conflict": 1}
-    assert len(provider.calls) == 1
+    provider = CountingEmbeddingProvider()
+    with pytest.raises(EmbeddingClaimUnresolved, match="operator resolution"):
+        await _index_batch(
+            db_session,
+            documents=[document],
+            config=CONFIG,
+            provider=provider,
+        )
+
+    assert provider.calls == []
     assert len((await db_session.execute(select(SemanticRetrievalUnit.id))).scalars().all()) == 1
 
 
 @pytest.mark.asyncio
 async def test_embedding_dispatch_splits_batch_at_provider_character_cap(db_session) -> None:
     human = await _user(db_session, user_id=8_044_042_230, is_bot=False)
-    for offset in range(17):
+    for offset in range(81):
         await _message(
             db_session,
             user_id=human.id,
             message_id=4042230 + offset,
-            text=(chr(ord("a") + offset) * 3996) + f"{offset:04d}",
+            text=f"{offset:04d}" + (chr(0x410 + (offset % 32)) * 796),
         )
     documents = await list_eligible_message_documents(db_session, chat_id=CHAT_ID, limit=100)
     provider = CountingEmbeddingProvider()
@@ -997,10 +1007,10 @@ async def test_embedding_dispatch_splits_batch_at_provider_character_cap(db_sess
         provider=provider,
     )
 
-    assert (result.indexed, result.skipped) == (17, 0)
-    assert [len(call) for call in provider.calls] == [16, 1]
+    assert (result.indexed, result.skipped) == (81, 0)
+    assert [len(call) for call in provider.calls] == [80, 1]
     assert all(sum(len(value) for value in call) <= 64_000 for call in provider.calls)
-    assert len((await db_session.execute(select(SemanticRetrievalUnit.id))).scalars().all()) == 17
+    assert len((await db_session.execute(select(SemanticRetrievalUnit.id))).scalars().all()) == 81
 
 
 @pytest.mark.asyncio
@@ -1008,11 +1018,12 @@ async def test_oversize_document_is_chunked_with_full_coverage(db_session) -> No
     from scripts.backfill_semantic_index import _coverage_report
 
     human = await _user(db_session, user_id=8_044_042_250, is_bot=False)
+    late_chunk = ("y" * 700) + "LATE-CHUNK-EVIDENCE"
     await _message(
         db_session,
         user_id=human.id,
         message_id=4042250,
-        text="x" * 8_001,
+        text=("early-prefix " + "x" * (800 - len("early-prefix "))) + late_chunk,
     )
     documents = await list_eligible_message_documents(db_session, chat_id=CHAT_ID)
     provider = CountingEmbeddingProvider()
@@ -1026,7 +1037,9 @@ async def test_oversize_document_is_chunked_with_full_coverage(db_session) -> No
 
     assert (result.indexed, result.skipped) == (2, 0)
     assert result.reason_counts == {"indexed:new_embedding": 2}
-    assert [tuple(len(value) for value in call) for call in provider.calls] == [(8_000, 1)]
+    assert [tuple(len(value) for value in call) for call in provider.calls] == [
+        (800, len(late_chunk))
+    ]
     units = (
         (
             await db_session.execute(
@@ -1049,26 +1062,201 @@ async def test_oversize_document_is_chunked_with_full_coverage(db_session) -> No
     assert coverage["coverage_percent"] == 100.0
     hits = await vector_search(
         db_session,
-        query_embedding=VECTOR_X,
+        query_embedding=VECTOR_Y,
         chat_id=CHAT_ID,
         embedding_model=CONFIG.model,
         limit=5,
     )
     assert len(hits) == 1
     assert hits[0].message_version_id == documents[0].message_version_ids[0]
+    assert hits[0].snippet == late_chunk
+    assert hits[0].snippet.index("LATE-CHUNK-EVIDENCE") > 400
 
 
 @pytest.mark.asyncio
-async def test_partial_provider_batch_is_durable_and_retry_does_not_repay(db_session) -> None:
-    from bot.services.llm_providers import ProviderTransientError
+async def test_whitespace_only_chunk_is_filtered_without_content_loss(db_session) -> None:
+    from scripts.backfill_semantic_index import _coverage_report
+
+    human = await _user(db_session, user_id=8_044_042_251, is_bot=False)
+    await _message(
+        db_session,
+        user_id=human.id,
+        message_id=4042251,
+        text=("a" * 800) + (" " * 800) + "b",
+    )
+    documents = await list_eligible_message_documents(db_session, chat_id=CHAT_ID)
+    provider = CountingEmbeddingProvider()
+
+    result = await _index_batch(
+        db_session,
+        documents=documents,
+        config=CONFIG,
+        provider=provider,
+    )
+
+    assert (result.indexed, result.skipped) == (2, 0)
+    assert [(document.chunk_index, document.chunk_count) for document in documents] == [
+        (0, 2),
+        (1, 2),
+    ]
+    assert provider.calls == [("a" * 800, "b")]
+    coverage = await _coverage_report(
+        db_session,
+        chat_id=CHAT_ID,
+        model=CONFIG.model,
+        batch_size=100,
+    )
+    assert coverage["status"] == "pass"
+    assert coverage["eligible"] == 2
+    assert coverage["unresolved_claims"] == 0
+
+
+@pytest.mark.asyncio
+async def test_card_vector_hit_hydrates_the_winning_late_chunk(db_session) -> None:
+    human = await _user(db_session, user_id=8_044_042_252, is_bot=False)
+    admin = await _user(db_session, user_id=8_044_042_253, is_bot=False, is_admin=True)
+    source = await _message(
+        db_session,
+        user_id=human.id,
+        message_id=4042252,
+        text="card provenance source",
+    )
+    card = await _approved_card(
+        db_session,
+        admin_id=admin.id,
+        source_ids=(source.version.id,),
+        title="early-card",
+    )
+    card.body_markdown = ("x" * 1_500) + " LATE-CARD-CHUNK"
+    await db_session.flush()
+    documents = await list_eligible_card_documents(db_session, chat_id=CHAT_ID)
+    assert len(documents) == 2
+    provider = CountingEmbeddingProvider()
+    await _index_batch(
+        db_session,
+        documents=documents,
+        config=CONFIG,
+        provider=provider,
+    )
+
+    hits = await vector_search(
+        db_session,
+        query_embedding=VECTOR_Y,
+        chat_id=CHAT_ID,
+        embedding_model=CONFIG.model,
+        limit=5,
+    )
+
+    assert len(hits) == 1
+    assert hits[0].card_id == card.id
+    assert hits[0].snippet == documents[1].canonical_text
+    assert "LATE-CARD-CHUNK" in hits[0].snippet
+    assert hits[0].snippet.index("LATE-CARD-CHUNK") > 400
+    assert hits[0].card_source_message_version_ids == (source.version.id,)
+
+
+@pytest.mark.asyncio
+async def test_vector_hydration_rejects_card_body_changed_after_embedding(db_session) -> None:
+    human = await _user(db_session, user_id=8_044_042_254, is_bot=False)
+    admin = await _user(db_session, user_id=8_044_042_255, is_bot=False, is_admin=True)
+    source = await _message(
+        db_session,
+        user_id=human.id,
+        message_id=4042254,
+        text="mutable card provenance",
+    )
+    card = await _approved_card(
+        db_session,
+        admin_id=admin.id,
+        source_ids=(source.version.id,),
+        title="Current card",
+    )
+    documents = await list_eligible_card_documents(db_session, chat_id=CHAT_ID)
+    await _index_batch(
+        db_session,
+        documents=documents,
+        config=CONFIG,
+        provider=CountingEmbeddingProvider(),
+    )
+
+    current_hits = await vector_search(
+        db_session,
+        query_embedding=VECTOR_X,
+        chat_id=CHAT_ID,
+        embedding_model=CONFIG.model,
+    )
+    assert len(current_hits) == 1
+    assert current_hits[0].snippet == documents[0].canonical_text
+
+    card.body_markdown = "replacement body that was never embedded"
+    await db_session.flush()
+
+    assert (
+        await vector_search(
+            db_session,
+            query_embedding=VECTOR_X,
+            chat_id=CHAT_ID,
+            embedding_model=CONFIG.model,
+        )
+        == []
+    )
+
+
+@pytest.mark.asyncio
+async def test_vector_hydration_rejects_media_description_changed_after_embedding(
+    db_session,
+) -> None:
+    human = await _user(db_session, user_id=8_044_042_256, is_bot=False)
+    source = await _message(
+        db_session,
+        user_id=human.id,
+        message_id=4042256,
+        text="message with mutable media description",
+    )
+    media = MessageMedia(
+        chat_message_id=source.message.id,
+        media_kind="photo",
+        source_message_url="https://t.me/c/404/2256",
+        description="original embedded visual description",
+        description_status="ready",
+        description_model="gpt-5-nano",
+    )
+    db_session.add(media)
+    await db_session.flush()
+    documents = await list_eligible_message_documents(db_session, chat_id=CHAT_ID)
+    await _index_batch(
+        db_session,
+        documents=documents,
+        config=CONFIG,
+        provider=CountingEmbeddingProvider(),
+    )
+
+    media.description = "replacement visual description that was never embedded"
+    await db_session.flush()
+
+    assert (
+        await vector_search(
+            db_session,
+            query_embedding=VECTOR_X,
+            chat_id=CHAT_ID,
+            embedding_model=CONFIG.model,
+        )
+        == []
+    )
+
+
+@pytest.mark.asyncio
+async def test_partial_provider_batch_is_durable_and_retry_fails_closed(db_session) -> None:
+    ProviderTransientError = _index_batch.__globals__["ProviderTransientError"]
+    EmbeddingClaimUnresolved = _index_batch.__globals__["EmbeddingClaimUnresolved"]
 
     human = await _user(db_session, user_id=8_044_042_260, is_bot=False)
-    for offset in range(17):
+    for offset in range(81):
         await _message(
             db_session,
             user_id=human.id,
             message_id=4042260 + offset,
-            text=(chr(ord("a") + offset) * 3996) + f"{offset:04d}",
+            text=f"{offset:04d}" + (chr(0x410 + (offset % 32)) * 796),
         )
     documents = await list_eligible_message_documents(db_session, chat_id=CHAT_ID, limit=100)
 
@@ -1095,9 +1283,9 @@ async def test_partial_provider_batch_is_durable_and_retry_does_not_repay(db_ses
             chat_id=CHAT_ID,
         )
     partial = raised.value.semantic_batch_result
-    assert (partial.indexed, partial.skipped) == (16, 0)
-    assert partial.reason_counts == {"indexed:new_embedding": 16}
-    assert [len(call) for call in first_provider.calls] == [16, 1]
+    assert (partial.indexed, partial.skipped) == (80, 0)
+    assert partial.reason_counts == {"indexed:new_embedding": 80}
+    assert [len(call) for call in first_provider.calls] == [80, 1]
     failed_run = (
         (
             await db_session.execute(
@@ -1109,28 +1297,234 @@ async def test_partial_provider_batch_is_durable_and_retry_does_not_repay(db_ses
     )
     assert failed_run.status == "failed"
     assert (failed_run.eligible_count, failed_run.indexed_count, failed_run.failed_count) == (
-        17,
-        16,
+        81,
+        80,
         1,
     )
     first_units = (await db_session.execute(select(SemanticRetrievalUnit))).scalars().all()
-    assert len(first_units) == 16
-    assert len({unit.llm_usage_ledger_id for unit in first_units}) == 1
+    assert len(first_units) == 81
+    assert [unit.embedding_status for unit in first_units].count("completed") == 80
+    assert [unit.embedding_status for unit in first_units].count("failed") == 1
+    assert len({unit.llm_usage_ledger_id for unit in first_units}) == 2
 
     retry_provider = CountingEmbeddingProvider()
-    retry = await _index_batch(
-        db_session,
-        documents=documents,
-        config=CONFIG,
-        provider=retry_provider,
-    )
+    with pytest.raises(EmbeddingClaimUnresolved):
+        await _index_batch(
+            db_session,
+            documents=documents,
+            config=CONFIG,
+            provider=retry_provider,
+        )
 
-    assert (retry.indexed, retry.skipped) == (1, 16)
-    assert [len(call) for call in retry_provider.calls] == [1]
-    assert retry_provider.calls[0] == (documents[-1].canonical_text,)
+    assert retry_provider.calls == []
     final_units = (await db_session.execute(select(SemanticRetrievalUnit))).scalars().all()
-    assert len(final_units) == 17
+    assert len(final_units) == 81
     assert len({unit.llm_usage_ledger_id for unit in final_units}) == 2
+
+
+@pytest.mark.asyncio
+async def test_paid_result_terminal_failure_keeps_reserved_claim_and_blocks_repay(
+    postgres_engine,
+    monkeypatch,
+) -> None:
+    from sqlalchemy.exc import OperationalError
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+    EmbeddingClaimUnresolved = _index_batch.__globals__["EmbeddingClaimUnresolved"]
+    _SemanticEmbeddingOutcomeRecorder = _index_batch.__globals__[
+        "_SemanticEmbeddingOutcomeRecorder"
+    ]
+
+    suffix = uuid.uuid4().int % 1_000_000
+    user_id = 8_044_042_270 + suffix
+    chat_id = -9_044_042_270 - suffix
+    factory = async_sessionmaker(postgres_engine, class_=AsyncSession, expire_on_commit=False)
+    original_complete = _SemanticEmbeddingOutcomeRecorder.complete
+
+    async def fail_terminal_commit(self, session, *, llm_usage_ledger_id, vectors):
+        raise OperationalError("forced terminal materialization failure", {}, RuntimeError())
+
+    monkeypatch.setattr(
+        _SemanticEmbeddingOutcomeRecorder,
+        "complete",
+        fail_terminal_commit,
+    )
+    first_provider = CountingEmbeddingProvider()
+    ledger_id: int | None = None
+    try:
+        async with factory() as session:
+            human = await _user(session, user_id=user_id, is_bot=False)
+            await _message(
+                session,
+                user_id=human.id,
+                message_id=4_042_270 + suffix,
+                text="paid result must never be dispatched twice",
+                chat_id=chat_id,
+            )
+            documents = await list_eligible_message_documents(session, chat_id=chat_id)
+            with pytest.raises(OperationalError):
+                await _index_batch(
+                    session,
+                    documents=documents,
+                    config=CONFIG,
+                    provider=first_provider,
+                )
+
+            assert len(first_provider.calls) == 1
+            claim = (
+                (
+                    await session.execute(
+                        select(SemanticRetrievalUnit).where(
+                            SemanticRetrievalUnit.chat_id == chat_id
+                        )
+                    )
+                )
+                .scalars()
+                .one()
+            )
+            assert claim.embedding_status == "reserved"
+            assert claim.embedding is None
+            assert claim.chunk_text is None
+            ledger_id = claim.llm_usage_ledger_id
+            ledger = await session.get(LlmUsageLedger, ledger_id)
+            assert ledger is not None
+            assert ledger.error == "reserved_in_flight"
+
+            monkeypatch.setattr(
+                _SemanticEmbeddingOutcomeRecorder,
+                "complete",
+                original_complete,
+            )
+            retry_provider = CountingEmbeddingProvider()
+            with pytest.raises(EmbeddingClaimUnresolved):
+                await _index_batch(
+                    session,
+                    documents=documents,
+                    config=CONFIG,
+                    provider=retry_provider,
+                )
+            assert retry_provider.calls == []
+    finally:
+        async with factory() as cleanup:
+            await cleanup.execute(
+                delete(SemanticRetrievalUnit).where(SemanticRetrievalUnit.chat_id == chat_id)
+            )
+            await cleanup.execute(delete(ChatMessage).where(ChatMessage.chat_id == chat_id))
+            if ledger_id is not None:
+                await cleanup.execute(delete(LlmUsageLedger).where(LlmUsageLedger.id == ledger_id))
+            await cleanup.execute(delete(User).where(User.id == user_id))
+            await cleanup.commit()
+
+
+@pytest.mark.asyncio
+async def test_sql_failure_preserves_committed_partition_accounting(
+    postgres_engine,
+    monkeypatch,
+) -> None:
+    from sqlalchemy.exc import DBAPIError
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+    _SemanticEmbeddingOutcomeRecorder = _index_batch.__globals__[
+        "_SemanticEmbeddingOutcomeRecorder"
+    ]
+
+    suffix = uuid.uuid4().int % 1_000_000
+    user_id = 8_044_042_800 + suffix
+    chat_id = -9_044_042_800 - suffix
+    factory = async_sessionmaker(postgres_engine, class_=AsyncSession, expire_on_commit=False)
+    original_complete = _SemanticEmbeddingOutcomeRecorder.complete
+    terminal_calls = 0
+
+    async def fail_second_terminal(self, session, *, llm_usage_ledger_id, vectors):
+        nonlocal terminal_calls
+        terminal_calls += 1
+        if terminal_calls == 2:
+            await session.execute(text("SELECT 1 / 0"))
+        await original_complete(
+            self,
+            session,
+            llm_usage_ledger_id=llm_usage_ledger_id,
+            vectors=vectors,
+        )
+
+    monkeypatch.setattr(
+        _SemanticEmbeddingOutcomeRecorder,
+        "complete",
+        fail_second_terminal,
+    )
+    provider = CountingEmbeddingProvider()
+    run_id: int | None = None
+    ledger_ids: set[int] = set()
+    try:
+        async with factory() as session:
+            human = await _user(session, user_id=user_id, is_bot=False)
+            for offset in range(81):
+                await _message(
+                    session,
+                    user_id=human.id,
+                    message_id=5_040_000 + suffix + offset,
+                    text=f"{offset:04d}" + (chr(0x410 + (offset % 32)) * 796),
+                    chat_id=chat_id,
+                )
+
+            with pytest.raises(DBAPIError):
+                await backfill_semantic_index(
+                    session,
+                    config=CONFIG,
+                    provider=provider,
+                    batch_size=100,
+                    chat_id=chat_id,
+                )
+        async with factory() as verify:
+            run = (
+                (
+                    await verify.execute(
+                        select(SemanticIndexRun).order_by(SemanticIndexRun.id.desc()).limit(1)
+                    )
+                )
+                .scalars()
+                .one()
+            )
+            run_id = run.id
+            assert run.status == "failed"
+            assert (
+                run.eligible_count,
+                run.indexed_count,
+                run.skipped_count,
+                run.failed_count,
+            ) == (81, 80, 0, 1)
+            assert run.reason_counts["indexed:new_embedding"] == 80
+            assert run.reason_counts["failed:DBAPIError"] == 1
+            assert run.cursor is None
+            units = (
+                (
+                    await verify.execute(
+                        select(SemanticRetrievalUnit).where(
+                            SemanticRetrievalUnit.chat_id == chat_id
+                        )
+                    )
+                )
+                .scalars()
+                .all()
+            )
+            assert [unit.embedding_status for unit in units].count("completed") == 80
+            assert [unit.embedding_status for unit in units].count("reserved") == 1
+            ledger_ids.update(unit.llm_usage_ledger_id for unit in units)
+            assert [len(call) for call in provider.calls] == [80, 1]
+    finally:
+        async with factory() as cleanup:
+            await cleanup.execute(
+                delete(SemanticRetrievalUnit).where(SemanticRetrievalUnit.chat_id == chat_id)
+            )
+            if run_id is not None:
+                await cleanup.execute(delete(SemanticIndexRun).where(SemanticIndexRun.id == run_id))
+            await cleanup.execute(delete(ChatMessage).where(ChatMessage.chat_id == chat_id))
+            if ledger_ids:
+                await cleanup.execute(
+                    delete(LlmUsageLedger).where(LlmUsageLedger.id.in_(ledger_ids))
+                )
+            await cleanup.execute(delete(User).where(User.id == user_id))
+            await cleanup.commit()
 
 
 @pytest.mark.asyncio
@@ -1442,8 +1836,11 @@ async def test_reconcile_invalidates_every_active_unit_that_became_ineligible(db
         embedding_model=CONFIG.model,
         embedding_model_version="text-embedding-3-small",
         embedding_dimensions=CONFIG.dimensions,
+        embedding_status="completed",
+        chunk_text="deapproved card",
         embedding=list(VECTOR_X),
         llm_usage_ledger_id=ledger.id,
+        indexed_at=datetime.now(timezone.utc),
     )
     db_session.add(card_unit)
     await db_session.flush()
@@ -1691,18 +2088,22 @@ async def test_vector_search_returns_approved_card_then_blocks_pending_forget(db
         title="Каноническая карточка",
     )
     ledger = await _ledger(db_session, suffix="b")
+    card_text = "\n".join(part.strip() for part in (card.title, card.body_markdown) if part.strip())
     unit = SemanticRetrievalUnit(
         source_type="card",
         source_id=str(card.id),
-        source_revision="updated:test:approved:test",
+        source_revision=f"updated:{card.updated_at.isoformat()}:approved:{card.approved_at.isoformat()}",
         chat_id=CHAT_ID,
-        content_hash="c" * 64,
+        content_hash=hashlib.sha256(card_text.encode()).hexdigest(),
         embedding_provider="openai",
         embedding_model="text-embedding-3-small",
         embedding_model_version="text-embedding-3-small",
         embedding_dimensions=1536,
+        embedding_status="completed",
+        chunk_text=card_text,
         embedding=list(VECTOR_X),
         llm_usage_ledger_id=ledger.id,
+        indexed_at=datetime.now(timezone.utc),
     )
     db_session.add(unit)
     await db_session.flush()

--- a/tests/services/test_semantic_index_postgres.py
+++ b/tests/services/test_semantic_index_postgres.py
@@ -2275,3 +2275,42 @@ async def test_nested_replies_share_resolved_root_for_diversity(db_session) -> N
     assert {hit.conversation_root_message_id for hit in enriched[:4]} == {5000}
     assert sum(hit.conversation_root_message_id == 5000 for hit in selected) == 2
     assert any(hit.message_id == 6000 for hit in selected)
+
+
+@pytest.mark.asyncio
+async def test_deep_adjacent_replies_share_the_actual_conversation_root(db_session) -> None:
+    human = await _user(db_session, user_id=8_044_045_002, is_bot=False)
+    first_message_id = 7000
+    await _message(
+        db_session,
+        user_id=human.id,
+        message_id=first_message_id,
+        text="root",
+    )
+    for message_id in range(first_message_id + 1, first_message_id + 71):
+        await _message(
+            db_session,
+            user_id=human.id,
+            message_id=message_id,
+            text=f"reply-{message_id}",
+            reply_to_message_id=message_id - 1,
+        )
+    origin = first_message_id + 70
+
+    enriched = await _with_conversation_roots(
+        db_session,
+        chat_id=CHAT_ID,
+        hits=[
+            _hit(
+                version_id=message_id,
+                author_id=human.id,
+                reply_to_message_id=message_id - 1,
+            )
+            for message_id in (origin, origin - 1)
+        ],
+    )
+
+    assert [hit.conversation_root_message_id for hit in enriched] == [
+        first_message_id,
+        first_message_id,
+    ]

--- a/tests/services/test_semantic_index_postgres.py
+++ b/tests/services/test_semantic_index_postgres.py
@@ -1,0 +1,1504 @@
+"""PostgreSQL integration and leakage tests for the semantic index."""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from typing import Literal
+
+import pytest
+from sqlalchemy import delete, select
+
+from bot.db.models import (
+    CardSource,
+    ChatMessage,
+    ForgetEvent,
+    KnowledgeCard,
+    LlmUsageLedger,
+    MessageMedia,
+    MessageVersion,
+    SemanticIndexRun,
+    SemanticRetrievalUnit,
+    SemanticRetrievalUnitSource,
+    User,
+)
+from bot.services.llm_gateway import EmbeddingGatewayConfig
+from bot.services.llm_providers.openai_embeddings import EmbeddingResult
+from bot.services.search import SearchHit, search_messages
+from bot.services.semantic_index import (
+    _index_batch,
+    _reconcile_ineligible_units,
+    _with_conversation_roots,
+    backfill_semantic_index,
+    hybrid_search,
+    list_eligible_card_documents,
+    list_eligible_message_documents,
+    reciprocal_rank_fusion,
+    vector_search,
+)
+
+
+CHAT_ID = -1_004_040_001
+OTHER_CHAT_ID = -1_004_040_002
+CONFIG = EmbeddingGatewayConfig(
+    model="text-embedding-3-small",
+    dimensions=1536,
+    daily_ceiling_usd=Decimal("100"),
+    monthly_ceiling_usd=Decimal("1000"),
+)
+VECTOR_X = (1.0,) + (0.0,) * 1535
+VECTOR_Y = (0.0, 1.0) + (0.0,) * 1534
+
+
+@pytest.fixture(autouse=True)
+def _semantic_runtime_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Allow the canonical forget-lock helper to import runtime settings."""
+
+    monkeypatch.setenv("BOT_TOKEN", "123456:test-token")
+    monkeypatch.setenv("DEV_MODE", "true")
+
+
+@dataclass(frozen=True, slots=True)
+class CreatedMessage:
+    message: ChatMessage
+    version: MessageVersion
+
+
+class CountingEmbeddingProvider:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, ...]] = []
+
+    async def embed(self, *, inputs, model: str, dimensions: int) -> EmbeddingResult:
+        values = tuple(inputs)
+        self.calls.append(values)
+        return EmbeddingResult(
+            vectors=tuple(
+                VECTOR_X if index % 2 == 0 else VECTOR_Y for index, _ in enumerate(values)
+            ),
+            tokens_in=sum(len(value) for value in values),
+            request_id=f"semantic-test-{len(self.calls)}",
+            raw_latency_ms=1,
+        )
+
+
+async def _user(
+    session,
+    *,
+    user_id: int,
+    is_bot: bool | None,
+    is_admin: bool = False,
+) -> User:
+    row = User(
+        id=user_id,
+        username=f"semantic_{user_id}",
+        first_name="Semantic",
+        last_name=None,
+        is_member=True,
+        is_admin=is_admin,
+        is_bot=is_bot,
+    )
+    session.add(row)
+    await session.flush()
+    return row
+
+
+async def _message(
+    session,
+    *,
+    user_id: int,
+    message_id: int,
+    text: str,
+    chat_id: int = CHAT_ID,
+    memory_policy: str = "normal",
+    message_kind: str = "text",
+    message_thread_id: int | None = None,
+    reply_to_message_id: int | None = None,
+    chat_redacted: bool = False,
+    version_redacted: bool = False,
+) -> CreatedMessage:
+    now = datetime.now(timezone.utc)
+    message = ChatMessage(
+        message_id=message_id,
+        chat_id=chat_id,
+        user_id=user_id,
+        text=text,
+        date=now,
+        memory_policy=memory_policy,
+        message_kind=message_kind,
+        message_thread_id=message_thread_id,
+        reply_to_message_id=reply_to_message_id,
+        is_redacted=chat_redacted,
+    )
+    session.add(message)
+    await session.flush()
+    version = MessageVersion(
+        chat_message_id=message.id,
+        version_seq=1,
+        text=text,
+        normalized_text=text,
+        content_hash=f"semantic-{uuid.uuid4().hex}",
+        is_redacted=version_redacted,
+    )
+    session.add(version)
+    await session.flush()
+    message.current_version_id = version.id
+    await session.flush()
+    return CreatedMessage(message=message, version=version)
+
+
+def _evidence_bundle(source: CreatedMessage):
+    from bot.services.evidence import EvidenceBundle, EvidenceItem
+
+    now = datetime.now(timezone.utc)
+    return EvidenceBundle(
+        query="delivery lock test",
+        chat_id=source.message.chat_id,
+        items=(
+            EvidenceItem(
+                message_version_id=source.version.id,
+                chat_message_id=source.message.id,
+                chat_id=source.message.chat_id,
+                message_id=source.message.message_id,
+                user_id=source.message.user_id,
+                snippet="governed evidence",
+                ts_rank=1.0,
+                captured_at=now,
+                message_date=source.message.date,
+            ),
+        ),
+        abstained=False,
+        created_at=now,
+    )
+
+
+async def _approved_card(
+    session,
+    *,
+    admin_id: int,
+    source_ids: tuple[int, ...],
+    title: str,
+    status: str = "approved",
+) -> KnowledgeCard:
+    approved = status == "approved"
+    card = KnowledgeCard(
+        title=title,
+        body_markdown=f"{title}: подтвержденное знание",
+        card_status=status,
+        approved_by_user_id=admin_id if approved else None,
+        approved_at=datetime.now(timezone.utc) if approved else None,
+    )
+    session.add(card)
+    await session.flush()
+    for position, message_version_id in enumerate(source_ids):
+        session.add(
+            CardSource(
+                card_id=card.id,
+                message_version_id=message_version_id,
+                position=position,
+            )
+        )
+    await session.flush()
+    return card
+
+
+async def _ledger(session, *, suffix: str) -> LlmUsageLedger:
+    row = LlmUsageLedger(
+        provider="openai",
+        model="text-embedding-3-small",
+        prompt_hash=(suffix * 64)[:64],
+        response_hash=(suffix * 64)[:64],
+        tokens_in=1,
+        tokens_out=0,
+        cost_usd=Decimal("0"),
+        latency_ms=1,
+        cache_hit=False,
+        call_type="semantic_embedding",
+    )
+    session.add(row)
+    await session.flush()
+    return row
+
+
+async def _unit(
+    session,
+    *,
+    source: CreatedMessage,
+    vector: tuple[float, ...],
+    ledger_id: int,
+) -> SemanticRetrievalUnit:
+    unit = SemanticRetrievalUnit(
+        source_type="message",
+        source_id=str(source.version.id),
+        source_revision="v1:media:none",
+        chat_id=source.message.chat_id,
+        content_hash=source.version.content_hash,
+        embedding_provider="openai",
+        embedding_model="text-embedding-3-small",
+        embedding_model_version="text-embedding-3-small",
+        embedding_dimensions=1536,
+        embedding=list(vector),
+        llm_usage_ledger_id=ledger_id,
+    )
+    session.add(unit)
+    await session.flush()
+    session.add(
+        SemanticRetrievalUnitSource(
+            unit_id=unit.id,
+            message_version_id=source.version.id,
+            position=0,
+        )
+    )
+    await session.flush()
+    return unit
+
+
+@pytest.mark.asyncio
+async def test_message_and_card_eligibility_fail_closed_without_leakage(db_session) -> None:
+    human = await _user(db_session, user_id=8_044_041_001, is_bot=False)
+    bot = await _user(db_session, user_id=8_044_041_002, is_bot=True)
+    unknown = await _user(db_session, user_id=8_044_041_003, is_bot=None)
+    admin = await _user(db_session, user_id=8_044_041_004, is_bot=False, is_admin=True)
+
+    eligible = await _message(
+        db_session,
+        user_id=human.id,
+        message_id=4041001,
+        text="человеческое текущее знание",
+    )
+    media = MessageMedia(
+        chat_message_id=eligible.message.id,
+        media_kind="photo",
+        source_message_url="https://t.me/c/404/1",
+        description="готовое описание изображения",
+        description_status="ready",
+        description_model="gpt-5-nano",
+    )
+    db_session.add(media)
+    bot_message = await _message(
+        db_session, user_id=bot.id, message_id=4041002, text="секрет от бота"
+    )
+    await _message(db_session, user_id=unknown.id, message_id=4041003, text="неизвестный автор")
+    await _message(
+        db_session,
+        user_id=human.id,
+        message_id=4041004,
+        text="offrecord секрет",
+        memory_policy="offrecord",
+    )
+    await _message(
+        db_session,
+        user_id=human.id,
+        message_id=4041005,
+        text="голосовая расшифровка",
+        message_kind="voice",
+    )
+    await _message(
+        db_session,
+        user_id=human.id,
+        message_id=4041006,
+        text="редактировано",
+        chat_redacted=True,
+    )
+    await _message(
+        db_session,
+        user_id=human.id,
+        message_id=4041007,
+        text="версия редактирована",
+        version_redacted=True,
+    )
+    forgotten = await _message(
+        db_session, user_id=human.id, message_id=4041008, text="ожидает удаления"
+    )
+    db_session.add(
+        ForgetEvent(
+            target_type="message",
+            target_id=str(forgotten.message.id),
+            actor_user_id=human.id,
+            authorized_by="self",
+            tombstone_key=f"message:{CHAT_ID}:{forgotten.message.message_id}",
+            status="pending",
+        )
+    )
+    foreign = await _message(
+        db_session,
+        user_id=human.id,
+        message_id=4041009,
+        text="другой чат",
+        chat_id=OTHER_CHAT_ID,
+    )
+    stale_parent = await _message(
+        db_session, user_id=human.id, message_id=4041010, text="старая редакция"
+    )
+    current = MessageVersion(
+        chat_message_id=stale_parent.message.id,
+        version_seq=2,
+        text="текущая редакция",
+        normalized_text="текущая редакция",
+        content_hash=f"semantic-{uuid.uuid4().hex}",
+        is_redacted=False,
+    )
+    db_session.add(current)
+    await db_session.flush()
+    stale_parent.message.current_version_id = current.id
+    approved = await _approved_card(
+        db_session,
+        admin_id=admin.id,
+        source_ids=(eligible.version.id,),
+        title="Одобренная карточка",
+    )
+    await _approved_card(
+        db_session,
+        admin_id=admin.id,
+        source_ids=(eligible.version.id,),
+        title="Черновик",
+        status="draft",
+    )
+    await _approved_card(
+        db_session,
+        admin_id=admin.id,
+        source_ids=(bot_message.version.id,),
+        title="Карточка бота",
+    )
+    await _approved_card(
+        db_session,
+        admin_id=admin.id,
+        source_ids=(eligible.version.id, foreign.version.id),
+        title="Карточка из разных чатов",
+    )
+    await db_session.flush()
+
+    message_documents = await list_eligible_message_documents(
+        db_session, chat_id=CHAT_ID, limit=100
+    )
+    card_documents = await list_eligible_card_documents(db_session, chat_id=CHAT_ID, limit=100)
+
+    assert {document.source_id for document in message_documents} == {
+        str(eligible.version.id),
+        str(current.id),
+    }
+    eligible_document = next(
+        document for document in message_documents if document.source_id == str(eligible.version.id)
+    )
+    assert "готовое описание изображения" in eligible_document.canonical_text
+    assert str(stale_parent.version.id) not in {
+        document.source_id for document in message_documents
+    }
+    assert str(foreign.version.id) not in {document.source_id for document in message_documents}
+    assert [document.source_id for document in card_documents] == [str(approved.id)]
+    assert card_documents[0].message_version_ids == (eligible.version.id,)
+
+
+@pytest.mark.asyncio
+async def test_unchanged_edit_copies_prior_vector_without_provider_and_preserves_audit(
+    db_session,
+) -> None:
+    human = await _user(db_session, user_id=8_044_042_001, is_bot=False)
+    source = await _message(
+        db_session,
+        user_id=human.id,
+        message_id=4042001,
+        text="первая редакция проекта",
+    )
+    provider = CountingEmbeddingProvider()
+    first_documents = await list_eligible_message_documents(db_session, chat_id=CHAT_ID)
+
+    first_result = await _index_batch(
+        db_session,
+        documents=first_documents,
+        config=CONFIG,
+        provider=provider,
+    )
+    assert (first_result.indexed, first_result.skipped) == (1, 0)
+    assert first_result.reason_counts == {"indexed:new_embedding": 1}
+    rerun_result = await _index_batch(
+        db_session,
+        documents=first_documents,
+        config=CONFIG,
+        provider=provider,
+    )
+    assert (rerun_result.indexed, rerun_result.skipped) == (0, 1)
+    assert rerun_result.reason_counts == {"skipped:unchanged": 1}
+    assert len(provider.calls) == 1
+
+    edited = MessageVersion(
+        chat_message_id=source.message.id,
+        version_seq=2,
+        text="первая редакция проекта",
+        normalized_text="первая редакция проекта",
+        content_hash=f"semantic-{uuid.uuid4().hex}",
+        is_redacted=False,
+    )
+    db_session.add(edited)
+    await db_session.flush()
+    source.message.current_version_id = edited.id
+    await db_session.flush()
+    edited_documents = await list_eligible_message_documents(db_session, chat_id=CHAT_ID)
+
+    assert [document.source_id for document in edited_documents] == [str(edited.id)]
+    edit_result = await _index_batch(
+        db_session,
+        documents=edited_documents,
+        config=CONFIG,
+        provider=provider,
+    )
+    assert (edit_result.indexed, edit_result.skipped) == (1, 0)
+    assert edit_result.reason_counts == {"indexed:reused_embedding": 1}
+    assert len(provider.calls) == 1
+    units = (
+        (await db_session.execute(select(SemanticRetrievalUnit).order_by(SemanticRetrievalUnit.id)))
+        .scalars()
+        .all()
+    )
+    assert len(units) == 2
+    assert units[0].source_id == str(source.version.id)
+    assert units[0].invalidation_reason == "source_revised"
+    assert units[0].invalidated_at is not None
+    assert units[1].source_id == str(edited.id)
+    assert units[1].invalidated_at is None
+    assert tuple(units[1].embedding) == tuple(units[0].embedding)
+    assert units[1].embedding_provider == units[0].embedding_provider
+    assert units[1].embedding_model_version == units[0].embedding_model_version
+    assert units[1].llm_usage_ledger_id == units[0].llm_usage_ledger_id
+    source_links = (
+        (
+            await db_session.execute(
+                select(SemanticRetrievalUnitSource).where(
+                    SemanticRetrievalUnitSource.unit_id == units[1].id
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert [link.message_version_id for link in source_links] == [edited.id]
+
+
+@pytest.mark.asyncio
+async def test_backfill_persists_exact_reason_counts(postgres_engine) -> None:
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+    factory = async_sessionmaker(postgres_engine, class_=AsyncSession, expire_on_commit=False)
+    suffix = uuid.uuid4().int % 1_000_000
+    user_id = 8_044_042_051 + suffix
+    chat_id = -9_044_042_051 - suffix
+    run_ids: set[int] = set()
+    ledger_ids: set[int] = set()
+    try:
+        async with factory() as session:
+            human = await _user(session, user_id=user_id, is_bot=False)
+            await _message(
+                session,
+                user_id=human.id,
+                message_id=4042051 + suffix,
+                text="persisted backfill reasons",
+                chat_id=chat_id,
+            )
+            await session.commit()
+            provider = CountingEmbeddingProvider()
+
+            first = await backfill_semantic_index(
+                session,
+                config=CONFIG,
+                provider=provider,
+                chat_id=chat_id,
+            )
+            run_ids.add(first.run_id)
+            first_run = await session.get(SemanticIndexRun, first.run_id)
+            assert first.reason_counts == {"indexed:new_embedding": 1}
+            assert first_run is not None
+            assert first_run.reason_counts == first.reason_counts
+
+            rerun = await backfill_semantic_index(
+                session,
+                config=CONFIG,
+                provider=provider,
+                chat_id=chat_id,
+            )
+            run_ids.add(rerun.run_id)
+            rerun_row = await session.get(SemanticIndexRun, rerun.run_id)
+            assert rerun.reason_counts == {"skipped:unchanged": 1}
+            assert rerun_row is not None
+            assert rerun_row.reason_counts == rerun.reason_counts
+            assert len(provider.calls) == 1
+    finally:
+        async with factory() as cleanup:
+            ledger_ids.update(
+                int(value)
+                for value in (
+                    await cleanup.execute(
+                        select(SemanticRetrievalUnit.llm_usage_ledger_id).where(
+                            SemanticRetrievalUnit.chat_id == chat_id
+                        )
+                    )
+                ).scalars()
+            )
+            await cleanup.execute(
+                delete(SemanticRetrievalUnit).where(SemanticRetrievalUnit.chat_id == chat_id)
+            )
+            if run_ids:
+                await cleanup.execute(
+                    delete(SemanticIndexRun).where(SemanticIndexRun.id.in_(run_ids))
+                )
+            await cleanup.execute(delete(ChatMessage).where(ChatMessage.chat_id == chat_id))
+            if ledger_ids:
+                await cleanup.execute(
+                    delete(LlmUsageLedger).where(LlmUsageLedger.id.in_(ledger_ids))
+                )
+            await cleanup.execute(delete(User).where(User.id == user_id))
+            await cleanup.commit()
+
+
+@pytest.mark.asyncio
+async def test_failed_backfill_accounts_for_every_eligible_document(postgres_engine) -> None:
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+    class FailingEmbeddingProvider:
+        async def embed(self, *, inputs, model: str, dimensions: int) -> EmbeddingResult:
+            raise ValueError("provider contract failure")
+
+    async with postgres_engine.connect() as connection:
+        outer_transaction = await connection.begin()
+        sessions = async_sessionmaker(
+            bind=connection,
+            class_=AsyncSession,
+            expire_on_commit=False,
+            join_transaction_mode="create_savepoint",
+        )
+        try:
+            async with sessions() as session:
+                human = await _user(session, user_id=8_044_042_071, is_bot=False)
+                for offset in range(2):
+                    await _message(
+                        session,
+                        user_id=human.id,
+                        message_id=4042071 + offset,
+                        text=f"failed batch document {offset}",
+                    )
+
+                with pytest.raises(ValueError, match="provider contract failure"):
+                    await backfill_semantic_index(
+                        session,
+                        config=CONFIG,
+                        provider=FailingEmbeddingProvider(),
+                        chat_id=CHAT_ID,
+                    )
+
+                run = (
+                    (
+                        await session.execute(
+                            select(SemanticIndexRun).order_by(SemanticIndexRun.id.desc())
+                        )
+                    )
+                    .scalars()
+                    .first()
+                )
+                assert run is not None
+                assert run.status == "failed"
+                assert run.eligible_count == 2
+                assert run.indexed_count == 0
+                assert run.skipped_count == 0
+                assert run.failed_count == 2
+                assert run.reason_counts == {"failed:ValueError": 2}
+                assert (
+                    run.eligible_count == run.indexed_count + run.skipped_count + run.failed_count
+                )
+        finally:
+            await outer_transaction.rollback()
+
+
+@pytest.mark.asyncio
+async def test_same_card_hash_reuses_vector_and_refreshes_revision_and_provenance(
+    db_session,
+) -> None:
+    human = await _user(db_session, user_id=8_044_042_101, is_bot=False)
+    admin = await _user(db_session, user_id=8_044_042_102, is_bot=False, is_admin=True)
+    first_source = await _message(
+        db_session,
+        user_id=human.id,
+        message_id=4042101,
+        text="первый источник без изменения карточки",
+    )
+    second_source = await _message(
+        db_session,
+        user_id=human.id,
+        message_id=4042102,
+        text="второй источник без изменения карточки",
+    )
+    card = await _approved_card(
+        db_session,
+        admin_id=admin.id,
+        source_ids=(first_source.version.id,),
+        title="Неизменное каноническое знание",
+    )
+    first_document = (await list_eligible_card_documents(db_session, chat_id=CHAT_ID))[0]
+    first_provider = CountingEmbeddingProvider()
+    first_result = await _index_batch(
+        db_session,
+        documents=[first_document],
+        config=CONFIG,
+        provider=first_provider,
+    )
+    assert (first_result.indexed, first_result.skipped) == (1, 0)
+
+    old_source_link = (
+        await db_session.execute(select(CardSource).where(CardSource.card_id == card.id))
+    ).scalar_one()
+    await db_session.delete(old_source_link)
+    db_session.add(
+        CardSource(
+            card_id=card.id,
+            message_version_id=second_source.version.id,
+            position=0,
+        )
+    )
+    card.updated_at = card.updated_at + timedelta(seconds=1)
+    await db_session.flush()
+    second_document = (await list_eligible_card_documents(db_session, chat_id=CHAT_ID))[0]
+    assert second_document.content_hash == first_document.content_hash
+    assert second_document.source_revision != first_document.source_revision
+    assert second_document.message_version_ids == (second_source.version.id,)
+
+    zero_call_provider = CountingEmbeddingProvider()
+    reused_result = await _index_batch(
+        db_session,
+        documents=[second_document],
+        config=CONFIG,
+        provider=zero_call_provider,
+    )
+    assert (reused_result.indexed, reused_result.skipped) == (1, 0)
+    assert reused_result.reason_counts == {"indexed:reused_embedding": 1}
+    assert zero_call_provider.calls == []
+
+    units = (
+        (
+            await db_session.execute(
+                select(SemanticRetrievalUnit).where(
+                    SemanticRetrievalUnit.source_type == "card",
+                    SemanticRetrievalUnit.source_id == str(card.id),
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(units) == 1
+    assert units[0].source_revision == second_document.source_revision
+    sources = (
+        (
+            await db_session.execute(
+                select(SemanticRetrievalUnitSource).where(
+                    SemanticRetrievalUnitSource.unit_id == units[0].id
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert [source.message_version_id for source in sources] == [second_source.version.id]
+
+
+@pytest.mark.asyncio
+async def test_pending_forget_created_during_embedding_prevents_unit_store(db_session) -> None:
+    human = await _user(db_session, user_id=8_044_042_201, is_bot=False)
+    source = await _message(
+        db_session,
+        user_id=human.id,
+        message_id=4042201,
+        text="контент забывается во время embedding",
+    )
+    documents = await list_eligible_message_documents(db_session, chat_id=CHAT_ID)
+
+    class ForgetBeforeStoreProvider(CountingEmbeddingProvider):
+        async def embed(self, *, inputs, model: str, dimensions: int) -> EmbeddingResult:
+            db_session.add(
+                ForgetEvent(
+                    target_type="message",
+                    target_id=str(source.message.id),
+                    actor_user_id=human.id,
+                    authorized_by="self",
+                    tombstone_key=f"message:{CHAT_ID}:{source.message.message_id}",
+                    status="pending",
+                )
+            )
+            await db_session.flush()
+            return await super().embed(inputs=inputs, model=model, dimensions=dimensions)
+
+    provider = ForgetBeforeStoreProvider()
+    result = await _index_batch(
+        db_session,
+        documents=documents,
+        config=CONFIG,
+        provider=provider,
+    )
+    assert (result.indexed, result.skipped) == (0, 1)
+    assert result.reason_counts == {"skipped:governance_race": 1}
+    assert len(provider.calls) == 1
+    assert (await db_session.execute(select(SemanticRetrievalUnit.id))).scalar_one_or_none() is None
+
+
+@pytest.mark.asyncio
+async def test_concurrent_winner_is_reported_as_conflict_not_unchanged(db_session) -> None:
+    human = await _user(db_session, user_id=8_044_042_221, is_bot=False)
+    source = await _message(
+        db_session,
+        user_id=human.id,
+        message_id=4042221,
+        text="конкурирующая индексация",
+    )
+    document = (await list_eligible_message_documents(db_session, chat_id=CHAT_ID))[0]
+    winner_ledger = await _ledger(db_session, suffix="winner")
+
+    class ConcurrentWinnerProvider(CountingEmbeddingProvider):
+        async def embed(self, *, inputs, model: str, dimensions: int) -> EmbeddingResult:
+            winner = SemanticRetrievalUnit(
+                source_type=document.source_type,
+                source_id=document.source_id,
+                source_revision=document.source_revision,
+                chat_id=document.chat_id,
+                content_hash=document.content_hash,
+                embedding_provider="openai",
+                embedding_model=model,
+                embedding_model_version="text-embedding-3-small",
+                embedding_dimensions=dimensions,
+                embedding=list(VECTOR_X),
+                llm_usage_ledger_id=winner_ledger.id,
+            )
+            db_session.add(winner)
+            await db_session.flush()
+            db_session.add(
+                SemanticRetrievalUnitSource(
+                    unit_id=winner.id,
+                    message_version_id=source.version.id,
+                    position=0,
+                )
+            )
+            await db_session.flush()
+            return await super().embed(inputs=inputs, model=model, dimensions=dimensions)
+
+    provider = ConcurrentWinnerProvider()
+    result = await _index_batch(
+        db_session,
+        documents=[document],
+        config=CONFIG,
+        provider=provider,
+    )
+
+    assert (result.indexed, result.skipped) == (0, 1)
+    assert result.reason_counts == {"skipped:conflict": 1}
+    assert len(provider.calls) == 1
+    assert len((await db_session.execute(select(SemanticRetrievalUnit.id))).scalars().all()) == 1
+
+
+@pytest.mark.asyncio
+async def test_two_session_backfill_serializes_before_paid_provider(postgres_engine) -> None:
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+    factory = async_sessionmaker(postgres_engine, class_=AsyncSession, expire_on_commit=False)
+    suffix = uuid.uuid4().int % 1_000_000
+    user_id = 8_044_043_000 + suffix
+    chat_id = -9_044_043_000 - suffix
+    first_entered = asyncio.Event()
+    release_first = asyncio.Event()
+
+    class BarrierProvider(CountingEmbeddingProvider):
+        async def embed(self, *, inputs, model: str, dimensions: int) -> EmbeddingResult:
+            self.calls.append(tuple(inputs))
+            first_entered.set()
+            await release_first.wait()
+            return EmbeddingResult(
+                vectors=(VECTOR_X,),
+                tokens_in=sum(len(value) for value in inputs),
+                request_id="serialized-backfill",
+                raw_latency_ms=1,
+            )
+
+    provider = BarrierProvider()
+    ledger_ids: set[int] = set()
+    try:
+        async with factory() as setup:
+            await _user(setup, user_id=user_id, is_bot=False)
+            await _message(
+                setup,
+                user_id=user_id,
+                message_id=4043000 + suffix,
+                text="serialized paid embedding",
+                chat_id=chat_id,
+            )
+            await setup.commit()
+
+        async def run_once():
+            async with factory() as session:
+                documents = await list_eligible_message_documents(
+                    session,
+                    chat_id=chat_id,
+                )
+                return await _index_batch(
+                    session,
+                    documents=documents,
+                    config=CONFIG,
+                    provider=provider,
+                )
+
+        first_task = asyncio.create_task(run_once())
+        await asyncio.wait_for(first_entered.wait(), timeout=2)
+        second_task = asyncio.create_task(run_once())
+        await asyncio.sleep(0.1)
+        assert len(provider.calls) == 1
+        release_first.set()
+        first, second = await asyncio.gather(first_task, second_task)
+
+        assert sorted((first.indexed, second.indexed)) == [0, 1]
+        assert sorted((first.skipped, second.skipped)) == [0, 1]
+        assert len(provider.calls) == 1
+        async with factory() as verification:
+            units = (
+                (
+                    await verification.execute(
+                        select(SemanticRetrievalUnit).where(
+                            SemanticRetrievalUnit.chat_id == chat_id
+                        )
+                    )
+                )
+                .scalars()
+                .all()
+            )
+            assert len(units) == 1
+            ledger_ids = {unit.llm_usage_ledger_id for unit in units}
+            assert len(ledger_ids) == 1
+    finally:
+        release_first.set()
+        async with factory() as cleanup:
+            await cleanup.execute(
+                delete(SemanticRetrievalUnit).where(SemanticRetrievalUnit.chat_id == chat_id)
+            )
+            from bot.db.models import ChatMessage
+
+            await cleanup.execute(delete(ChatMessage).where(ChatMessage.chat_id == chat_id))
+            if ledger_ids:
+                await cleanup.execute(
+                    delete(LlmUsageLedger).where(LlmUsageLedger.id.in_(ledger_ids))
+                )
+            await cleanup.execute(delete(User).where(User.id == user_id))
+            await cleanup.commit()
+
+
+@pytest.mark.asyncio
+async def test_delivery_scope_blocks_pending_forget_creation(postgres_engine) -> None:
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+    from bot.db.models import ForgetEvent
+    from bot.db.repos.forget_event import ForgetEventRepo
+    from bot.services.llm_gateway import hold_evidence_delivery_locks
+
+    factory = async_sessionmaker(postgres_engine, class_=AsyncSession, expire_on_commit=False)
+    suffix = uuid.uuid4().int % 1_000_000
+    user_id = 8_044_044_000 + suffix
+    chat_id = -9_044_044_000 - suffix
+    async with factory() as setup:
+        await _user(setup, user_id=user_id, is_bot=False)
+        source = await _message(
+            setup,
+            user_id=user_id,
+            message_id=4044000 + suffix,
+            text="pending forget must wait",
+            chat_id=chat_id,
+        )
+        await setup.commit()
+    bundle = _evidence_bundle(source)
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    async def hold_delivery() -> None:
+        async with factory() as session:
+            async with hold_evidence_delivery_locks(session, bundle):
+                entered.set()
+                await release.wait()
+
+    async def create_forget() -> None:
+        async with factory() as session:
+            await ForgetEventRepo.create(
+                session,
+                target_type="message",
+                target_id=str(source.message.id),
+                actor_user_id=None,
+                authorized_by="system",
+                tombstone_key=f"message:{chat_id}:{source.message.message_id}:delivery-lock",
+            )
+            await session.commit()
+
+    holder = asyncio.create_task(hold_delivery())
+    await asyncio.wait_for(entered.wait(), timeout=2)
+    writer = asyncio.create_task(create_forget())
+    await asyncio.sleep(0.1)
+    assert writer.done() is False
+    release.set()
+    await asyncio.gather(holder, writer)
+
+    async with factory() as cleanup:
+        await cleanup.execute(
+            delete(ForgetEvent).where(ForgetEvent.tombstone_key.like("%:delivery-lock"))
+        )
+        await cleanup.execute(delete(ChatMessage).where(ChatMessage.chat_id == chat_id))
+        await cleanup.execute(delete(User).where(User.id == user_id))
+        await cleanup.commit()
+
+
+@pytest.mark.asyncio
+async def test_delivery_scope_blocks_edit_offrecord_writer(postgres_engine) -> None:
+    from sqlalchemy import update
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+    from bot.db.locks import advisory_lock_chat_message
+    from bot.services.llm_gateway import hold_evidence_delivery_locks
+
+    factory = async_sessionmaker(postgres_engine, class_=AsyncSession, expire_on_commit=False)
+    suffix = uuid.uuid4().int % 1_000_000
+    user_id = 8_044_045_000 + suffix
+    chat_id = -9_044_045_000 - suffix
+    async with factory() as setup:
+        await _user(setup, user_id=user_id, is_bot=False)
+        source = await _message(
+            setup,
+            user_id=user_id,
+            message_id=4045000 + suffix,
+            text="offrecord edit must wait",
+            chat_id=chat_id,
+        )
+        await setup.commit()
+    bundle = _evidence_bundle(source)
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    async def hold_delivery() -> None:
+        async with factory() as session:
+            async with hold_evidence_delivery_locks(session, bundle):
+                entered.set()
+                await release.wait()
+
+    async def apply_offrecord() -> None:
+        async with factory() as session:
+            await advisory_lock_chat_message(
+                session,
+                source.message.chat_id,
+                source.message.message_id,
+            )
+            await session.execute(
+                update(ChatMessage)
+                .where(ChatMessage.id == source.message.id)
+                .values(memory_policy="offrecord", is_redacted=True, text=None)
+            )
+            await session.commit()
+
+    holder = asyncio.create_task(hold_delivery())
+    await asyncio.wait_for(entered.wait(), timeout=2)
+    writer = asyncio.create_task(apply_offrecord())
+    await asyncio.sleep(0.1)
+    assert writer.done() is False
+    release.set()
+    await asyncio.gather(holder, writer)
+
+    async with factory() as cleanup:
+        await cleanup.execute(delete(ChatMessage).where(ChatMessage.chat_id == chat_id))
+        await cleanup.execute(delete(User).where(User.id == user_id))
+        await cleanup.commit()
+
+
+@pytest.mark.asyncio
+async def test_cancelled_delivery_scope_releases_dedicated_xact_lock(postgres_engine) -> None:
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+    from bot.services.advisory_locks import hold_session_advisory_locks
+
+    factory = async_sessionmaker(postgres_engine, class_=AsyncSession, expire_on_commit=False)
+    lock_id = 8_044_046_000 + (uuid.uuid4().int % 1_000_000)
+    entered = asyncio.Event()
+
+    async def cancelled_holder() -> None:
+        async with factory() as session:
+            async with hold_session_advisory_locks(session, (lock_id,)):
+                entered.set()
+                await asyncio.Event().wait()
+
+    holder = asyncio.create_task(cancelled_holder())
+    await asyncio.wait_for(entered.wait(), timeout=2)
+    holder.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await holder
+
+    async def reacquire() -> None:
+        async with factory() as session:
+            async with hold_session_advisory_locks(session, (lock_id,)):
+                return
+
+    await asyncio.wait_for(reacquire(), timeout=2)
+
+
+@pytest.mark.asyncio
+async def test_reconcile_invalidates_every_active_unit_that_became_ineligible(db_session) -> None:
+    human = await _user(db_session, user_id=8_044_042_251, is_bot=False)
+    admin = await _user(db_session, user_id=8_044_042_252, is_bot=False, is_admin=True)
+    offrecord = await _message(
+        db_session, user_id=human.id, message_id=4042251, text="offrecord source"
+    )
+    redacted = await _message(
+        db_session, user_id=human.id, message_id=4042252, text="redacted source"
+    )
+    stale = await _message(db_session, user_id=human.id, message_id=4042253, text="stale source")
+    card_source = await _message(
+        db_session, user_id=human.id, message_id=4042254, text="deapproved card source"
+    )
+    card = await _approved_card(
+        db_session,
+        admin_id=admin.id,
+        source_ids=(card_source.version.id,),
+        title="deapproved card",
+    )
+    ledger = await _ledger(db_session, suffix="reconcile")
+    await _unit(db_session, source=offrecord, vector=VECTOR_X, ledger_id=ledger.id)
+    await _unit(db_session, source=redacted, vector=VECTOR_X, ledger_id=ledger.id)
+    await _unit(db_session, source=stale, vector=VECTOR_X, ledger_id=ledger.id)
+    card_unit = SemanticRetrievalUnit(
+        source_type="card",
+        source_id=str(card.id),
+        source_revision="updated:test:approved:test",
+        chat_id=CHAT_ID,
+        content_hash="d" * 64,
+        embedding_provider="openai",
+        embedding_model=CONFIG.model,
+        embedding_model_version="text-embedding-3-small",
+        embedding_dimensions=CONFIG.dimensions,
+        embedding=list(VECTOR_X),
+        llm_usage_ledger_id=ledger.id,
+    )
+    db_session.add(card_unit)
+    await db_session.flush()
+    db_session.add(
+        SemanticRetrievalUnitSource(
+            unit_id=card_unit.id,
+            message_version_id=card_source.version.id,
+            position=0,
+        )
+    )
+    offrecord.message.memory_policy = "offrecord"
+    redacted.version.is_redacted = True
+    replacement = MessageVersion(
+        chat_message_id=stale.message.id,
+        version_seq=2,
+        text="new current version",
+        normalized_text="new current version",
+        content_hash=f"semantic-{uuid.uuid4().hex}",
+        is_redacted=False,
+    )
+    db_session.add(replacement)
+    await db_session.flush()
+    stale.message.current_version_id = replacement.id
+    card.card_status = "draft"
+    await db_session.flush()
+
+    assert (
+        await _reconcile_ineligible_units(
+            db_session,
+            embedding_model=CONFIG.model,
+            chat_id=CHAT_ID,
+        )
+        == 4
+    )
+    units = (await db_session.execute(select(SemanticRetrievalUnit))).scalars().all()
+    assert len(units) == 4
+    assert all(unit.invalidated_at is not None for unit in units)
+    assert {unit.invalidation_reason for unit in units} == {"source_ineligible"}
+    assert (
+        await _reconcile_ineligible_units(
+            db_session,
+            embedding_model=CONFIG.model,
+            chat_id=CHAT_ID,
+        )
+        == 0
+    )
+
+
+@pytest.mark.asyncio
+async def test_stale_vector_card_cannot_displace_fresh_fts_provenance(db_session) -> None:
+    human = await _user(db_session, user_id=8_044_042_301, is_bot=False)
+    admin = await _user(db_session, user_id=8_044_042_302, is_bot=False, is_admin=True)
+    old_source = await _message(
+        db_session,
+        user_id=human.id,
+        message_id=4042301,
+        text="old card provenance",
+    )
+    new_source = await _message(
+        db_session,
+        user_id=human.id,
+        message_id=4042302,
+        text="new card provenance",
+    )
+    card = await _approved_card(
+        db_session,
+        admin_id=admin.id,
+        source_ids=(old_source.version.id,),
+        title="уникальный семантический маяк",
+    )
+    document = (await list_eligible_card_documents(db_session, chat_id=CHAT_ID))[0]
+    await _index_batch(
+        db_session,
+        documents=[document],
+        config=CONFIG,
+        provider=CountingEmbeddingProvider(),
+    )
+
+    old_link = (
+        await db_session.execute(select(CardSource).where(CardSource.card_id == card.id))
+    ).scalar_one()
+    await db_session.delete(old_link)
+    db_session.add(
+        CardSource(
+            card_id=card.id,
+            message_version_id=new_source.version.id,
+            position=0,
+        )
+    )
+    await db_session.flush()
+
+    result = await hybrid_search(
+        db_session,
+        query="уникальный семантический маяк",
+        query_embedding=VECTOR_X,
+        chat_id=CHAT_ID,
+        embedding_model=CONFIG.model,
+    )
+
+    matching = [hit for hit in result.hits if hit.card_id == card.id]
+    assert len(matching) == 1
+    assert matching[0].card_source_message_version_ids == (new_source.version.id,)
+    assert result.candidate_ranks[f"card:{card.id}"] == {"fts": 1}
+
+
+@pytest.mark.asyncio
+async def test_human_only_fts_excludes_voice_audio_and_any_card_voice_provenance(
+    db_session,
+) -> None:
+    human = await _user(db_session, user_id=8_044_042_301, is_bot=False)
+    admin = await _user(db_session, user_id=8_044_042_302, is_bot=False, is_admin=True)
+    clean = await _message(
+        db_session,
+        user_id=human.id,
+        message_id=4042301,
+        text="утечкомаркер безопасный текст",
+    )
+    voice = await _message(
+        db_session,
+        user_id=human.id,
+        message_id=4042302,
+        text="утечкомаркер голосовой секрет",
+        message_kind="voice",
+    )
+    audio = await _message(
+        db_session,
+        user_id=human.id,
+        message_id=4042303,
+        text="утечкомаркер аудио секрет",
+        message_kind="audio",
+    )
+    clean_card = await _approved_card(
+        db_session,
+        admin_id=admin.id,
+        source_ids=(clean.version.id,),
+        title="утечкомаркер чистая карточка",
+    )
+    mixed_voice_card = await _approved_card(
+        db_session,
+        admin_id=admin.id,
+        source_ids=(clean.version.id, voice.version.id),
+        title="утечкомаркер смешанная голосовая карточка",
+    )
+    audio_card = await _approved_card(
+        db_session,
+        admin_id=admin.id,
+        source_ids=(audio.version.id,),
+        title="утечкомаркер аудио карточка",
+    )
+    await db_session.flush()
+
+    hits = await search_messages(
+        db_session,
+        "утечкомаркер",
+        chat_id=CHAT_ID,
+        limit=20,
+        include_cards=True,
+        human_only=True,
+    )
+
+    assert {hit.message_version_id for hit in hits if hit.source_type == "message"} == {
+        clean.version.id
+    }
+    assert {hit.card_id for hit in hits if hit.source_type == "card"} == {clean_card.id}
+    assert mixed_voice_card.id not in {hit.card_id for hit in hits}
+    assert audio_card.id not in {hit.card_id for hit in hits}
+    assert all(voice.version.id not in hit.card_source_message_version_ids for hit in hits)
+    assert all(audio.version.id not in hit.card_source_message_version_ids for hit in hits)
+
+
+@pytest.mark.asyncio
+async def test_exact_cosine_excludes_current_question_and_foreign_chat(db_session) -> None:
+    human = await _user(db_session, user_id=8_044_043_001, is_bot=False)
+    bot = await _user(db_session, user_id=8_044_043_002, is_bot=True)
+    current_question = await _message(
+        db_session, user_id=human.id, message_id=4043001, text="текущий вопрос"
+    )
+    citable = await _message(
+        db_session, user_id=human.id, message_id=4043002, text="точный полезный ответ"
+    )
+    weaker = await _message(
+        db_session, user_id=human.id, message_id=4043004, text="менее похожий ответ"
+    )
+    forgotten = await _message(
+        db_session, user_id=human.id, message_id=4043005, text="удаляемый секрет"
+    )
+    bot_source = await _message(
+        db_session, user_id=bot.id, message_id=4043006, text="ответ от бота"
+    )
+    foreign = await _message(
+        db_session,
+        user_id=human.id,
+        message_id=4043003,
+        text="секрет другого чата",
+        chat_id=OTHER_CHAT_ID,
+    )
+    ledger = await _ledger(db_session, suffix="a")
+    await _unit(db_session, source=current_question, vector=VECTOR_X, ledger_id=ledger.id)
+    await _unit(db_session, source=citable, vector=VECTOR_X, ledger_id=ledger.id)
+    await _unit(db_session, source=weaker, vector=VECTOR_Y, ledger_id=ledger.id)
+    await _unit(db_session, source=forgotten, vector=VECTOR_X, ledger_id=ledger.id)
+    await _unit(db_session, source=bot_source, vector=VECTOR_X, ledger_id=ledger.id)
+    await _unit(db_session, source=foreign, vector=VECTOR_X, ledger_id=ledger.id)
+    db_session.add(
+        ForgetEvent(
+            target_type="message",
+            target_id=str(forgotten.message.id),
+            actor_user_id=human.id,
+            authorized_by="self",
+            tombstone_key=f"message:{CHAT_ID}:{forgotten.message.message_id}",
+            status="pending",
+        )
+    )
+    await db_session.flush()
+
+    hits = await vector_search(
+        db_session,
+        query_embedding=VECTOR_X,
+        chat_id=CHAT_ID,
+        embedding_model="text-embedding-3-small",
+        exclude_chat_message_id=current_question.message.id,
+    )
+
+    assert [hit.message_version_id for hit in hits] == [
+        citable.version.id,
+        weaker.version.id,
+    ]
+    assert all(hit.chat_id == CHAT_ID for hit in hits)
+    assert all("секрет другого чата" not in hit.snippet for hit in hits)
+    assert all("удаляемый секрет" not in hit.snippet for hit in hits)
+    assert all("ответ от бота" not in hit.snippet for hit in hits)
+
+
+@pytest.mark.asyncio
+async def test_vector_search_returns_approved_card_then_blocks_pending_forget(db_session) -> None:
+    human = await _user(db_session, user_id=8_044_044_001, is_bot=False)
+    admin = await _user(db_session, user_id=8_044_044_002, is_bot=False, is_admin=True)
+    source = await _message(
+        db_session, user_id=human.id, message_id=4044001, text="источник карточки"
+    )
+    card = await _approved_card(
+        db_session,
+        admin_id=admin.id,
+        source_ids=(source.version.id,),
+        title="Каноническая карточка",
+    )
+    ledger = await _ledger(db_session, suffix="b")
+    unit = SemanticRetrievalUnit(
+        source_type="card",
+        source_id=str(card.id),
+        source_revision="updated:test:approved:test",
+        chat_id=CHAT_ID,
+        content_hash="c" * 64,
+        embedding_provider="openai",
+        embedding_model="text-embedding-3-small",
+        embedding_model_version="text-embedding-3-small",
+        embedding_dimensions=1536,
+        embedding=list(VECTOR_X),
+        llm_usage_ledger_id=ledger.id,
+    )
+    db_session.add(unit)
+    await db_session.flush()
+    db_session.add(
+        SemanticRetrievalUnitSource(
+            unit_id=unit.id,
+            message_version_id=source.version.id,
+            position=0,
+        )
+    )
+    await db_session.flush()
+
+    hits = await vector_search(
+        db_session,
+        query_embedding=VECTOR_X,
+        chat_id=CHAT_ID,
+        embedding_model="text-embedding-3-small",
+    )
+    assert len(hits) == 1
+    assert hits[0].source_type == "card"
+    assert hits[0].card_id == card.id
+    assert hits[0].card_source_message_version_ids == (source.version.id,)
+
+    db_session.add(
+        ForgetEvent(
+            target_type="message",
+            target_id=str(source.message.id),
+            actor_user_id=human.id,
+            authorized_by="self",
+            tombstone_key=f"message:{CHAT_ID}:{source.message.message_id}",
+            status="pending",
+        )
+    )
+    await db_session.flush()
+    blocked = await vector_search(
+        db_session,
+        query_embedding=VECTOR_X,
+        chat_id=CHAT_ID,
+        embedding_model="text-embedding-3-small",
+    )
+    assert blocked == []
+
+
+def _hit(
+    *,
+    version_id: int,
+    author_id: int | None,
+    source_type: Literal["message", "card"] = "message",
+    message_thread_id: int | None = None,
+    reply_to_message_id: int | None = None,
+    conversation_root_message_id: int | None = None,
+) -> SearchHit:
+    now = datetime.now(timezone.utc)
+    card_id = uuid.UUID(int=version_id) if source_type == "card" else None
+    return SearchHit(
+        message_version_id=version_id,
+        chat_message_id=version_id,
+        chat_id=CHAT_ID,
+        message_id=version_id,
+        user_id=author_id,
+        snippet=f"hit-{version_id}",
+        ts_rank=1.0,
+        captured_at=now,
+        message_date=now,
+        source_type=source_type,
+        card_id=card_id,
+        message_thread_id=message_thread_id,
+        reply_to_message_id=reply_to_message_id,
+        conversation_root_message_id=conversation_root_message_id,
+    )
+
+
+def test_rrf_deduplicates_and_enforces_author_and_card_diversity() -> None:
+    same_author = [_hit(version_id=index, author_id=77) for index in range(1, 5)]
+    cards = [_hit(version_id=index, author_id=None, source_type="card") for index in range(10, 13)]
+    another_author = _hit(version_id=20, author_id=88)
+
+    selected, ranks = reciprocal_rank_fusion(
+        vector_hits=[*same_author, *cards, another_author],
+        fts_hits=[same_author[0], another_author, *cards],
+        limit=5,
+    )
+
+    assert len(selected) == 5
+    assert sum(hit.user_id == 77 for hit in selected) == 2
+    assert sum(hit.source_type == "card" for hit in selected) == 2
+    assert len({(hit.source_type, hit.card_id, hit.message_version_id) for hit in selected}) == 5
+    assert ranks["message:1"] == {"vector": 1, "fts": 1}
+
+
+def test_rrf_caps_explicit_telegram_topic_without_collapsing_non_topic_chat() -> None:
+    topic_hits = [
+        _hit(version_id=index, author_id=100 + index, message_thread_id=9001)
+        for index in range(1, 4)
+    ]
+    non_topic_hits = [_hit(version_id=index, author_id=100 + index) for index in range(10, 13)]
+
+    selected, _ = reciprocal_rank_fusion(
+        vector_hits=[*topic_hits, *non_topic_hits],
+        fts_hits=[],
+        limit=5,
+    )
+
+    assert sum(hit.message_thread_id == 9001 for hit in selected) == 2
+    assert sum(hit.message_thread_id is None for hit in selected) == 3
+
+
+def test_rrf_caps_direct_reply_conversation_without_collapsing_standalone_messages() -> None:
+    replies = [
+        _hit(version_id=index, author_id=100 + index, reply_to_message_id=9001)
+        for index in range(1, 4)
+    ]
+    standalone = [_hit(version_id=index, author_id=100 + index) for index in range(10, 13)]
+
+    selected, _ = reciprocal_rank_fusion(
+        vector_hits=[*replies, *standalone],
+        fts_hits=[],
+        limit=5,
+    )
+
+    assert sum(hit.reply_to_message_id == 9001 for hit in selected) == 2
+    assert sum(hit.reply_to_message_id is None for hit in selected) == 3
+
+
+@pytest.mark.asyncio
+async def test_nested_replies_share_resolved_root_for_diversity(db_session) -> None:
+    human = await _user(db_session, user_id=8_044_045_001, is_bot=False)
+    await _message(db_session, user_id=human.id, message_id=5000, text="root")
+    await _message(
+        db_session,
+        user_id=human.id,
+        message_id=5001,
+        text="child",
+        reply_to_message_id=5000,
+    )
+    await _message(
+        db_session,
+        user_id=human.id,
+        message_id=5002,
+        text="grandchild",
+        reply_to_message_id=5001,
+    )
+    await _message(
+        db_session,
+        user_id=human.id,
+        message_id=5003,
+        text="sibling",
+        reply_to_message_id=5000,
+    )
+    await _message(db_session, user_id=human.id, message_id=6000, text="standalone")
+    hits = [
+        _hit(
+            version_id=message_id,
+            author_id=100 + message_id,
+            reply_to_message_id=reply_to,
+        )
+        for message_id, reply_to in (
+            (5000, None),
+            (5001, 5000),
+            (5002, 5001),
+            (5003, 5000),
+            (6000, None),
+        )
+    ]
+
+    enriched = await _with_conversation_roots(db_session, chat_id=CHAT_ID, hits=hits)
+    selected, _ = reciprocal_rank_fusion(vector_hits=enriched, fts_hits=[], limit=5)
+
+    assert {hit.conversation_root_message_id for hit in enriched[:4]} == {5000}
+    assert sum(hit.conversation_root_message_id == 5000 for hit in selected) == 2
+    assert any(hit.message_id == 6000 for hit in selected)

--- a/tests/services/test_semantic_index_postgres.py
+++ b/tests/services/test_semantic_index_postgres.py
@@ -740,6 +740,86 @@ async def test_pending_forget_created_during_embedding_prevents_unit_store(db_se
 
 
 @pytest.mark.asyncio
+async def test_forget_that_wins_source_lock_blocks_stale_text_before_provider(
+    postgres_engine,
+) -> None:
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+    from bot.services.advisory_locks import hold_session_advisory_locks
+    from bot.services.forget_cascade import _p6_mvid_advisory_lock_id
+
+    factory = async_sessionmaker(postgres_engine, class_=AsyncSession, expire_on_commit=False)
+    suffix = uuid.uuid4().int % 1_000_000
+    user_id = 8_044_042_210 + suffix
+    chat_id = -9_044_042_210 - suffix
+    provider = CountingEmbeddingProvider()
+    try:
+        async with factory() as setup:
+            human = await _user(setup, user_id=user_id, is_bot=False)
+            source = await _message(
+                setup,
+                user_id=human.id,
+                message_id=4042210 + suffix,
+                text="этот текст нельзя отправлять после forget",
+                chat_id=chat_id,
+            )
+            await setup.commit()
+
+        async with factory() as index_session:
+            stale_documents = await list_eligible_message_documents(
+                index_session,
+                chat_id=chat_id,
+            )
+            assert len(stale_documents) == 1
+            lock_id = _p6_mvid_advisory_lock_id(source.version.id)
+
+            async with factory() as forget_session:
+                async with hold_session_advisory_locks(forget_session, (lock_id,)):
+                    forget_session.add(
+                        ForgetEvent(
+                            target_type="message",
+                            target_id=str(source.message.id),
+                            actor_user_id=human.id,
+                            authorized_by="self",
+                            tombstone_key=f"message:{chat_id}:{source.message.message_id}",
+                            status="pending",
+                        )
+                    )
+                    await forget_session.commit()
+                    index_task = asyncio.create_task(
+                        _index_batch(
+                            index_session,
+                            documents=stale_documents,
+                            config=CONFIG,
+                            provider=provider,
+                        )
+                    )
+                    await asyncio.sleep(0.1)
+                    assert index_task.done() is False
+                    assert provider.calls == []
+
+            result = await asyncio.wait_for(index_task, timeout=2)
+
+        assert (result.indexed, result.skipped) == (0, 1)
+        assert result.reason_counts == {"skipped:governance_race": 1}
+        assert provider.calls == []
+        async with factory() as verification:
+            assert (
+                await verification.execute(
+                    select(SemanticRetrievalUnit.id).where(SemanticRetrievalUnit.chat_id == chat_id)
+                )
+            ).scalar_one_or_none() is None
+    finally:
+        async with factory() as cleanup:
+            await cleanup.execute(
+                delete(ForgetEvent).where(ForgetEvent.target_id == str(source.message.id))
+            )
+            await cleanup.execute(delete(ChatMessage).where(ChatMessage.chat_id == chat_id))
+            await cleanup.execute(delete(User).where(User.id == user_id))
+            await cleanup.commit()
+
+
+@pytest.mark.asyncio
 async def test_concurrent_winner_is_reported_as_conflict_not_unchanged(db_session) -> None:
     human = await _user(db_session, user_id=8_044_042_221, is_bot=False)
     source = await _message(

--- a/tests/services/test_semantic_index_postgres.py
+++ b/tests/services/test_semantic_index_postgres.py
@@ -1435,10 +1435,10 @@ async def test_sql_failure_preserves_committed_partition_accounting(
     original_complete = _SemanticEmbeddingOutcomeRecorder.complete
     terminal_calls = 0
 
-    async def fail_second_terminal(self, session, *, llm_usage_ledger_id, vectors):
+    async def fail_third_terminal(self, session, *, llm_usage_ledger_id, vectors):
         nonlocal terminal_calls
         terminal_calls += 1
-        if terminal_calls == 2:
+        if terminal_calls == 3:
             await session.execute(text("SELECT 1 / 0"))
         await original_complete(
             self,
@@ -1450,7 +1450,7 @@ async def test_sql_failure_preserves_committed_partition_accounting(
     monkeypatch.setattr(
         _SemanticEmbeddingOutcomeRecorder,
         "complete",
-        fail_second_terminal,
+        fail_third_terminal,
     )
     provider = CountingEmbeddingProvider()
     run_id: int | None = None
@@ -1458,7 +1458,7 @@ async def test_sql_failure_preserves_committed_partition_accounting(
     try:
         async with factory() as session:
             human = await _user(session, user_id=user_id, is_bot=False)
-            for offset in range(81):
+            for offset in range(82):
                 await _message(
                     session,
                     user_id=human.id,
@@ -1466,6 +1466,19 @@ async def test_sql_failure_preserves_committed_partition_accounting(
                     text=f"{offset:04d}" + (chr(0x410 + (offset % 32)) * 796),
                     chat_id=chat_id,
                 )
+            documents = await list_eligible_message_documents(
+                session,
+                chat_id=chat_id,
+                limit=100,
+            )
+            assert len(documents) == 82
+            preindexed = await _index_batch(
+                session,
+                documents=documents[:1],
+                config=CONFIG,
+                provider=CountingEmbeddingProvider(),
+            )
+            assert (preindexed.indexed, preindexed.skipped) == (1, 0)
 
             with pytest.raises(DBAPIError):
                 await backfill_semantic_index(
@@ -1492,8 +1505,10 @@ async def test_sql_failure_preserves_committed_partition_accounting(
                 run.indexed_count,
                 run.skipped_count,
                 run.failed_count,
-            ) == (81, 80, 0, 1)
+            ) == (82, 80, 1, 1)
+            assert run.eligible_count == run.indexed_count + run.skipped_count + run.failed_count
             assert run.reason_counts["indexed:new_embedding"] == 80
+            assert run.reason_counts["skipped:unchanged"] == 1
             assert run.reason_counts["failed:DBAPIError"] == 1
             assert run.cursor is None
             units = (
@@ -1507,7 +1522,7 @@ async def test_sql_failure_preserves_committed_partition_accounting(
                 .scalars()
                 .all()
             )
-            assert [unit.embedding_status for unit in units].count("completed") == 80
+            assert [unit.embedding_status for unit in units].count("completed") == 81
             assert [unit.embedding_status for unit in units].count("reserved") == 1
             ledger_ids.update(unit.llm_usage_ledger_id for unit in units)
             assert [len(call) for call in provider.calls] == [80, 1]
@@ -1875,10 +1890,31 @@ async def test_reconcile_invalidates_every_active_unit_that_became_ineligible(db
         )
         == 4
     )
-    units = (await db_session.execute(select(SemanticRetrievalUnit))).scalars().all()
+    units = (
+        (
+            await db_session.execute(
+                select(SemanticRetrievalUnit).execution_options(populate_existing=True)
+            )
+        )
+        .scalars()
+        .all()
+    )
     assert len(units) == 4
     assert all(unit.invalidated_at is not None for unit in units)
     assert {unit.invalidation_reason for unit in units} == {"source_ineligible"}
+    assert {unit.embedding_status for unit in units} == {"failed"}
+    assert all(unit.chunk_text is None for unit in units)
+    assert all(unit.embedding is None for unit in units)
+    assert all(unit.indexed_at is None for unit in units)
+    redacted_ledger = await db_session.get(
+        LlmUsageLedger,
+        ledger.id,
+        populate_existing=True,
+    )
+    assert redacted_ledger.prompt_hash is None
+    assert redacted_ledger.response_hash is None
+    assert redacted_ledger.tokens_in == 1
+    assert redacted_ledger.latency_ms == 1
     assert (
         await _reconcile_ineligible_units(
             db_session,

--- a/tests/services/test_semantic_quota_postgres.py
+++ b/tests/services/test_semantic_quota_postgres.py
@@ -259,6 +259,7 @@ async def test_next_admission_releases_stale_crashed_reservation(db_session) -> 
         status="reserved",
         outcome=None,
         reserved_at=now - timedelta(minutes=16),
+        progress_at=now - timedelta(minutes=16),
     )
     db_session.add(stale)
     await db_session.flush()
@@ -277,6 +278,13 @@ async def test_next_admission_releases_stale_crashed_reservation(db_session) -> 
     await db_session.refresh(stale)
     assert stale.status == "released"
     assert stale.outcome == "technical_failure"
+    # A late worker observes the reconciler's identical terminal state as an
+    # idempotent success instead of crashing after paid work.
+    await SemanticQuotaRepo.finalize(
+        db_session,
+        attempt_id=stale.id,
+        outcome="technical_failure",
+    )
 
 
 @pytest.mark.asyncio
@@ -292,6 +300,7 @@ async def test_stale_delivery_intent_is_consumed_not_released(db_session) -> Non
         status="reserved",
         outcome="answered",
         reserved_at=now - timedelta(minutes=16),
+        progress_at=now - timedelta(minutes=16),
         delivery_started_at=now - timedelta(minutes=15, seconds=30),
     )
     db_session.add(stale)
@@ -312,3 +321,114 @@ async def test_stale_delivery_intent_is_consumed_not_released(db_session) -> Non
     assert stale.finalized_at == now
     assert replacement.allowed is True
     assert replacement.used == 1
+
+
+@pytest.mark.asyncio
+async def test_prior_day_stale_idempotent_replay_is_released(db_session) -> None:
+    now = datetime(2026, 7, 16, 12, tzinfo=timezone.utc)
+    stale = SemanticQaAttempt(
+        idempotency_key="prior-day-stale:crashed",
+        user_tg_id=8_040_400_007,
+        chat_id=-100404,
+        source_chat_message_id=None,
+        local_day=(now - timedelta(days=1)).date(),
+        slot_number=1,
+        status="reserved",
+        outcome=None,
+        reserved_at=now - timedelta(days=1),
+        progress_at=now - timedelta(days=1),
+    )
+    db_session.add(stale)
+    await db_session.flush()
+
+    replay = await SemanticQuotaRepo.reserve(
+        db_session,
+        idempotency_key=stale.idempotency_key,
+        user_tg_id=stale.user_tg_id,
+        chat_id=stale.chat_id,
+        source_chat_message_id=None,
+        now=now,
+    )
+
+    await db_session.refresh(stale)
+    assert replay.allowed is False
+    assert replay.replayed is True
+    assert replay.status == "released"
+    assert replay.outcome == "technical_failure"
+    assert replay.used == 0
+    assert stale.status == "released"
+    assert stale.finalized_at == now
+
+
+@pytest.mark.asyncio
+async def test_prior_day_stale_delivery_replay_is_conservatively_consumed(db_session) -> None:
+    now = datetime(2026, 7, 16, 12, tzinfo=timezone.utc)
+    stale = SemanticQaAttempt(
+        idempotency_key="prior-day-stale:delivery-started",
+        user_tg_id=8_040_400_008,
+        chat_id=-100404,
+        source_chat_message_id=None,
+        local_day=(now - timedelta(days=1)).date(),
+        slot_number=1,
+        status="reserved",
+        outcome="answered",
+        reserved_at=now - timedelta(days=1),
+        progress_at=now - timedelta(days=1),
+        delivery_started_at=now - timedelta(hours=23, minutes=59),
+    )
+    db_session.add(stale)
+    await db_session.flush()
+
+    replay = await SemanticQuotaRepo.reserve(
+        db_session,
+        idempotency_key=stale.idempotency_key,
+        user_tg_id=stale.user_tg_id,
+        chat_id=stale.chat_id,
+        source_chat_message_id=None,
+        now=now,
+    )
+
+    await db_session.refresh(stale)
+    assert replay.allowed is False
+    assert replay.replayed is True
+    assert replay.status == "consumed"
+    assert replay.outcome == "answered"
+    assert replay.used == 0
+    assert stale.status == "consumed"
+    assert stale.finalized_at == now
+
+
+@pytest.mark.asyncio
+async def test_recent_progress_prevents_old_live_reservation_from_reconciliation(
+    db_session,
+) -> None:
+    now = datetime(2026, 7, 16, 12, tzinfo=timezone.utc)
+    live = SemanticQaAttempt(
+        idempotency_key="stale:live-progress",
+        user_tg_id=8_040_400_009,
+        chat_id=-100404,
+        source_chat_message_id=None,
+        local_day=now.date(),
+        slot_number=1,
+        status="reserved",
+        outcome=None,
+        reserved_at=now - timedelta(hours=1),
+        progress_at=now - timedelta(seconds=30),
+    )
+    db_session.add(live)
+    await db_session.flush()
+
+    replacement = await SemanticQuotaRepo.reserve(
+        db_session,
+        idempotency_key="stale:live-progress-replacement",
+        user_tg_id=live.user_tg_id,
+        chat_id=live.chat_id,
+        source_chat_message_id=None,
+        now=now,
+    )
+
+    await db_session.refresh(live)
+    assert live.status == "reserved"
+    assert replacement.allowed is True
+    assert replacement.used == 1
+    assert replacement.attempt_id != live.id

--- a/tests/services/test_semantic_quota_postgres.py
+++ b/tests/services/test_semantic_quota_postgres.py
@@ -1,0 +1,314 @@
+"""PostgreSQL acceptance tests for the durable semantic-Q&A quota."""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from collections.abc import AsyncIterator
+from datetime import datetime, timedelta, timezone
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import delete, func, select, update
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from bot.db.models import SemanticQaAttempt
+from bot.db.repos.semantic_quota import AttemptOutcome, SemanticQuotaRepo
+
+
+async def _persist_delivery_intent(
+    session: AsyncSession,
+    *,
+    attempt_id: int,
+    outcome: AttemptOutcome,
+    now: datetime,
+) -> None:
+    """Seed the pre-Telegram state when a repo test exercises finalize directly."""
+
+    await session.execute(
+        update(SemanticQaAttempt)
+        .where(SemanticQaAttempt.id == attempt_id)
+        .values(outcome=outcome, delivery_started_at=now)
+    )
+    await session.flush()
+
+
+@pytest_asyncio.fixture()
+async def concurrent_quota_sessions(postgres_engine) -> AsyncIterator[tuple[object, str]]:
+    """Use unique committed rows for the real multi-connection race, then scrub only them.
+
+    A PostgreSQL xact advisory-lock race cannot be exercised inside the single outer
+    transaction used by ``db_session``: the lock is released only by commit/rollback.
+    This fixture therefore commits unique test-owned rows across independent connections
+    and removes exactly that prefix at teardown; it never truncates or resets shared data.
+    """
+
+    prefix = f"test-semantic-concurrency-{uuid.uuid4().hex}"
+    factory = async_sessionmaker(postgres_engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield factory, prefix
+    finally:
+        async with factory() as cleanup:
+            await cleanup.execute(
+                delete(SemanticQaAttempt).where(
+                    SemanticQaAttempt.idempotency_key.like(f"{prefix}:%")
+                )
+            )
+            await cleanup.commit()
+
+
+@pytest.mark.asyncio
+async def test_three_concurrent_reservations_admit_exactly_two(
+    concurrent_quota_sessions,
+) -> None:
+    factory, prefix = concurrent_quota_sessions
+    ready = asyncio.Event()
+    waiting = 0
+    waiting_lock = asyncio.Lock()
+    user_tg_id = 8_040_400_001
+    now = datetime(2026, 7, 16, 12, tzinfo=timezone.utc)
+
+    async def reserve(index: int):
+        nonlocal waiting
+        async with waiting_lock:
+            waiting += 1
+            if waiting == 3:
+                ready.set()
+        await ready.wait()
+        async with factory() as session:
+            decision = await SemanticQuotaRepo.reserve(
+                session,
+                idempotency_key=f"{prefix}:{index}",
+                user_tg_id=user_tg_id,
+                chat_id=-100404,
+                source_chat_message_id=None,
+                now=now,
+            )
+            await session.commit()
+            return decision
+
+    decisions = await asyncio.gather(*(reserve(index) for index in range(3)))
+
+    assert sum(decision.allowed for decision in decisions) == 2
+    assert sorted(decision.used for decision in decisions) == [0, 1, 2]
+    async with factory() as verification:
+        rows = (
+            (
+                await verification.execute(
+                    select(SemanticQaAttempt).where(
+                        SemanticQaAttempt.idempotency_key.like(f"{prefix}:%")
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+    assert sorted(row.status for row in rows) == ["denied", "reserved", "reserved"]
+    assert sorted(row.slot_number for row in rows if row.slot_number is not None) == [1, 2]
+
+
+@pytest.mark.asyncio
+async def test_technical_failure_releases_slot_for_reuse(db_session) -> None:
+    now = datetime(2026, 7, 16, 12, tzinfo=timezone.utc)
+    first = await SemanticQuotaRepo.reserve(
+        db_session,
+        idempotency_key="technical-release:first",
+        user_tg_id=8_040_400_002,
+        chat_id=-100404,
+        source_chat_message_id=None,
+        now=now,
+    )
+    await SemanticQuotaRepo.finalize(
+        db_session,
+        attempt_id=first.attempt_id,
+        outcome="technical_failure",
+    )
+    replacement = await SemanticQuotaRepo.reserve(
+        db_session,
+        idempotency_key="technical-release:replacement",
+        user_tg_id=8_040_400_002,
+        chat_id=-100404,
+        source_chat_message_id=None,
+        now=now,
+    )
+
+    assert first.allowed is True
+    assert replacement.allowed is True
+    assert replacement.used == 0
+    assert (
+        await db_session.scalar(
+            select(SemanticQaAttempt.status).where(SemanticQaAttempt.id == first.attempt_id)
+        )
+        == "released"
+    )
+
+
+@pytest.mark.asyncio
+async def test_answered_and_abstained_both_consume_quota(db_session) -> None:
+    now = datetime(2026, 7, 16, 12, tzinfo=timezone.utc)
+    outcomes: tuple[AttemptOutcome, ...] = ("answered", "abstained")
+    for index, outcome in enumerate(outcomes, start=1):
+        decision = await SemanticQuotaRepo.reserve(
+            db_session,
+            idempotency_key=f"consumed:{index}",
+            user_tg_id=8_040_400_003,
+            chat_id=-100404,
+            source_chat_message_id=None,
+            now=now,
+        )
+        assert decision.allowed is True
+        await _persist_delivery_intent(
+            db_session,
+            attempt_id=decision.attempt_id,
+            outcome=outcome,
+            now=now,
+        )
+        await SemanticQuotaRepo.finalize(
+            db_session,
+            attempt_id=decision.attempt_id,
+            outcome=outcome,
+        )
+
+    denied = await SemanticQuotaRepo.reserve(
+        db_session,
+        idempotency_key="consumed:third",
+        user_tg_id=8_040_400_003,
+        chat_id=-100404,
+        source_chat_message_id=None,
+        now=now,
+    )
+
+    assert denied.allowed is False
+    assert denied.used == 2
+    statuses = (
+        await db_session.execute(
+            select(SemanticQaAttempt.status, SemanticQaAttempt.outcome)
+            .where(SemanticQaAttempt.user_tg_id == 8_040_400_003)
+            .order_by(SemanticQaAttempt.id)
+        )
+    ).all()
+    assert statuses == [
+        ("consumed", "answered"),
+        ("consumed", "abstained"),
+        ("denied", "quota_denied"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_reservation_idempotency_never_allocates_a_second_slot(db_session) -> None:
+    async def reserve():
+        return await SemanticQuotaRepo.reserve(
+            db_session,
+            idempotency_key="idempotent:one",
+            user_tg_id=8_040_400_004,
+            chat_id=-100404,
+            source_chat_message_id=None,
+            now=datetime(2026, 7, 16, 12, tzinfo=timezone.utc),
+        )
+
+    first = await reserve()
+    repeated = await reserve()
+
+    assert repeated.allowed is False
+    assert repeated.replayed is True
+    assert repeated.status == "reserved"
+    assert repeated.attempt_id == first.attempt_id
+    assert first.used == 0
+    assert repeated.used == 1
+    assert repeated.limit == first.limit
+    assert repeated.resets_at == first.resets_at
+    assert (
+        await db_session.scalar(
+            select(func.count())
+            .select_from(SemanticQaAttempt)
+            .where(SemanticQaAttempt.idempotency_key == "idempotent:one")
+        )
+        == 1
+    )
+
+    await _persist_delivery_intent(
+        db_session,
+        attempt_id=first.attempt_id,
+        outcome="answered",
+        now=datetime(2026, 7, 16, 12, tzinfo=timezone.utc),
+    )
+    await SemanticQuotaRepo.finalize(
+        db_session,
+        attempt_id=first.attempt_id,
+        outcome="answered",
+    )
+    finalized_replay = await reserve()
+    assert finalized_replay.allowed is False
+    assert finalized_replay.replayed is True
+    assert finalized_replay.status == "consumed"
+    assert finalized_replay.outcome == "answered"
+    assert finalized_replay.attempt_id == first.attempt_id
+    assert finalized_replay.used == 1
+
+
+@pytest.mark.asyncio
+async def test_next_admission_releases_stale_crashed_reservation(db_session) -> None:
+    now = datetime(2026, 7, 16, 12, tzinfo=timezone.utc)
+    stale = SemanticQaAttempt(
+        idempotency_key="stale:crashed",
+        user_tg_id=8_040_400_005,
+        chat_id=-100404,
+        source_chat_message_id=None,
+        local_day=now.date(),
+        slot_number=1,
+        status="reserved",
+        outcome=None,
+        reserved_at=now - timedelta(minutes=16),
+    )
+    db_session.add(stale)
+    await db_session.flush()
+
+    replacement = await SemanticQuotaRepo.reserve(
+        db_session,
+        idempotency_key="stale:replacement",
+        user_tg_id=8_040_400_005,
+        chat_id=-100404,
+        source_chat_message_id=None,
+        now=now,
+    )
+
+    assert replacement.allowed is True
+    assert replacement.used == 0
+    await db_session.refresh(stale)
+    assert stale.status == "released"
+    assert stale.outcome == "technical_failure"
+
+
+@pytest.mark.asyncio
+async def test_stale_delivery_intent_is_consumed_not_released(db_session) -> None:
+    now = datetime(2026, 7, 16, 12, tzinfo=timezone.utc)
+    stale = SemanticQaAttempt(
+        idempotency_key="stale:delivery-started",
+        user_tg_id=8_040_400_006,
+        chat_id=-100404,
+        source_chat_message_id=None,
+        local_day=now.date(),
+        slot_number=1,
+        status="reserved",
+        outcome="answered",
+        reserved_at=now - timedelta(minutes=16),
+        delivery_started_at=now - timedelta(minutes=15, seconds=30),
+    )
+    db_session.add(stale)
+    await db_session.flush()
+
+    replacement = await SemanticQuotaRepo.reserve(
+        db_session,
+        idempotency_key="stale:delivery-replacement",
+        user_tg_id=8_040_400_006,
+        chat_id=-100404,
+        source_chat_message_id=None,
+        now=now,
+    )
+
+    await db_session.refresh(stale)
+    assert stale.status == "consumed"
+    assert stale.outcome == "answered"
+    assert stale.finalized_at == now
+    assert replacement.allowed is True
+    assert replacement.used == 1

--- a/tests/services/test_semantic_scheduler.py
+++ b/tests/services/test_semantic_scheduler.py
@@ -28,7 +28,11 @@ async def test_semantic_index_tick_is_strict_noop_when_flag_off(monkeypatch) -> 
     backfill = AsyncMock()
 
     monkeypatch.setattr(scheduler, "async_session", _session_context(session))
-    monkeypatch.setattr(feature_flags.FeatureFlagRepo, "get", AsyncMock(return_value=False))
+    monkeypatch.setattr(
+        feature_flags.FeatureFlagRepo,
+        "any_enabled",
+        AsyncMock(return_value=False),
+    )
     monkeypatch.setattr(semantic_index, "backfill_semantic_index", backfill)
 
     await scheduler.run_semantic_index_tick()
@@ -36,7 +40,7 @@ async def test_semantic_index_tick_is_strict_noop_when_flag_off(monkeypatch) -> 
     backfill.assert_not_awaited()
 
 
-async def test_semantic_index_tick_runs_idempotent_reconciliation(monkeypatch) -> None:
+async def test_semantic_index_tick_runs_when_scoped_canary_is_enabled(monkeypatch) -> None:
     scheduler = import_module("bot.services.scheduler")
     feature_flags = import_module("bot.db.repos.feature_flag")
     gateway = import_module("bot.services.llm_gateway")
@@ -47,12 +51,14 @@ async def test_semantic_index_tick_runs_idempotent_reconciliation(monkeypatch) -
     backfill = AsyncMock(return_value=report)
 
     monkeypatch.setattr(scheduler, "async_session", _session_context(session))
-    monkeypatch.setattr(feature_flags.FeatureFlagRepo, "get", AsyncMock(return_value=True))
+    any_enabled = AsyncMock(return_value=True)
+    monkeypatch.setattr(feature_flags.FeatureFlagRepo, "any_enabled", any_enabled)
     monkeypatch.setattr(gateway, "load_embedding_gateway_config", Mock(return_value=config))
     monkeypatch.setattr(semantic_index, "backfill_semantic_index", backfill)
 
     await scheduler.run_semantic_index_tick()
 
+    any_enabled.assert_awaited_once_with(session, "memory.qa.semantic.enabled")
     backfill.assert_awaited_once_with(
         session,
         config=config,
@@ -71,7 +77,11 @@ async def test_semantic_index_tick_reports_unresolved_claim(monkeypatch, caplog)
     )
 
     monkeypatch.setattr(scheduler, "async_session", _session_context(session))
-    monkeypatch.setattr(feature_flags.FeatureFlagRepo, "get", AsyncMock(return_value=True))
+    monkeypatch.setattr(
+        feature_flags.FeatureFlagRepo,
+        "any_enabled",
+        AsyncMock(return_value=True),
+    )
     monkeypatch.setattr(
         gateway,
         "load_embedding_gateway_config",

--- a/tests/services/test_semantic_scheduler.py
+++ b/tests/services/test_semantic_scheduler.py
@@ -60,6 +60,31 @@ async def test_semantic_index_tick_runs_idempotent_reconciliation(monkeypatch) -
     )
 
 
+async def test_semantic_index_tick_reports_unresolved_claim(monkeypatch, caplog) -> None:
+    scheduler = import_module("bot.services.scheduler")
+    feature_flags = import_module("bot.db.repos.feature_flag")
+    gateway = import_module("bot.services.llm_gateway")
+    semantic_index = import_module("bot.services.semantic_index")
+    session = AsyncMock()
+    backfill = AsyncMock(
+        side_effect=semantic_index.EmbeddingClaimUnresolved(unit_id=404, status="reserved")
+    )
+
+    monkeypatch.setattr(scheduler, "async_session", _session_context(session))
+    monkeypatch.setattr(feature_flags.FeatureFlagRepo, "get", AsyncMock(return_value=True))
+    monkeypatch.setattr(
+        gateway,
+        "load_embedding_gateway_config",
+        Mock(return_value=SimpleNamespace(model="text-embedding-3-small", dimensions=1536)),
+    )
+    monkeypatch.setattr(semantic_index, "backfill_semantic_index", backfill)
+
+    await scheduler.run_semantic_index_tick()
+
+    session.rollback.assert_awaited_once()
+    assert "semantic_index_tick_failed" in caplog.text
+
+
 def test_start_scheduler_registers_semantic_index_tick(monkeypatch) -> None:
     scheduler = import_module("bot.services.scheduler")
     jobs: list[tuple[object, str | None, dict[str, object]]] = []

--- a/tests/services/test_semantic_scheduler.py
+++ b/tests/services/test_semantic_scheduler.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from tests.conftest import import_module
+
+
+pytestmark = pytest.mark.usefixtures("app_env")
+
+
+def _session_context(session):
+    @asynccontextmanager
+    async def context():
+        yield session
+
+    return context
+
+
+async def test_semantic_index_tick_is_strict_noop_when_flag_off(monkeypatch) -> None:
+    scheduler = import_module("bot.services.scheduler")
+    feature_flags = import_module("bot.db.repos.feature_flag")
+    semantic_index = import_module("bot.services.semantic_index")
+    session = AsyncMock()
+    backfill = AsyncMock()
+
+    monkeypatch.setattr(scheduler, "async_session", _session_context(session))
+    monkeypatch.setattr(feature_flags.FeatureFlagRepo, "get", AsyncMock(return_value=False))
+    monkeypatch.setattr(semantic_index, "backfill_semantic_index", backfill)
+
+    await scheduler.run_semantic_index_tick()
+
+    backfill.assert_not_awaited()
+
+
+async def test_semantic_index_tick_runs_idempotent_reconciliation(monkeypatch) -> None:
+    scheduler = import_module("bot.services.scheduler")
+    feature_flags = import_module("bot.db.repos.feature_flag")
+    gateway = import_module("bot.services.llm_gateway")
+    semantic_index = import_module("bot.services.semantic_index")
+    session = AsyncMock()
+    config = SimpleNamespace(model="text-embedding-3-small", dimensions=1536)
+    report = SimpleNamespace(run_id=9, eligible=7, indexed=2, skipped=5, failed=0)
+    backfill = AsyncMock(return_value=report)
+
+    monkeypatch.setattr(scheduler, "async_session", _session_context(session))
+    monkeypatch.setattr(feature_flags.FeatureFlagRepo, "get", AsyncMock(return_value=True))
+    monkeypatch.setattr(gateway, "load_embedding_gateway_config", Mock(return_value=config))
+    monkeypatch.setattr(semantic_index, "backfill_semantic_index", backfill)
+
+    await scheduler.run_semantic_index_tick()
+
+    backfill.assert_awaited_once_with(
+        session,
+        config=config,
+        chat_id=-1001234567890,
+    )
+
+
+def test_start_scheduler_registers_semantic_index_tick(monkeypatch) -> None:
+    scheduler = import_module("bot.services.scheduler")
+    jobs: list[tuple[object, str | None, dict[str, object]]] = []
+
+    monkeypatch.setattr(
+        scheduler.scheduler,
+        "add_job",
+        lambda function, trigger, **kwargs: jobs.append(
+            (function, kwargs.get("id"), {"trigger": trigger, **kwargs})
+        ),
+    )
+    monkeypatch.setattr(scheduler.scheduler, "start", lambda: None)
+
+    scheduler.start_scheduler(object())
+
+    matches = [job for job in jobs if job[1] == "semantic_index_tick"]
+    assert len(matches) == 1
+    function, _, kwargs = matches[0]
+    assert function is scheduler.run_semantic_index_tick
+    assert kwargs["trigger"] == "interval"
+    assert kwargs["minutes"] == 15
+    assert kwargs["max_instances"] == 1

--- a/tests/test_chat_messages_no_auto_member.py
+++ b/tests/test_chat_messages_no_auto_member.py
@@ -81,6 +81,7 @@ def test_save_chat_message_does_not_auto_mark_member(app_env, monkeypatch) -> No
         username="not_member_yet",
         first_name="Alice",
         last_name="Example",
+        is_bot=False,
     )
     user_set_member.assert_not_called()
     # T1-09/10/11 added normalized kwargs to MessageRepo.save. T1-12 added

--- a/tests/test_start_vouched.py
+++ b/tests/test_start_vouched.py
@@ -52,6 +52,7 @@ def test_start_vouched_status_sends_pending_message(app_env, monkeypatch) -> Non
         username="alice",
         first_name="Alice",
         last_name=None,
+        is_bot=None,
     )
     application_get_active.assert_awaited_once_with(session, 111)
     message.answer.assert_awaited_once_with(texts.VOUCHED_PENDING)

--- a/uv.lock
+++ b/uv.lock
@@ -1151,6 +1151,57 @@ wheels = [
 ]
 
 [[package]]
+name = "numpy"
+version = "2.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/fd/89965aa4ac08c74998539fcbf24fa3540f3e15237fbeb6bcf9c908f4aade/numpy-2.5.1.tar.gz", hash = "sha256:a48a113e6afea91f5608793bafa7ef2ad481fefbda87ec5069f483de61cb9fa3", size = 20755553, upload-time = "2026-07-04T17:08:00.933Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/7b/14687aa674250e5e546f616f486b0d56d3631cd5b2415739141ce40bdcea/numpy-2.5.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2c889b56fe48b1018f764b0eec8df59ab654e9148aa91faa12596043500de277", size = 16801574, upload-time = "2026-07-04T17:06:12.423Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/19/cc5bb2a3f2913d27d6dbb2c78d25921fabaedc6741d4a5a615a11f3c5bf3/numpy-2.5.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ab451b59c5643c570974c43aef780703ef1d3b4965d2be07afd530615a9358d1", size = 11772250, upload-time = "2026-07-04T17:06:15.726Z" },
+    { url = "https://files.pythonhosted.org/packages/42/77/fdf34a71dd30f54979b18603bee915e0aaf825b07afe79acd60b04b691e2/numpy-2.5.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:78798bd5b9ad744056af8efa90e3b9ddaa53272a0848a483084a1cc0a13b2dc0", size = 5331516, upload-time = "2026-07-04T17:06:17.913Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/e2/eb7efa015b4cce41e2517bf182a7fce0d7d5b9d9ed76a29bfa0f4fe4505c/numpy-2.5.1-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:2ae0ca40bcb22d6ba59c1dfd5446f49940b0f2d821fde133f10dda11f816b84e", size = 6664863, upload-time = "2026-07-04T17:06:20.02Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/4b/a2b32dd94ee9ffbeecb28152240042a3949db33b1c834d44090b80e1b3b8/numpy-2.5.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:61ac47e772e6b8ea489e1d2f441a34c5c3ac17327e7ce294cbdf535795ad4e75", size = 15167977, upload-time = "2026-07-04T17:06:21.621Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/a9/6e73d68500f80773f65f0654ea932019d6694329a0eb0ed0533de38df376/numpy-2.5.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:59fda5e192b570217ec2580c96f00e9a7e12ef6866a900eb089b62c1a32545ca", size = 16672469, upload-time = "2026-07-04T17:06:24.064Z" },
+    { url = "https://files.pythonhosted.org/packages/24/7d/ad3e59015135f5261c95fd4cafeff159c955febd83a99a1d9250c4233815/numpy-2.5.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f7119ebff1a9829e9f431a4f9d28e703023bb6b9fe7c8f724467dbfc27c94ab3", size = 16527531, upload-time = "2026-07-04T17:06:26.69Z" },
+    { url = "https://files.pythonhosted.org/packages/83/d0/a39b2fbcde9cb17a1dac678f254b33a6336298af9df338824c685425d5e8/numpy-2.5.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e824c2acf8862052246be5a44c15da1777940c60d010dd2aab897824d9c430f9", size = 18431940, upload-time = "2026-07-04T17:06:29.521Z" },
+    { url = "https://files.pythonhosted.org/packages/04/12/cff070947791c1ed425ff76413189adbdc2fbe215eba7ce7fa454a03c7f8/numpy-2.5.1-cp312-cp312-win32.whl", hash = "sha256:08d60c810432eb83360958dea0999ac4cfb94531ea8efcbf0b7f277c2068aeb2", size = 6066764, upload-time = "2026-07-04T17:06:32.571Z" },
+    { url = "https://files.pythonhosted.org/packages/65/66/53f31807a48a750f9d748da273bc3fcedd12b27ff1f3e373bfec55ef2dc0/numpy-2.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:f7d60026c0bdb1380e83bfa7a0419c4577ee4b9a08880afcb6dadeb74c649fa2", size = 12430966, upload-time = "2026-07-04T17:06:34.926Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/2a/d1a88066b1c14186f5d3c0d18c94f17b064511982bab0578d49ee9d43c29/numpy-2.5.1-cp312-cp312-win_arm64.whl", hash = "sha256:17a25e09640602e10bc8de0e6fa2b3fd68eedd84ba6d7842dc8f32f9ab87bd0b", size = 10350488, upload-time = "2026-07-04T17:06:37.785Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/07/ec2a3f0c91761581d4b7104a740791800025983f9a4dc4e73f91a99aeac4/numpy-2.5.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0bfebd8695f9863592fe744be833a258120b14a9f39da255e8aa8fade2c0ddd1", size = 16796419, upload-time = "2026-07-04T17:06:40.37Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/ab/ddb499fc4f8780354395face5b65c7fd107bcd6e1d667a5f07d046956f6f/numpy-2.5.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:30b44a6b53a7ae63c54c089a8726e5563ed302716c5b7ccc85afade40b0e7ff6", size = 11765832, upload-time = "2026-07-04T17:06:42.768Z" },
+    { url = "https://files.pythonhosted.org/packages/88/b3/3c28c558a09fc72100c646dac6d2fce8e834c471b0edca01a29996706117/numpy-2.5.1-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:6165343f81b56ef8f514f396989e529b61d9dc709b99421b07e9f3e698e2287d", size = 5325143, upload-time = "2026-07-04T17:06:45.466Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/0e/ce19b985bb15c596f4f05954e76cccc77c845083b3b8f938a6c68e523128/numpy-2.5.1-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:4939237038ada79308dda3204ac6462df056b5672b2e25db1149cf873668b3e1", size = 6659749, upload-time = "2026-07-04T17:06:47.288Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/20/1ee6614d64332a1bba6411f38e68cb79eec1b2459e20a623777c5c5492a2/numpy-2.5.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c6759f538fb912fc46de0a6b1758ccf7b57bc7c7ebebc23974fdac3de8db0cd", size = 15164716, upload-time = "2026-07-04T17:06:49.494Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/a7/2bcd3fdbb87804755c35b729bf8709d62025c5f4cfd7d5b2415997097515/numpy-2.5.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9726558e8db4a5bf7929a70ae50f63abda4daf0efe810e3bfbab95976f75fc1a", size = 16661440, upload-time = "2026-07-04T17:06:52.061Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/d7/a41e3310c886fe457d36e670bbf24fae411aca8a7b6ad92a32afd924077c/numpy-2.5.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:3935f3b419b244a02732676fa5317a9193cc596a4c0646db07e5b421229ac9f7", size = 16526305, upload-time = "2026-07-04T17:06:54.605Z" },
+    { url = "https://files.pythonhosted.org/packages/53/75/4333a9a707c1edd3a4e1a0c58eca52c0f31e55089fa80db02b5565b24df7/numpy-2.5.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:dc932a65ded7ce9013d120845a2514dcccb1a67bfc8deb8d37633762951904a6", size = 18423008, upload-time = "2026-07-04T17:06:57.54Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/90/e314a32b1c11a2ffe818ddad3a57b50b4b6e1b6c487192eb50cdef0415d0/numpy-2.5.1-cp313-cp313-win32.whl", hash = "sha256:4b4ff1608417eb7a59da7b967bbb798cacfe071d2caf526a24281cd562072ed9", size = 6063885, upload-time = "2026-07-04T17:07:00.14Z" },
+    { url = "https://files.pythonhosted.org/packages/10/70/800b3fca480af32df9e8ea9f3d4a0c8feb4b32d7f195d174eabbda4829ad/numpy-2.5.1-cp313-cp313-win_amd64.whl", hash = "sha256:6c3fe51bc6a16453d452997053454f309e8e0ed7b42d6b361ce4ac8c32913d74", size = 12425674, upload-time = "2026-07-04T17:07:02.387Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/0b/196350c122f50f6ca56846f2d71efd5e0d24b7b2e07355e019b2e2c7a11e/numpy-2.5.1-cp313-cp313-win_arm64.whl", hash = "sha256:f7feb014281029e628ba2d5a007407443b06e418b6fe451d1e2adcbc8eba0107", size = 10350256, upload-time = "2026-07-04T17:07:04.878Z" },
+    { url = "https://files.pythonhosted.org/packages/db/f4/731b6085a83faf6ca843394cbd5e217280c214399f7e8b21b9f552af0ae2/numpy-2.5.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:7c786fe9a5bbe360022e584c5a34cf6b54265c71bd7ec8ac3d8fec38968071f8", size = 16795063, upload-time = "2026-07-04T17:07:07.374Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/64/0e215f2048dd11a55bb989ed41b3585ef57452404e638d703a211a3e4157/numpy-2.5.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:32985c896d897419ef8da6917872d80b78ad0ea26d85b23245c7366ffde76d75", size = 11776652, upload-time = "2026-07-04T17:07:09.907Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/59/2b844c7a6e9deff69b404a66221e1542937734f65d5e6e39411876053862/numpy-2.5.1-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:efd736408cc97c79b9e6917338dfc8f06013b2274f992e96b1d9a81a71e2a2c2", size = 5335944, upload-time = "2026-07-04T17:07:12.227Z" },
+    { url = "https://files.pythonhosted.org/packages/86/51/9bf7cb2cabcebc9e017e4ec7e6322b378317a542c08b4cb68479c1efc716/numpy-2.5.1-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:ab84dc6b074fa881cae55bea94cc4f68e285181ba7f32497bf7dee6b1496165b", size = 6656266, upload-time = "2026-07-04T17:07:14.368Z" },
+    { url = "https://files.pythonhosted.org/packages/83/3e/fb7615b211b82a32f44d5180a6d421b61f84d4fadd578b48ba4ac34e189f/numpy-2.5.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:caf3e317d33d60c37986b452613f4ab51246d0691350c03d0cb4a898627f4a95", size = 15179720, upload-time = "2026-07-04T17:07:16.272Z" },
+    { url = "https://files.pythonhosted.org/packages/41/5f/0f992cb24560673496c5d68de61913b57166ce530ffda07c1f280e0cc464/numpy-2.5.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:54ad769f17bc2d833b620851989f62054fb9ab93c969d9e1dc3c8e3d56beea21", size = 16664835, upload-time = "2026-07-04T17:07:19.021Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/2f/97d6475ee91afe2587797d09446f9d3e475ad4cb681662d824809327b75a/numpy-2.5.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c12afb53450fa976d4c681c50a7423729a4c51c0465ed9f32b8a9cabbc472373", size = 16539135, upload-time = "2026-07-04T17:07:22.015Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/5b/4db81e4ba0be7e2776b1de68c82aa862c7f8ec27e1b4927d4ae075e20678/numpy-2.5.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e8c11c405efc5ff6816d5983c96cdfa215bab3428961243af3ff59b228490438", size = 18426684, upload-time = "2026-07-04T17:07:24.941Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/64/c0ba2d90724d450279a7df8f32057241070250a26a7e2b5337d77347f481/numpy-2.5.1-cp314-cp314-win32.whl", hash = "sha256:f2479a47f8d5932d1718168a681ad6e536a9df484c83cfcf9de365e164537ace", size = 6116103, upload-time = "2026-07-04T17:07:27.622Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/1a/837f9ed7405adcd7a40538792eb169eddd8fa5630c16a1ef49dae71a30f4/numpy-2.5.1-cp314-cp314-win_amd64.whl", hash = "sha256:24d0eb82c0541d3415a33425db64ae439dffccd7b4dbcb30e7c35120205c506a", size = 12562177, upload-time = "2026-07-04T17:07:29.887Z" },
+    { url = "https://files.pythonhosted.org/packages/22/ed/49707938b6dd0a78a9178dd93227dc89e4c11af47f5c798d70366e8d0483/numpy-2.5.1-cp314-cp314-win_arm64.whl", hash = "sha256:5a4c988b38d261deeeaad9954e3deb091ad905c94e8bb6708654ef1d97f286b0", size = 10627739, upload-time = "2026-07-04T17:07:32.568Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/c7/bb4b882cfe7f299cbc8b66e42e7dd78cf9d14e40f9469fc5e3db7e15b3bd/numpy-2.5.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a33276be12fa045805f477f22482088b66bb758ffbe89a9d21457de863a32e22", size = 11894709, upload-time = "2026-07-04T17:07:34.941Z" },
+    { url = "https://files.pythonhosted.org/packages/40/3f/5af7f4a7f6224aef48017aa82bb6174c7a659d724be0c75017b7e64a55b4/numpy-2.5.1-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:f089d7b00756190aacf1f5d34bdf38c3c430ac82b4f868f8cede73380460fce7", size = 5453810, upload-time = "2026-07-04T17:07:37.495Z" },
+    { url = "https://files.pythonhosted.org/packages/20/c9/3474309bc94d634d3f9c3eddf03250ecb8c22cd948ef16fef69a77cc5d7b/numpy-2.5.1-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:09e9bfd8d2cf479c7d174804fb3811c53a8e9f20a37444008606b57d6b7a826d", size = 6761189, upload-time = "2026-07-04T17:07:39.563Z" },
+    { url = "https://files.pythonhosted.org/packages/90/8a/558ae39fdd55d7e7f7fef9a84a6e964ac6b23edbd2a07e52bb084500507d/numpy-2.5.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e68d8dd1e7eba712948f2053a29ec86917bc70ba1358df869d9f06649ef9cf09", size = 15225039, upload-time = "2026-07-04T17:07:41.682Z" },
+    { url = "https://files.pythonhosted.org/packages/63/27/ca7392b2d030277bdf0273e7d23255b3ee57d57a7c170a6f4fb3981e1e5d/numpy-2.5.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:99d5095fa265a0c4152e7bb12759e14381ef5496152f1ce58f44bdf55c44beb4", size = 16701306, upload-time = "2026-07-04T17:07:44.611Z" },
+    { url = "https://files.pythonhosted.org/packages/02/42/03d53ae7996c44d4374a8262e9dc41671fd56cbb98f7d47ef85cf5da4c6b/numpy-2.5.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:ab87a91b3cc3382b8956095bd8f95e00cf679bb81554339be1a2ba404a1473c1", size = 16589955, upload-time = "2026-07-04T17:07:47.694Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/15/6c1784ae469640e65db111e9a34b3d0f14d91e8a38b9ce34810ced370dbb/numpy-2.5.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:224ca51130ef7da85bea2191625181cb4f337f9cb64b471f10c1a12aa8b60077", size = 18464252, upload-time = "2026-07-04T17:07:50.684Z" },
+    { url = "https://files.pythonhosted.org/packages/94/a8/f98e50356cf167df656c526c2dfeec2d7dde182f2a3da4b458a5938e2776/numpy-2.5.1-cp314-cp314t-win32.whl", hash = "sha256:6eab239876581b2b3c5a242281b6007bbdbcd1c7085d7709bb57c5929b11e6bf", size = 6263298, upload-time = "2026-07-04T17:07:53.445Z" },
+    { url = "https://files.pythonhosted.org/packages/72/ac/96ae880cdecad0b3275d9359fcec72667b49a4863c9f12942e43679dda02/numpy-2.5.1-cp314-cp314t-win_amd64.whl", hash = "sha256:83ce9c80d5b521b0d77ddcbe5447c218d247929b6cc056ca5351342accfff0af", size = 12748623, upload-time = "2026-07-04T17:07:55.384Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/5a/4d2b1601df3602dba7a14f3348ba9bfe94a18adb428e693df6154c293831/numpy-2.5.1-cp314-cp314t-win_arm64.whl", hash = "sha256:5a6db61f9aaa57e369905c67d852045d3c4f7126405b29d09b19dec118e9c9cb", size = 10697674, upload-time = "2026-07-04T17:07:58.506Z" },
+]
+
+[[package]]
 name = "oauthlib"
 version = "3.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1175,6 +1226,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
+]
+
+[[package]]
+name = "pgvector"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/25/6c/6d8b4b03b958c02fa8687ec6063c49d952a189f8c91ebbe51e877dfab8f7/pgvector-0.4.2.tar.gz", hash = "sha256:322cac0c1dc5d41c9ecf782bd9991b7966685dee3a00bc873631391ed949513a", size = 31354, upload-time = "2025-12-05T01:07:17.87Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/26/6cee8a1ce8c43625ec561aff19df07f9776b7525d9002c86bceb3e0ac970/pgvector-0.4.2-py3-none-any.whl", hash = "sha256:549d45f7a18593783d5eec609ea1684a724ba8405c4cb182a0b2b08aeff04e08", size = 27441, upload-time = "2025-12-05T01:07:16.536Z" },
 ]
 
 [[package]]
@@ -1891,6 +1954,7 @@ dependencies = [
     { name = "markdown-it-py" },
     { name = "neo4j" },
     { name = "networkx" },
+    { name = "pgvector" },
     { name = "pydantic-settings" },
     { name = "python-dotenv" },
     { name = "python-multipart" },
@@ -1940,6 +2004,7 @@ requires-dist = [
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.15" },
     { name = "neo4j", specifier = ">=5.0,<6" },
     { name = "networkx", specifier = ">=3.0,<4" },
+    { name = "pgvector", specifier = ">=0.4.1,<0.5" },
     { name = "psycopg", extras = ["binary"], marker = "extra == 'healing'", specifier = ">=3.2" },
     { name = "pydantic-settings", specifier = ">=2.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3" },


### PR DESCRIPTION
## Что изменилось

- Добавлен production-ready semantic Q&A: OpenAI text-embedding-3-small, exact pgvector cosine + FTS/RRF и DeepSeek V4 Flash synthesis с обязательными Telegram citations.
- Реализована durable квота 2 запроса на пользователя за сутки Europe/Moscow, idempotency, progress lease, cost/usage audit и conservative delivery intent.
- Добавлены privacy/governance fences: human/current/normal/non-voice sources only, полный card provenance, question+evidence locks, повторная revalidation перед provider/render/delivery и semantic forget cascade, включая quota-denied traces.
- Добавлены migration 089, pinned PG15+pgvector production image, idempotent backfill/audit/shadow CLI, scheduler, feature flag и подробный rollout/rollback runbook.
- Добавлен frozen private eval gate ≥50 случаев: все 5 категорий и 6 privacy-классов, immutable runner observations, annotation-only review sidecar, release/dataset/artifact hash binding и fail-closed CI validation.

## Зачем

Issue #404 требует semantic recall поверх существующего production-потока без обхода FTS fallback, privacy/forget guarantees, лимитов и аудита стоимости. Реализация сохраняет текущие env names и обычный поиск при выключенном flag или после двух semantic запросов.

## Проверки

- Полный pytest на чистом PostgreSQL 15 + pgvector 0.8.2: 3047 passed, 6 skipped.
- Final exact-PostgreSQL semantic index + handler suite: 101 passed.
- Final private eval/semantic eval suite: 34 passed.
- Ruff check и format check всех изменённых Python-файлов: pass.
- Privacy lint, shell syntax и git diff check: pass.
- Migration 089 -> 088 -> 089: pass; schema head 089, PostgreSQL 15.17, pgvector 0.8.2, HNSW index count 0.
- Независимые adversarial Ponytail/BMAD reviews: финальный PASS; simplicity-pass применён.

## Rollout

Production flag остаётся OFF до post-merge backup/restore rehearsal, migration, двойного idempotent backfill, private live eval, scoped Telegram canary и quota/cost/privacy audit по docs/runbooks/semantic-qa.md. Umbrella issue #404 будет закрыт только после этих operational gates и global enable.

Closes #418
Implements #404
