### PR TITLE
fix: retain third same-author semantic result

### DIFF
--- a/bot/services/semantic_index.py
+++ b/bot/services/semantic_index.py
@@ -49,6 +49,7 @@ EMBEDDING_MODEL_VERSION = "text-embedding-3-small"
 DEFAULT_BACKFILL_BATCH_SIZE = 64
 DEFAULT_VECTOR_CANDIDATE_LIMIT = 20
 MAX_SEMANTIC_EVIDENCE = 5
+MAX_RESULTS_PER_AUTHOR = 3
 RRF_K = 60
 
 _FORGET_EXCLUDES = forget_excludes_sql_fragment()
@@ -2159,7 +2160,7 @@ def reciprocal_rank_fusion(
             if card_count >= 2:
                 continue
         elif hit.user_id is not None:
-            if author_counts.get(hit.user_id, 0) >= 2:
+            if author_counts.get(hit.user_id, 0) >= MAX_RESULTS_PER_AUTHOR:
                 continue
         if hit.message_thread_id is not None and thread_counts.get(hit.message_thread_id, 0) >= 2:
             continue

--- a/tests/services/test_semantic_index_postgres.py
+++ b/tests/services/test_semantic_index_postgres.py
@@ -2230,6 +2230,19 @@ def test_rrf_deduplicates_and_enforces_author_and_card_diversity() -> None:
     assert ranks["message:1"] == {"vector": 1, "fts": 1}
 
 
+def test_rrf_allows_three_messages_per_author_but_excludes_the_fourth() -> None:
+    same_author = [_hit(version_id=index, author_id=77) for index in range(1, 5)]
+    other_authors = [_hit(version_id=index, author_id=100 + index) for index in range(5, 7)]
+
+    selected, _ = reciprocal_rank_fusion(
+        vector_hits=[*same_author, *other_authors],
+        fts_hits=[],
+        limit=5,
+    )
+
+    assert [hit.message_version_id for hit in selected] == [1, 2, 3, 5, 6]
+
+
 def test_rrf_caps_explicit_telegram_topic_without_collapsing_non_topic_chat() -> None:
     topic_hits = [
         _hit(version_id=index, author_id=100 + index, message_thread_id=9001)


### PR DESCRIPTION
## Summary

- raise the RRF per-author diversity cap from two to three within the unchanged five-result evidence limit
- keep card, Telegram-topic, direct-conversation, governance, and total-result caps unchanged
- add a focused regression proving the third result is retained and the fourth is excluded

## Evidence

- focused RRF suite: 4 passed
- private frozen 60-case shadow: macro Recall@5 0.806818; semantic hybrid−FTS +0.75; exact hybrid−FTS +0.583333; leakage 0; retrieval p95 1.321s
- frozen dataset SHA-256: `a84949e698b430a4c69ba4ced3843fd15161df716293a6fdfefc2e1b6c865ae0`

Closes #427
Refs #404
