### PR TITLE
fix: serialize aiogram updates without Default sentinels

### DIFF
--- a/bot/services/ingestion.py
+++ b/bot/services/ingestion.py
@@ -29,6 +29,7 @@ from bot.db.repos.feature_flag import FeatureFlagRepo
 from bot.db.repos.ingestion_run import IngestionRunRepo
 from bot.db.repos.telegram_update import TelegramUpdateRepo
 from bot.services.governance import detect_policy, redact_raw_for_offrecord
+from bot.services.telegram_serialization import serialize_telegram_object
 
 logger = logging.getLogger(__name__)
 
@@ -49,7 +50,7 @@ _UPDATE_EVENT_FIELDS: tuple[str, ...] = (
 
 def _compute_raw_hash(raw_dict: dict[str, Any]) -> str:
     """Deterministic SHA-256 over a stable JSON serialization of the update payload."""
-    canonical = json.dumps(raw_dict, sort_keys=True, default=str)
+    canonical = json.dumps(raw_dict, sort_keys=True, allow_nan=False)
     return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
 
 
@@ -137,7 +138,7 @@ async def record_update(
     if not await is_raw_archive_enabled(session):
         return None
 
-    raw_dict = update.model_dump(mode="json", exclude_none=True)
+    raw_dict = serialize_telegram_object(update)
     raw_hash = _compute_raw_hash(raw_dict)
     update_type = _classify_update_type(update)
     chat_id, message_id = _extract_chat_and_message_ids(update)

--- a/bot/services/message_persistence.py
+++ b/bot/services/message_persistence.py
@@ -25,6 +25,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Literal
 
+from aiogram.types import TelegramObject
 from sqlalchemy import func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -36,6 +37,7 @@ from bot.db.repos.offrecord_mark import OffrecordMarkRepo
 from bot.services.content_hash import compute_content_hash
 from bot.services.governance import detect_policy
 from bot.services.normalization import extract_entities_unified, extract_normalized_fields
+from bot.services.telegram_serialization import serialize_telegram_object
 
 
 @dataclass(frozen=True)
@@ -226,15 +228,17 @@ async def persist_message_with_policy(
     else:
         persist_text = getattr(message, "text", None)
         persist_caption = normalized["caption"]
-        # raw_json tracks text presence (gatekeeper-era behaviour).
-        # Uses model_dump() when available (aiogram Message); falls back to None for
-        # importer ducks that lack model_dump.
+        # raw_json tracks text presence (gatekeeper-era behaviour). Live aiogram
+        # messages use aiogram's strict serializer so nested Default sentinels are
+        # resolved correctly. Structurally-compatible importer/test ducks retain the
+        # existing model_dump contract; ducks without it intentionally store no raw JSON.
         _model_dump = getattr(message, "model_dump", None)
-        persist_raw_json = (
-            _model_dump(mode="json", exclude_none=True)
-            if message.text and _model_dump is not None
-            else None
-        )
+        if message.text and isinstance(message, TelegramObject):
+            persist_raw_json = serialize_telegram_object(message)
+        elif message.text and _model_dump is not None:
+            persist_raw_json = _model_dump(mode="json", exclude_none=True)
+        else:
+            persist_raw_json = None
         is_redacted_flag = False
 
     user_id = message.from_user.id if message.from_user is not None else None

--- a/bot/services/telegram_serialization.py
+++ b/bot/services/telegram_serialization.py
@@ -1,0 +1,30 @@
+"""Strict JSON serialization for aiogram objects received from Telegram."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from aiogram.types import TelegramObject
+from aiogram.utils.serialization import deserialize_telegram_object
+
+
+def serialize_telegram_object(value: TelegramObject) -> dict[str, Any]:
+    """Return aiogram's JSON-compatible representation of a Telegram object.
+
+    Direct ``model_dump(mode="json")`` cannot serialize nested aiogram ``Default``
+    sentinels.  Aiogram's public serializer resolves those sentinels against empty bot
+    defaults and omits them, preserving the received payload without inventing values.
+    """
+    serialized = deserialize_telegram_object(
+        value,
+        default=None,
+        include_api_method_name=False,
+    )
+    if serialized.files:
+        raise TypeError("incoming Telegram object unexpectedly contains upload files")
+    payload = serialized.data
+    if not isinstance(payload, dict):
+        raise TypeError("aiogram TelegramObject serialization did not produce an object")
+    json.dumps(payload, allow_nan=False)
+    return payload

--- a/tests/middlewares/test_raw_update_durability.py
+++ b/tests/middlewares/test_raw_update_durability.py
@@ -10,6 +10,7 @@ from aiogram.types import (
     ChatMemberLeft,
     ChatMemberMember,
     ChatMemberUpdated,
+    LinkPreviewOptions,
     Message,
     Update,
     User,
@@ -63,6 +64,7 @@ def _bot_message_update(update_id: int, secret: str) -> Update:
             chat=Chat(id=-1001234567890, type="supergroup", title="community"),
             from_user=User(id=4203, is_bot=True, first_name="Shkoder"),
             text=f"bot-output {secret}",
+            link_preview_options=LinkPreviewOptions(is_disabled=False),
         ),
     )
 
@@ -159,6 +161,10 @@ async def test_all_raw_update_shapes_survive_downstream_rollback(
             )
         assert len(rows) == 3
         assert {row.update_type for row in rows} == set(expected_types)
+        link_preview_row = next(row for row in rows if row.update_id == update_ids[2])
+        assert link_preview_row.raw_json["message"]["link_preview_options"] == {
+            "is_disabled": False
+        }
         assert secret not in caplog.text
         assert all(record.exc_info is None for record in caplog.records)
     finally:

--- a/tests/services/test_ingestion.py
+++ b/tests/services/test_ingestion.py
@@ -12,6 +12,7 @@ Covers the BLOCKER cross-cutting requirement from AUTHORIZED_SCOPE.md:
 from __future__ import annotations
 
 import itertools
+import json
 from datetime import datetime, timezone
 
 import pytest
@@ -112,6 +113,63 @@ def test_compute_raw_hash_is_deterministic(app_env) -> None:
     b = _compute_raw_hash({"y": [1, 2, 3], "x": 1})  # different key order
     assert a == b
     assert len(a) == 64
+
+
+def test_compute_raw_hash_rejects_non_json_values(app_env) -> None:
+    """Raw hashing must fail fast instead of stringifying unknown payload objects."""
+    from aiogram.client.default import Default
+
+    from bot.services.ingestion import _compute_raw_hash
+
+    with pytest.raises(TypeError):
+        _compute_raw_hash({"unexpected": Default("parse_mode")})
+
+
+def test_telegram_serializer_resolves_nested_aiogram_defaults(app_env) -> None:
+    """Telegram link previews carry aiogram Default sentinels in omitted fields."""
+    from aiogram.types import LinkPreviewOptions
+
+    from bot.services.telegram_serialization import serialize_telegram_object
+
+    update = _make_message_update(text="https://example.test/evidence")
+    assert update.message is not None
+    update = update.model_copy(
+        update={
+            "message": update.message.model_copy(
+                update={"link_preview_options": LinkPreviewOptions(is_disabled=False)}
+            )
+        }
+    )
+
+    payload = serialize_telegram_object(update)
+
+    assert payload["message"]["link_preview_options"] == {"is_disabled": False}
+    json.dumps(payload)
+
+
+async def test_record_update_persists_link_preview_without_defaults(db_session) -> None:
+    """Regression: raw archive ON must accept real updates containing link previews."""
+    from aiogram.types import LinkPreviewOptions
+
+    from bot.db.repos.feature_flag import FeatureFlagRepo
+    from bot.services.ingestion import RAW_ARCHIVE_FLAG, record_update
+
+    await FeatureFlagRepo.set_enabled(db_session, RAW_ARCHIVE_FLAG, enabled=True)
+    update = _make_message_update(text="https://example.test/evidence")
+    assert update.message is not None
+    update = update.model_copy(
+        update={
+            "message": update.message.model_copy(
+                update={"link_preview_options": LinkPreviewOptions(is_disabled=False)}
+            )
+        }
+    )
+
+    row = await record_update(db_session, update)
+
+    assert row is not None
+    assert row.raw_json["message"]["link_preview_options"] == {"is_disabled": False}
+    assert "Default(" not in json.dumps(row.raw_json)
 
 
 # ─── get_or_create_live_run ─────────────────────────────────────────────────────────────

--- a/tests/services/test_message_persistence.py
+++ b/tests/services/test_message_persistence.py
@@ -259,6 +259,43 @@ async def test_persist_normal_sets_raw_json_for_text_message(app_env) -> None:
     assert call_kwargs["raw_json"] is not None
 
 
+async def test_persist_live_link_preview_resolves_aiogram_defaults(app_env) -> None:
+    """Regression: normalized live persistence accepts Telegram link previews."""
+    from aiogram.types import Chat, LinkPreviewOptions, Message, User
+
+    from bot.services.message_persistence import persist_message_with_policy
+
+    message = Message(
+        message_id=101,
+        date=datetime.now(timezone.utc),
+        chat=Chat(id=-1_001_234_567_890, type="supergroup", title="dev"),
+        from_user=User(id=999, is_bot=False, first_name="Probe"),
+        text="https://example.test/evidence",
+        link_preview_options=LinkPreviewOptions(is_disabled=False),
+    )
+    fake_row = _fake_cm(1)
+    session = AsyncMock()
+
+    with (
+        patch("bot.services.message_persistence.advisory_lock_chat_message", new=AsyncMock()),
+        patch(
+            "bot.services.message_persistence.MessageRepo.save",
+            new=AsyncMock(return_value=fake_row),
+        ) as mock_save,
+        patch(
+            "bot.services.message_persistence.OffrecordMarkRepo.create_for_message",
+            new=AsyncMock(),
+        ),
+        patch(
+            "bot.services.message_persistence.MessageVersionRepo.insert_version",
+            new=AsyncMock(return_value=_fake_v1()),
+        ),
+    ):
+        await persist_message_with_policy(session, message)
+
+    assert mock_save.call_args.kwargs["raw_json"]["link_preview_options"] == {"is_disabled": False}
+
+
 async def test_persist_normal_no_raw_json_for_caption_only(app_env) -> None:
     """Caption-only photo: raw_json is None (message.text is falsy)."""
     from bot.services.message_persistence import persist_message_with_policy


### PR DESCRIPTION
## Summary

Unblocks the production rollout for #404. With raw update archiving enabled, incoming Telegram messages containing `LinkPreviewOptions` carried nested aiogram `Default` sentinels. Direct Pydantic JSON dumping failed first in raw ingestion and then again in normalized message persistence.

This change:

- uses aiogram's supported serializer for real `TelegramObject` values in both live paths;
- preserves explicit values such as `is_disabled=false` while omitting unresolved defaults;
- rejects upload files, non-object payloads, NaN, and unknown non-JSON values instead of stringifying them;
- keeps the existing explicit importer/test-duck adapter unchanged.

## Evidence

- Exact PostgreSQL targeted suite: `38 passed`
- Full suite: `3051 passed, 6 skipped`
- Ruff on changed files: pass
- Privacy lint: pass
- Exact production Docker image smoke with pinned aiogram 3.27.0: pass
- Adversarial simplicity/privacy review: PASS

## Rollout

The production polling bot remains stopped and semantic Q&A remains globally OFF until this PR is merged and the new image digest is deployed. Production semantic backfill and its idempotency/audit checks have already passed independently with 100% coverage.

Closes #426
